### PR TITLE
[techsupport] update bgp cmd regex after changes

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -80,10 +80,10 @@ bgp_cmds = [
     "vtysh{} -c 'show bgp ipv6 summary'",
     "vtysh{} -c 'show bgp ipv6 neighbors'",
     "vtysh{} -c 'show bgp ipv6'",
-    re.compile('vtysh{}\s+-c "show ip bgp neighbors .* advertised-routes"'),
-    re.compile('vtysh{}\s+-c "show ip bgp neighbors .* routes"'),
-    re.compile('vtysh{}\s+-c "show bgp ipv6 neighbors .* advertised-routes"'),
-    re.compile('vtysh{}\s+-c "show bgp ipv6 neighbors .* routes"'),
+    re.compile('vtysh{}\s+-c \\\\"show ip bgp neighbors .* advertised-routes\\\\"'),
+    re.compile('vtysh{}\s+-c \\\\"show ip bgp neighbors .* routes\\\\"'),
+    re.compile('vtysh{}\s+-c \\\\"show bgp ipv6 neighbors .* advertised-routes\\\\"'),
+    re.compile('vtysh{}\s+-c \\\\"show bgp ipv6 neighbors .* routes\\\\"'),
 ]
 
 nat_cmds = [


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update the regex of BGP commands after last changes #2117 to stabilize the test test_techsupport_commands.

In the test test_techsupport_commands, verified the commands in the output of the techsupport.
After the change, the test failed as regex didn't have a match for bgp commands.
The difference is **"\\"** before the quotes.

Previous output:
`imeout --foreground 5m vtysh  -c "show ip bgp neighbors fc00::72 routes" .......`

Current output:
`vtysh -c \"show ip bgp neighbors 10.0.0.5 routes\" | dummy_cleanup_method ......`




### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix failed test

#### How did you do it?
regex updated

#### How did you verify/test it?
Executed with the new version. The test passed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
