### PR TITLE
Support physical interfaces and portchannels in decap. 

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -11,16 +11,16 @@ topology:       Supports all the variations of t0 and t1 topologies.
 
 Usage:          Examples of how to start the test
                 ptf --test-dir /root/ptftests IP_decap_test.DecapPacketTest --platform-dir ptftests --qlen=1000 \
-                    --platform remote -t 'lo_ipv6s=["fc00:1::32", "fc00:1::33"];ttl_mode="pipe";dscp_mode="uniform";\
-                    lo_ips=["10.1.0.32", "10.1.0.33"];ignore_ttl=False;router_macs=["d4:af:f7:4d:a5:4c", \
+                    --platform remote -t 'ipv6s=["fc00:1::32", "fc00:1::33"];ttl_mode="pipe";dscp_mode="uniform";\
+                    ips=["10.1.0.32", "10.1.0.33"];ignore_ttl=False;router_macs=["d4:af:f7:4d:a5:4c", \
                     "d4:af:f7:4d:a8:64"];max_internal_hops=0;outer_ipv6=True;outer_ipv4=True;inner_ipv4=True;\
                     inner_ipv6=True;fib_info_files=["/root/fib_info_dut0.txt", "/root/fib_info_dut1.txt"];\
                     ptf_test_port_map="/root/ptf_test_port_map.json"' --relax --debug info \
                     --log-file /tmp/decap.debug.log
 
 Parameters:     fib_info_files - The fib_info files location
-                lo_ips -  The loop_back IPs that are configured in the decap rule
-                lo_ipv6s -  The loop_back IPv6 IPs that are configured in the decap rule
+                ips -  The IPs that are configured in the decap rule
+                ipv6s -  The IPv6 IPs that are configured in the decap rule
                 router_macs - The mac addresses of the DUTs.
                 dscp_mode - The rule for the dscp parameter in the decap packet that is configured in the JSON file
                             ('pipe' for inner and 'uniform' for outer)
@@ -91,8 +91,8 @@ class DecapPacketTest(BaseTest):
         self.test_inner_ipv4 = self.test_params.get('inner_ipv4', True)
         self.test_inner_ipv6 = self.test_params.get('inner_ipv6', True)
 
-        self.lo_ips = self.test_params.get('lo_ips')
-        self.lo_ipv6s = self.test_params.get('lo_ipv6s')
+        self.ips = self.test_params.get('ips')
+        self.ipv6s = self.test_params.get('ipv6s')
         self.router_macs = self.test_params.get('router_macs')
         self.dscp_mode = self.test_params.get('dscp_mode')
         self.ttl_mode = self.test_params.get('ttl_mode')
@@ -208,8 +208,8 @@ class DecapPacketTest(BaseTest):
         target_mac = self.ptf_test_port_map[str(src_port)]['target_mac']  # Outer dest mac
 
         active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
-        lo_ip = self.lo_ips[active_dut_index]
-        lo_ipv6 = self.lo_ipv6s[active_dut_index]
+        ip = self.ips[active_dut_index]
+        ipv6 = self.ipv6s[active_dut_index]
 
         # Set DSCP value for the inner layer
         dscp_in = self.DSCP_RANGE[self.dscp_in_idx]
@@ -283,7 +283,7 @@ class DecapPacketTest(BaseTest):
                                 eth_dst=target_mac,
                                 eth_src=src_mac,
                                 ip_src='1.1.1.1',
-                                ip_dst=lo_ip,
+                                ip_dst=ip,
                                 ip_tos=tos_out,
                                 ip_ttl=outer_ttl,
                                 inner_frame=inner_pkt)
@@ -292,7 +292,7 @@ class DecapPacketTest(BaseTest):
                                 eth_dst=target_mac,
                                 eth_src=src_mac,
                                 ipv6_src='1::1',
-                                ipv6_dst=lo_ipv6,
+                                ipv6_dst=ipv6,
                                 ipv6_tc=tc_out,
                                 ipv6_hlim=outer_ttl,
                                 inner_frame=inner_pkt)

--- a/ansible/roles/test/templates/decap_conf.j2
+++ b/ansible/roles/test/templates/decap_conf.j2
@@ -3,7 +3,7 @@
         {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V4_TUNNEL" : {
                         "tunnel_type":"IPINIP",
-                        "dst_ip":"{{ lo_ip }}",
+                        "dst_ip":"{{ ip }}",
                         "dscp_mode":"{{ dscp_mode }}",
                         "ecn_mode":"{{ ecn_mode }}",
                         "ttl_mode":"{{ ttl_mode }}"
@@ -17,7 +17,7 @@
         {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V6_TUNNEL" : {
                         "tunnel_type":"IPINIP",
-                        "dst_ip":"{{ lo_ipv6 }}",
+                        "dst_ip":"{{ ipv6 }}",
                         "dscp_mode":"{{ dscp_mode }}",
                         "ecn_mode":"{{ ecn_mode }}",
                         "ttl_mode":"{{ ttl_mode }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Originally, in script `test_decap.py`, it only supports the loopback interface in topo T0 and T1. Now it also support portchannels in topo T0 and physical interfaces in topo T1.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Originally, in script `test_decap.py`, it only supports the loopback interface in topo T0 and T1. Now it also support portchannels in topo T0 and physical interfaces in topo T1.

#### How did you do it?
Change the function which is used to get interface ip, and use `pytest.fixture(params=["lo", "PortChannel", "PhysicalPort"])` to realize parametrize. 

#### How did you verify/test it?
I run the test case both on T0 and T1 ropo. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
