### PR TITLE
[warm-reboot] Reduce downtime expectation from 1s to 0s for MLNX SKUs

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -105,10 +105,7 @@ class AdvancedReboot:
             if self.kvmTest:
                 self.rebootLimit = 200 # Default reboot limit for kvm
             elif 'warm-reboot' in self.rebootType:
-                if isMellanoxDevice(self.duthost):
-                    self.rebootLimit = 1
-                else:
-                    self.rebootLimit = 0
+                self.rebootLimit = 0
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Reduce warm-reboot dataplane downtime expectation from 1s to 0s for Mellanox platforms. For all other SKUs, the expectation was already 0s.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In SONiC 201911 and later versions, Mellanox devices also claim to provide 0s downtime during warmreboot. Updating test with this expectation.

#### How did you do it?
Remove MLNX check, and set downtime expectation to 0s for all the platforms (except KVM).

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
