### PR TITLE
[RESTAPI] skip further tests if no VLAN interfaces found

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -154,4 +154,7 @@ def vlan_members(duthosts, rand_one_dut_hostname, tbinfo):
     VLAN_INDEX = 0
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vlan_interfaces = mg_facts["minigraph_vlans"].values()[VLAN_INDEX]["members"]
-    return vlan_interfaces
+    if vlan_interfaces is not None:
+        return vlan_interfaces
+    else:
+        return []

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -66,6 +66,8 @@ def test_data_path(construct_url, vlan_members):
     pytest_assert(r.json() == json.loads(expected))
     logger.info("VLAN 2000 with ip_prefix: 100.0.10.1/24 under vnet_id: vnet-guid-2 has been successfully created")
 
+    if len(vlan_members) < 1:
+        pytest.skip("No VLAN interface available")
     vlan_intf = vlan_members[0]
     logger.info("VLAN Interface: "+vlan_intf)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
On some platforms where VLAN is not available, skip RESTAPI tests if no VLAN interfaces are found 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
