### PR TITLE
Remove unnecessary fdb flush for test_configurable_drop_counters

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -158,8 +158,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
         send_dropped_traffic(counter_type, pkt, rx_port)
     finally:
         mock_server["fanout_neighbor"].no_shutdown(mock_server["fanout_intf"])
-        duthost.command("sonic-clear fdb all")
-        duthost.command("sonic-clear arp")
+        time.sleep(3)
         # Delete the static fdb entry
         apply_fdb_config(duthost, testbed_params['vlan_interface']['attachto'],
                             mock_server['server_dst_intf'], mock_server['server_dst_mac'],


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_configurable_drop_counters` may cause orchagent crash during unshutdown interface/flush fdb/remove static fdb these operations.
Issue reported here: https://github.com/Azure/sonic-buildimage/issues/11046
#### How did you do it?
The issue is fixed, but we can remove unnecessary fdb flush for `test_configurable_drop_counters`.
And also add sleep 3 sec after shutdown interface.

#### How did you verify/test it?
run  `test_configurable_drop_counters`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
