### PR TITLE
[cacl] work around the docker bridge network issue

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -37,8 +37,21 @@ def docker_network(duthost):
     ipam_info = json.loads(output['stdout'])[0]['IPAM']
 
     docker_network = {}
-    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0]['Gateway'],
-                                'IPv6Address' : ipam_info['Config'][1]['Gateway'] }
+    """
+    FIXME: Work around dockerd issue. The Gateway entry might be missing. In that case, use 'Subnet' instead.
+           Sample output when docker hit the issue (Note that the IPv6 gateway is missing):
+				"Config": [
+					{
+						"Subnet": "240.127.1.1/24",
+						"Gateway": "240.127.1.1"
+					},
+					{
+						"Subnet": "fd00::/80"
+					}
+				]
+    """
+    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', ipam_info['Config'][0].get('Subnet')),
+                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet')) }
 
     docker_network['container'] = {}
     for k,v in docker_containers_info.items():


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There is a docker bridge network issue that would randomly cause "docker inspect bridge" to not show 'Gateway' IP.

Reference: https://github.com/moby/moby/issues/26799

#### How did you do it?
We could use the 'Subnet' entry for the test purpose.

#### How did you verify/test it?
Run test against device exhibiting the docker bridge network issue.