### PR TITLE
Fix netns_mgmt_ip_addr issue of vm_topology caused by bad cherry-pick

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -843,56 +843,6 @@ class VMTopology(object):
                     vlan_id = self.vlan_ids[str(intf)]
                     self.add_dut_vlan_subif_to_docker(ptf_if, vlan_separator, vlan_id)
 
-    def enable_netns_loopback(self):
-        """Enable loopback device in the netns."""
-        VMTopology.cmd("ip netns exec %s ifconfig lo up" % self.netns)
-
-    def setup_netns_source_routing(self):
-        """Setup policy-based routing to forward packet to its igress ports."""
-
-        def get_existing_rt_tables():
-            """Get existing routing tables."""
-            rt_tables = {}
-            with open(RT_TABLE_FILEPATH) as fd:
-                for line in fd.readlines():
-                    if line.startswith("#"):
-                        continue
-                    fields = line.split()
-                    if fields and len(fields) == 2:
-                        rt_tables[int(fields[0])] = fields[1]
-            return rt_tables
-
-        # NOTE: routing tables are visible to all network namespaces, but the route entries in one
-        # routing table created in one network namespace are not visible to other network namespaces.
-        # For the policy based routing applied to each netns, for each interface, there is a routing
-        # table correspondinly with the same name. And this routing table could be shared across multiple
-        # network namespaces, each network namespace has its own route entries stored on this routing
-        # table.
-        rt_tables = get_existing_rt_tables()
-        slot_start_index = 100
-
-        for i, intf in enumerate(self.host_interfaces):
-            is_active_active = intf in self.host_interfaces_active_active
-            if self._is_multi_duts and not self._is_cable and isinstance(intf, list) and is_active_active:
-                host_ifindex = intf[0][2] if len(intf[0]) == 3 else i
-                ns_if = NETNS_IFACE_TEMPLATE % host_ifindex
-                if not VMTopology.intf_exists(ns_if, netns=self.netns):
-                    raise RuntimeError("Interface %s not exists in netns %s" % (ns_if, self.netns))
-                rt_slot = slot_start_index + int(host_ifindex)
-                if rt_slot > 252:
-                    raise RuntimeError("Kernel only supports up to 252 additional routing tables")
-                rt_name = ns_if
-                ns_if_addr = ipaddress.ip_interface(self.mux_cable_facts[host_ifindex]["soc_ipv4"].decode())
-                gateway_addr = str(ns_if_addr.network.network_address + 1)
-                if rt_slot not in rt_tables:
-                    # add route table mapping, use interface name as route table name
-                    VMTopology.cmd("ip netns exec %s echo \"%s\t%s\n\" >> /etc/iproute2/rt_tables" % (self.netns, rt_slot, rt_name), shell=True, split_cmd=False)
-                VMTopology.cmd("ip netns exec %s ip rule add iif %s table %s" % (self.netns, ns_if, rt_name))
-                VMTopology.cmd("ip netns exec %s ip rule add from %s table %s" % (self.netns, ns_if_addr.ip, rt_name))
-                VMTopology.cmd("ip netns exec %s ip route flush table %s" % (self.netns, rt_name))
-                VMTopology.cmd("ip netns exec %s ip route add %s dev %s table %s" % (self.netns, ns_if_addr.network, ns_if, rt_name))
-                VMTopology.cmd("ip netns exec %s ip route add default via %s dev %s table %s" % (self.netns, gateway_addr, ns_if, rt_name))
-
     def remove_host_ports(self):
         """
         remove dut port from the ptf docker
@@ -1069,7 +1019,7 @@ class VMTopology(object):
 
         # Reached max retry, fail with exception
         err_msg = 'ret_code=%d, error message="%s". cmd="%s%s"' \
-            % (ret_code, err, cmdline_ori, ' | ' + grep_cmd_ori if grep_cmd_ori else '')
+            % (ret_code, err, cmdline, ' | ' + grep_cmd if grep_cmd else '')
         raise Exception(err_msg)
 
     @staticmethod
@@ -1341,7 +1291,6 @@ def main():
             ptf_mgmt_ip_gw = module.params['ptf_mgmt_ip_gw']
             ptf_mgmt_ipv6_gw = module.params['ptf_mgmt_ipv6_gw']
             mgmt_bridge = module.params['mgmt_bridge']
-            netns_mgmt_ip_addr = module.params['netns_mgmt_ip_addr']
 
             # Add management port to PTF docker and configure IP
             net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr, ptf_mgmt_ipv6_gw)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
While PR #6020 was cherry-picked to the 202012 branch, conflicts were
not properly resolved and caused issue like below during `refresh-dut`:

```
TASK [vm_set : Bind topology t1-lag to VMs. base vm = VM0104] ******************
Thursday 28 July 2022  19:24:21 +0000 (0:00:50.959)       0:05:28.314 *********
fatal: [STR-ACS-VSERV-01]: FAILED! => {"changed": false, "msg": "'netns_mgmt_ip_addr'"}
```

This PR is to fix the issue introduced by conflicts resolving during cherry-pick.

#### How did you do it?
* Removed master branch only code
* Fixed the variable name issue in the `cmd` method.

#### How did you verify/test it?
Tested `add-topo`, `remove-topo` and `refresh-dut`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
