### PR TITLE
[restapi] Fix issue with missing VXLAN tunnel when running tests separately

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -155,3 +155,10 @@ def vlan_members(duthosts, rand_one_dut_hostname, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vlan_interfaces = mg_facts["minigraph_vlans"].values()[VLAN_INDEX]["members"]
     return vlan_interfaces
+
+@pytest.fixture(autouse=True)
+def remove_vxlan_tunnel_after_test(duthosts, rand_one_dut_hostname):
+    #This fixture is implemented due to DELETE request for VXLAN tunnel currently being not supported
+    duthost = duthosts[rand_one_dut_hostname]
+    yield
+    duthost.command('sudo config vxlan del default_vxlan_tunnel')

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -155,10 +155,3 @@ def vlan_members(duthosts, rand_one_dut_hostname, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vlan_interfaces = mg_facts["minigraph_vlans"].values()[VLAN_INDEX]["members"]
     return vlan_interfaces
-
-@pytest.fixture(autouse=True)
-def remove_vxlan_tunnel_after_test(duthosts, rand_one_dut_hostname):
-    #This fixture is implemented due to DELETE request for VXLAN tunnel currently being not supported
-    duthost = duthosts[rand_one_dut_hostname]
-    yield
-    duthost.command('sudo config vxlan del default_vxlan_tunnel')

--- a/tests/restapi/restapi_operations.py
+++ b/tests/restapi/restapi_operations.py
@@ -48,6 +48,14 @@ class Restapi:
         else:
             logger.error("Malformed URL for "+path+"!")
 
+    def get_config_tunnel_decap_tunnel_type(self, construct_url, tunnel_type):
+        path = API_VERSION+'/config/tunnel/decap/{tunnel_type}'.format(tunnel_type=tunnel_type)
+        url = construct_url(path)
+        if url:
+            return self.request(GET, url)
+        else:
+            logger.error("Malformed URL for "+path+"!")
+
     # VRF/VNET
     def post_config_vrouter_vrf_id(self, construct_url, vrf_id, params):
         path = API_VERSION+'/config/vrouter/{vrf_id}'.format(vrf_id=vrf_id)

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -208,11 +208,14 @@ def test_data_path(construct_url, vlan_members):
 This test creates a VNET. It adds routes to the VNET and deletes them
 '''
 def test_create_vrf(construct_url):
-    # Create Default VxLan Tunnel
-    params = '{"ip_addr": "10.1.0.32"}'
-    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
-    r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
-    pytest_assert(r.status_code == 204)
+    # Check if default VXLAN tunnel is created
+    r = restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan')
+    if r.status_code == 404:
+        # Create Default VxLan Tunnel if it is not already created
+        params = '{"ip_addr": "10.1.0.32"}'
+        logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
+        r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
+        pytest_assert(r.status_code == 204)
 
     # Create VNET
     params = '{"vnid": 7039114}'
@@ -274,11 +277,14 @@ def test_create_vrf(construct_url):
 This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN member, VLAN neighbor and routes to each VNET
 '''
 def test_create_interface(construct_url, vlan_members):
-    # Create Default VxLan Tunnel
-    params = '{"ip_addr": "10.1.0.32"}'
-    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
-    r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
-    pytest_assert(r.status_code == 204)
+    # Check if default VXLAN tunnel is created
+    r = restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan')
+    if r.status_code == 404:
+        # Create Default VxLan Tunnel if it is not already created
+        params = '{"ip_addr": "10.1.0.32"}'
+        logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
+        r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
+        pytest_assert(r.status_code == 204)
 
     # Create VNET
     params = '{"vnid": 7039115}'

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -208,6 +208,12 @@ def test_data_path(construct_url, vlan_members):
 This test creates a VNET. It adds routes to the VNET and deletes them
 '''
 def test_create_vrf(construct_url):
+    # Create Default VxLan Tunnel
+    params = '{"ip_addr": "10.1.0.32"}'
+    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
+    r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
+    pytest_assert(r.status_code == 204)
+
     # Create VNET
     params = '{"vnid": 7039114}'
     logger.info("Creating VNET vnet-guid-10 with vnid: 7039114")
@@ -268,6 +274,12 @@ def test_create_vrf(construct_url):
 This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN member, VLAN neighbor and routes to each VNET
 '''
 def test_create_interface(construct_url, vlan_members):
+    # Create Default VxLan Tunnel
+    params = '{"ip_addr": "10.1.0.32"}'
+    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
+    r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
+    pytest_assert(r.status_code == 204)
+
     # Create VNET
     params = '{"vnid": 7039115}'
     logger.info("Creating VNET vnet-guid-3 with vnid: 7039115")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Allows restapi tests to be run separately

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
restapi suite consists of 3 tests - `test_data_path`, `test_create_vrf`, `test_create_interface`. When run together, they all pass. However, when `test_create_vrf` or `test_create_interface` is run separately, it fails with the following error:
```
        r = restapi.post_config_vrouter_vrf_id(construct_url, 'vnet-guid-10', params)
>       pytest_assert(r.status_code == 204)
E       Failed: <Failed instance>
```
This occurs due to `post_config_vrouter_vrf_id` returning code 409:
`{"error":{"code":409,"sub-code":1,"message":"Default VxLAN VTEP must be created prior to creating VRF","fields":["tunnel"]}}`

VXLAN tunnel creation is only present in `test_data_path`. Since it is not removed during test, this tunnel remains until all tests are finished. So the tests will always pass when run together, but fail when run separately.
#### How did you do it?
Added GET request for VXLAN tunnel to check if default tunnel is present at the start of `test_create_vrf` and  `test_create_interface` tests. If default tunnel is not present added step to create it.
#### How did you verify/test it?
- run restapi suite
- run each of the tests separately

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
