### PR TITLE
Start/stop logrotate.timer systemd service by best effort for loganalyzer

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -32,8 +32,9 @@ class DisableLogrotateCronContext:
         """
         Disable logrotate cron task / systemd timer and make sure the running logrotate is stopped.
         """
-        # Disable logrotate systemd timer
-        self.ansible_host.command("systemctl stop logrotate.timer")
+        # Disable logrotate systemd timer by best effort. The reason is that logrotate.timer service is not
+        # available in older version like 201911.
+        self.ansible_host.command("systemctl stop logrotate.timer", module_ignore_errors=True)
         # Disable logrotate cron task
         self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate")
         logging.debug("Waiting for logrotate from previous cron task or systemd timer run to finish")
@@ -57,8 +58,9 @@ class DisableLogrotateCronContext:
         """
         # Enable logrotate cron task back
         self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate")
-        # Enable logrotate systemd timer
-        self.ansible_host.command("systemctl start logrotate.timer")
+        # Enable logrotate systemd timer by best effort. The reason is that logrotate.timer service is not
+        # available in older version like 201911.
+        self.ansible_host.command("systemctl start logrotate.timer", module_ignore_errors=True)
 
 
 class LogAnalyzerError(Exception):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PR #5414 introduced code to stop/start the logrotate.timer systemd service for
loganalyzer. On older images that do not have the logrotate.timer service,
this operation will fail.

#### How did you do it?
This change made stopping/starting logrotate.time a best effort operation.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
