### PR TITLE
[garp_service]: Only send GARPs once at startup

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -224,7 +224,7 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses):
         template = Template(f.read())
 
     ptfhost.copy(content=json.dumps(garp_config, indent=4, sort_keys=True), dest=os.path.join(TMP_DIR, 'garp_conf.json'))
-    ptfhost.copy(content=template.render(garp_service_args = '--interval 1'), dest=os.path.join(SUPERVISOR_CONFIG_DIR, 'garp_service.conf'))
+    ptfhost.copy(content=template.render(garp_service_args = ''), dest=os.path.join(SUPERVISOR_CONFIG_DIR, 'garp_service.conf'))
     logger.info("Starting GARP Service on PTF host")
     ptfhost.shell('supervisorctl update')
     ptfhost.shell('supervisorctl start garp_service')


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

MUST wait to merge until https://github.com/Azure/sonic-buildimage/pull/6912 and https://github.com/Azure/sonic-utilities/pull/1465 are merged and have been propagated into the internal 202012 image.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Soon (after the linked PRs above are merged and in the internal image) constantly sending GARP requests will be unnecessary since the ARP table on the standby ToR will be restored after config reload.

#### How did you do it?
Remove the `--interval` argument when starting `garp_service` to make it a oneshot service.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
