### PR TITLE
Testcase modification to fetch attributes from platform.json and check if functionality is supported on DUT

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -9,6 +9,7 @@ SERVER_PORT = 8000
 
 IPTABLES_PREPEND_RULE_CMD = 'iptables -I INPUT 1 -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
+IPTABLES_ENTRY = 'INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 
 
 @pytest.fixture(scope='function')
@@ -80,8 +81,9 @@ def stop_platform_api_service(duthosts):
                 duthost.command('docker exec -i pmon supervisorctl reread')
                 duthost.command('docker exec -i pmon supervisorctl update')
 
-                # Delete the iptables rule we added
-                duthost.command(IPTABLES_DELETE_RULE_CMD)
+                # Delete the iptables rule we added, if present
+                if IPTABLES_ENTRY in duthost.shell("sudo iptables --list-rules")['stdout']:
+                    duthost.command(IPTABLES_DELETE_RULE_CMD)
 
 
 @pytest.fixture(scope='function')

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -158,18 +158,6 @@ class TestSfpApi(PlatformApiTestBase):
     # Helper functions
     #
 
-    def get_sfp_attributes(self, duthost, sfp_idx, def_value, *keys):
-        if duthost.facts.get("chassis"):
-            sfps = duthost.facts.get("chassis").get("sfps")
-            if sfps:
-                sfp_value = sfps[sfp_idx]
-                for key in keys:
-                    value = sfp_value.get(key)
-                    if value is None:
-                        return def_value
-                return value
-        return def_value
-
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         #For QSFP-DD specification compliance will return type as passive or active
@@ -543,17 +531,6 @@ class TestSfpApi(PlatformApiTestBase):
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
-        sfp_skipped = 0
-        num_sfps = int(chassis.get_num_sfps(platform_api_conn))
-        for j in range(num_sfps):
-            support_tx_disable_channel = self.get_sfp_attributes(duthost, j, True, "tx_disable_channel")
-            if not support_tx_disable_channel:
-                logger.info("test_sfp: tx_disable_channel is not supported")
-                sfp_skipped += 1
-                continue
-
-        if sfp_skipped == num_sfps:
-            pytest.skip("test_sfp:tx_disable_channel is not supported on all sfps")
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             # First ensure that the transceiver type supports setting TX disable on individual channels

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -552,6 +552,9 @@ class TestSfpApi(PlatformApiTestBase):
                 sfp_skipped += 1
                 continue
 
+        if sfp_skipped == num_sfps:
+            pytest.skip("test_sfp:tx_disable_channel is not supported on all sfps")
+
         for i in self.sfp_setup["sfp_test_port_indices"]:
             # First ensure that the transceiver type supports setting TX disable on individual channels
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -589,8 +592,6 @@ class TestSfpApi(PlatformApiTestBase):
                 else:
                     expected_mask = expected_mask >> 1
 
-        if sfp_skipped == num_sfps:
-            pytest.skip("test_sfp:tx_disable_channel is not supported on all sfps")
         self.assert_expectations()
 
     def _check_lpmode_status(self, sfp,platform_api_conn, i, state):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.platform_api import chassis, sfp
+from tests.common.helpers.platform_api import sfp
 from tests.common.utilities import skip_release
 from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some vendors do not support the following functionality:
 - watchdog disarm/rearm
 - fetching certain attributes of a module
 
This causes test_module.py, and test_watchdog.py to fail

Also, test_tx_disable_channel leaves port with a single lane disabled (using mask of 1) - thus causing port to not rx/tx packets correctly.

#### How did you do it?

1. test_module.py: 

  - platform.json change:
        - added a get_module_attributes block in platform.json that describes the attributes that cannot be fetched. Example:
       
 ```
   	    "get_module_attributes": {
                  "model": false 
             }
```
- testcase change:
		- added a method get_module_attributes to fetch the required attribute from the platform.json
		- in testcases of non-supported attributes, added a check that skips the testcase if the fetched attribute is described as
not supported("false") in the platform.json

2. test_watchdog.py:

- platform.json change:
		- added watchdog block in platform.json that describes disarm support ("false"). Example:

```
    "watchdog": {
            "disarm": false
        }
```
- testcase change:
		- added get_watchdog method to fetch attribute from platform.json
		- added a check in autouse fixture that skips the testcase by checking disarm support from platform.json

3. test_sfp.py:

- testcase change:
		- Get original mask of tx_disable_channel for each SFP, and after setting all combinations from 15 to 1, set the mask back to the original mask of tx_disable_channel.

#### How did you verify/test it?

 ran against DUT with modified platform.json and validated that the tests were skipped

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
