### PR TITLE
[storage_backend] Skip test_port_mirroring on backend topo

### DIFF
--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -4,8 +4,11 @@ Conftest file for span tests
 
 import pytest
 
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies
+
+
 @pytest.fixture(scope="module")
-def cfg_facts(duthosts, rand_one_dut_hostname):
+def cfg_facts(duthosts, rand_one_dut_hostname, skip_test_module_over_backend_topologies):
     '''
     Used to get config facts for selected DUT
 


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4029 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip `span/test_port_mirroring.py` on storage backend topo.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
