### PR TITLE
Fix merge error for #1096

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/update_supervisor.yml
+++ b/ansible/roles/test/tasks/common_tasks/update_supervisor.yml
@@ -1,0 +1,12 @@
+- fail: msg="supervisor_host is not defined"
+  when: "supervisor_host is not defined"
+
+- name: "Reread supervisor configuration"
+  shell: "supervisorctl reread"
+  become: "yes"
+  delegate_to: "{{ supervisor_host }}"
+
+- name: "Update supervisor configuration"
+  shell: "supervisorctl update"
+  become: "yes"
+  delegate_to: "{{ supervisor_host }}"


### PR DESCRIPTION
'update_supervisor.yml' is not present in 201811 branch. all tasks in this file were directly called from advanced_reboot.yml. Adding it and using it the way it is done in master branch.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)
