### PR TITLE
Make cacl run only on frontend nodes

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -63,18 +63,18 @@ def docker_network(duthost):
     return docker_network
 
 @pytest.fixture(scope="function")
-def collect_ignored_rules(duthosts, rand_one_dut_hostname):
+def collect_ignored_rules(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Collect existing iptables rules before test, set them as ignored as they are not related to CACL test cases.
 
     Args:
         duthosts: All DUTs belong to the testbed.
-        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        enum_rand_one_per_hwsku_frontend_hostname: hostname of a random chosen dut to run test.
 
     Returns:
         None
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     ignored_rules_v4 = duthost.command("iptables -S")["stdout_lines"]
     ignored_rules_v6 = duthost.command("ip6tables -S")["stdout_lines"]
@@ -85,20 +85,20 @@ def collect_ignored_rules(duthosts, rand_one_dut_hostname):
     return ignored_rules
 
 @pytest.fixture(scope="function")
-def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules):
+def clean_scale_rules(duthosts, enum_rand_one_per_hwsku_frontend_hostname, collect_ignored_rules):
     """
     Clear other control ACL rules before test to avoid miscalucation,
     delete ACL template json file and clean ACL rules, recover configuration after test.
 
     Args:
         duthosts: All DUTs belong to the testbed.
-        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        enum_rand_one_per_hwsku_frontend_hostname: hostname of a random chosen dut to run test.
         collect_ignored_rules: ignored iptable/ip6table rules.
 
     Returns:
         None
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     yield
 
@@ -756,7 +756,7 @@ def verify_nat_cacl(duthost, localhost, creds, docker_network, asic_index):
     unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
     pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables nat rules: {}".format(repr(unexpected_ip6tables_rules)))
 
-def test_cacl_application(duthosts, rand_one_dut_hostname, localhost, creds, docker_network):
+def test_cacl_application(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, creds, docker_network):
     """
     Test case to ensure caclmgrd is applying control plane ACLs properly
 
@@ -764,19 +764,19 @@ def test_cacl_application(duthosts, rand_one_dut_hostname, localhost, creds, doc
     rules based on the DuT's configuration and comparing them against the
     actual iptables/ip6tables rules on the DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     verify_cacl(duthost, localhost, creds, docker_network)
 
-def test_multiasic_cacl_application(duthosts, rand_one_dut_hostname, localhost, creds,docker_network, enum_frontend_asic_index):
+def test_multiasic_cacl_application(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, creds,docker_network, enum_frontend_asic_index):
 
     if enum_frontend_asic_index is None:
         pytest.skip("Not Multi-asic platform. Skipping !!")
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     verify_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
     verify_nat_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
 
-def test_cacl_scale_rules_ipv4(duthosts, rand_one_dut_hostname, collect_ignored_rules, clean_scale_rules):
+def test_cacl_scale_rules_ipv4(duthosts, enum_rand_one_per_hwsku_frontend_hostname, collect_ignored_rules, clean_scale_rules):
     """
     Test case to ensure cover scale rules for control plan ACL for ipv4
 
@@ -784,7 +784,7 @@ def test_cacl_scale_rules_ipv4(duthosts, rand_one_dut_hostname, collect_ignored_
     and generating our own set of expected iptables rules based on the DUT's configuration and comparing them against the actual iptables
     rules on the DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     ignored_iptable_rules_v4 = collect_ignored_rules["v4"]
 
     generate_scale_rules(duthost, "ipv4")
@@ -810,7 +810,7 @@ def test_cacl_scale_rules_ipv4(duthosts, rand_one_dut_hostname, collect_ignored_
     unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules) - set(ignored_iptable_rules_v4)
     pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables rules: {}".format(repr(unexpected_iptables_rules)))
 
-def test_cacl_scale_rules_ipv6(duthosts, rand_one_dut_hostname, collect_ignored_rules, clean_scale_rules):
+def test_cacl_scale_rules_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, collect_ignored_rules, clean_scale_rules):
     """
     Test case to ensure cover scale rules for control plan ACL for ipv6
 
@@ -818,7 +818,7 @@ def test_cacl_scale_rules_ipv6(duthosts, rand_one_dut_hostname, collect_ignored_
     and generating our own set of expected ip6tables rules based on the DUT's configuration and comparing them against the actual ip6tables
     rules on the DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     ignored_iptable_rules_v6 = collect_ignored_rules["v6"]
 
     generate_scale_rules(duthost, "ipv6")

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -21,10 +21,10 @@ SONIC_SSH_PORT  = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def test_cacl_function(duthosts, rand_one_dut_hostname, localhost, creds):
+def test_cacl_function(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, creds):
     """Test control plane ACL functionality on a SONiC device"""
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     dut_mgmt_ip = duthost.mgmt_ip
 
     # Start an NTP client

--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -17,7 +17,7 @@ def generate_expected_rules(duthost):
     return ebtables_rules
 
 
-def test_ebtables_application(duthosts, rand_one_dut_hostname, enum_asic_index):
+def test_ebtables_application(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index):
     """
     Test case to ensure ebtables rules are applied are corectly on DUT during init
 
@@ -25,7 +25,7 @@ def test_ebtables_application(duthosts, rand_one_dut_hostname, enum_asic_index):
     rules based on the DuT's configuration and comparing them against the
     actual ebtables rules on the DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     expected_ebtables_rules = generate_expected_rules(duthost)
 
     stdout = duthost.asic_instance(enum_asic_index).command("sudo ebtables -L FORWARD")["stdout"]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Existing cacl tests use rand_one_dut_hostname.

On a T2 chassis, however, we could pick supervisor card as the random DUT. On supervisor card the tests fail applying ACL's as there are no frontpanel ports on the superisor card.

#### How did you do it?
Modified tests to use enum_rand_one_per_hwsku_frontend_hostname fixture instead of rand_one_dut_hostname

#### How did you verify/test it?
Ran tests against T2 chassis, and all tests passed when we picked a linecard as DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
