### PR TITLE
Add multi-asic support for tests in test_lag_2.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -531,9 +531,9 @@ passw_hardening/test_passw_hardening.py:
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
-    reason: "Only support t1-lag topology"
+    reason: "Only support t1-lag and t2 topology"
     conditions:
-        - "topo_name not in ['t1-lag']"
+        - "topo_name not in ['t1-lag'] and 't2' not in topo_name"
 
 pc/test_po_cleanup.py:
   skip:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -465,8 +465,12 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
     finally:
         # Recover interfaces in case of failure
         lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+        namespace_id = lag_facts['lags'][dut_lag]['po_namespace_id']
         for lag_name in test_lags:
-            asic_index = int(lag_facts['lags'][dut_lag]['po_namespace_id'])
+            if namespace_id:
+                asic_index = int(lag_facts['lags'][dut_lag]['po_namespace_id'])
+            else:
+                asic_index = DEFAULT_ASIC_ID
             asichost = duthost.asic_instance(asic_index)
             for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                 if port_info['link']['up']:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -12,7 +12,6 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.helpers.dut_ports import get_duthost_with_name
 from tests.common.config_reload import config_reload
-from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add multi-asic support for tests in test_lag_2.py
Enabling tests to run on T2 topology 
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Added multi-asic support to two test cases and their supporting methods:
    - test_lag_db_status 
    - test_lag_db_status_with_po_update
    - get_oper_status_from_db
    - get_admin_status_from_db
    - check_status_is_syncd
    - check_link_is_up

Enabling tests to run on T2 topology
    - tests_mark_conditions.yaml
    
#### How did you do it?
Get the asic_index of the portChannel under the test. 
Use the asic_index to get the appropriate asichost.
Use this asichost to preform the operations in the testcase.

#### How did you verify/test it?
Tested the two testcases on a muli asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
