### PR TITLE
Fixed bgp session check post container restart

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -500,7 +500,9 @@ class MultiAsicSonicHost(object):
             for k, v in bgp_facts['bgp_neighbors'].items():
                 if v['state'] == state:
                     if k.lower() in neigh_ips:
-                        neigh_ok.append(k)
+                        if k.lower() not in neigh_ok:
+                            # Append only when not present to prevent duplication
+                            neigh_ok.append(k)
             logging.info("bgp neighbors that match the state: {}".format(neigh_ok))
 
         if len(neigh_ips) == len(neigh_ok):


### PR DESCRIPTION
1. Added a sleep to wait for bgp list to be populated post container restart.
2. Added separate bgp session state check logic to check bgp state post wait after container restart
3. Fix added to put only unique entries to neigh_ok list. Duplicate entries cause len(neigh_ok) exceed expected len(neigh_ips). Fixes container_checker and container_autorestart tests.

Signed-off-by: anamehra <anamehra@cisco.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. cotainer_autorestart and container_checker test fails on multi-asic due to not all bgp neighbors in the established state.
2. Some container_checker test pass even if the bgp neighbor list is empty, false pass.

### Type of change
Modified container_autorestart test to check bgp neighbor list separately after critical processes are up.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. Added a sleep to wait for bgp list to be populated post container restart.
2. Added separate bgp session state check logic to check bgp state post wait after container restart
3. Fix added to put only unique entries to neigh_ok list. Duplicate entries cause len(neigh_ok) exceed expected len(neigh_ips). This is used by container_autorestart and container_checker test scripts.

#### How did you verify/test it?
run container_checker/test_container_checker.py on multi-asic Linecard.
run autorestart/test_container_autorestart.py on multi-asic Linecard.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
