### PR TITLE
[testcase]: MACsec LLDP test fixing for vSONiC

### DIFF
--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -33,6 +33,12 @@ def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, 
     for k, v in macsec_profile.items():
         cmd += " '{}' '{}' ".format(k, v)
     host.command(cmd)
+    if send_sci is "false":
+        # The MAC address of SONiC host is locally administrated
+        # So, LLDPd will use an arbitrary fixed value (00:60:08:69:97:ef) as the source MAC address of LLDP packet (https://lldpd.github.io/usage.html)
+        # But the MACsec driver in Linux used by SONiC VM has a bug that cannot handle the packet with different source MAC address to SCI if the send_sci = false
+        # So, if send_sci = false and the neighbor device is SONiC VM, LLDPd need to use the real MAC address as the source MAC address
+        host.command("lldpcli configure system bond-slave-src-mac-type real")
 
 
 def delete_macsec_profile(host, profile_name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix MACsec LLDP test cannot pass if the neighbor devices is vSONiC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The MAC address of SONiC host is locally administrated. So, LLDPd will use an arbitrary fixed value (00:60:08:69:97:ef) as the source MAC address of LLDP packet (https://lldpd.github.io/usage.html). But the MACsec driver in Linux used by SONiC VM has a bug that cannot handle the packet with different source MAC address to SCI if the send_sci = false.

#### How did you do it?
If send_sci = false and the neighbor device is SONiC VM, LLDPd need to use the real MAC address as the source MAC address.

#### How did you verify/test it?
Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
