### PR TITLE
Add Bandwidth in DeviceInterfaceLink

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -61,7 +61,9 @@
 {% for intf in asic_config['neigh_asic'][neigh_asic]['intfs'][0] | sort %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
+{% if switch_type is not defined %}
         <Bandwidth>40000</Bandwidth>
+{% endif %}
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>{{ neigh_asic }}</EndDevice>
         <EndPort>{{ intf }}</EndPort>
@@ -78,7 +80,11 @@
 {% if inventory_hostname not in device_conn or port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
+{% if port_alias[loop.index - 1] in port_speed %}
+        <Bandwidth>{{ port_speed[port_alias[loop.index - 1]] }}</Bandwidth>
+{% else %}
         <Bandwidth>40000</Bandwidth>
+{% endif %}
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
         <EndPort>{{ asic_intf }}</EndPort>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The minigraph template changes for chassis PR: https://github.com/Azure/sonic-mgmt/pull/4479 removed Bandwidth element with the assumption that interface speed should be configured from port_config. But that will not be the case for multi-asic platform.  Due to this change, internal interfaces in multi-asic were coming up without speed configured.

#### How did you do it?
Add default interface speed in minigraph png template.
#### How did you verify/test it?
Bring up mutli-asic VS and verify that internal interfaces are coming up with default speed and internal BGP sessions are coming up.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
