### PR TITLE
[dhcp_relay] Skip release 202106 for dhcpv6 relay tests

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -110,7 +110,7 @@ def test_dhcp_relay_default(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_r
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201811", "201911"])
+    skip_release(duthost, ["201811", "201911", "202106"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
@@ -136,7 +136,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, du
        then test whether the DHCP relay agent relays packets properly.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201811", "201911"])
+    skip_release(duthost, ["201811", "201911", "202106"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down
@@ -177,7 +177,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_host
        relays packets properly.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201811", "201911"])
+    skip_release(duthost, ["201811", "201911", "202106"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Skip release for 202106 as SONiC dhcp6relay is not yet incorporated into branch 202106

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
202106 DHCPv6 Relay test runs are failing

#### How did you do it?
Skip release 202106

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Signed-off-by: Kelly Yeh kellyyeh@microsoft.com