### PR TITLE
adding acl toggle interfaces test

### DIFF
--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -68,6 +68,22 @@
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
 
+    - name: Toggle interfaces up/down
+      include: roles/test/tasks/port_toggle.yml
+
+    - name: Run the test after toggling interfaces
+      include: ptf_runner.yml
+      vars:
+          ptf_test_name: ACL Test
+          ptf_test_dir: acstests
+          ptf_test_path: acltb_test.AclTest
+          ptf_platform: remote
+          ptf_test_params:
+            - verbose=True
+            - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
+            - switch_info=\"/tmp/acltb_switch_info.txt\"
+            - testbed_type=\"{{ testbed_type }}\"
+
     - name: Clean up ACL rules.
       vars:
         command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it? Added one step in the acl test run that toggles all interfaces up and down, reruns the PTF test, and makes sure that the tests still run after the interfaces are back up
How did you verify/test it? Ran it in my local repo
Any platform specific information? No
Supported testbed topology if it's a new test case? t1, t1-lag, t1-64-lag

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
https://github.com/Azure/sonic-mgmt/pull/593
[I have been having git uses in my local, created this new branch to reflect cleaner changes made for above, previous pull request]
