### PR TITLE
Update copp configuration for dropping packets with TTL=0

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzerError
+from tests.common import config_reload
 
 
 RX_DRP = "RX_DRP"
@@ -82,6 +83,59 @@ def fanouthost(duthosts, rand_one_dut_hostname, fanouthosts, conn_graph_facts, l
     if fanout:
         if hasattr(fanout, 'restore_drop_counter_config'):
             fanout.restore_drop_counter_config()
+
+
+@pytest.fixture
+def configure_copp_drop_for_ttl_error(duthosts, rand_one_dut_hostname):
+    """
+    Fixture that allows to update copp configuration for dropping packets with TTL=0
+
+    Args:
+        duthosts: fixture to get DUT hosts defined in testbed
+        rand_one_dut_hostname: fixture to return the randomly selected duthost
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    copp_trap_group_json = "/tmp/copp_trap_group.json"
+    copp_trap_rule_json = "/tmp/copp_trap_rule.json"
+
+    cmd_copp_trap_group = '''
+cat << EOF >  %s
+{
+   "COPP_GROUP": {
+        "ttl_error": {
+            "queue": "4",
+            "trap_action": "drop"
+        }
+  }
+}
+EOF
+''' % (copp_trap_group_json)
+
+    cmd_copp_trap_rule = '''
+cat << EOF > %s
+{
+   "COPP_TRAP": {
+        "ttl_error": {
+            "trap_ids": "ttl_error",
+            "trap_group": "ttl_error",
+            "always_enabled": "true"
+        }
+    }
+}
+EOF
+''' % (copp_trap_rule_json)
+
+    duthost.shell(cmd_copp_trap_group)
+    duthost.command("sudo config load {} -y".format(copp_trap_group_json))
+
+    duthost.shell(cmd_copp_trap_rule)
+    duthost.command("sudo config load {} -y".format(copp_trap_rule_json))
+
+    yield
+
+    duthost.command("rm {} {}".format(copp_trap_group_json, copp_trap_rule_json))
+    config_reload(duthost)
+
 
 def is_mellanox_devices(hwsku):
     """
@@ -800,7 +854,7 @@ def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, p
     do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
-def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
+def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled, configure_copp_drop_for_ttl_error):
     """
     @summary: Create an IP packet with TTL=0.
     """


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added fixture that allows to update copp configuration for dropping packets with TTL=0

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In case of [SONiC](https://github.com/Azure/sonic-swss/blob/4e53afc1ceef1a1fea8db32689c20e6e6d6f34e4/orchagent/copporch.cpp#L177), the SAI_HOSTIF_TRAP_TYPE_TTL_ERROR entry is get installed as a default entry with action trap. So should be added rule which allows to update copp configuration for dropping packets with TTL=0. 
#### How did you do it?
Added approach for dropping packets with TTL=0
#### How did you verify/test it?
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[port_channel_members] PASSED                                                                  [ 33%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[vlan_members] PASSED                                                                          [ 66%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members] SKIPPED                                                                          [100%]
#### Any platform specific information?
SONiC Software Version: SONiC.master.94647-dirty-20220429.133828
Distribution: Debian 11.3
Kernel: 5.10.0-8-2-amd64
Build commit: d258db8aa
Build date: Fri Apr 29 19:07:06 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
