### PR TITLE
[testbed]add option to run test without testbed_name if no testbed to…

### DIFF
--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -69,3 +69,11 @@
   when:
     - testbed_name is defined
     - testcase_name is defined
+    - testbed_name| lower != 'none'
+
+- name: call test directly if no testbed_name is required
+  include: test_sonic_by_testname.yml
+  when:
+    - testbed_name is defined
+    - testcase_name is defined
+    - testbed_name| lower == 'none'


### PR DESCRIPTION
…pology is required

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
add option to run test without testbed_name has to match restiction

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
some tests do not really need a testbed_name to run, such as snmp, sensors ...
call test by name was written that testbed_name is required to run and will check of testbed_name matches dut. Add an option to call test directly if a test does not require to have a testbed(VMs, PTF) associated...

#### How did you verify/test it?
tested in my local testbed and it worked
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
