### PR TITLE
[kvm]Avoid running ebtables test in KVM

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -113,7 +113,6 @@ test_t0() {
       container_checker/test_container_checker.py \
       cacl/test_cacl_application.py \
       cacl/test_cacl_function.py \
-      cacl/test_ebtables_application.py \
       dhcp_relay/test_dhcp_relay.py \
       dhcp_relay/test_dhcpv6_relay.py \
       iface_namingmode/test_iface_namingmode.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Avoid running ebtables test in KVM https://github.com/Azure/sonic-buildimage/pull/11585
ebtables shouldn't be installed in KVM which blocks L2 forwarding. So removed the logic to install ebtables rules in SONiC. Hence removing the ebtables tests to be executed on KVM.

Summary:
Fixes # ([issue](https://github.com/Azure/sonic-buildimage/issues/11381))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Removed ebtables test from being executed in KVM.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
