### PR TITLE
Remove `active_tor_mac` from fixture `dualtor_info`

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1072,7 +1072,6 @@ def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
     res = {}
     res['ptfhost'] = ptfhost
     res['standby_tor_mac'] = standby_tor.facts['router_mac']
-    res['active_tor_mac'] = active_tor.facts['router_mac']
     vlan_name = standby_tor_mg_facts['minigraph_vlans'].keys()[0]
     res['vlan_mac'] = standby_tor.get_dut_iface_mac(vlan_name)
     res['standby_tor_ip'] = _get_iface_ip(standby_tor_mg_facts, 'Loopback0')

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -83,6 +83,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
         (48, 48)
     ]
     dualtor_meta = dualtor_info(ptfhost, upper_tor_host, lower_tor_host, tbinfo)
+    active_tor_mac = lower_tor_host.facts['router_mac']
     
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
     # Always select the first port in first LAG as src_port
@@ -94,7 +95,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
     for dscp_combination in DSCP_COMBINATIONS:
         pkt, expected_pkt = _build_testing_packet(src_ip=DUMMY_IP,
                                                   dst_ip=SERVER_IP,
-                                                  active_tor_mac=dualtor_meta['active_tor_mac'],
+                                                  active_tor_mac=active_tor_mac,
                                                   standby_tor_mac=dualtor_meta['standby_tor_mac'],
                                                   active_tor_ip=dualtor_meta['active_tor_ip'],
                                                   standby_tor_ip=dualtor_meta['standby_tor_ip'],
@@ -139,7 +140,7 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
         (48, 7)
     ]
     dualtor_meta = dualtor_info(ptfhost, upper_tor_host, lower_tor_host, tbinfo)
-    
+    active_tor_mac = lower_tor_host.facts['router_mac']
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
     # Always select the first port in first LAG as src_port
     src_port = list(t1_ports.values())[0][0]
@@ -154,7 +155,7 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
     for dscp, queue in TEST_DATA:
         pkt, _ = _build_testing_packet(src_ip=DUMMY_IP,
                                         dst_ip=SERVER_IP,
-                                        active_tor_mac=dualtor_meta['active_tor_mac'],
+                                        active_tor_mac=active_tor_mac,
                                         standby_tor_mac=dualtor_meta['standby_tor_mac'],
                                         active_tor_ip=dualtor_meta['active_tor_ip'],
                                         standby_tor_ip=dualtor_meta['standby_tor_ip'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR #5923 updated fixture `dualtor_info` to add `active_tor_mac`. However, it caused issue for some other test cases because the return dict is directly passed to `check_tunnel_balance`, and the function complained that
```
  File "/azp/agent/_work/5/s/tests/dualtor/test_orchagent_standby_tor_downstream.py", line 204, in test_standby_tor_downstream_loopback_route_readded
    check_tunnel_balance(**params)
TypeError: check_tunnel_balance() got an unexpected keyword argument 'active_tor_mac'
```
This PR addressed the issue by removing `active_tor_mac` from the fixture. The variable is added for test case `test_encap_dscp_rewrite` and `test_bounced_back_traffic_in_expected_queue`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to fix issue caused by updating fixture `dualtor_info`.

#### How did you do it?
Remove the newly added variable `active_tor_mac` from fixture `dualtor_info`.

#### How did you verify/test it?
The change is verified by running test cases `test_standby_tor_downstream_loopback_route_readded` and `test_tunnel_qos_remap.py`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
