### PR TITLE
[upgrade_sonic] Add retry for downloading image stage

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -98,7 +98,7 @@
           reduce_and_add_sonic_images:
           become: true
           register: result
-          retries: 10
+          retries: 5
           delay: 10
           until: result is not failed
           args:


### PR DESCRIPTION
What is the motivation for this PR?
The downloading image stage is happened to fail sometimes, then the nightly test will be broken.

How did you do it?
Add retry for this stage

How did you verify/test it?
Run upgrade_sonic.yml

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
