### PR TITLE
[testcase]: Fix typo in test_system_is_running

### DIFF
--- a/tests/system_health/test_system_status.py
+++ b/tests/system_health/test_system_status.py
@@ -14,5 +14,5 @@ def test_system_is_running(duthost):
         status = duthost.shell('sudo systemctl is-system-running', module_ignore_errors=True)['stdout']
         return status != "starting"
 
-    if not wait_until(180, 10.0, is_system_ready, duthost):
+    if not wait_until(180, 10, 0, is_system_ready, duthost):
         pytest.fail('Failed to find routed interface in 180 s')


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Failure caused by the test case, test_system_is_running 

#### How did you do it?
Fix a typo in testcase test_system_is_running due to comma to dot

#### How did you verify/test it?
Check Azp status

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
