### PR TITLE
[advance-reboot] Add timeout to reboot cases

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 HOST_MAX_COUNT = 126
 TIME_BETWEEN_SUCCESSIVE_TEST_OPER = 420
 PTFRUNNER_QLEN = 1000
+REBOOT_CASE_TIMEOUT = 1800
 
 class AdvancedReboot:
     '''
@@ -422,22 +423,26 @@ class AdvancedReboot:
     def runRebootTest(self):
         # Run advanced-reboot.ReloadTest for item in preboot/inboot list
         count = 0
+        result = True
+        final_result = True
         for rebootOper in self.rebootData['sadList']:
             count += 1
             try:
                 self.__setupRebootOper(rebootOper)
                 result = self.__runPtfRunner(rebootOper)
                 self.__verifyRebootOper(rebootOper)
+            except Exception:
+                result = False
             finally:
                 # always capture the test logs
                 self.__fetchTestLogs(rebootOper)
                 self.__clearArpAndFdbTables()
                 self.__revertRebootOper(rebootOper)
             if not result:
-                return result
+                final_result = False
             if len(self.rebootData['sadList']) > 1 and count != len(self.rebootData['sadList']):
                 time.sleep(TIME_BETWEEN_SUCCESSIVE_TEST_OPER)
-        return result
+        return final_result
 
     def runRebootTestcase(self, prebootList=None, inbootList=None, prebootFiles=None):
         '''
@@ -531,18 +536,24 @@ class AdvancedReboot:
         self.__updateAndRestartArpResponder(rebootOper)
 
         logger.info('Run advanced-reboot ReloadTest on the PTF host')
-        result = ptf_runner(
-            self.ptfhost,
-            "ptftests",
-            "advanced-reboot.ReloadTest",
-            qlen=PTFRUNNER_QLEN,
-            platform_dir="ptftests",
-            platform="remote",
-            params=params,
-            log_file=u'/tmp/advanced-reboot.ReloadTest.log',
-            module_ignore_errors=self.moduleIgnoreErrors,
-            timeout=1800
-        )
+        try:
+            result = ptf_runner(
+                self.ptfhost,
+                "ptftests",
+                "advanced-reboot.ReloadTest",
+                qlen=PTFRUNNER_QLEN,
+                platform_dir="ptftests",
+                platform="remote",
+                params=params,
+                log_file=u'/tmp/advanced-reboot.ReloadTest.log',
+                module_ignore_errors=self.moduleIgnoreErrors,
+                timeout=REBOOT_CASE_TIMEOUT
+            )
+        except Exception as err:
+            logger.error("Timed out after {}s of executing advance reboot case: {}.".format(
+                REBOOT_CASE_TIMEOUT, str(rebootOper)) + ". Error message: {}".format(err.message))
+            raise Exception
+
         return result
 
     def __restorePrevImage(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Advance reboot cases are sometimes seen to get hung. This causes run_tests.sh to get hung. This PR adds a timeout to the advance-reboot cases.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?


#### How did you do it?
Added timeout to ptfrunner.
Handled exception to allow running next cases (in sad case)

#### How did you verify/test it?
Tested on a physical testbed: set a timeout of 20s and all sad cases timed out but still continued with the next one.

```
03:41:36 advanced_reboot.__runPtfRunner           L0542 INFO   | Run advanced-reboot ReloadTest on the PTF host
03:42:00 advanced_reboot.__runPtfRunner           L0558 ERROR  | Timed out after 20s of executing advance reboot case: neigh_lag_member_down:3:6.. Error message: run module shell failed
03:42:00 advanced_reboot.__fetchTestLogs          L0374 INFO   | Extract log files on dut host
03:42:04 advanced_reboot.__fetchTestLogs          L0383 INFO   | Fetching log files from ptf and dut hosts
03:42:21 advanced_reboot.__clearArpAndFdbTables   L0347 INFO   | Clearing arp entries on DUT  str-7260cx3-acs-1
03:42:22 advanced_reboot.__clearArpAndFdbTables   L0350 INFO   | Clearing all fdb entries on DUT  str-7260cx3-acs-1
03:42:23 advanced_reboot.__revertRebootOper       L0491 INFO   | Running revert handler for reboot operation neigh_lag_member_down:3:6
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
