### PR TITLE
Support vm-type parameter in recover_server.py

### DIFF
--- a/ansible/recover_server.py
+++ b/ansible/recover_server.py
@@ -41,7 +41,7 @@ root.addHandler(handler)
 def parse_testbed(testbedfile, testbed_servers):
     """Return a dictionary containing mapping from server name to testbeds."""
     testbed = imp.load_source('testbed', os.path.join(SONIC_MGMT_DIR, 'tests/common/testbed.py'))
-    testbeds = {_: list() for _ in testbed_servers}
+    testbeds = {server_name: list() for server_name in testbed_servers}
     for tbname, tb in testbed.TestbedInfo(testbedfile).testbed_topo.items():
         if tb['server'] in testbeds:
             testbeds[tb['server']].append(tb)
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     parser.add_argument('--testbed', default='testbed.csv', help='testbed file(default: testbed.csv)')
     parser.add_argument('--vm-file', default='veos', help='vm inventory file(default: veos)')
     parser.add_argument('--vm-type', default='veos', help='vm type (veos|ceos|vsonic, default: veos)')
-    parser.add_argument('--inventory', help='Deprecated, will acquire from testbed configuration automatically')
+    parser.add_argument('--inventory', help='Deprecated. Inventory info is already in testbed.(csv|yaml), no need to specify in argument')
     parser.add_argument('--passfile', default='password.txt', help='Ansible vault password file(default: password.txt)')
     parser.add_argument('--skip-cleanup', action='store_true', help='Skip cleanup server')
     parser.add_argument('--dry-run', action='store_true', help='Dry run')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
https://msazure.visualstudio.com/One/_workitems/edit/10687183
enhance recover_server.py to support vm_type parameter to add cEOS topology.
#### How did you do it?
1. Add vm_type parameter in outermost function
2. Auto get inventory name from testbed.yaml|csv
#### How did you verify/test it?
run it and see how it goes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
