### PR TITLE
[MASIC] test_bgp_update_timer to support for multi-asic

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -45,7 +45,7 @@ def log_bgp_updates(duthost, iface, save_path, n0):
     else:
         start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)
     stop_pcap = "pkill -f '%s'" % start_pcap
-    start_pcap = "sudo ip netns exec %s 'nohup %s &'" % (n0.namespace, start_pcap)
+    start_pcap = "sudo ip netns exec %s nohup %s &" % (n0.namespace, start_pcap)
     duthost.shell(start_pcap)
     try:
         yield

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -53,9 +53,9 @@ def log_bgp_updates(duthost, iface, save_path, ns):
 
 
 @pytest.fixture
-def is_quagga(duthosts, rand_one_dut_hostname):
+def is_quagga(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Return True if current bgp is using Quagga."""
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     show_res = duthost.asic_instance().run_vtysh("-c 'show version'")
     return "Quagga" in show_res["stdout"]
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -66,9 +66,9 @@ def is_dualtor(tbinfo):
 
 
 @pytest.fixture
-def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces):
-    duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+def common_setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     conn0, conn1 = setup_interfaces
     conn0_ns = DEFAULT_NAMESPACE if "namespace" not in conn0.keys() else conn0["namespace"]
     conn1_ns = DEFAULT_NAMESPACE if "namespace" not in conn1.keys() else conn1["namespace"]
@@ -142,7 +142,7 @@ def constants(is_quagga, setup_interfaces):
     return _constants
 
 
-def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_dut_hostname,
+def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                           toggle_all_simulator_ports_to_rand_selected_tor_m):
 
     def bgp_update_packets(pcap_file):
@@ -196,7 +196,7 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_d
         else:
             return False
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     n0, n1 = common_setup_teardown
     try:

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -43,13 +43,14 @@ def log_bgp_updates(duthost, iface, save_path, ns):
         # have it use LINUX_SLL (Linux cooked) instead.
         start_pcap = "tcpdump -y LINUX_SLL -i %s -w %s port 179" % (iface, save_path)
     else:
-        start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)    
-    nohup_start_pcap = "nohup %s &" % (start_pcap)
-    duthost.asic_instance_from_namespace(ns).command(nohup_start_pcap)
+        start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)  
+    # for multi-asic dut, add 'ip netns exec asicx' to the beggining of tcpdump cmd 
+    stop_pcap = "sudo pkill -f '%s %s'" % (duthost.asic_instance_from_namespace(ns).ns_arg, start_pcap)
+    duthost.shell("nohup {} {} &".format(duthost.asic_instance_from_namespace(ns).ns_arg, start_pcap)) 
     try:
         yield
     finally:
-        duthost.asic_instance_from_namespace(ns).kill_command(start_pcap, module_ignore_errors=True)
+        duthost.shell(stop_pcap, module_ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -382,17 +382,6 @@ class SonicAsic(object):
         cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
 
         return self.sonichost.command(cmdstr)
-
-    
-    def kill_command(self, cmdstr):
-        """ kill cmdstr or kill "ip netns exec 'cmdstr'" base on type of testbed"""
-        if not self.sonichost.is_multi_asic or self.namespace == DEFAULT_NAMESPACE:
-            kill_cmd = "pkill -f '%s'" % cmdstr
-            return self.sonichost.command(kill_cmd)
-
-        cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
-        kill_cmd = "pkill -f '%s'" % cmdstr
-        return self.sonichost.command(kill_cmd)
         
     def run_vtysh(self, cmdstr):
         """

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -383,6 +383,17 @@ class SonicAsic(object):
 
         return self.sonichost.command(cmdstr)
 
+    
+    def kill_command(self, cmdstr):
+        """ kill cmdstr or kill "ip netns exec 'cmdstr'" base on type of testbed"""
+        if not self.sonichost.is_multi_asic or self.namespace == DEFAULT_NAMESPACE:
+            kill_cmd = "pkill -f '%s'" % cmdstr
+            return self.sonichost.command(kill_cmd)
+
+        cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
+        kill_cmd = "pkill -f '%s'" % cmdstr
+        return self.sonichost.command(kill_cmd)
+        
     def run_vtysh(self, cmdstr):
         """
             Add -n option with ASIC instance on multi ASIC

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -516,11 +516,15 @@ class SonicAsic(object):
         return False
 
     def portchannel_on_asic(self, portchannel):
-        cmd = 'sudo sonic-cfggen -n {} -v "PORTCHANNEL.keys()" -d'.format(self.cli_ns_option)
+        cmd = 'sudo sonic-cfggen {} -v "PORTCHANNEL.keys()" -d'.format(self.cli_ns_option)
         pcs =  self.shell(cmd)["stdout_lines"][0].decode("utf-8")
         if pcs is not None and portchannel in pcs:
             return True
         return False
+    
+    def write_to_config_db(self, dst_path):
+        cmd = 'sonic-cfggen {} -j {} -w'.format(self.cli_ns_option, dst_path)
+        return self.shell(cmd)
 
     def get_portchannel_and_members_in_ns(self, tbinfo):
         """

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -48,7 +48,7 @@ class BGPNeighbor(object):
             _write_variable_from_j2_to_configdb(
                 self.duthost,
                 "bgp/templates/neighbor_metadata_template.j2",
-                self.namespace = namespace,
+                namespace=self.namespace,
                 save_dest_path=NEIGHBOR_SAVE_DEST_TMPL % self.name,
                 neighbor_name=self.name,
                 neighbor_lo_addr=self.ip,
@@ -60,7 +60,7 @@ class BGPNeighbor(object):
             _write_variable_from_j2_to_configdb(
                 self.duthost,
                 "bgp/templates/bgp_template.j2",
-                self.namespace = namespace,
+                namespace=self.namespace,
                 save_dest_path=BGP_SAVE_DEST_TMPL % self.name,
                 db_table_name="BGP_NEIGHBOR",
                 peer_addr=self.ip,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is to make the test support for multi-asic duts.
To achieve that, some cmds in the test need to specify correct namespace, also, bgp neighbors need to create on specified ASIC(s).
Note that the 2 created pseudoswitchs does not need to be on the same asic, they can still announce routes across asics through backend asics.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?
To support test_bgp_update_timer test for multi-asic duts
#### How did you do it?
To achieve that, some cmds in the test need to specify correct namespace, also, bgp neighbors need to create on specified ASIC(s).
Note that the 2 created pseudoswitchs does not need to be on the same asic, they can still announce routes across asics through backend asics.

#### How did you verify/test it?
run this test on multi-asic device:
AzDevOps@8bcda3ef7587:/var/src/sonic-mgmt-int/tests$ sudo ./run_tests.sh -i '../ansible/strsvc,../ansible/veos' -n vmsvc1-t1-masic-acs-1  -u -e "--disable_loganalyzer --skip_sanity" -c bgp/test_bgp_update_timer.py
=== Running tests in groups ===
=================================================================================================================== test session starts ===================================================================================================================

collecting 0 items                                                                                                                                                                                                                                        
------------------------------------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------------------------------------
18:28:59 bgp.<module>                             L2530 WARNING| [bgp.py] use_2_bytes_asn: True
collected 1 item                                                                                                                                                                                                                                          

bgp/test_bgp_update_timer.py::test_bgp_update_timer PASSED                                                                                                                                                                                          [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
