### PR TITLE
[test_sub_port] Select test ports from vlan members

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -67,7 +67,7 @@ def port_type(request):
 
 
 @pytest.fixture
-def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_type):
+def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_type, tbinfo):
     """
     Define configuration of sub-ports for TC run
 
@@ -119,7 +119,12 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
     prefix = 30
     network = ipaddress.ip_network(ip_subnet)
 
-    config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_num, port_type)
+    # for normal t0, get_port tries to retrieve test ports from vlan members
+    # let's enforce same behavior for t0-backend
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_num, port_type, exclude_sub_interface_ports=True)
+    else:
+        config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_num, port_type)
 
     subnets = [i for i, _ in zip(network.subnets(new_prefix=22), config_port_indices)]
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Let's select testing ports from vlan members on `t0-backend`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
