### PR TITLE
Adding cisco-8000 to the list of platforms for forward action.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -692,7 +692,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     def set_traffic_action(self, duthost, action):
         action = action if action != "dontcare" else "drop"
-        if duthost.facts["asic_type"] == "mellanox":
+        if duthost.facts["asic_type"] in ["mellanox", "cisco-8000"]:
             self.rx_action = "forward"
         else:
             self.rx_action = action

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -292,7 +292,7 @@ class SendVerifyTraffic(object):
             tx_action = "forward"
             wd_action = "forward"
 
-        if dut.facts['asic_type'] == 'mellanox':
+        if dut.facts['asic_type'] in ['mellanox', 'cisco-8000']:
             rx_action = "forward"
 
         logger.info("--- Verify PFCwd function for pfcwd action {}, Tx traffic {}, Rx traffic {} ---".format(wd_action, tx_action, rx_action))


### PR DESCRIPTION
For cisco-8000 platforms, set forward action on Rx in presence of pfc-wd
Change is made after: https://github.com/sonic-net/sonic-mgmt/pull/5665