### PR TITLE
test_ro_disk: Save logs before making disk read-only

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -5,14 +5,12 @@ import logging
 import time
 from pkg_resources import parse_version
 
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait
 from .test_ro_user import ssh_remote_run
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any')
 ]
 
@@ -95,6 +93,16 @@ def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_al
         ret = chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "ls")
         
         assert ret, "Failed to ssh as rw user"
+
+        # Force a log rotate to get logs so far recorded.
+        # The read-only state and follow up reboot could wipe off current logs
+        #
+        logging.info("test_ro_disk: Flushing & log rotating to save logs so far")
+        duthost.shell("logger -p local0.notice 'test_ro_disk: Initiating log rotate'")
+        duthost.shell("pkill -HUP rsyslogd")    # To flush logs from daemon to file
+        time.sleep(30)                          # Give a pause before rotate
+        duthost.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+        time.sleep(30)                          # Pause before making disk RO
 
         # Set disk in RO state
         simulate_ro(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The logs recorded in DUT during the test are completely lost. If you need to analyze a test run, via syslogs in DUT, it would not be  easy to locate the time point of the test (_as the timestamp in logs/test.log & in DUT's syslog could differ_).

#### How did you do it?
Remove loganalyzer-disable
Flush the rsyslog (_close & re-open all files_) and force a log rotate, before making disk RO

#### How did you verify/test it?
Now you could see the loganalyzer marker and the logs from test, until the point of making disk RO.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
