### PR TITLE
[TestPsuApi::test_master_led] psu_id is not in range when random.randint(0, self.num_psus) is used

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import random
 import pytest
 import yaml
 


### PR DESCRIPTION
Sometime it returns 2 and it's invalid pus_id and the test fails

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (4544)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the Intermittent failure on platform_tests/api/test_psu.py::TestPsuApi::test_master_led
#### How did you do it?
Use the psu_id in correct range 
#### How did you verify/test it?
Run the platform_tests/api/test_psu.py::TestPsuApi::test_master_led test multiple times and see if the failure doesn't happen any more.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
