### PR TITLE
Align topo Arista portchannel names with all other topo patterns

### DIFF
--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -190,10 +190,10 @@ configuration:
         ipv4: 100.1.0.35/32
         ipv6: 2064:100::26/128
       Ethernet1:
-        lacp: 2
+        lacp: 1
       Ethernet2:
-        lacp: 2
-      Port-Channel2:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.35/31
         ipv6: fc00::26/126
     bp_interface:
@@ -214,10 +214,10 @@ configuration:
         ipv4: 100.1.0.37/32
         ipv6: 2064:100::2A/128
       Ethernet1:
-        lacp: 3
+        lacp: 1
       Ethernet2:
-        lacp: 3
-      Port-Channel3:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.37/31
         ipv6: fc00::2A/126
     bp_interface:
@@ -238,10 +238,10 @@ configuration:
         ipv4: 100.1.0.39/32
         ipv6: 2064:100::2E/128
       Ethernet1:
-        lacp: 4
+        lacp: 1
       Ethernet2:
-        lacp: 4
-      Port-Channel4:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.39/31
         ipv6: fc00::2E/126
     bp_interface:

--- a/ansible/vars/topo_t0-64-32.yml
+++ b/ansible/vars/topo_t0-64-32.yml
@@ -102,10 +102,10 @@ configuration:
         ipv4: 100.1.0.2/32
         ipv6: 2064:100::2/128
       Ethernet1:
-        lacp: 4
+        lacp: 1
       Ethernet2:
-        lacp: 4
-      Port-Channel4:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
     bp_interface:
@@ -126,10 +126,10 @@ configuration:
         ipv4: 100.1.0.3/32
         ipv6: 2064:100::3/128
       Ethernet1:
-        lacp: 16
+        lacp: 1
       Ethernet2:
-        lacp: 16
-      Port-Channel16:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
     bp_interface:
@@ -150,10 +150,10 @@ configuration:
         ipv4: 100.1.0.4/32
         ipv6: 2064:100::4/128
       Ethernet1:
-        lacp: 20
+        lacp: 1
       Ethernet2:
-        lacp: 20
-      Port-Channel20:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
     bp_interface:

--- a/ansible/vars/topo_t0-64.yml
+++ b/ansible/vars/topo_t0-64.yml
@@ -155,10 +155,10 @@ configuration:
         ipv4: 100.1.0.2/32
         ipv6: 2064:100::2/128
       Ethernet1:
-        lacp: 4
+        lacp: 1
       Ethernet2:
-        lacp: 4
-      Port-Channel4:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
     bp_interface:
@@ -179,10 +179,10 @@ configuration:
         ipv4: 100.1.0.3/32
         ipv6: 2064:100::3/128
       Ethernet1:
-        lacp: 16
+        lacp: 1
       Ethernet2:
-        lacp: 16
-      Port-Channel16:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
     bp_interface:
@@ -203,10 +203,10 @@ configuration:
         ipv4: 100.1.0.4/32
         ipv6: 2064:100::4/128
       Ethernet1:
-        lacp: 20
+        lacp: 1
       Ethernet2:
-        lacp: 20
-      Port-Channel20:
+        lacp: 1
+      Port-Channel1:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
     bp_interface:


### PR DESCRIPTION
So that we can safely assume the first PortChannel on Arista EOS VM is name as Port-Channel1, as all other topo.