### PR TITLE
[upgrade_path] Fix test_upgrade_path - update new sniffer script

### DIFF
--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -66,6 +66,7 @@ def prepare_ptf(ptfhost, duthost, tbinfo):
     arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
     ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="-e"),
                  dest="/etc/supervisor/conf.d/arp_responder.conf")
+    ptfhost.copy(src='scripts/dual_tor_sniffer.py', dest="/root/ptftests/advanced_reboot_sniffer.py")
 
     ptfhost.shell("supervisorctl reread")
     ptfhost.shell("supervisorctl update")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update and fix test_upgrade_path to use new sniffer script
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The PR https://github.com/Azure/sonic-mgmt/pull/4531 added a new way of sniffing the packets in advance-reboot script.

This is common script between dualtor, advance-reboot and upgrade path tests.

PR 4531 updated advanced_reboot.py but did not update upgrade_helpers.py

Port the below change to upgrade helpers too:
https://github.com/Azure/sonic-mgmt/blob/6a409f3c87a6b59f466f7242946a7807e83d5f93/tests/common/fixtures/advanced_reboot.py#L334

#### How did you do it?
Push the sniffer script to the ptf device.

#### How did you verify/test it?
Tested it on a physical device. With fix the failures in upgrade_path is fixed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
