### PR TITLE
Check dut health status after running one test case .

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1750,7 +1750,7 @@ def check_dut_health_status(duthosts, request):
                 duthost.hostname]:
                 config_db_check_pass = False
 
-        if not (core_dump_check_pass or config_db_check_pass):
+        if not (core_dump_check_pass and config_db_check_pass):
             check_result = {"core_dump_check": {"pass": core_dump_check_pass, "new_core_dumps": new_core_dumps},
                             "config_db_check": {"pass": config_db_check_pass, "pre_only_config": pre_only_config, "cur_only_config": cur_only_config, "inconsistent_config": inconsistent_config}}
             logger.warning("Check Dut health failed: Dut health check results {}, running module {}".format(json.dumps(check_result), module_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Dut health status may be changed after running one test case, such as core dump and configuration. And these changes may affect the next running test case. So we define a module level fixture to check the dut health status after running one test case, if they are different, we will reload the configuration before the module running and give a warning in the log. The pattern of the log is `Check Dut health failed:`

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Dut health status may be changed after running one test case, such as core dump and configuration. And these changes may affect the next running test case. So we define a module level fixture to check the dut health status after running one test case, if they are different, we will reload the configuration before the module running and give a warning in the log. The pattern of the log is `Check Dut health failed:`

#### How did you do it?
Compare the running config with golden config, if they are same, continue. Otherwise, reload the testbed configuration using the config before the module running. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
