### PR TITLE
[chassis] skip stopping the database-chassis container on supervisor

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -222,7 +222,9 @@ def test_container_checker(duthosts, enum_dut_feature_container, rand_selected_d
 
     skip_containers = disabled_containers[:]
     skip_containers.append("gbsyncd")
-    skip_containers.append("database")
+    skip_containers.append("database")  
+    skip_containers.append("database-chassis")
+
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The `test_container_checker` is currently stopping the `database-chassis` container when running on the supervisor card. The test does a `config reload` to clean up after the test but `config reload` will not start database-chassis.
This causes the `database-chassis` container is never started again

#### How did you do it?
Add the `database-chassis` container to the `skip_container` list
#### How did you verify/test it?
run the `test_container_checker`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
