### PR TITLE
[Kubernetes Testing] Add Private Docker Registry for Testing

### DIFF
--- a/ansible/roles/k8s_haproxy/tasks/main.yml
+++ b/ansible/roles/k8s_haproxy/tasks/main.yml
@@ -92,3 +92,63 @@
   service:
     name: apache2
     state: restarted
+
+- name: Install packages that allow apt to be used over HTTPS
+  apt:
+    name: "{{ packages }}"
+    state: present
+    update_cache: yes
+  environment: "{{ proxy_env | default({}) }}"
+  vars:
+    packages:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - gnupg-agent
+    - software-properties-common
+
+- name: Add an apt signing key for docker
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+  environment: "{{ proxy_env | default({}) }}"
+
+- name: Add apt repository for stable version
+  apt_repository:
+    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+    state: present
+  environment: "{{ proxy_env | default({}) }}"
+
+- name: Install docker and its dependencies
+  apt:
+    name: "{{ packages }}"
+    state: present
+    update_cache: yes
+  vars:
+    packages:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+  environment: "{{ proxy_env | default({}) }}"
+
+- name: Ensure docker.service.d dir exists
+  file: >
+    path=/etc/systemd/system/docker.service.d
+    recurse=yes
+    state=directory
+
+- name: Set docker proxies
+  template:
+    src: 'docker-proxy.j2'
+    dest: '/etc/systemd/system/docker.service.d/http-proxy.conf'
+  when: proxy_env['https_proxy'] is defined
+
+- name: Enable docker systemd service
+  service:
+    name: 'docker'
+    state: 'started'
+    enabled: 'yes'
+  
+- name: Start private docker registry
+  shell: sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
+  environment: "{{ proxy_env | default({}) }}"

--- a/ansible/roles/k8s_haproxy/tasks/main.yml
+++ b/ansible/roles/k8s_haproxy/tasks/main.yml
@@ -149,6 +149,10 @@
     state: 'started'
     enabled: 'yes'
   
+- name: Reboot the machine
+  reboot:
+
 - name: Start private docker registry
   shell: sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
   environment: "{{ proxy_env | default({}) }}"
+

--- a/ansible/roles/k8s_haproxy/templates/docker-proxy.j2
+++ b/ansible/roles/k8s_haproxy/templates/docker-proxy.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{ proxy_env['http_proxy'] | default({}) }}"
+Environment="HTTPS_PROXY={{ proxy_env['https_proxy'] | default({}) }}"
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add private docker registry to Kubernetes master so that Kubernetes testing can pull feature images from private registry (running on HAProxy VM)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For testing, kube mode features need to source the image from a registry. If the registry is hosted remotely in ACR, we introduce unnecessary complexity (proxy, credentials, etc.) Having a private registry accessible from DUT simplifies image sourcing done by Kubernetes. 

#### How did you do it?
Add docker, spin up docker registry on HAProxy machine

#### How did you verify/test it?
Verified from DUT by pushing and pulling feature images from registry 


