### PR TITLE
Add hard delay back after ```config reload```

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -173,7 +173,9 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         # Config save and reload if specified
         if config_reload_test:
             duthost.shell('config save -y')
-            config_reload(duthost)
+            config_reload(duthost, wait=350)
+            #FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
+            # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We saw test failures after PR #4440 . It is because the static routes is not applied right after BGP sessions are re-established. 
But we also saw that BGP sessions are recovered after around 7 minutes after config reload on some Mellanox devices. To work around this issue, we need a hard delay after ```config reload```, and then wait BGP established.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix regression cause by PR #4440
#### How did you do it?
Add hard delay back after ```config reload```.

#### How did you verify/test it?
Verified on both broadcom and mellanox.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
