### PR TITLE
Add test_lag_2 to kvmtest

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -111,7 +111,6 @@ test_t0() {
     ntp/test_ntp.py \
     pc/test_po_cleanup.py \
     pc/test_po_update.py \
-    pc/test_lag_2.py \
     route/test_default_route.py \
     route/test_static_route.py \
     arp/test_neighbor_mac.py \


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add ```test_lag_2``` to kvmtest.
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
