### PR TITLE
[Doc]Update SAIServer builder obtaining method

### DIFF
--- a/docs/testbed/sai_quality/ExampleCheckSonicVersionAndBuildSaiserverDocker.md
+++ b/docs/testbed/sai_quality/ExampleCheckSonicVersionAndBuildSaiserverDocker.md
@@ -1,49 +1,58 @@
 In this article, you will get known how to get a saiserver docker and get a builder to build saiserver binary
 
 1. Check SONiC version in a DUT
+**Old version might hit some issue caused by related package upgrade, you can always use the latest tag of a major version(i.e major is 20201231) but notice the matching image version.**
    ```
    show version
-   
-   SONiC Software Version: SONiC.20201231.08
-   ```
-   
-2. In your dev envrironment, re-located code to that tag and resident on a new branch, 
-   here we use repository[Azure/sonic-mgmt: Configuration management examples for SONiC](https://github.com/Azure/sonic-mgmt)
-   
-   Getting a sonic version matched SAI Header version, please follow the doc at [Check SAI header version and SONiC branch](./CheckSAIHeaderVersionAndSONiCBranch.md)
 
-   ```	
-   git checkout tags/<tag> -b <branch>
-   
-   Example:
-   git checkout tags/20201231.08 -b richardyu/20201231-08
+   SONiC Software Version: SONiC.20201231.39
    ```
-   *note: Check submodule recursively*
+2.  In your dev envrironment, install prerequirment lib, e.g. pip and jinja, re-located code to that tag and resident on a new branch, 
+here we use repository [sonic-buildimage](https://github.com/Azure/sonic-buildimage)
+Follow the doc at [Check SAI header version and SONiC branch](https://github.com/Azure/sonic-mgmt/blob/master/docs/testbed/sai_quality/CheckSAIHeaderVersionAndSONiCBranch.md)
+    ```	
+    # git checkout tags/<tag> -b <branch>
+    # Example:
 
-   ```
-   git submodule update --init --recursive
-   ```
-   *Note: Follow the resource to get how to build a binary and docker*
+    git checkout tags/20201231.39 -b richardyu/20201231-39
+    ```
+    *note: Check submodule recursively*
+    ```
+    git submodule update --init --recursive
+
+    # Execute make init once after cloning the repo, or after fetching remote repo with submodule updates
+
+    make init
+    ```
+    *Note: Follow the resource to get how to build a binary and docker*
    [GitHub - Azure/sonic-buildimage: Scripts which perform an installable binary image build for SONiC](https://github.com/Azure/sonic-buildimage)
 
 3. Start a local build
    ```
-   #NOSTRETCH=y : Current image is buster
-   #KEEP_SLAVE_ON=yes: Keeps slave container up and active after building process concludes.
-
+   # Clean environment as needed
+   make reset
+   # Init env
+   make init
+   # NOSTRETCH=y : Current image is buster
+   # KEEP_SLAVE_ON=yes: Keeps slave container up and active after building process concludes.
+   #setup environment as broadcom flatform
    make configure PLATFORM=broadcom
-   NOSTRETCH=y KEEP_SLAVE_ON=yes make target/docker-saiserver-brcm.gz
+   #start build
+   NOSTRETCH=y NOJESSIE=y KEEP_SLAVE_ON=yes ENABLE_SYNCD_RPC=y make target/debs/buster/saiserver_0.9.4_amd64.deb
    ```
+   **You can get this build target by running command like(adjust as needed): NOSTRETCH=y NOJESSIE=y ENABLE_SYNCD_RPC=y make list**
 
 
 4. Wait for the build process 
 5. In the end, you will get something like this, and prompt as below (inside docker)
    ```
-   [ 01 ] [ target/docker-saiserver-brcm.gz ]
-   7e28d9702f570fdb94c8c530a9bf1f3feac0a113737d013b89ebc3dedc48470f
-   richardyu@e1df2df072c4:/sonic$
+   # Check if thrift installed
+   richardyu@a0363ed6ca36:/sonic$ thrift
+   Usage: thrift [options] file
+
+   Use thrift -help for a list of options
    ```
-6. In the same host, outside the docker above
+6. Keep this terminal and start another terminal, login the same host
  - Check the docker, the builder appears with the name as sonic-slave-***, it always the recently created one
    ```
    docker ps
@@ -55,11 +64,11 @@ In this article, you will get known how to get a saiserver docker and get a buil
  - Commit that docker as a saiserver-docker builder for other bugging or related resource building usages.
    ```
    docker commit <docker_name> <docker_image>:<tag>
-   docker commit condescending_lovelace saisever-builder-20201231-08:0.0.1
+   docker commit condescending_lovelace saisever-builder-20201231-39:0.0.1
    ```
 7. Then, exit from the docker above (console as 'richardyu@e1df2df072c4'), you can get your buildout artifacts in folder `./target`, there also contains the logs, and other accessories
 8. For building the saiserver binary, you can mount your local SAI repository to that docker and just start that docker for your building purpose.
    ```
-   #SAI repo is located inside local /code folder
-   docker run --name saisever-builder-20201231-08 -v  /code:/data -di saisever-builder-20201231-08:0.0.1 bash
+   # SAI repo is located inside local /code folder
+   docker run --name saisever-builder-20201231-39 -v  /code:/data -di saisever-builder-20201231-39:0.0.1 bash
    ```


### PR DESCRIPTION
Update SAIServer builder obtaining method
1. Update the saiserver tag version, as the previous one has a bug after Redis
upgrade, cannot be used anymore.
2. Upgrade the build target for generating an intermedia builder docker

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
- [x] Document

### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. Update the saiserver tag version, as the previous one has a bug after Redis
upgrade, cannot be used anymore.
2. Upgrade the build target for generating an intermedia builder docker
#### How did you do it?
local build environment
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
