### PR TITLE
Support for Nokia-IXR7250E-36x100G linecard

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -185,7 +185,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "et6448m":
             for i in range(0, 52):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
-        elif hwsku == "Nokia-IXR7250E-36x400G":
+        elif hwsku == "Nokia-IXR7250E-36x400G" or hwsku == "Nokia-IXR7250E-36x100G":
             for i in range(0, 36):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == 'Nokia-IXR7250E-SUP-10':

--- a/ansible/vars/topo_Nokia-IXR7250E-36x100G.yml
+++ b/ansible/vars/topo_Nokia-IXR7250E-36x100G.yml
@@ -1,0 +1,16 @@
+slot0:
+    ASIC0:
+      topology:
+        NEIGH_ASIC:
+      configuration_properties:
+        common:
+          asic_type: FrontEnd 
+      configuration:
+
+    ASIC1:
+      topology:
+        NEIGH_ASIC:
+      configuration_properties:
+        common:
+          asic_type: FrontEnd
+      configuration:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Need to add support for Nokia-IXR7259E-36x100G linecard.

#### How did you do it?
Added support in port_utils.py, and topo file for this hwsku to get add-topo and gen-mg to work on this card

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
