### PR TITLE
Added missing arguments in some of the function calls in voq_disrups.py

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -155,7 +155,7 @@ def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo):
 
 
 @pytest.mark.skip(reason="Not yet implemented - reboot of supervisor does not reset line cards.")
-def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
+def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs, tbinfo):
     """
     Tests the system after supervisor reset, all cards should reboot and interfaces/neighbors should be in sync across
     the system.
@@ -172,14 +172,12 @@ def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_mac
     logger.info("-" * 80)
 
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)
 
     logger.info("=" * 80)
     logger.info("Coldboot on node: %s", duthosts.supervisor_nodes[0].hostname)
     logger.info("-" * 80)
 
-    reboot(duthosts.supervisor_nodes[0], localhost, wait=600)
-    assert wait_until(300, 20, duthosts.supervisor_nodes[0].critical_services_fully_started), "Not all critical services are fully started"
     reboot(duthosts.supervisor_nodes[0], localhost, wait=240)
     assert wait_until(300, 20, 2, duthosts.supervisor_nodes[0].critical_services_fully_started), "Not all critical services are fully started"
 
@@ -190,10 +188,10 @@ def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_mac
     logger.info("-" * 80)
 
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)
 
 
-def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
+def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs, tbinfo):
     """
     Tests the system after all cards are explicitly reset, interfaces/neighbors should be in sync across the system.
 
@@ -216,7 +214,7 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("-" * 80)
 
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)
 
     logger.info("=" * 80)
     logger.info("Coldboot on all nodes")
@@ -225,8 +223,10 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
     t0 = time.time()
 
     parallel_run(reboot_node, [localhost], {}, duthosts.nodes, timeout=1000)
+
     for node in duthosts.nodes:
         assert wait_until(300, 20, 2, node.critical_services_fully_started), "Not all critical services are fully started"
+
     poll_bgp_restored(duthosts)
 
     t1 = time.time()
@@ -241,10 +241,10 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("-" * 80)
 
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)
 
 
-def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
+def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs, tbinfo):
     """
     Tests the system after a config reload on a linecard, interfaces/neighbors should be in sync across the system.
 
@@ -259,7 +259,7 @@ def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("-" * 80)
 
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)
 
     logger.info("=" * 80)
     logger.info("Config reload on node: %s", duthosts.frontend_nodes[0].hostname)
@@ -272,4 +272,4 @@ def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("Postcheck")
     logger.info("-" * 80)
     check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
-    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Some function calls were missing one or more arguments in voq/test_voq_disrupts.py. 
Added the missing arguments.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix the missing arguments in some function calls.

#### How did you do it?
Added tbinfo to test_reboot_supervisor, test_reboot_system and test_config_load_lc definations
Added tbinfo to all check_ip_fwd calls
Added 2 to all assert_wait_until calls.  2 is the delay

#### How did you verify/test it?
Tested on linecard and supervisor in a VoQ chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
