### PR TITLE
[QoS] Fix a typo in qos test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -214,11 +214,11 @@ class QosSaiBase(QosBase):
         if self.isBufferInApplDb(dut_asic):
             db = "0"
             keystr = "{0}:{1}:{2}".format(table, port, priorityGroup)
-            bufkeystr = "BUFFER_POOL_TABLE:"
+            bufkeystr = "BUFFER_PROFILE_TABLE:"
         else:
             db = "4"
             keystr = "{0}|{1}|{2}".format(table, port, priorityGroup)
-            bufkeystr = "BUFFER_POOL|"
+            bufkeystr = "BUFFER_PROFILE|"
 
         if check_qos_db_fv_reference_with_table(dut_asic) == True:
             bufferProfileName = dut_asic.run_redis_cmd(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix a typo in QoS test: the table prefix should be `BUFFER_PROFILE` or `BUFFER_PROFILE_TABLE` instead of `BUFFER_POOL` in `__getBufferProfile`

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
