### PR TITLE
[advanced_reboot] Improve reboot_type detection in negative fast and warm reboot cases

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -57,6 +57,7 @@ def test_cancelled_fast_reboot(request, add_fail_step_to_reboot, verify_dut_heal
     @param request: Pytest request instance
     @param get_advanced_reboot: advanced reboot test fixture
     '''
+    add_fail_step_to_reboot('fast-reboot')
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot', allow_fail=True)
     advancedReboot.runRebootTestcase()
 
@@ -71,6 +72,7 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
     @param request: Pytest request instance
     @param get_advanced_reboot: advanced reboot test fixture
     '''
+    add_fail_step_to_reboot('warm-reboot')
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_fail=True)
     advancedReboot.runRebootTestcase()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve `add_fail_step_to_reboot` fixture to detect reboot cause based on the argument passed.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The `add_fail_step_to_reboot` fixture checks the reboot type based on the testcase name. This works for test_warm_reboot and test_fast_reboot. But, this fails for test_upgrade_path.
There should be a better way to find reboot type in the caller testcase.

#### How did you do it?
Move the logic inside `add_fail_step_to_reboot` to a function inside the fixture. The fixture yields this function.
Reboot type is passed as an argument to the yielded function.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
