### PR TITLE
[bgp]Include t2 topology in setup interfaces fixture

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -322,7 +322,7 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
 
     @contextlib.contextmanager
-    def _setup_interfaces_t1(mg_facts, peer_count):
+    def _setup_interfaces_t1_or_t2(mg_facts, peer_count):
         try:
             connections = []
             is_backend_topo = "backend" in tbinfo["topo"]["name"]
@@ -410,8 +410,8 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] == "t0":
         setup_func = _setup_interfaces_t0
-    elif tbinfo["topo"]["type"] == "t1":
-        setup_func = _setup_interfaces_t1
+    elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
+        setup_func = _setup_interfaces_t1_or_t2
     else:
         raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Setup interfaces fixture not working for t2 topology, included t2 topology 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Setup interfaces fixture not working for t2 topology,

#### How did you do it?
Include "t2" topology in topologies to support

#### How did you verify/test it?
Before
```
       peer_count = getattr(request.module, "PEER_COUNT", 1)
        if "dualtor" in tbinfo["topo"]["name"]:
            setup_func = _setup_interfaces_dualtor
        elif tbinfo["topo"]["type"] == "t0":
            setup_func = _setup_interfaces_t0
        elif tbinfo["topo"]["type"] in set(["t1"]):
            setup_func = _setup_interfaces_t1
        else:
>           raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
E           TypeError: Unsupported topology: t2

bgp/conftest.py:416: TypeError
```

After

```
collected 1 item

bgp/test_bgp_update_timer.py .                                                                                                                                                                                                                                          [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================================== 1 passed, 1 warnings in 215.12 seconds ====================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
