### PR TITLE
[advance-reboot] Fix eos command compatibility issues on cEOS VMs

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -465,7 +465,7 @@ class Arista(object):
         help_cmd = "show ip bgp ?" if v4 else "show ipv6 bgp ?"
         ip_bgp_help = self.do_cmd(help_cmd)
         for line in ip_bgp_help.split('\n'):
-            if re.match('neighbors *BGP Neighbor informations', line.strip()):
+            if re.match('neighbors *BGP Neighbor information', line.strip()):
                 # if help regex contains:
                 # "neighbors          BGP Neighbor information"
                 suffix = 'neighbors'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix advance-reboot SAD case failures due to `show ipv6 bgp neighbors` cmd not supported on cEOS neighbor VMs.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Fix issue:
After transitioning to cEOS VMs, the advance-reboot SAD cases are failing.
The failures happen because `show ipv6 bgp neighbors` command is not valid on cEOS VMs.
The command is replaced by `show ipv6 bgp peers`.

Enhancement:
There is already such a patch for `show lacp neighbor` command added in PR https://github.com/Azure/sonic-mgmt/pull/4340
But, at present, `show lacp peer/neighbor` command is constructed repeatedly, and puts a continuous message in the logs.
This command can be just once constructed and reuse later.

#### How did you do it?

During init time, a call is made to construct the LACP and BGP show commands.

The fix is backward compatible. It will work on both vEOS (slowly obsoleting) and cEOS (actively transitioning).

#### How did you verify/test it?
Tested `test_warm_reboot_multi_sad_inboot` on physical and virtual testbed. The issue with SAD cases is not seen anymore.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
