### PR TITLE
Adds a function to get the number of healthy PSUs in a device

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -155,6 +155,25 @@ def get_psu_num(dut):
 
     return psu_num
 
+def get_healthy_psu_num(duthost):
+    """
+        @Summary: get number of healthy PSUs
+        @param: DUT host instance
+        @return: Number of healthy PSUs
+    """
+    PSUUTIL_CMD = "sudo psuutil status"
+    healthy_psus = 0
+    psuutil_status_output = duthost.command(PSUUTIL_CMD)
+    pdb.set_trace()
+
+    psus_status = psuutil_status_output["stdout_lines"][2:]
+    for iter in psus_status:
+        fields = iter.split()
+        if fields[2] == 'OK':
+            healthy_psus += 1
+
+    return healthy_psus
+
 
 def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
     """
@@ -219,7 +238,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
-    psu_num = get_psu_num(duthost)
+    psu_num = get_healthy_psu_num(duthost)
     pytest_require(psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
 
     logging.info("Create PSU controller for testing")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This commit adds a function to check the status of PSUs and presenting the number of healthy PSUs

Summary:
The issue of non-healthy PSUs is fixed by querying the device for the status of each PSU and only adding it to the list of healthy PSUs if that PSU's status is 'OK'.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911
- [ x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested it on the Celestica device that was previously failing and saw that the test passed with this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
