### PR TITLE
[test_tagged_arp] Skip dualtor topology

### DIFF
--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -26,7 +26,7 @@ DUMMY_IP_PREFIX = "188.123"
 DUMMY_ARP_COUNT = 10
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def skip_dualtor(tbinfo):
     """Skip running `test_tagged_arp` over dualtor."""
     pytest_require("dualtor" not in tbinfo["topo"]["name"], "Skip 'test_tagged_arp' over dualtor.")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Let's skip `test_tagged_arp` on dualtor testbeds.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
