### PR TITLE
[202012][kvmtest] remove non-existing test files from pr test list

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -152,14 +152,10 @@ test_t0() {
       tests="\
       generic_config_updater/test_aaa.py \
       generic_config_updater/test_bgpl.py \
-      generic_config_updater/test_bgp_prefix.py \
-      generic_config_updater/test_bgp_speaker.py \
       generic_config_updater/test_cacl.py \
       generic_config_updater/test_dhcp_relay.py \
-      generic_config_updater/test_eth_interface.py \
       generic_config_updater/test_ipv6.py \
       generic_config_updater/test_lo_interface.py \
-      generic_config_updater/test_monitor_config.py \
       generic_config_updater/test_portchannel_interface.py \
       generic_config_updater/test_syslog.py \
       generic_config_updater/test_vlan_interface.py \


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
buildimage 202012 PR test failing because some test files are not existing in 202012 branch.

#### How did you do it?
Remove these test files from PR test list

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

