### PR TITLE
[snmp] skip psu fans during test_fan_info

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -277,15 +277,14 @@ def test_fan_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_enti
         entity_info = redis_hgetall(duthost, STATE_DB, entity_info_key)
         position = int(entity_info['position_in_parent'])
         parent_name = entity_info['parent_name']
-        if parent_name == CHASSIS_KEY:
+        if 'PSU' in parent_name:
+            continue
+        elif parent_name == CHASSIS_KEY:
             parent_oid = MODULE_TYPE_FAN_DRAWER + position * MODULE_INDEX_MULTIPLE
         else:
             parent_entity_info = redis_hgetall(duthost, STATE_DB, PHYSICAL_ENTITY_KEY_TEMPLATE.format(parent_name))
             parent_position = int(parent_entity_info['position_in_parent'])
-            if 'PSU' in parent_name:
-                parent_oid = MODULE_TYPE_PSU + parent_position * MODULE_INDEX_MULTIPLE
-            else:
-                parent_oid = MODULE_TYPE_FAN_DRAWER + parent_position * MODULE_INDEX_MULTIPLE
+            parent_oid = MODULE_TYPE_FAN_DRAWER + parent_position * MODULE_INDEX_MULTIPLE
         expect_oid = parent_oid + DEVICE_TYPE_FAN + position * DEVICE_INDEX_MULTIPLE
         assert expect_oid in snmp_physical_entity_info, 'Cannot find fan {} in physical entity mib'.format(name)
         fan_snmp_fact = snmp_physical_entity_info[expect_oid]


### PR DESCRIPTION
**Summary:**

Updates test_fan_info to skip PSU fans

Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

**Back port request**
 - [ ] 201911
 - [ ] 202012

**Approach**
**What is the motivation for this PR?**
[Submodule update](https://github.com/Azure/sonic-buildimage/commit/7a3a433b8d2249f51614aa5dc46e989789cdeff5) changed fan information in redis database. Changes added 2 psu fans to 4 existing fans to FAN_INFO on Arista platform. According to [documentation](https://github.com/Azure/SONiC/pull/766/files), FAN_INFO is the source of fan mib entries, PSU_INFO - of psu related entries, meaning tests for checking physical entity mib should be separated for FAN_INFO and PSU_INFO, and PSU entries should not be checked in a fan test (in this case - in test_fan_info)

**How did you do it?**
I checked handling of psu related entries in another test created for fan mib entries - test_remove_insert_fan_and_check_fan_info. This test [skips psu entries](https://github.com/Azure/sonic-mgmt/blob/master/tests/snmp/test_snmp_phy_entity.py#L706):
```
        if 'PSU' in parent_name:
            continue
```

**How did you verify/test it?**
Run snmp/test_snmp_phy_entity.py::test_fan_info

**Any platform specific information?**

**Supported testbed topology if it's a new test case?**
**Documentation**
[extension-to-physical-entity-mib](https://github.com/Azure/SONiC/blob/master/doc/snmp/extension-to-physical-entity-mib.md)