### PR TITLE
Fix test regression of test_lag_2 caused by deprecated command

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -98,7 +98,7 @@ class EosHost(AnsibleHostBase):
         # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed'] 
         # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
         # error.
-        if out['changed'] == False:
+        if out['failed'] == True or out['changed'] == False:
             # new eos deprecate lacp rate and use lacp timer command
             out = self.eos_config(
                 lines=['lacp timer %s' % mode],


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
```test_lag_2[lacp_rate]``` was failing because ```lacp rate``` command is deprecated in latest EOS. However, the return value of ```eos_config``` will mark the ```failed``` field as ```False```. Hence the check in original code can't detect the error.
https://github.com/Azure/sonic-mgmt/blob/6dfcb1d62524516e09228c0be282b40aa3838466/tests/common/devices/eos.py#L98-L107 

This PR fix the issue by checking ```out['changed']``` instead of ```out['failed']```.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix test regression of ```test_lag_2[lacp_rate]``` caused by deprecated command.

#### How did you do it?
This PR fix the issue by checking ```out['changed']``` instead of ```out['failed']```.

#### How did you verify/test it?
Verified on testbed running CEOS. Test can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
