### PR TITLE
Enhance the config_system_checks_passed to check queued systemd job

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -31,6 +31,12 @@ def config_system_checks_passed(duthost):
         out1 = duthost.shell("systemctl show {} --property=LastTriggerUSecMonotonic --value".format(service))
         if out1['stdout'].strip() == "0":
             return False
+
+    logging.info("Checking if systemd queued job is empty")
+    out = duthost.shell("systemctl list-jobs")
+    if "No jobs running" not in out['stdout']:
+        return False
+
     logging.info("All checks passed")
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add an systemd queued job checking for config_system_checks_passed function.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

When I run test_reload_config.py test, it failed due to a command is cancelled by systemd.
```
        logging.info("Stopping swss docker and checking config reload")
>       duthost.shell("sudo service swss stop")

platform_tests/test_reload_config.py:90: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
...
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": "sudo service swss stop", 
E               "delta": "0:00:01.469972", 
E               "end": "2022-05-29 15:34:54.213934", 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "sudo service swss stop", 
E                       "_uses_shell": true, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2022-05-29 15:34:52.743962", 
E               "stderr": "Job for swss.service canceled.", 
E               "stderr_lines": [
E                   "Job for swss.service canceled."
E               ], 
E               "stdout": "", 
E               "stdout_lines": [], 
E               "warnings": [
E                   "Consider using 'become', 'become_method', and 'become_user' rather than running sudo"
E               ]
E           }
```

#### How did you do it?

Due to the "config reload" operation will use "replace-irreversibly" job mode to restart some services. The incoming contradict request will be cancelled.
To prevent this, check if any queued job before executing the "restart swss" request.

#### How did you verify/test it?

Run the test_reload_config for multiple times to make sure the request will not be cancelled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
