### PR TITLE
Improve the cleanup-vmhost playbook to install cleanup.sh firstly

### DIFF
--- a/ansible/testbed_cleanup.yml
+++ b/ansible/testbed_cleanup.yml
@@ -4,6 +4,19 @@
 - hosts: servers:&vm_host
   gather_facts: no
   tasks:
+
+    - name: Get absolute path of {{ root_path }}
+      command: "realpath {{ root_path }}"
+      register: real_root_path
+
+    - name: Set variable abs_root_path
+      set_fact:
+        abs_root_path: "{{ real_root_path.stdout }}"
+
+    - name: Install cleanup script
+      template: src=roles/vm_set/templates/cleanup.sh.j2
+                dest={{ abs_root_path }}/cleanup.sh
+
     - name: run apt update and upgrade
       include_tasks: update_reboot.yml
 
@@ -13,5 +26,5 @@
       with_items: '{{ range(0,3)|list }}'
 
     - name: run cleanup script
-      shell: bash /home/azure/veos-vm/cleanup.sh
+      shell: bash {{ abs_root_path }}/cleanup.sh
       become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The playbook for cleanup vmhost depends on availability of the cleanup.sh script on
test server. 

#### How did you do it?
This change add a step to always install the cleanup.sh script to test server before run it.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
