### PR TITLE
Add exception handling for macsec ImportError

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,12 @@ from tests.common.cache import FactsCache
 
 from tests.common.connections.console_host import ConsoleHost
 from tests.common.utilities import str2bool
-from tests.macsec import MacsecPlugin
+
+try:
+    from tests.macsec import MacsecPlugin
+except ImportError as e:
+    logging.error(e)
+
 from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
 from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Only scapy version over 2.4.5 supports macsec. When we run test using scapy which version is less than 2.4.5, it will raise ImportError and cause the test failure. In this pr, we add exception handling for macsec ImportError, so, it will not break the test.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Only scapy version over 2.4.5 supports macsec. When we run test using scapy which version is less than 2.4.5, it will raise ImportError and cause the test failure. In this pr, we add exception handling for macsec ImportError, so, it will not break the test.

#### How did you do it?
Add try...except to catch the error. 

#### How did you verify/test it?
By running the test and it will not break the test. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
