### PR TITLE
Run pfcwd on frontend nodes of a T2 chassis

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -21,6 +21,17 @@ def fanout_graph_facts(localhost, duthosts, rand_one_dut_hostname, conn_graph_fa
             facts[fanout] = {k: v[fanout] for k, v in get_graph_facts(duthost, localhost, fanout).items()}
     return facts
 
+@pytest.fixture(scope="module")
+def enum_fanout_graph_facts(localhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, conn_graph_facts):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    facts = dict()
+    dev_conn = conn_graph_facts.get('device_conn', {})
+    for _, val in dev_conn[duthost.hostname].items():
+        fanout = val["peerdevice"]
+        if fanout not in facts:
+            facts[fanout] = {k: v[fanout] for k, v in get_graph_facts(duthost, localhost, fanout).items()}
+    return facts
+
 
 def get_graph_facts(duthost, localhost, hostnames):
     """

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -41,7 +41,7 @@ def two_queues(request):
     Args:
         request: pytest request object
         duthosts: AnsibleHost instance for multi DUT
-        rand_one_dut_hostname: hostname of DUT
+        enum_rand_one_per_hwsku_frontend_hostname: hostname of DUT
 
     Returns:
         two_queues: False/True
@@ -50,19 +50,19 @@ def two_queues(request):
 
 
 @pytest.fixture(scope="module")
-def fake_storm(request, duthosts, rand_one_dut_hostname):
+def fake_storm(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Enable/disable fake storm based on platform and input parameters
 
     Args:
         request: pytest request object
         duthosts: AnsibleHost instance for multi DUT
-        rand_one_dut_hostname: hostname of DUT
+        enum_rand_one_per_hwsku_frontend_hostname: hostname of DUT
 
     Returns:
         fake_storm: False/True
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     return request.config.getoption('--fake-storm') if not isMellanoxDevice(duthost) else False
 
 
@@ -89,7 +89,7 @@ def update_t1_test_ports(duthost, mg_facts, test_ports, asic_index, tbinfo):
 
 @pytest.fixture(scope="module")
 def setup_pfc_test(
-    duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts, tbinfo,
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, conn_graph_facts, tbinfo,
     enum_frontend_asic_index
 ):
     """
@@ -104,7 +104,7 @@ def setup_pfc_test(
         setup_info: dictionary containing pfc timers, generated test ports and selected test ports
     """
     SUPPORTED_T1_TOPOS = {"t1-lag", "t1-64-lag"}
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_list = mg_facts['minigraph_ports'].keys()
     ports = (' ').join(port_list)

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -91,7 +91,7 @@ def cfg_teardown(duthost):
     duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
 @pytest.fixture(scope='class')
-def cfg_setup(setup_pfc_test, duthosts, rand_one_dut_hostname):
+def cfg_setup(setup_pfc_test, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Class level automatic fixture. Prior to the test run, create all the templates
     needed for each individual test and copy them on the DUT.
@@ -101,7 +101,7 @@ def cfg_setup(setup_pfc_test, duthosts, rand_one_dut_hostname):
         setup_pfc_test: module fixture defined in module conftest.py
         duthost: instance of AnsibleHost class
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     setup_info = setup_pfc_test
     pfc_wd_test_port = setup_info['test_ports'].keys()[0]
     logger.info("Creating json templates for all config tests")
@@ -143,7 +143,7 @@ def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
     return original_value
 
 @pytest.fixture(scope='class')
-def mg_cfg_setup(duthosts, rand_one_dut_hostname):
+def mg_cfg_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Class level automatic fixture. Prior to the test run, enable default pfcwd configuration
     before load_minigraph.
@@ -151,11 +151,11 @@ def mg_cfg_setup(duthosts, rand_one_dut_hostname):
 
     Args:
         duthost: instance of AnsibleHost class
-        rand_one_dut_hostname(string) : randomly pick a dut in multi DUT setup
+        enum_rand_one_per_hwsku_frontend_hostname(string) : randomly pick a dut in multi DUT setup
     Returns:
         None
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     logger.info("Enable pfcwd in configuration file")
     original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "enable")
@@ -168,7 +168,7 @@ def mg_cfg_setup(duthosts, rand_one_dut_hostname):
         config_reload(duthost, config_source='minigraph')
 
 @pytest.fixture(scope='function', autouse=True)
-def stop_pfcwd(duthosts, rand_one_dut_hostname):
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
 
@@ -179,7 +179,7 @@ def stop_pfcwd(duthosts, rand_one_dut_hostname):
         None
     """
     yield
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
@@ -220,7 +220,7 @@ class TestPfcConfig(object):
             out = duthost.command(cmd)
             pytest_assert(out["rc"] == 0, "Failed to execute cmd {}: Error: {}".format(cmd, out["stderr"]))
 
-    def test_forward_action_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_forward_action_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests if the config gets loaded properly for a valid cfg template
 
@@ -230,10 +230,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_fwd_action", "config_test_ignore_messages")
 
-    def test_invalid_action_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_invalid_action_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when invalid action is configured
 
@@ -243,10 +243,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_invalid_action", None, [CONFIG_TEST_EXPECT_INVALID_ACTION_RE], True)
 
-    def test_invalid_detect_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_invalid_detect_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when invalid detect time is configured
 
@@ -256,10 +256,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_invalid_detect_time", None, [CONFIG_TEST_EXPECT_INVALID_DETECT_TIME_RE], True)
 
-    def test_low_detect_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_low_detect_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when detect time < lower bound is configured
 
@@ -269,10 +269,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_low_detect_time", None, [CONFIG_TEST_EXPECT_INVALID_DETECT_TIME_RE], True)
 
-    def test_high_detect_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_high_detect_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when detect time > higher bound is configured
 
@@ -282,10 +282,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_high_detect_time", None, [CONFIG_TEST_EXPECT_INVALID_DETECT_TIME_RE], True)
 
-    def test_invalid_restore_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_invalid_restore_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when invalid restore time is configured
 
@@ -295,10 +295,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_invalid_restore_time", None, [CONFIG_TEST_EXPECT_INVALID_RESTORE_TIME_RE], True)
 
-    def test_low_restore_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_low_restore_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when restore time < lower bound is configured
 
@@ -308,10 +308,10 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_low_restore_time", None, [CONFIG_TEST_EXPECT_INVALID_RESTORE_TIME_RE], True)
 
-    def test_high_restore_time_cfg(self, duthosts, rand_one_dut_hostname):
+    def test_high_restore_time_cfg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for syslog error when restore time > higher bound is configured
 
@@ -321,12 +321,12 @@ class TestPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         self.execute_test(duthost, "pfc_wd_high_restore_time", None, [CONFIG_TEST_EXPECT_INVALID_RESTORE_TIME_RE], True)
 
 @pytest.mark.usefixtures('mg_cfg_setup')
 class TestDefaultPfcConfig(object):
-    def test_default_cfg_after_load_mg(self, duthosts, rand_one_dut_hostname):
+    def test_default_cfg_after_load_mg(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Tests for checking if pfcwd gets started after load_minigraph
 
@@ -336,7 +336,7 @@ class TestDefaultPfcConfig(object):
         Returns:
             None
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         config_reload(duthost, config_source='minigraph')
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -19,19 +19,19 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='class', autouse=True)
-def stop_pfcwd(duthosts, rand_one_dut_hostname):
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
 
     Args:
         duthost (AnsibleHost): DUT instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
 @pytest.fixture(scope='class', autouse=True)
-def storm_test_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, rand_one_dut_hostname, fanouthosts):
+def storm_test_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 
@@ -44,7 +44,7 @@ def storm_test_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, rand_
     Yields:
         storm_hndle (PFCStorm): class PFCStorm instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     setup_info = setup_pfc_test
     neighbors = setup_info['neighbors']
     port_list = setup_info['port_list']
@@ -139,7 +139,7 @@ class TestPfcwdAllPortStorm(object):
                 storm_hndle.stop_pfc_storm()
             time.sleep(5)
 
-    def test_all_port_storm_restore(self, duthosts, rand_one_dut_hostname, storm_test_setup_restore):
+    def test_all_port_storm_restore(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, storm_test_setup_restore):
         """
         Tests PFC storm/restore on all ports
 
@@ -147,7 +147,7 @@ class TestPfcwdAllPortStorm(object):
             duthost (AnsibleHost): DUT instance
             storm_test_setup_restore (fixture): class scoped autouse setup fixture
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         storm_hndle = storm_test_setup_restore
         logger.info("--- Testing if PFC storm is detected on all ports ---")
         self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_DETECT_RE], syslog_marker="all_port_storm",

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -2,7 +2,7 @@ import logging
 import os
 import pytest
 
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.pfc_storm import PFCMultiStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from .files.pfcwd_helper import start_wd_on_ports
@@ -31,13 +31,13 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("pfcwd stop")
 
 @pytest.fixture(scope='class', autouse=True)
-def storm_test_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+def storm_test_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 
     Args:
         setup_pfc_test (fixture): module scoped, autouse PFC fixture
-        fanout_graph_facts (fixture): fanout graph info
+        enum_fanout_graph_facts (fixture): fanout graph info
         duthost (AnsibleHost): DUT instance
         fanouthosts (AnsibleHost): fanout instance
 
@@ -55,7 +55,7 @@ def storm_test_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum_
     pfc_wd_restore_time = 200
     pfc_wd_restore_time_large = 30000
     peer_params = populate_peer_info(port_list, neighbors, pfc_queue_index, pfc_frames_number)
-    storm_hndle = set_storm_params(duthost, fanout_graph_facts, fanouthosts, peer_params)
+    storm_hndle = set_storm_params(duthost, enum_fanout_graph_facts, fanouthosts, peer_params)
     start_wd_on_ports(duthost, ports, pfc_wd_restore_time, pfc_wd_detect_time)
 
     yield storm_hndle

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import time
 
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -698,7 +698,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.rx_action = action
         self.tx_action = action
 
-    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         PFCwd functional test
 
@@ -706,14 +706,14 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             request(object) : pytest request object
             fake_storm(fixture) : Module scoped fixture for enable/disable fake storm
             setup_pfc_test(fixture) : Module scoped autouse fixture for PFCwd
-            fanout_graph_facts(fixture) : fanout graph info
+            enum_fanout_graph_facts(fixture) : fanout graph info
             ptfhost(AnsibleHost) : ptf host instance
             duthost(AnsibleHost) : DUT instance
             fanouthosts(AnsibleHost): fanout instance
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
-        self.fanout_info = fanout_graph_facts
+        self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
         self.fanout = fanouthosts
@@ -757,7 +757,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                      logger.info("--- Stop PFC WD ---")
                      self.dut.command("pfcwd stop")
 
-    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -774,7 +774,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             request(object) : pytest request object
             fake_storm(fixture) : Module scoped fixture for enable/disable fake storm
             setup_pfc_test(fixture) : Module scoped autouse fixture for PFCwd
-            fanout_graph_facts(fixture) : fanout graph info
+            enum_fanout_graph_facts(fixture) : fanout graph info
             ptfhost(AnsibleHost) : ptf host instance
             duthost(AnsibleHost) : DUT instance
             enum_rand_one_per_hwsku_frontend_hostname(string) : randomly pick a dut in multi DUT setup
@@ -782,7 +782,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
-        self.fanout_info = fanout_graph_facts
+        self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
         self.fanout = fanouthosts
@@ -828,7 +828,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             logger.info("--- Stop PFC WD ---")
             self.dut.command("pfcwd stop")
 
-    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts, tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Test PfCWD functionality after toggling port
 
@@ -846,7 +846,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             request(object) : pytest request object
             fake_storm(fixture) : Module scoped fixture for enable/disable fake storm
             setup_pfc_test(fixture) : Module scoped autouse fixture for PFCWD
-            fanout_graph_facts(fixture) : Fanout graph info
+            enum_fanout_graph_facts(fixture) : Fanout graph info
             tbinfo(fixture) : Testbed info
             ptfhost(AnsibleHost) : PTF host instance
             duthost(AnsibleHost) : DUT instance
@@ -854,7 +854,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
-        self.fanout_info = fanout_graph_facts
+        self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
         self.fanout = fanouthosts

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -37,14 +37,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function', autouse=True)
-def stop_pfcwd(duthosts, rand_one_dut_hostname):
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
 
     Args:
         duthost(AnsibleHost) : dut instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
@@ -698,7 +698,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.rx_action = action
         self.tx_action = action
 
-    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, fanouthosts):
+    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         PFCwd functional test
 
@@ -711,7 +711,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             duthost(AnsibleHost) : DUT instance
             fanouthosts(AnsibleHost): fanout instance
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
         self.fanout_info = fanout_graph_facts
         self.ptf = ptfhost
@@ -757,7 +757,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                      logger.info("--- Stop PFC WD ---")
                      self.dut.command("pfcwd stop")
 
-    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, fanouthosts):
+    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -777,10 +777,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             fanout_graph_facts(fixture) : fanout graph info
             ptfhost(AnsibleHost) : ptf host instance
             duthost(AnsibleHost) : DUT instance
-            rand_one_dut_hostname(string) : randomly pick a dut in multi DUT setup
+            enum_rand_one_per_hwsku_frontend_hostname(string) : randomly pick a dut in multi DUT setup
             fanouthosts(AnsibleHost): fanout instance
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
         self.fanout_info = fanout_graph_facts
         self.ptf = ptfhost
@@ -828,7 +828,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             logger.info("--- Stop PFC WD ---")
             self.dut.command("pfcwd stop")
 
-    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, tbinfo, ptfhost, duthosts, rand_one_dut_hostname, fanouthosts):
+    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Test PfCWD functionality after toggling port
 
@@ -852,7 +852,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             duthost(AnsibleHost) : DUT instance
             fanouthosts(AnsibleHost): Fanout instance
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
         self.fanout_info = fanout_graph_facts
         self.ptf = ptfhost

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from .files.pfcwd_helper import start_wd_on_ports
@@ -46,13 +46,13 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
     yield
 
 @pytest.fixture(scope='class', autouse=True)
-def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 
     Args:
         setup_pfc_test (fixture): module scoped, autouse PFC fixture
-        fanout_graph_facts (fixture): fanout graph info
+        enum_fanout_graph_facts (fixture): fanout graph info
         duthost (AnsibleHost): DUT instance
         fanouthosts (AnsibleHost): fanout instance
 
@@ -68,7 +68,7 @@ def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum
     eth0_ip = setup_info['eth0_ip']
     pfc_wd_test_port = test_ports.keys()[0]
     neighbors = setup_info['neighbors']
-    fanout_info = fanout_graph_facts
+    fanout_info = enum_fanout_graph_facts
     dut = duthost
     fanout = fanouthosts
     peer_params = populate_peer_info(neighbors, fanout_info, pfc_wd_test_port)

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -16,19 +16,19 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module', autouse=True)
-def stop_pfcwd(duthosts, rand_one_dut_hostname):
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
 
     Args:
         duthost (AnsibleHost): DUT instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
 @pytest.fixture(autouse=True)
-def ignore_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
+def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
     """
     Fixture that ignores expected failures during test execution.
 
@@ -41,12 +41,12 @@ def ignore_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
             ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
             ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*"
         ]
-        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
 
     yield
 
 @pytest.fixture(scope='class', autouse=True)
-def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, rand_one_dut_hostname, fanouthosts):
+def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 
@@ -60,7 +60,7 @@ def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthosts, rand
         timers (dict): pfcwd timer values
         storm_handle (PFCStorm): class PFCStorm instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Pfcwd timer test setup ---")
     setup_info = setup_pfc_test
     test_ports = setup_info['test_ports']
@@ -211,7 +211,7 @@ class TestPfcwdAllTimer(object):
         timestamp_ms = self.dut.shell("date -d {} +%s%3N".format(timestamp))['stdout']
         return int(timestamp_ms)
 
-    def test_pfcwd_timer_accuracy(self, duthosts, rand_one_dut_hostname, pfcwd_timer_setup_restore):
+    def test_pfcwd_timer_accuracy(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, pfcwd_timer_setup_restore):
         """
         Tests PFCwd timer accuracy
 
@@ -219,7 +219,7 @@ class TestPfcwdAllTimer(object):
             duthost (AnsibleHost): DUT instance
             pfcwd_timer_setup_restore (fixture): class scoped autouse setup fixture
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = pfcwd_timer_setup_restore
         self.storm_handle = setup_info['storm_handle']
         self.timers = setup_info['timers']

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -39,31 +39,31 @@ pytestmark = [pytest.mark.disable_loganalyzer,
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_pfcwd_wb_tests(duthosts, rand_one_dut_hostname):
+def skip_pfcwd_wb_tests(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Skip Pfcwd warm reboot tests on certain asics
 
     Args:
         duthosts (pytest fixture): list of Duts
-        rand_one_dut_hostname (str): hostname of DUT
+        enum_rand_one_per_hwsku_frontend_hostname (str): hostname of DUT
 
     Returns:
         None
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     SKIP_LIST = ["td2"]
     asic_type = duthost.get_asic_name()
     pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST), "Warm reboot is not supported on {}".format(asic_type))
 
 @pytest.fixture(autouse=True)
-def setup_pfcwd(duthosts, rand_one_dut_hostname):
+def setup_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Setup PFCwd before the test run
 
     Args:
         duthost(AnsibleHost) : dut instance
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("Setup the default pfcwd config for warm-reboot test")
     duthost.command("redis-cli -n 4 hset \"DEVICE_METADATA|localhost\" "
                     "default_pfcwd_status enable")
@@ -550,7 +550,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         yield request.param
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts,
-                      rand_one_dut_hostname, localhost, fanouthosts, two_queues):
+                      enum_rand_one_per_hwsku_frontend_hostname, localhost, fanouthosts, two_queues):
         """
         Tests PFCwd warm reboot with various testcase actions
 
@@ -573,7 +573,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
             localhost(AnsibleHost) : localhost instance
             fanouthosts(AnsibleHost): fanout instance
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         logger.info("--- {} ---".format(TESTCASE_INFO[testcase_action]['desc']))
         self.pfcwd_wb_helper(fake_storm, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,
                              fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts, two_queues)

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -7,7 +7,7 @@ import time
 import traceback
 
 from tests.common.broadcom_data import is_broadcom_device
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -458,7 +458,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         logger.info("--- Disabling fake storm on port {} queue {}".format(port, queue))
                         PfcCmd.set_storm_status(self.dut, self.oid_map[(port, queue)], "disabled")
 
-    def pfcwd_wb_helper(self, fake_storm, testcase_actions, setup_pfc_test, fanout_graph_facts, ptfhost,
+    def pfcwd_wb_helper(self, fake_storm, testcase_actions, setup_pfc_test, enum_fanout_graph_facts, ptfhost,
                         duthost, localhost, fanouthosts, two_queues):
         """
         Helper method that initializes the vars and starts the test execution
@@ -467,14 +467,14 @@ class TestPfcwdWb(SetupPfcwdFunc):
             fake_storm(bool): if fake storm is enabled or disabled
             testcase_actions(list): list of actions that the test will go through
             setup_pfc_test(fixture): module scoped autouse fixture
-            fanout_graph_facts(fixture): fanout info
+            enum_fanout_graph_facts(fixture): fanout info
             ptfhost(AnsibleHost): PTF instance
             duthost(AnsibleHost): DUT instance
             localhost(AnsibleHost): local instance
             fanouthosts(AnsibleHost): fanout instance
         """
         setup_info = setup_pfc_test
-        self.fanout_info = fanout_graph_facts
+        self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
         self.fanout = fanouthosts
@@ -549,7 +549,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         """
         yield request.param
 
-    def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts,
+    def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts, ptfhost, duthosts,
                       enum_rand_one_per_hwsku_frontend_hostname, localhost, fanouthosts, two_queues):
         """
         Tests PFCwd warm reboot with various testcase actions
@@ -567,7 +567,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                                logic
 
             setup_pfc_test(fixture) : Module scoped autouse fixture for PFCwd
-            fanout_graph_facts(fixture) : fanout graph info
+            enum_fanout_graph_facts(fixture) : fanout graph info
             ptfhost(AnsibleHost) : ptf host instance
             duthost(AnsibleHost) : DUT instance
             localhost(AnsibleHost) : localhost instance
@@ -576,4 +576,4 @@ class TestPfcwdWb(SetupPfcwdFunc):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         logger.info("--- {} ---".format(TESTCASE_INFO[testcase_action]['desc']))
         self.pfcwd_wb_helper(fake_storm, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,
-                             fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts, two_queues)
+                             enum_fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts, two_queues)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Use enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname to avoid picking up running on supervisor card.

Also, use enum_rand_one_frontend_hostname for getting correct fanout_graph_facts for the DUT selected by enum_rand_one_per_hwsku_frontend_hostname 

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To use enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname to avoid picking up running on supervisor card.


#### How did you do it?
Use enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname to avoid picking up running pfcwd tests against supervisor card.

For picking the right fanout_graph, a dded enum_fanout_graph_facts fixture which uses enum_rand_one_frontend_hostmame and modified pfcwd tests to use enum_fanout_graph_facts instead of fanout_graph_facts that used.

  
#### How did you verify/test it?
Ran the entire pfcwd suite on a multi ASICs chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
