### PR TITLE
Added support for one portChannel and one routed interface if two por…

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -94,14 +94,38 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
     if "backend" in tbinfo["topo"]["name"]:
         crm_intf1 = mg_facts["minigraph_vlan_sub_interfaces"][0]["attachto"]
         crm_intf2 = mg_facts["minigraph_vlan_sub_interfaces"][2]["attachto"]
-    elif len(mg_facts["minigraph_portchannel_interfaces"]) >= 4:
-        crm_intf1 = mg_facts["minigraph_portchannel_interfaces"][0]["attachto"]
-        crm_intf2 = mg_facts["minigraph_portchannel_interfaces"][2]["attachto"]
     else:
-        crm_intf1 = mg_facts["minigraph_interfaces"][0]["attachto"]
-        crm_intf2 = mg_facts["minigraph_interfaces"][2]["attachto"]
-    yield (crm_intf1, crm_intf2)
+        crm_intf1 = None
+        crm_intf2 = None
+        intf_status = asichost.show_interface(command='status')['ansible_facts']['int_status']
 
+        # 1. we try to get crm interfaces from portchannel interfaces
+        for a_pc in mg_facts["minigraph_portchannels"]:
+            if intf_status[a_pc]['oper_state'] == 'up':
+                # this is a pc that I can use.
+                if crm_intf1 is None:
+                    crm_intf1 = a_pc
+                elif crm_intf2 is None:
+                    crm_intf2 = a_pc
+
+        if crm_intf1 is not None and crm_intf2 is not None:
+            yield (crm_intf1, crm_intf2)
+
+        # 2.  we try to get crm interfaces from routed interfaces
+        for a_intf in mg_facts["minigraph_interfaces"]:
+            intf = a_intf['attachto']
+            if intf_status[intf]['oper_state'] == 'up':
+                if crm_intf1 is None:
+                    crm_intf1 = intf
+                elif crm_intf2 is None:
+                    crm_intf2 = intf
+
+        if crm_intf1 is not None and crm_intf2 is not None:
+            yield (crm_intf1, crm_intf2)
+
+    if crm_intf1 is None or crm_intf2 is None:
+        pytest.skip("Not enough interfaces on this host/asic (%s/%s) to support test." % (duthost.hostname,
+                                                                                          asichost.asic_index))
 
 @pytest.fixture(scope="module", autouse=True)
 def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -109,7 +109,7 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
                     crm_intf2 = a_pc
 
         if crm_intf1 is not None and crm_intf2 is not None:
-            yield (crm_intf1, crm_intf2)
+            return (crm_intf1, crm_intf2)
 
         # 2.  we try to get crm interfaces from routed interfaces
         for a_intf in mg_facts["minigraph_interfaces"]:
@@ -121,7 +121,7 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
                     crm_intf2 = intf
 
         if crm_intf1 is not None and crm_intf2 is not None:
-            yield (crm_intf1, crm_intf2)
+            return (crm_intf1, crm_intf2)
 
     if crm_intf1 is None or crm_intf2 is None:
         pytest.skip("Not enough interfaces on this host/asic (%s/%s) to support test." % (duthost.hostname,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
test_crm_nexthop_group will fail if either two PortChannels or two routed interfaces  don't exits on the dut.   
Added support to check for one portChannel and one routed interface on the dut also.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
To provide  support for the testcase to run if only  one routed interface and one PortChannel exit on the dut.
Currently the test case runs if either two portChannels or two routed interface exist.

#### How did you do it?
The testcase will check either for two PortChannels or two routed interfaces on the dut first. 
If it does exist it will check for one routed interface and one portChannel on the dut.

#### How did you verify/test it?
Ran the the testcase on a dut with only one routed interface and one portChanned.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
