### PR TITLE
[chassis] modify the tests in file test_copp.py to run on T2 chassis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,19 +302,6 @@ def rand_one_dut_hostname(request):
     logger.info("Randomly select dut {} for testing".format(dut_hostnames[0]))
     return dut_hostnames[0]
 
-@pytest.fixture(scope="module")
-def rand_one_dut_frontend_hostname(request):
-    """
-    This fixture returns a random linecard dut hostname.
-    """
-    all_dut_hostnames = generate_params_dut_hostname(request)
-    inv_files = get_inventory_files(request)
-    dut_hostnames = [hostname for hostname in all_dut_hostnames if is_frontend_node(inv_files, hostname) == True]
-    assert len(dut_hostnames) != 0, "No Frontend/Linecard host found"
-    if len(dut_hostnames) > 1:
-        dut_hostnames = random.sample(dut_hostnames, 1)
-    logger.info("Randomly select frontend dut {} for testing".format(dut_hostnames[0]))
-    return dut_hostnames[0]
 
 @pytest.fixture(scope="module")
 def rand_selected_dut(duthosts, rand_one_dut_hostname):

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -63,14 +63,14 @@ class TestCOPP(object):
                                           "IP2ME",
                                           "SNMP",
                                           "SSH"])
-    def test_policer(self, protocol, duthosts, rand_one_dut_frontend_hostname, ptfhost, copp_testbed, dut_type):
+    def test_policer(self, protocol, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, copp_testbed, dut_type):
         """
             Validates that rate-limited COPP groups work as expected.
 
             Checks that the policer enforces the rate limit for protocols
             that have a set rate limit.
         """
-        duthost = duthosts[rand_one_dut_frontend_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         _copp_runner(duthost,
                      ptfhost,
                      protocol,
@@ -82,14 +82,14 @@ class TestCOPP(object):
                                           "LACP",
                                           "LLDP",
                                           "UDLD"])
-    def test_no_policer(self, protocol, duthosts, rand_one_dut_frontend_hostname, ptfhost, copp_testbed, dut_type):
+    def test_no_policer(self, protocol, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, copp_testbed, dut_type):
         """
             Validates that non-rate-limited COPP groups work as expected.
 
             Checks that the policer does not enforce a rate limit for protocols
             that do not have any set rate limit.
         """
-        duthost = duthosts[rand_one_dut_frontend_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         _copp_runner(duthost,
                      ptfhost,
                      protocol,
@@ -97,8 +97,8 @@ class TestCOPP(object):
                      dut_type)
 
 @pytest.fixture(scope="class")
-def dut_type(duthosts, rand_one_dut_frontend_hostname):
-    duthost = duthosts[rand_one_dut_frontend_hostname]
+def dut_type(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     cfg_facts = json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])  # return config db contents(running-config)
     dut_type = None
 
@@ -112,7 +112,7 @@ def dut_type(duthosts, rand_one_dut_frontend_hostname):
 @pytest.fixture(scope="class")
 def copp_testbed(
     duthosts,
-    rand_one_dut_frontend_hostname,
+    enum_rand_one_per_hwsku_frontend_hostname,
     creds,
     ptfhost,
     tbinfo,
@@ -121,7 +121,7 @@ def copp_testbed(
     """
         Pytest fixture to handle setup and cleanup for the COPP tests.
     """
-    duthost = duthosts[rand_one_dut_frontend_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     test_params = _gather_test_params(tbinfo, duthost, request)
 
     if test_params.topo not in (_SUPPORTED_PTF_TOPOS + _SUPPORTED_T1_TOPOS + _SUPPORTED_T2_TOPOS):
@@ -136,7 +136,7 @@ def copp_testbed(
         _teardown_testbed(duthost, creds, ptfhost, test_params, tbinfo)
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(rand_one_dut_frontend_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
     """
         Ignore expected failures logs during test execution.
 
@@ -153,7 +153,7 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_frontend_hostname, logan
     ]
 
     if loganalyzer:  # Skip if loganalyzer is disabled
-        loganalyzer[rand_one_dut_frontend_hostname].ignore_regex.extend(ignoreRegex)
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
 
 def _copp_runner(dut, ptf, protocol, test_params, dut_type):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
modify the tests in file` test_copp.py` to run on T2 chassis

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently the tests in the file `test_copp.py` are skipped for the T2 chassis. This PR has the changes to add support to run on T2 chassis
#### How did you do it?
The following changes are done
-  change the tests in `test_copp.py` to use the `enum_rand_one_per_hwsku_frontend_node` fixture to get random DUT
-  change the logic to get a random ptf port to support multi DUT topology. 

#### How did you verify/test it?
verify the tests in `test_copp.py` pass

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
