### PR TITLE
Update test_dhcp_relay to support t0-56-po2vlan

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -186,7 +186,7 @@ def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
             yield testing_mode, duthost, 'dual_testbed'
     elif tbinfo['topo']['name'] == 't0-56-po2vlan':
         if testing_mode == SINGLE_TOR_MODE:
-            if subtype_exist:
+            if subtype_exist and subtype_value == 'DualToR':
                 assert False, "Wrong DHCP setup on t0-56-vlan2po testbeds"
 
             yield testing_mode, duthost, 'single_testbed'


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3125

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_dhcp_relay does not support t0-56-po2vlan.

#### How did you do it?
Ignore PortChannel in this test case as short term fix.
Skip dual tor mode for t0-56-po2vlan.

#### How did you verify/test it?
Run test with t0 topology and t0-56-po2vlan topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
