### PR TITLE
[SNMP] tagged packets hits vlan port, query SNMP FDB

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -227,7 +227,7 @@ class DefineOid(object):
         self.ipCidrRouteStatus = dp + "1.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0" # + .next hop IP
 
         # Dot1q MIB
-        self.fdbEntry = dp + "1.3.6.1.2.1.17.7.1.2.2.1.2"
+        self.dot1qTpFdbEntry = dp + "1.3.6.1.2.1.17.7.1.2.2.1.2" # + .VLAN.MAC
 
 def decode_hex(hexstring):
 
@@ -940,7 +940,7 @@ def main():
         errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,
             cmdgen.UdpTransportTarget((m_args['host'], 161)),
-            cmdgen.MibVariable(p.fdbEntry,),
+            cmdgen.MibVariable(p.dot1qTpFdbEntry,),
         )
 
         if errorIndication:
@@ -950,9 +950,9 @@ def main():
             for oid, val in varBinds:
                 current_oid = oid.prettyPrint()
                 current_val = val.prettyPrint()
-                if v.fdbEntry in current_oid:
+                if v.dot1qTpFdbEntry in current_oid:
                     # extract fdb info from oid
-                    items = current_oid.split(v.fdbEntry + ".")[1].split(".")
+                    items = current_oid.split(v.dot1qTpFdbEntry + ".")[1].split(".")
                     # VLAN + MAC(6)
                     if len(items) != 7:
                         continue


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4390

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The port or port channel members in a vlan could be tagged or untagged. The existing testcase is for untagged. With the multiple vlans overlapping, there are tagged port/portchannel. We need new testcases for such configuration.

#### How did you do it?
Update snmp_facts module to support SNMP FDB interface.
Add new test case to send tagged packet and verify SNMP FDB table.

#### How did you verify/test it?
Run test case with t0 topology and t0-56-po2vlan topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
