### PR TITLE
[restart_ptf] add force_kill for ptf container deletion, add logs in case the error shows again

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -20,9 +20,25 @@
     vars:
       ptf_portchannel_action: stop
 
+  - name: Get infos of ptf container
+    docker_container_info:
+      name: ptf_{{ vm_set_name }}
+    register: ptf_docker_info
+
+  - name: Flush ptf network info log
+    shell: |
+      date > /tmp/ptf_network_{{ vm_set_name }}.log
+
+  - name: Collect ptf network info before deleting
+    shell: |
+      echo "before deleting" >> /tmp/ptf_network_{{ vm_set_name }}.log
+      ls /proc/{{ ptf_docker_info.container.State.Pid }}/net/vlan/ >> /tmp/ptf_network_{{ vm_set_name }}.log
+      echo "-----------------------------" >> /tmp/ptf_network_{{ vm_set_name }}.log
+
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}
+      force_kill: yes
       state: absent
     become: yes
 
@@ -33,6 +49,12 @@
       password: "{{ docker_registry_password }}"
     become: yes
     when: docker_registry_username is defined and docker_registry_password is defined
+
+  - name: Collect ptf network info before recreating
+    shell: |
+      echo "Before recreating" >> /tmp/ptf_network_{{ vm_set_name }}.log
+      ls /proc/{{ ptf_docker_info.container.State.Pid }}/net/vlan/ >> /tmp/ptf_network_{{ vm_set_name }}.log
+      echo "-----------------------------" >> /tmp/ptf_network_{{ vm_set_name }}.log
 
   - name: Create ptf container ptf_{{ vm_set_name }}
     docker_container:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4292

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Ref to #4292, the vlan port 2020 exists before recreating ptf container,
but vlan port 2020 should be deleted already with the deletion of the old ptf container, as well as the network namespace.

I'm not sure whether it's because the behaviour of ansible: maybe the deletion of the container is async, so the container and network namespace still exist when we're trying to create a new one?

I can't reproduce the issue on the physical testbed with an endless running of restart-ptf.
I add the force_kill flag to see whether it helps, and I add some log to see whether it fits my guess, if the error happens again in the future.
#### How did you do it?
1. add force_kill flag while deleting old ptf container
2. add log
#### How did you verify/test it?
Rerun restart-ptf and it works well.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
