### PR TITLE
set ansible ssh user and passwd before port_alias for sonic fanout

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,10 +1,10 @@
 - debug: msg="{{ device_info }}"
 
-- name: find interface name mapping
-  port_alias: hwsku="{{ device_info["HwSku"] }}"
-
 - name: prepare fanout switch admin login info
   set_fact: ansible_user={{ fanout_sonic_user }} ansible_password={{ fanout_sonic_password }}
+
+- name: find interface name mapping
+  port_alias: hwsku="{{ device_info["HwSku"] }}"
 
 - name: build fanout vlan config
   template: src=sonic_deploy.j2


### PR DESCRIPTION
port_alias needs login into the device

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
tested on real device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
