### PR TITLE
Ignore two syslog messages when doing reboot/config_reload of T2 chassis with DNX chipset

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -7,6 +7,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.configlet.util.common import chk_for_pfc_wd
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,9 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         ))
 
     logger.info('reloading {}'.format(config_source))
+
+    # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
+    ignore_t2_syslog_msgs(duthost)
 
     if config_source == 'minigraph':
         if start_dynamic_buffer and duthost.facts['asic_type'] == 'mellanox':

--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -55,7 +55,7 @@ class DutHosts(object):
 
         """
         # TODO: Initialize the nodes in parallel using multi-threads?
-        self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname)
+        self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname, self, tbinfo['topo']['type'])
                                   for hostname in tbinfo["duts"] if hostname in duts])
         self.supervisor_nodes = self._Nodes([node for node in self.nodes if node.is_supervisor_node()])
         self.frontend_nodes = self._Nodes([node for node in self.nodes if node.is_frontend_node()])

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -23,13 +23,16 @@ class MultiAsicSonicHost(object):
 
     _DEFAULT_SERVICES = ["pmon", "snmp", "lldp", "database"]
 
-    def __init__(self, ansible_adhoc, hostname):
+    def __init__(self, ansible_adhoc, hostname, duthosts, topo_type):
         """ Initializing a MultiAsicSonicHost.
 
         Args:
             ansible_adhoc : The pytest-ansible fixture
             hostname: Name of the host in the ansible inventory
         """
+        self.duthosts = duthosts
+        self.topo_type = topo_type
+        self.loganalyzer = None
         self.sonichost = SonicHost(ansible_adhoc, hostname)
         self.asics = [SonicAsic(self.sonichost, asic_index) for asic_index in self.sonichost.facts[ASICS_PRESENT]]
 
@@ -44,6 +47,7 @@ class MultiAsicSonicHost(object):
                     self.backend_asics.append(asic)
 
         self.critical_services_tracking_list()
+
 
     def __str__(self):
         return '<MultiAsicSonicHost {}>'.format(self.hostname)

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -280,3 +280,28 @@ def verify_orchagent_running_or_assert(duthost):
         wait_until(120, 10, 0, _orchagent_running),
         "Orchagent is not running"
     )
+
+
+def ignore_t2_syslog_msgs(duthost):
+
+    """
+        When we reboot / config_reload on T2 chassis cards, we see 2 error messages in the linecards
+
+        1) During config_reload/reboot of linecard, LAGS are deleted, but ports are up,
+        and we get mac learning events from SAI to orchagent which is in middle of cleanup and doesn't have the right data.
+        This causes error message like Failed to get port by bridge port ID
+
+        2) reboot/config_reload on supoervisor  will cause all the fabric links in the linecard to
+        bounce which results in SAI sending messages orchagent regarding the fabric port state change.
+        However, in linecards in T2 chassis, there is modelling of fabric ports in orchagent. Thus, orchagent generates
+        error message indication to port object found for the port.
+        Please see https://github.com/Azure/sonic-buildimage/issues/9033 for details.
+    """
+    if duthost.topo_type == "t2" and duthost.facts.get('platform_asic') == "broadcom-dnx":
+        ignoreRegex = [".*orchagent.*Failed to get port by bridge port ID.*"]
+        if duthost.is_supervisor_node():
+            ignoreRegex.extend([".*orchagent.*Failed to get port object for port id.*"])
+        for a_dut in duthost.duthosts.frontend_nodes:
+            # DUT's loganalyzer would be null if we have disable_loganalyzer specified
+            if a_dut.loganalyzer:
+                a_dut.loganalyzer.ignore_regex.extend(ignoreRegex)

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -72,6 +72,7 @@ class LogAnalyzerError(Exception):
 class LogAnalyzer:
     def __init__(self, ansible_host, marker_prefix, dut_run_dir="/tmp", start_marker=None, additional_files={}):
         self.ansible_host = ansible_host
+        ansible_host.loganalyzer = self
         self.dut_run_dir = dut_run_dir
         self.extracted_syslog = os.path.join(self.dut_run_dir, "syslog")
         self.marker_prefix = marker_prefix.replace(' ', '_')

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -7,6 +7,7 @@ import os
 from multiprocessing.pool import ThreadPool
 from collections import deque
 from .utilities import wait_until, get_plt_reboot_ctrl
+from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,9 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
 
     dut_datetime = duthost.get_now_time()
     DUT_ACTIVE.clear()
+
+    # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
+    ignore_t2_syslog_msgs(duthost)
 
     if reboot_type != REBOOT_TYPE_POWEROFF:
         reboot_res = pool.apply_async(execute_reboot_command)

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -440,7 +440,6 @@ class TestModuleApi(PlatformApiTestBase):
         # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
         ignore_t2_syslog_msgs(duthosts[enum_rand_one_per_hwsku_hostname])
 
-        support_reboot_other_modules = self.get_module_facts(duthosts[enum_rand_one_per_hwsku_hostname], True, "reboot_other_modules")
         for mod_idx in range(self.num_modules):
             mod_name = module.get_name(platform_api_conn, mod_idx)
             if mod_name in self.skip_mod_list:

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -8,6 +8,7 @@ from tests.common.helpers.platform_api import chassis, module
 from tests.platform_tests.cli.util import get_skip_mod_list
 from platform_api_test_base import PlatformApiTestBase
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -435,6 +436,11 @@ class TestModuleApi(PlatformApiTestBase):
     def test_reboot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         reboot_type = 'default'
         reboot_timeout = 300
+
+        # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
+        ignore_t2_syslog_msgs(duthosts[enum_rand_one_per_hwsku_hostname])
+
+        support_reboot_other_modules = self.get_module_facts(duthosts[enum_rand_one_per_hwsku_hostname], True, "reboot_other_modules")
         for mod_idx in range(self.num_modules):
             mod_name = module.get_name(platform_api_conn, mod_idx)
             if mod_name in self.skip_mod_list:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Ignore two syslog messages when doing reboot/config_reload of T2 chassis with DNX chipset

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When we reboot / config_reload on T2 chassis cards, we see 2 error messages in the linecards

1) During config_reload/reboot of linecard, LAGS are deleted, but ports are up,
and we get mac learning events from SAI to orchagent which is in middle of cleanup and doesn't have the right data.
This causes error message like Failed to get port by bridge port ID

2) reboot/config_reload on supoervisor  will cause all the fabric links in the linecard to
bounce which results in SAI sending messages orchagent regarding the fabric port state change.
However, in linecards in T2 chassis, there is modelling of fabric ports in orchagent. Thus, orchagent generates
error message indication to port object found for the port.

#### How did you do it?
Created ignore_t2_syslog_msgs method in dut_utils.py
Called the method in cases when we do rebbot or reload
    - tests/common/config_reload.py
    - tests/common/reboot.py
    - tests/platform_tests/api/test_module.py
    
#### How did you verify/test it?
Tested the reboot/reload testcases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
