### PR TITLE
Innovium(Marvell) specific changes for everflow cases on packet verification

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -216,6 +216,9 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["mellanox"]:
             import binascii
             payload = binascii.unhexlify("0"*44) + str(payload) # Add the padding
+        elif self.asic_type in ["innovium"]:
+            import binascii
+            payload = binascii.unhexlify("0"*24) + str(payload) # Add the padding
 
         exp_pkt = testutils.simple_gre_packet(
                 eth_src = self.router_mac,
@@ -247,6 +250,9 @@ class EverflowPolicerTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "flags")
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
 
+        if self.asic_type in ["innovium"]:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
+
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "timestamp")
@@ -263,6 +269,10 @@ class EverflowPolicerTest(BaseTest):
                 pkt = scapy.Ether(pkt).load
                 pkt = pkt[22:] # Mask the Mellanox specific inner header
                 pkt = scapy.Ether(pkt)
+            elif self.asic_type in ["innovium"]:
+                pkt = scapy.Ether(pkt)[scapy.GRE].payload
+                pkt_str = str(pkt)
+                pkt = scapy.Ether(pkt_str[8:])
             elif self.asic_type == "barefoot":
                 pkt = scapy.Ether(pkt).load
             else:

--- a/ansible/roles/test/files/acstests/everflow_tb_test.py
+++ b/ansible/roles/test/files/acstests/everflow_tb_test.py
@@ -149,6 +149,8 @@ class EverflowTest(BaseTest):
             payload = str(scapy_pkt[scapy.GRE].payload)[22:]
         if self.asic_type in ["barefoot"]:
             payload = str(scapy_pkt[scapy.GRE].payload)[12:]
+        if self.asic_type in ["innovium"]:
+            payload = str(scapy_pkt[scapy.GRE].payload)[8:]
 
         inner_pkt = scapy.Ether(payload)
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -741,7 +741,7 @@ class BaseEverflowTest(object):
         if duthost.facts["asic_type"] in ["mellanox"]:
             payload = binascii.unhexlify("0" * 44) + str(payload)
 
-        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000"]:
+        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000" , "innovium"]:
             payload = binascii.unhexlify("0" * 24) + str(payload)
 
         expected_packet = testutils.simple_gre_packet(
@@ -762,7 +762,7 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "len")
         expected_packet.set_do_not_care_scapy(packet.IP, "flags")
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
-        if duthost.facts["asic_type"] in ["cisco-8000"]:
+        if duthost.facts["asic_type"] in ["cisco-8000","innovium"]:
             expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
         if not check_ttl:
             expected_packet.set_do_not_care_scapy(packet.IP, "ttl")


### PR DESCRIPTION
Signed-off-by: kbabujp kbabujp@marvell.com

Adding conditional packet verification for Everflow test cases in Innovium(Marvell) chip type

For Innovium chip type,
* Padding added for Mirror packet payload
* Mask the GRE Seq number and Innovium header

Summary:
To pass everflow cases Innovium(Marvell) chip, we need these changes.

Test utils packet verification conditional check added

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Packet verification conditional check added to pass Everflow cases in Innovium(Marvell) chip type

#### How did you do it?

#### How did you verify/test it?
Ran all the tests and it passed

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
NA
### Documentation
