### PR TITLE
fixed test_null_route_helper: changed a default ACL rule

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -149,6 +149,11 @@ def apply_pre_defined_rules(rand_selected_dut, create_acl_table):
     rand_selected_dut.shell("acl-loader update full " + ACL_JSON_FILE_DEST)
     # Wait 5 seconds for ACL rule creation
     time.sleep(5)
+    #  remove default DROP rule to make ACCEPT by default
+    rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|{}|DEFAULT_RULE"'.format(ACL_TABLE_NAME_V4))
+    rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|{}|DEFAULT_RULE"'.format(ACL_TABLE_NAME_V6))
+    time.sleep(5)
+
     yield
     # Clear ACL rules
     rand_selected_dut.shell('sonic-db-cli CONFIG_DB keys "ACL_RULE|{}*" | xargs sonic-db-cli CONFIG_DB del'.format(ACL_TABLE_NAME_V4))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed test_null_route_helper: changed a default ACL rule
Fixes # (issue)
- expected packet is not forwarded

test_null_route_helper preconfigures some ACL rules before the test and then checks packets pass/drop while issuing corresponding block/unblock requests using null_route_helper. Test fails because an expected packet is not forwarded. The issue appeared to be a misconfigured default ACL action for the preconfigured table - [author intended it](https://github.com/Azure/sonic-utilities/pull/1718#discussion_r676414697) to be ACCEPT but it is DROP...

```
...

NULL_ROUTE_ACL_TABLE_V4  RULE_6        9994        DROP      DST_IP: 10.2.1.2/32
                                                             ETHER_TYPE: 2048
NULL_ROUTE_ACL_TABLE_V6  RULE_6        9994        DROP      DST_IPV6: 103:23:2:1::1/128
                                                             IP_TYPE: IPV6ANY
NULL_ROUTE_ACL_TABLE_V4  RULE_9998     2           FORWARD   DST_IP: 0.0.0.0/0
                                                             ETHER_TYPE: 2048
                                                             SRC_IP: 0.0.0.0/0
NULL_ROUTE_ACL_TABLE_V6  RULE_9998     2           FORWARD   DST_IPV6: ::/0
                                                             IP_TYPE: IPV6ANY
                                                             SRC_IPV6: ::/0
NULL_ROUTE_ACL_TABLE_V4  DEFAULT_RULE  1           DROP      ETHER_TYPE: 2048
NULL_ROUTE_ACL_TABLE_V6  DEFAULT_RULE  1           DROP      IP_TYPE: IPV6ANY
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test issue
#### How did you do it?
Made a change [based on info](https://github.com/Azure/sonic-utilities/pull/1718#discussion_r676414697) provided in the PR
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any acl/null_route/test_null_route_helper.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
