### PR TITLE
[install image] removing config_db.json with -f option

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -79,7 +79,7 @@ def install_new_sonic_image(module, new_image_url):
     # to force next image to load minigraph.
     if path.exists("/host/old_config/minigraph.xml"):
         exec_command(module,
-                     cmd="rm /host/old_config/config_db.json",
+                     cmd="rm -f /host/old_config/config_db.json",
                      msg="Remove config_db.json in preference of minigraph.xml")
 
 def main():


### PR DESCRIPTION
Summary:
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

If a DUT has already have the target image installed, then there will be no host/old_config/config_db.json afterward installing. Add -f option to ignore file not exists error.

At a second look, the DUT must have experienced multiple failure to get to this point: it must have an image installed but never rebooted (otherwise /host/old_config would have been removed). And then installed with another image which is already installed, so that we have /host/old_config/minigraph.yml, but no /host/old_config/config_db.json.

Either way, ignoring this failure would be necessary.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run ansible playboot upgrade_sonic.yml specifying an image already installed on the DUT.