### PR TITLE
[test_tagged_arp] Add t0-backend support

### DIFF
--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -19,6 +19,7 @@ pytestmark = [
     pytest.mark.topology('t0', 't0-56-po2vlan')
 ]
 
+PTF_PORT_MAPPING_MODE = "use_orig_interface"
 DUMMY_MAC_PREFIX = "02:11:22:33"
 DUMMY_IP_PREFIX = "188.123"
 DUMMY_ARP_COUNT = 10

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -1,5 +1,8 @@
 import pytest
 import logging
+import itertools
+import collections
+
 from jinja2 import Template
 
 logger = logging.getLogger(__name__)
@@ -167,7 +170,7 @@ def vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, 
     config_ports = {k: v for k,v in cfg_facts['PORT'].items() if v.get('admin_status', 'down') == 'up'}
     config_portchannels = cfg_facts.get('PORTCHANNEL', {})
     config_port_indices = {k: v for k, v in mg_facts['minigraph_ptf_indices'].items() if k in config_ports}
-    config_ports_vlan = defaultdict(list)
+    config_ports_vlan = collections.defaultdict(list)
     vlan_members = cfg_facts.get('VLAN_MEMBER', {})
     # key is dev name, value is list for configured VLAN member.
     for k, v in cfg_facts['VLAN'].items():


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4528

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix `test_tagged_arp` failure on `t0-backend`
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
