### PR TITLE
Macsec test updates for t2_min topology.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -325,6 +325,18 @@ macsec/test_macsec.py:
     conditions:
       - "platform not in ['x86_64-arista_7280cr3mk_32d4', 'x86_64-kvm_x86_64-r0']"
 
+macsec/test_macsec.py::TestInteropProtocol::test_bgp:
+  skip:
+    reason: 'test_bgp skip in Brcm based T2, complete portchannel SAI fix planned for 8.1'
+    conditions:
+      - "'t2' in topo_name"
+
+macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor:
+  skip:
+    reason: 'test_server_to_neighbor needs downstream neighbors, which is not present in this topo'
+    conditions:
+      - "'t2' in topo_name"
+
 #######################################
 #####           nat               #####
 #######################################

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -130,7 +130,7 @@ class MacsecPlugin(object):
         links = collections.defaultdict(dict)
 
         def filter(interface, neighbor, mg_facts, tbinfo):
-            if tbinfo["topo"]["type"] == "t0" and "Server" in neighbor["name"]:
+            if ((tbinfo["topo"]["type"] == "t0" and "Server" in neighbor["name"]) or (tbinfo["topo"]["type"] == "t2" and "T1" in neighbor["name"])) :
                 port = mg_facts["minigraph_neighbors"][interface]["port"]
                 links[interface] = {
                     "name": neighbor["name"],
@@ -145,7 +145,7 @@ class MacsecPlugin(object):
         links = collections.defaultdict(dict)
 
         def filter(interface, neighbor, mg_facts, tbinfo):
-            if tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"]:
+            if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"]) or (tbinfo["topo"]["type"] == "t2" and "T3" in neighbor["name"])):
                 for item in mg_facts["minigraph_bgp"]:
                     if item["name"] == neighbor["name"]:
                         if isinstance(ip_address(item["addr"]), IPv4Address):
@@ -185,9 +185,6 @@ class MacsecPlugin(object):
                 return
             port = mg_facts["minigraph_neighbors"][interface]["port"]
 
-            # Currently in t2 topology macsec is validated on regular interfaces. To remove this once it is validated with PC.
-            if tbinfo["topo"]["type"] == "t2" and self.is_interface_portchannel_member(mg_facts['minigraph_portchannels'], interface):
-                return
             links[interface] = {
                 "name": neighbor["name"],
                 "host": nbrhosts[neighbor["name"]]["host"],

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -1,7 +1,7 @@
 import time
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
-from macsec_platform_helper import global_cmd
+from macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
 from macsec_helper import get_mka_session, getns_prefix
 
 
@@ -66,8 +66,15 @@ def delete_macsec_profile(host, port, profile_name):
             parents=['mac security'])
         return
 
-    cmd = "sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(getns_prefix(host, port), profile_name)
-    host.command(cmd)
+    #if port is None, the macsec profile is deleted from all namespaces if multi-asic
+    if host.is_multi_asic and port is None:
+        for ns in host.get_asic_namespace_list():
+            CMD_PREFIX = "-n {}".format(ns) if ns is not None else " "
+            cmd = "sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(CMD_PREFIX, profile_name)
+            host.command(cmd)
+    else:
+        cmd = "sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(getns_prefix(host, port), profile_name)
+        host.command(cmd)
 
 
 def enable_macsec_port(host, port, profile_name):
@@ -76,12 +83,20 @@ def enable_macsec_port(host, port, profile_name):
             lines=['mac security profile {}'.format(profile_name)],
             parents=['interface {}'.format(port)])
         return
+    
+    pc = find_portchannel_from_member(port, get_portchannel(host))
+    if pc:
+        host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
 
-    cmd = "sonic-db-cli {} CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(
-        getns_prefix(host, port), port, profile_name)
+    cmd = "sonic-db-cli {} CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(getns_prefix(host, port), port, profile_name)
     host.command(cmd)
 
-
+    if pc:
+        host.command("sudo config portchannel {} member add {} {}".format(getns_prefix(host, port), pc["name"], port))
+    
+    # wait after macsec enable 
+    time.sleep(2)
+        
 def disable_macsec_port(host, port):
     if isinstance(host, EosHost):
         host.eos_config(
@@ -89,9 +104,18 @@ def disable_macsec_port(host, port):
             parents=['interface {}'.format(port)])
         return
 
+    pc = find_portchannel_from_member(port, get_portchannel(host))
+    if pc:
+        host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
+        
     cmd = "sonic-db-cli {} CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(getns_prefix(host, port), port)
     host.command(cmd)
 
+    if pc:
+        host.command("sudo config portchannel {} member add {} {}".format(getns_prefix(host, port), pc["name"], port))
+
+    # wait after macsec disable 
+    time.sleep(2)
 
 def enable_macsec_feature(duthost, macsec_nbrhosts):
     nbrhosts = macsec_nbrhosts
@@ -125,9 +149,16 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     for dut_port, nbr in ctrl_links.items():
         disable_macsec_port(duthost, dut_port)
         disable_macsec_port(nbr["host"], nbr["port"])
-        delete_macsec_profile(nbr["host"], nbr["port"], profile_name)
         devices.add(nbr["host"])
-        delete_macsec_profile(duthost, dut_port, profile_name)
+
+    # Delete the macsec profile once after it is removed from all interfaces. if we pass port as None, 
+    # the profile is removed from the DB in all namespaces.
+    delete_macsec_profile(duthost, None, profile_name)
+
+    # Delete the macsec profile in neighbors
+    for d in devices:
+       delete_macsec_profile(d, None, profile_name) 
+
     # Waiting for all mka session were cleared in all devices
     for d in devices:
         if isinstance(d, EosHost):

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -87,11 +87,13 @@ def enable_macsec_port(host, port, profile_name):
     pc = find_portchannel_from_member(port, get_portchannel(host))
     if pc:
         host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
+        time.sleep(2)
 
     cmd = "sonic-db-cli {} CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(getns_prefix(host, port), port, profile_name)
     host.command(cmd)
 
     if pc:
+        time.sleep(2)
         host.command("sudo config portchannel {} member add {} {}".format(getns_prefix(host, port), pc["name"], port))
     
     # wait after macsec enable 
@@ -107,11 +109,13 @@ def disable_macsec_port(host, port):
     pc = find_portchannel_from_member(port, get_portchannel(host))
     if pc:
         host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
+        time.sleep(2)
         
     cmd = "sonic-db-cli {} CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(getns_prefix(host, port), port)
     host.command(cmd)
 
     if pc:
+        time.sleep(2)
         host.command("sudo config portchannel {} member add {} {}".format(getns_prefix(host, port), pc["name"], port))
 
     # wait after macsec disable 

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -82,7 +82,7 @@ class TestControlPlane():
         _, _, _, last_dut_egress_sa_table, last_dut_ingress_sa_table = get_appl_db(
             duthost, port_name, nbr["host"], nbr["port"])
         up_link = upstream_links[port_name]
-        output = duthost.command("ping {} -w {} -q -i 0.1".format(up_link["local_ipv4_addr"], rekey_period * 2))["stdout_lines"]
+        output = duthost.command("{} ping {} -w {} -q -i 0.1".format(get_ipnetns_prefix(duthost, port_name), up_link["local_ipv4_addr"], rekey_period * 2))["stdout_lines"]
         _, _, _, new_dut_egress_sa_table, new_dut_ingress_sa_table = get_appl_db(
             duthost, port_name, nbr["host"], nbr["port"])
         assert last_dut_egress_sa_table != new_dut_egress_sa_table
@@ -147,7 +147,7 @@ class TestDataPlane():
     def test_dut_to_neighbor(self, duthost, ctrl_links, upstream_links):
         for up_port, up_link in upstream_links.items():
             ret = duthost.command(
-                "ping -c {} {}".format(4, up_link['local_ipv4_addr']))
+                "{} ping -c {} {}".format(get_ipnetns_prefix(duthost, up_port), 4, up_link['local_ipv4_addr']))
             assert not ret['failed']
 
     def test_neighbor_to_neighbor(self, duthost, ctrl_links, upstream_links, nbr_device_numbers):
@@ -220,17 +220,18 @@ class TestDataPlane():
             assert up_port in ctrl_links
 
             asic = duthost.get_port_asic_instance(up_port)
+            ns = duthost.get_namespace_from_asic_id(asic.asic_index) if duthost.is_multi_asic else ''
             egress_sa_name = get_macsec_sa_name(asic, up_port, True)
             ingress_sa_name = get_macsec_sa_name(asic, up_port, False)
             if not egress_sa_name or not ingress_sa_name:
                 continue
 
-            egress_start_counters += Counter(get_macsec_counters(asic, egress_sa_name))
-            ingress_start_counters += Counter(get_macsec_counters(asic, ingress_sa_name))
+            egress_start_counters += Counter(get_macsec_counters(asic, ns, egress_sa_name))
+            ingress_start_counters += Counter(get_macsec_counters(asic, ns, ingress_sa_name))
 
         # Launch traffic
         ret = duthost.command(
-            "ping -c {} -s {} {}".format(PKT_NUM, PKT_OCTET, nbr_ip_addr))
+            "{} ping -c {} -s {} {}".format(get_ipnetns_prefix(duthost, port_name), PKT_NUM, PKT_OCTET, nbr_ip_addr))
         assert not ret['failed']
         sleep(10) # wait 10s for polling counters
 
@@ -239,13 +240,14 @@ class TestDataPlane():
         ingress_end_counters = Counter()
         for up_port in up_ports:
             asic = duthost.get_port_asic_instance(up_port)
+            ns = duthost.get_namespace_from_asic_id(asic.asic_index) if duthost.is_multi_asic else ''
             egress_sa_name = get_macsec_sa_name(asic, up_port, True)
             ingress_sa_name = get_macsec_sa_name(asic, up_port, False)
             if not egress_sa_name or not ingress_sa_name:
                 continue
 
-            egress_end_counters += Counter(get_macsec_counters(asic, egress_sa_name))
-            ingress_end_counters += Counter(get_macsec_counters(asic, ingress_sa_name))
+            egress_end_counters += Counter(get_macsec_counters(asic, ns, egress_sa_name))
+            ingress_end_counters += Counter(get_macsec_counters(asic, ns, ingress_sa_name))
 
         i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
         assert egress_end_counters[i] - egress_start_counters[i] >= PKT_NUM
@@ -350,6 +352,11 @@ class TestFaultHandling():
         disable_macsec_port(duthost, port_name)
         disable_macsec_port(nbr["host"], nbr["port"])
         delete_macsec_profile(nbr["host"], nbr["port"], profile_name)
+ 
+        # Wait till macsec session has gone down.
+        wait_until(20, 3, 0,
+            lambda: not duthost.iface_macsec_ok(port_name) and
+                    not nbr["host"].iface_macsec_ok(nbr["port"]))
 
         # Set a wrong cak to the profile
         primary_cak = "0" * len(primary_cak)
@@ -377,22 +384,22 @@ class TestInteropProtocol():
     Macsec interop with other protocols
     '''
 
-    def test_port_channel(self, duthost, ctrl_links):
+    def test_port_channel(self, duthost, profile_name, ctrl_links):
         '''Verify lacp
         '''
         ctrl_port, _ = ctrl_links.items()[0]
         pc = find_portchannel_from_member(ctrl_port, get_portchannel(duthost))
         assert pc["status"] == "Up"
 
+        disable_macsec_port(duthost, ctrl_port)
         # Remove ethernet interface <ctrl_port> from PortChannel interface <pc>
-        duthost.command("sudo config portchannel member del {} {}".format(
-            pc["name"], ctrl_port))
+        duthost.command("sudo config portchannel {} member del {} {}".format(getns_prefix(duthost, ctrl_port), pc["name"], ctrl_port))
         assert wait_until(20, 1, 0, lambda: get_portchannel(
             duthost)[pc["name"]]["status"] == "Dw")
 
+        enable_macsec_port(duthost, ctrl_port, profile_name)
         # Add ethernet interface <ctrl_port> back to PortChannel interface <pc>
-        duthost.command("sudo config portchannel member add {} {}".format(
-            pc["name"], ctrl_port))
+        duthost.command("sudo config portchannel {} member add {} {}".format(getns_prefix(duthost, ctrl_port), pc["name"], ctrl_port))
         assert wait_until(20, 1, 0, lambda: find_portchannel_from_member(
             ctrl_port, get_portchannel(duthost))["status"] == "Up")
 
@@ -433,9 +440,8 @@ class TestInteropProtocol():
         BGP_HOLDTIME = int(bgp_config["holdtime"])
         BGP_TIMEOUT = 90
 
-        def check_bgp_established(up_link):
-            command = "sonic-db-cli STATE_DB HGETALL 'NEIGH_STATE_TABLE|{}'".format(
-                up_link["local_ipv4_addr"])
+        def check_bgp_established(ctrl_port, up_link):
+            command = "sonic-db-cli {} STATE_DB HGETALL 'NEIGH_STATE_TABLE|{}'".format(getns_prefix(duthost, ctrl_port), up_link["local_ipv4_addr"])
             fact = sonic_db_cli(duthost, command)
             logger.info("bgp state {}".format(fact))
             return fact["state"] == "Established"
@@ -443,7 +449,7 @@ class TestInteropProtocol():
         # Ensure the BGP sessions have been established
         for ctrl_port in ctrl_links.keys():
             assert wait_until(BGP_TIMEOUT, 5, 0,
-                              check_bgp_established, upstream_links[ctrl_port])
+                              check_bgp_established, ctrl_port, upstream_links[ctrl_port])
 
         # Check the BGP sessions are present after port macsec disabled
         for ctrl_port, nbr in ctrl_links.items():
@@ -454,7 +460,7 @@ class TestInteropProtocol():
                         not nbr["host"].iface_macsec_ok(nbr["port"]))
             # BGP session should keep established even after holdtime
             assert wait_until(BGP_TIMEOUT, BGP_KEEPALIVE, BGP_HOLDTIME,
-                              check_bgp_established, upstream_links[ctrl_port])
+                              check_bgp_established, ctrl_port, upstream_links[ctrl_port])
 
         # Check the BGP sessions are present after port macsec enabled
         for ctrl_port, nbr in ctrl_links.items():
@@ -468,7 +474,7 @@ class TestInteropProtocol():
                 ctrl_port, get_portchannel(duthost))["status"] == "Up")
             # BGP session should keep established even after holdtime
             assert wait_until(BGP_TIMEOUT, BGP_KEEPALIVE, BGP_HOLDTIME,
-                              check_bgp_established, upstream_links[ctrl_port])
+                              check_bgp_established, ctrl_port, upstream_links[ctrl_port])
 
     def test_snmp(self, duthost, ctrl_links, upstream_links, creds):
         '''


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Improve the testcase coverage for macsec in t2 topology and multi-asic devices

Updates in this PR.

1. Update the downstream/upstream links for T2 topology
2. If port is a member of portchannel, remove from portchannel, enable/disable macsec, then add it back to portchannel
3. test_counters, test_bgp, test_dut_to_neighbor to support multi-asic 
4. test_server_to_neighbor needs both upstream and downstream neighbors. T2 linecards will either have upstream or downstream neighbors - not both. So skip for T2 toplogy.



#### How did you do it?


#### How did you verify/test it?

Tests are validated with **topo_t2_2lc_min_ports-masic** topology with ceos-macsec dockers as peer running in servers.

```
jujoseph@c3e1277334f8:~/CHASSIS/CHASSIS/sonic-mgmt-int/tests$ ./run_tests.sh -u -n vms29-t2--1 -d str2--lc1-1 -c macsec/test_macsec.py -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec --macsec_profile=256_XPN_SCI"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, allure-pytest-2.8.22, repeat-0.9.1, ansible-2.2.2
collected 15 items                                                                                                                                                                                                                                             

macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED                                                                                                                                                               [  6%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED                                                                                                                                                                                [ 13%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED                                                                                                                                                                            [ 20%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[256_XPN_SCI] SKIPPED                                                                                                                                                                       [ 26%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN_SCI] SKIPPED                                                                                                                                                                       [ 33%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN_SCI] PASSED                                                                                                                                                                           [ 40%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN_SCI] PASSED                                                                                                                                                                      [ 46%]
macsec/test_macsec.py::TestDataPlane::test_counters[256_XPN_SCI] PASSED                                                                                                                                                                                  [ 53%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN_SCI] PASSED                                                                                                                                                                             [ 60%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN_SCI] PASSED                                                                                                                                                         [ 66%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN_SCI] PASSED                                                                                                                                                                        [ 73%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN_SCI] PASSED                                                                                                                                                                                [ 80%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN_SCI] SKIPPED                                                                                                                                                                                [ 86%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN_SCI] SKIPPED                                                                                                                                                                               [ 93%]
macsec/test_macsec.py::TestDeployment::test_config_reload[256_XPN_SCI] PASSED                                                                                                                                                                            [100%]

------------------------------------------------------------------------------------- generated xml file: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [1] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/macsec/test_macsec.py:439: SKIP test_bgp for T2 topology.
SKIPPED [1] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/macsec/test_macsec.py:487: The test is for Single ASIC devices
SKIPPED [1] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/macsec/test_macsec.py:79: If the rekey period is 0 which means rekey by period isn't active.
SKIPPED [1] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/macsec/test_macsec.py:99: SKIP test_server_to_neighbor as there are no downstream neighbors.
=========================================================================================================== 11 passed, 4 skipped in 1312.68 seconds ============================================================================================================
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
