### PR TITLE
[storage_backend] Add `test_untagged_packet_not_routed`

### DIFF
--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -68,7 +68,7 @@ def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_v
     return None
 
 def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action=None,
-                                type_of_traffic=None, ttl=64, pktlen=100, ip_tunnel=None):
+                                type_of_traffic=None, ttl=64, pktlen=100, ip_tunnel=None, **kwargs):
     """
     Send packet from PTF to DUT and
     verify that DUT sends/doesn't packet to PTF.
@@ -93,7 +93,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src,
         if 'TCP' in tr_type or 'UDP' in tr_type:
             generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, tr_type, pktlen, ttl)
         elif 'ICMP' in tr_type:
-            generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type, ttl)
+            generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type, ttl, untagged_icmp_request=kwargs.pop("untagged_icmp_request", False))
         elif 'decap' in tr_type:
             generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, tr_type, ip_tunnel)
         else:
@@ -170,7 +170,7 @@ def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port,
     pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
 
 
-def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type, ttl=64):
+def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type, ttl=64, untagged_icmp_request=False):
     """
     Send ICMP request packet from PTF to DUT and
     verify that DUT sends/doesn't send ICMP reply packet to PTF.
@@ -185,6 +185,7 @@ def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip
         pkt_action: Packet action (forwarded or drop)
         tr_type: Type of traffic (TCP or UDP)
         ttl: Time to live
+        untagged_icmp_request: send untagged ICMP request if True
     """
     vlan_vid = None
     dl_vlan_enable = False
@@ -205,7 +206,7 @@ def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip
                         ip_src=ip_src,
                         ip_dst=ip_dst,
                         vlan_vid=vlan_vid,
-                        dl_vlan_enable=dl_vlan_enable,
+                        dl_vlan_enable=not untagged_icmp_request and dl_vlan_enable,
                         tr_type=tr_type,
                         ttl=64)
 

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -78,6 +78,34 @@ class TestSubPorts(object):
                                         ip_dst=value['ip'],
                                         pkt_action='drop')
 
+    @pytest.mark.parametrize("port_type", ["port"])
+    def test_untagged_packet_not_routed(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+        """
+        Validates that untagged packet aren't routed.
+
+        Test steps:
+            1.) Setup configuration of sub-ports on the DUT.
+            2.) Setup configuration of sub-ports on the PTF.
+            3.) Create untagged ICMP packet.
+            4.) Send untagged ICMP request packet from PTF to DUT.
+            5.) Verify that DUT doesn't sends ICMP reply packet to PTF.
+            6.) Clear configuration of sub-ports on the DUT.
+            7.) Clear configuration of sub-ports on the DUT.
+
+        Pass Criteria: PTF doesn't gets ICMP reply packet from DUT.
+        """
+        sub_ports = apply_config_on_the_dut["sub_ports"]
+
+        for sub_port, config in sub_ports.items():
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=config["neighbor_port"],
+                                        dst_port=sub_port,
+                                        ip_src=config["neighbor_ip"],
+                                        ip_dst=config["ip"],
+                                        pkt_action="drop",
+                                        untagged_icmp_request=True
+                                        )
 
     def test_admin_status_down_disables_forwarding(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
         """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3834

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add `test_untagged_packet_not_routed` to verify that untagged packet sent to subinterface will be dropped.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
