### PR TITLE
Check operational status of ports on fanout when we bring up ports on DUT as part of VoQ link flap tests

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -105,7 +105,7 @@ class EosHost(AnsibleHostBase):
     def check_intf_link_state(self, interface_name):
         show_int_result = self.eos_command(
             commands=['show interface %s' % interface_name])
-        return 'Up' in show_int_result['stdout_lines'][0]
+        return 'up' in show_int_result['stdout_lines'][0]
 
     def links_status_down(self, ports):
         show_int_result = self.eos_command(commands=['show interface status'])

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -96,6 +96,9 @@ class FanoutHost(object):
 
         return self.host.no_shutdown(interface_name)
 
+    def check_intf_link_state(self, interface_name):
+        return self.host.check_intf_link_state(interface_name)
+
     def __str__(self):
         return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1264,6 +1264,10 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
 
         return True
 
+    def check_intf_link_state(self, interface_name):
+        intf_status = self.show_interface(command="status",interfaces=[interface_name])["ansible_facts"]['int_status']
+        return intf_status[interface_name]['oper_state'] == 'up'
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -827,6 +827,9 @@ class LinkFlap(object):
         logging.info("status: %s", status)
         return status[dut_intf]['oper_state'] == exp_status
 
+    def check_fanout_link_state (self, fanout, fanout_port):
+        return fanout.check_intf_link_state(fanout_port)
+
     def linkflap_down(self, fanout, fanport, dut, dut_intf):
         """
         Brings down an interface on a fanout and polls the DUT for the interface to be operationally down.
@@ -869,6 +872,8 @@ class LinkFlap(object):
             sleep_time = 90
         pytest_assert(wait_until(sleep_time, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        pytest_assert(wait_until(30, 1, 0, self.check_fanout_link_state, fanout, fanport),
+                      "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
 
     def localport_admindown(self, dut, asic, dut_intf):
         """
@@ -888,7 +893,7 @@ class LinkFlap(object):
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'down'),
                       "dut port {} didn't go down as expected".format(dut_intf))
 
-    def localport_adminup(self, dut, asic, dut_intf):
+    def localport_adminup(self, dut, asic, dut_intf, fanouthosts):
         """
         Admins up a port on the DUT and polls for oper status to be up.
 
@@ -905,7 +910,13 @@ class LinkFlap(object):
         asic.startup_interface(dut_intf)
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        if "portchannel" not in dut_intf.lower():
+            # Wait for fanout port to be operationally up as well.
+            fanout, fanport = fanout_switch_port_lookup(fanouthosts, dut.hostname, dut_intf)
+            pytest_assert(wait_until(30,1,0,self.check_fanout_link_state, fanout, fanport),
+                          "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
 
+        time.sleep(2)
 
 
 def pick_ports(cfg_facts):
@@ -941,7 +952,8 @@ def pick_ports(cfg_facts):
 class TestNeighborLinkFlap(LinkFlap):
 
     def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                                        all_cfg_facts, setup, teardown, nbrhosts, nbr_macs, established_arp):
+                                        all_cfg_facts, setup, teardown, nbrhosts, nbr_macs, established_arp,
+                                        fanouthosts):
         """
         Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
 
@@ -994,7 +1006,7 @@ class TestNeighborLinkFlap(LinkFlap):
             try:
                 check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
             finally:
-                self.localport_adminup(per_host, asic, intf)
+                self.localport_adminup(per_host, asic, intf, fanouthosts)
 
             for neighbor in neighbors:
                 sonic_ping(asic, neighbor, verbose=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In VoQ tests against a T2 VoQ chassis we sometimes see 5-6 seconds delay before which the ping to the neighbor works after the port on the DUT is brought up as part of the voq link flap tests.

Currently, when we bring the link up on either the DUT or the fanout, we would only check if the link is up on the DUT.

What we see is that even though the DUT becomes operationally up, the remote peer doesn't become operationally up right away at the same time. It seems to take 2-6 seconds more than the DUT port. If the port is not up on the fanout, then the packets from the DUT is not forwarded to the testbed server, and thus the ping fails.

#### How did you do it?
Fix is to check the link status on the fanout port as well, whenever we bring a port up.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
