### PR TITLE
[SAI-PTF]Fix defect in SAI warmboot structure

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -147,6 +147,18 @@ def create_sai_test_interface_param(duthost):
         interfaces_list.append(interface_tmp)
     interfaces_para = " --interface ".join(interfaces_list)
     interfaces_para = "--interface " + interfaces_para
+
+    if not interfaces_list:
+        interfaces_para = __generate_default_interfaces()
+    return interfaces_para
+
+def __generate_default_interfaces():
+    interfaces_list = []
+    for index in range(32):
+        interface_tmp = "\'0-{0}@eth{0}\'".format(index)
+        interfaces_list.append(interface_tmp)
+    interfaces_para = " --interface ".join(interfaces_list)
+    interfaces_para = "--interface " + interfaces_para
     return interfaces_para
 
 

--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -79,6 +79,7 @@ def test_warm_boot_from_ptf(
     """
     Test_failed = False
     for stage in WARM_TEST_STAGES:
+        logger.info("Warm reboot test, run in stage: {}.".format(stage))
         if Test_failed:
             break
         if stage == WARM_TEST_STARTING:
@@ -96,7 +97,7 @@ def test_warm_boot_from_ptf(
                 saiserver_warmboot_config(duthost, "restore")
         except BaseException as e:
             Test_failed = True
-            logger.info("Test case [{}] failed, failed as {}.".format(ptf_sai_test_case, e))               
+            logger.info("Test case [{}] failed, failed as {}.".format(ptf_sai_test_case, e))
             stop_and_rm_sai_test_container(duthost, get_sai_test_container_name(request))        
             pytest.fail("Test case [{}] failed".format(ptf_sai_test_case), e)
         finally:

--- a/tests/scripts/sai_qualify/sai_warm_profile.sh
+++ b/tests/scripts/sai_qualify/sai_warm_profile.sh
@@ -7,7 +7,6 @@ back_profile(){
     echo "backup profile: $profile"
     if [[ -f "$profile.bak" ]]; then
         echo "Skip backup profile: $profile, $profile.bak alredy exist."
-        exit 1 # Exit script
     else
         cp $profile $profile.bak
     fi
@@ -27,7 +26,6 @@ config_warmboot_init(){
     echo "change $profile for warmboot init"
     echo "SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin" >> $profile
     echo "SAI_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin" >> $profile
-    echo "SAI_BOOT_TYPE=1" >> $profile
 }
 
 config_warmboot_start(){


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix defect in SAI warmboot structure
Fixes # (issue) 
- lack of log message in warmboot test.
- shell for config sai warmboot in 'init' and 'start' mode cannot work when restore file already prepared

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix bugs in SAI warmboot structure, include;


Signed-off-by: richardyu-ms <richard.yu@microsoft.com>
#### How did you do it?
- shell for change sai.profile (brcm)
- add log for warmboot stage
- create default interfaces parameters for PTF test
#### How did you verify/test it?
checked the framework in testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
