### PR TITLE
[dualtor]: Resolve neighbor after neighbor removal

### DIFF
--- a/ansible/roles/test/files/acstests/router_utils.py
+++ b/ansible/roles/test/files/acstests/router_utils.py
@@ -4,7 +4,6 @@ import ptf.dataplane as dataplane
 
 from ptf.testutils import *
 from ptf.mask import Mask
-import ipaddress
 
 import pprint
 import ipaddress

--- a/ansible/roles/test/files/ptftests/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/pfc_pause_test.py
@@ -7,7 +7,6 @@ import random
 import socket
 import sys
 import struct
-import ipaddress
 import re
 
 import ptf

--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -4,7 +4,6 @@ import random
 import socket
 import sys
 import struct
-import ipaddress
 import re
 
 import ptf

--- a/ansible/roles/test/files/ptftests/py3/fg_ecmp_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fg_ecmp_test.py
@@ -17,7 +17,6 @@ import random
 import time
 import os
 import json
-import ipaddress
 
 import ptf
 import ptf.packet as scapy

--- a/ansible/roles/test/files/ptftests/vnet_vxlan.py
+++ b/ansible/roles/test/files/ptftests/vnet_vxlan.py
@@ -23,9 +23,8 @@ from ptf.dataplane import match_exp_pkt
 from ptf.mask import Mask
 import datetime
 import subprocess
-import ipaddress
 from pprint import pprint
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address, ip_network, IPv4Address, IPv6Address
 
 class VNET(BaseTest):
     def __init__(self):
@@ -361,7 +360,7 @@ class VNET(BaseTest):
                 tcp_dport=5000)
             udp_sport = 1234 # Use entropy_hash(pkt)
             udp_dport = self.vxlan_port
-            if isinstance(ip_address(test['host']), ipaddress.IPv4Address):
+            if isinstance(ip_address(test['host']), IPv4Address):
                 vxlan_pkt = simple_vxlan_packet(
                     eth_dst=self.dut_mac,
                     eth_src=self.random_mac,
@@ -374,7 +373,7 @@ class VNET(BaseTest):
                     vxlan_vni=int(test['vni']),
                     with_udp_chksum=False,
                     inner_frame=pkt)
-            elif isinstance(ip_address(test['host']), ipaddress.IPv6Address):
+            elif isinstance(ip_address(test['host']), IPv6Address):
                 vxlan_pkt = simple_vxlanv6_packet(
                     eth_dst=self.dut_mac,
                     eth_src=self.random_mac,
@@ -452,7 +451,7 @@ class VNET(BaseTest):
                 tcp_dport=5000)
             udp_sport = 1234 # Use entropy_hash(pkt)
             udp_dport = self.vxlan_port
-            if isinstance(ip_address(test['host']), ipaddress.IPv4Address):
+            if isinstance(ip_address(test['host']), IPv4Address):
                 encap_pkt = simple_vxlan_packet(
                     eth_src=self.dut_mac,
                     eth_dst=self.random_mac,
@@ -466,7 +465,7 @@ class VNET(BaseTest):
                     vxlan_vni=vni,
                     inner_frame=exp_pkt)
                 encap_pkt[IP].flags = 0x2
-            elif isinstance(ip_address(test['host']), ipaddress.IPv6Address):
+            elif isinstance(ip_address(test['host']), IPv6Address):
                 encap_pkt = simple_vxlanv6_packet(
                     eth_src=self.dut_mac,
                     eth_dst=self.random_mac,
@@ -484,7 +483,7 @@ class VNET(BaseTest):
             masked_exp_pkt = Mask(encap_pkt)
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-            if isinstance(ip_address(test['host']), ipaddress.IPv4Address):
+            if isinstance(ip_address(test['host']), IPv4Address):
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
             else:
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1219,17 +1219,18 @@ def build_packet_to_server(duthost, ptfadapter, target_server_ip):
 
 
 @contextlib.contextmanager
-def crm_neighbor_checker(duthost):
+def crm_neighbor_checker(duthost, ip_version="ipv4", expect_change=False):
+    resource_name = "{}_neighbor".format(ip_version)
     crm_facts_before = duthost.get_crm_facts()
-    ipv4_neighbor_before = crm_facts_before["resources"]["ipv4_neighbor"]["used"]
-    logging.info("ipv4 neighbor before test: %s", ipv4_neighbor_before)
+    neighbor_before = crm_facts_before["resources"][resource_name]["used"]
+    logging.info("{} neighbor before test: {}".format(ip_version, neighbor_before))
     yield
     time.sleep(crm_facts_before["polling_interval"])
     crm_facts_after = duthost.get_crm_facts()
-    ipv4_neighbor_after = crm_facts_after["resources"]["ipv4_neighbor"]["used"]
-    logging.info("ipv4 neighbor after test: %s", ipv4_neighbor_after)
-    if ipv4_neighbor_after != ipv4_neighbor_before:
-        raise ValueError("ipv4 neighbor differs, before %s, after %s", ipv4_neighbor_before, ipv4_neighbor_after)
+    neighbor_after = crm_facts_after["resources"][resource_name]["used"]
+    logging.info("{} neighbor after test: {}".format(ip_version, neighbor_after))
+    if neighbor_after != neighbor_before and not expect_change:
+        raise ValueError("{} neighbor differs, before {}, after {}".format(ip_version, neighbor_before, neighbor_after))
 
 
 def get_ptf_server_intf_index(tor, tbinfo, iface):

--- a/tests/common/plugins/test_completeness/__init__.py
+++ b/tests/common/plugins/test_completeness/__init__.py
@@ -39,7 +39,7 @@ class CompletenessLevel(enum.IntEnum):
         Returns:
             CompletenessLevel as a string
         """
-        if type(level) is not CompletenessLevel:
+        if not isinstance(level, CompletenessLevel):
             logging.error("Invalid completeness type. Expected: {}. Format {}".format(str(CompletenessLevel), type(level))) 
         level_name = level.name.lower()
         return level_name

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -85,7 +85,7 @@ def test_active_tor_remove_neighbor_downstream_active(
                 yield
         finally:
             ptfhost.shell("supervisorctl start %s" % neighbor_advertise_process)
-            duthost.shell("timeout 0.2 ping -c1 -W1 -i0 -n -q {} || true".format(server_ip))
+            duthost.shell("docker exec -it swss supervisorctl restart arp_update")
 
     try:
         removed_neighbor = {}

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -55,7 +55,7 @@ def testbed_setup(ip_version, ptfhost, rand_selected_dut, rand_unselected_dut, t
 def test_active_tor_remove_neighbor_downstream_active(
     conn_graph_facts, ptfadapter, ptfhost, testbed_setup,
     rand_selected_dut, tbinfo,
-    set_crm_polling_interval,
+    require_mocked_dualtor, set_crm_polling_interval,
     tunnel_traffic_monitor, vmhost
 ):
     """


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-buildimage/issues/10920

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
https://github.com/Azure/sonic-swss/pull/2137 changed the expected behavior for this test. Previously, the test sequence was as follows:

1. Test sends traffic to server address with arp_responder running, kernel performs neighbor discovery and is able to resolve the neighbor IP and program it to the hardware
2. Test stops arp_responder and removes the neighbor entry, then sends more traffic to the same server address. Because arp_responder is stopped, the neighbor is unresolvable and the ToR will have failed neighbor entries for the server IP in both the kernel and hardware.
3. Test restarts arp_responder and sends more traffic to the same server address. The kernel will perform neighbor discovery here and is able to resolve the neighbor since arp_responder is running.

After the above PR, in step 2 of the test sequence orchagent will program a tunnel route for the server IP in the hardware but leave the failed neighbor entry in the kernel. This means that in step 3 when the test sends more traffic, the tunnel route causes the kernel's neighbor discovery mechanism to be bypassed.

#### How did you do it?
After restarting arp_responder, also restart arp_update to force the kernel to resolve the neighbor. 

Also, improve the test case cleanup

#### How did you verify/test it?
Run the test case and verify that it passes. 

Note: LogAnalyzer may fail for this test case because of the route check script - this is expected until the route check script can be fixed to accommodate the above PR.

Will not pass until https://github.com/sonic-net/sonic-buildimage/pull/11615 is merged

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
