### PR TITLE
[everflow]: Add --table_name argument in EVERFLOW test

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/apply_config.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/apply_config.yml
@@ -5,16 +5,38 @@
     tests_location: roles/test/tasks/everflow_testbed
     testname: apply_config
 
-- name: Get session info.
+- name: Clean path
+  file:
+    state: absent
+    path: "{{run_dir}}"
+  become: yes
+
+- name: Get session info
   include: roles/test/tasks/everflow_testbed/get_session_info.yml
 
-- name: Copy python script for session configuration.
+- name: Copy python script for session configuration
   copy: src=roles/test/files/helpers/mirror_session.py dest={{ run_dir }}/
 
-- name: Copy ACL rules configuration file.
+- name: Copy data plane ACL rules configuration file
+  copy: src=roles/test/tasks/acl/acltb_test_rules.json dest={{ run_dir }}/
+
+- name: Copy EVERFLOW ACL rules configuration file
   copy: src={{ tests_location }}/{{ testname}}/acl_rule_persistent.json dest={{ run_dir }}/
 
-- command: "python {{ run_dir }}/mirror_session.py create {{ session_name }} {{ session_src_ip }} {{ session_dst_ip }} {{ session_gre }} {{ session_dscp }} {{ session_ttl }} {{ session_queue }}"
+- name: Create EVERFLOW mirror session
+  command: "python {{ run_dir }}/mirror_session.py create {{ session_name }} {{ session_src_ip }} {{ session_dst_ip }} {{ session_gre }} {{ session_dscp }} {{ session_ttl }} {{ session_queue }}"
 
-- command: "acl-loader update full {{ run_dir }}/acl_rule_persistent.json --session_name={{ session_name }}"
+- name: Apply data plane ACL rules
+  command: "acl-loader update full {{ run_dir }}/acltb_test_rules.json"
   become: yes
+
+- name: Apply EVERFLOW ACL rules
+  command: "acl-loader update full {{ run_dir }}/acl_rule_persistent.json --table_name=EVERFLOW --session_name={{ session_name }}"
+  become: yes
+
+- name: Get number of data plane ACL rules after applying EVERFLOW ACL rules
+  command: "bash -c 'acl-loader show rule | grep DATAACL | wc -l'"
+  register: acl_loader_output
+
+- name: Assert there are 14 data plane ACL rules
+  assert: { that: "{{'14' in acl_loader_output.stdout_lines}}" }

--- a/ansible/roles/test/tasks/everflow_testbed/del_config.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/del_config.yml
@@ -5,16 +5,35 @@
     tests_location: roles/test/tasks/everflow_testbed
     testname: del_config
 
-- name: Get session info.
+- name: Get session info
   include: roles/test/tasks/everflow_testbed/get_session_info.yml
 
-- name: Copy python script for session configuration.
+- name: Copy python script for session configuration
   copy: src=roles/test/files/helpers/mirror_session.py dest={{ run_dir }}/
-
-- name: Copy ACL rules configuration file.
-  copy: src={{ tests_location }}/{{ testname}}/acl_rule_persistent-del.json dest={{ run_dir }}/
-
-- command: "acl-loader update full {{ run_dir }}/acl_rule_persistent-del.json"
   become: yes
 
-- command: "python {{ run_dir }}/mirror_session.py delete {{ session_name }}"
+- name: Copy data plane ACL rules configuration file
+  copy: src=roles/test/tasks/acl/acltb_test_rules-del.json dest={{ run_dir }}/
+  become: yes
+
+- name: Copy EVERFLOW ACL rules configuration file
+  copy: src={{ tests_location }}/{{ testname}}/acl_rule_persistent-del.json dest={{ run_dir }}/
+  become: yes
+
+- name: Remove EVERFLOW ACL rules
+  command: "acl-loader update full {{ run_dir }}/acl_rule_persistent-del.json --table_name=EVERFLOW"
+  become: yes
+
+- name: Remove EVERFLOW mirror session
+  command: "python {{ run_dir }}/mirror_session.py delete {{ session_name }}"
+
+- name: Get number of data plane ACL rules after applying EVERFLOW ACL rules
+  command: "bash -c 'acl-loader show rule | grep DATAACL | wc -l'"
+  register: acl_loader_output
+
+- name: Assert there are 14 data plane ACL rules
+  assert: { that: "{{'14' in acl_loader_output.stdout_lines}}" }
+
+- name: Remove dataplane ACL rules
+  command: "acl-loader update full {{ run_dir }}/acltb_test_rules-del.json"
+  become: yes


### PR DESCRIPTION
acl-loader will support --table_name option so that only specific table
will be updated. This test covers the scenario that we have data plane
ACLs while we want to apply and remove EVERFLOW ACLs. The 14 data plane
ACLs are applied first and we check if they stay there during the whole
EVERFLOW test. These ACLs will be removed at the end of the test.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
