### PR TITLE
Fix test_auto_negotiation_advertised_speeds_all to get correct mlnxlink port id

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -17,6 +17,7 @@ from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
 from tests.common.utilities import skip_release
+from tests.common.platform.interface_utils import get_physical_port_indices
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -423,7 +424,7 @@ class MlnxCableSupportedSpeedsHelper(object):
 
         if not cls.device_path:
             cls.device_path = duthost.shell('ls /dev/mst/*_pci_cr0')['stdout'].strip()
-        port_index = cls.sorted_ports[duthost].index(dut_port_name) + 1
+        port_index = get_physical_port_indices(duthost, [dut_port_name]).get(dut_port_name)
         cmd = 'mlxlink -d {} -p {} | grep "Supported Cable Speed"'.format(cls.device_path, port_index)
         output = duthost.shell(cmd)['stdout'].strip()
         # Valid output should be something like "Supported Cable Speed:0x68b1f141 (100G,56G,50G,40G,25G,10G,1G)"


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
This PR is fix for comments from PR: https://github.com/Azure/sonic-mgmt/pull/4318
Original PR should be closed(PR owner will not maintain it)

### Original PR description
During the test randomly selected 3 ports are taken to setup autonegotiation.
When not split port is taken it worked, but if there is a split port mlnxlink
port id will be wrong

### What is the motivation for this PR?
Correct the test logic to take the correct port id for mlnxlink command
actual_speed = int_status[dut_port]['speed'][:-1] + '000'

```
pytest_assert(actual_speed == highest_speed, 'Actual speed is not the highest speed') 
```
E Failed: Actual speed is not the highest speed
_ = arc-switch1004
actual_speed = '100000'
candidates = {'Ethernet28': ( arc-switch1004, 'Ethernet28', { os: 'onyx', hostname: 'arc-switch1005', device_ty... arc-switch1004, 'Ethernet6', { os: 'onyx', hostname: 'arc-switch1005', device_type: 'FanoutLeaf' }, 'ethernet 1/2/2')}
dut_port = 'Ethernet28'
duthost = arc-switch1004
dutname = 'arc-switch1004'
fanout = { os: 'onyx', hostname: 'arc-switch1005', device_type: 'FanoutLeaf' }
fanout_port = 'ethernet 1/8'
highest_speed = '50000'
int_status = {'Ethernet0': {'admin_state': u'up', 'alias': u'etp1a', 'fec': u'N/A', 'name': u'Ethernet0', ...}, 'Ethernet10': {'adm...0', ...}, 'Ethernet104': {'admin_state': u'down', 'alias': u'etp27a', 'fec': u'N/A', 'name': u'Ethernet104', ...}, ...}
item = ( arc-switch1004, 'Ethernet6', { os: 'onyx', hostname: 'arc-switch1005', device_type: 'FanoutLeaf' }, 'ethernet 1/2/2')
success = True
supported_speeds = ['1000', '10000', '25000', '50000']
wait_result = True
