### PR TITLE
Add test_lag_db_status and test_lag_db_status_with_po_update back

### DIFF
--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -1,3 +1,6 @@
+import logging
+
+logger = logging.getLogger(__name__)
 
 def encode_dut_port_name(dutname, portname):
     return dutname + '|' + portname
@@ -15,3 +18,10 @@ def decode_dut_port_name(dut_portname):
         dutname = None
         portname = None
     return dutname, portname
+
+def get_duthost_with_name(duthosts, dut_name):
+    for duthost in duthosts:
+        if dut_name in [ 'unknown', duthost.hostname ]:
+            return duthost
+    logger.error("Can't find duthost with name {}.".format(dut_name))
+    return

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -267,6 +267,15 @@ platform_tests/test_auto_negotiation.py:
     conditions: https://github.com/Azure/sonic-mgmt/issues/5447
 
 #######################################
+#####             pc              #####
+#######################################
+pc/test_lag_2.py::test_lag_db_status_with_po_update:
+  skip:
+    reason: "Only support t1-lag topology"
+    conditions:
+        - "topo_name not in ['t1-lag']"
+
+#######################################
 #####           qos               #####
 #######################################
 qos/test_buffer_traditional.py:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -434,7 +434,7 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
         for lag_name in test_lags:
             for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                 if not check_status_is_syncd(duthost, po_intf, port_info, lag_name):
-                    pytest.fail("{} member {}'s status {} is not synced with oper_status in state_db.".format(lag_name, po_intf))
+                    pytest.fail("{} member {}'s status is not synced with oper_status in state_db.".format(lag_name, po_intf))
 
         # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
         for lag_name in test_lags:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -10,6 +10,8 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
+from tests.common.helpers.dut_ports import get_duthost_with_name
+from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -318,3 +320,190 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, con
 
     pytest_assert(some_test_ran, "Didn't run any test.")
 
+@pytest.fixture(scope='function')
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    """
+        Ignore expected failures logs during test execution.
+
+        LAG tests are triggering following orchagent complaints but the don't cause
+        harm to DUT.
+       Args:
+            duthosts: list of DUTs.
+            rand_one_dut_hostname: Hostname of a random chosen dut
+            loganalyzer: Loganalyzer utility fixture
+    """
+    # When loganalyzer is disabled, the object could be None
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",  # Valid test_lag_db_status and test_lag_db_status_with_po_update
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+
+@pytest.fixture(scope='function')
+def teardown(duthost):
+    """Recover testbed if case of test_lag_db_status_with_po_update failed"""
+    original_lag_facts = {}
+
+    original_lag_facts[duthost.hostname] = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    yield
+    # After test, compare lag_facts to check if port status is unchanged,
+    # otherwise recover DUT by reloading minigraph
+    try:
+        original_data = original_lag_facts[duthost.hostname]
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+        for lag_name in original_data['lags'].keys():
+            for po_intf, port_info in original_data['lags'][lag_name]['po_stats']['ports'].items():
+                if port_info['link']['up'] == lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]['link']['up']:
+                    logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
+                    continue
+                else:
+                    logger.info("{}'s lag_facts is changed, original_data {}\n, lag_facts {}".format(duthost.hostname, original_data, lag_facts))
+                    raise Exception("Raise exception for config_reload in next step.")
+    except Exception as e:
+        # If port was removed from portchannel, it will throw KeyError exception, or catch exception in previous steps,
+        # reload DUT to recover it
+        logger.info("{}'s lag_facts is changed, comparison failed with exception: {}".format(duthost.hostname, repr(e)))
+        config_reload(duthost, config_source="minigraph")
+    return
+
+
+def get_oper_status_from_db(duthost, port_name):
+    """Get netdev_oper_status from state_db for interface"""
+    cmd = "redis-cli -n 6 hget \"PORT_TABLE|{}\" netdev_oper_status".format(port_name)
+    status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
+    # If PORT_TABLE in STATE_DB doesn't have key netdev_oper_status,
+    # check oper_status in APPL_DB instead. This scenario happens on 202012.
+    if not status:
+        cmd = "redis-cli -n 0 hget \"PORT_TABLE:{}\" oper_status".format(port_name)
+        status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
+    return status
+
+def get_admin_status_from_db(duthost, port_name):
+    """Get netdev_oper_status from state_db for interface"""
+    cmd = "redis-cli -n 6 hget \"PORT_TABLE|{}\" admin_status".format(port_name)
+    status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
+    # If PORT_TABLE in STATE_DB doesn't have key admin_status,
+    # check admin_status in APPL_DB instead. This scenario happens on 202012.
+    if not status:
+        cmd = "redis-cli -n 0 hget \"PORT_TABLE:{}\" admin_status".format(port_name)
+        status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
+    return status
+
+def check_status_is_syncd(duthost, po_intf, port_info, lag_name):
+    """Check if interface's status is synced with the netdev_oper_status in state_db"""
+    port_status = port_info['link']['up'] if port_info['link'] else False
+    status_from_db = True if str(get_oper_status_from_db(duthost, po_intf)) == 'up' else False
+    return status_from_db == port_status
+
+def check_link_is_up(duthost, po_intf, port_info, lag_name):
+    """Check if interface's status and the netdev_oper_status in state_db are both up"""
+    new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    port_info = new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
+    port_status = port_info['link']['up'] if port_info['link'] else False
+    oper_status_from_db = True if str(get_oper_status_from_db(duthost, po_intf)) == 'up' else False
+    admin_status_from_db = True if str(get_admin_status_from_db(duthost, po_intf)) == 'up' else False
+    return port_status and oper_status_from_db and admin_status_from_db
+
+def check_link_is_down(duthost, po_intf):
+    """Check if interface's status and the netdev_oper_status in state_db are both up"""
+    oper_status = get_oper_status_from_db(duthost, po_intf)
+    admin_status = get_admin_status_from_db(duthost, po_intf)
+
+    return str(oper_status) == 'down' and str(admin_status) == 'down'
+
+def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, ignore_expected_loganalyzer_exceptions):
+    # Test state_db status for lag interfaces
+    dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
+    logger.info("Start test_lag_db_status test on dut {} for lag {}".format(dut_name, dut_lag))
+    duthost = get_duthost_with_name(duthosts, dut_name)
+    if duthost is None:
+        pytest.fail("Failed with duthost is not found for dut name {}.".format(dut_name))
+
+    test_lags = []
+    try:
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+
+        # Test for each lag
+        if dut_lag == "unknown":
+            test_lags = lag_facts['names']
+        else:
+            pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
+            test_lags = [ dut_lag ]
+        # 1. Check if status of interface is in sync with state_db after bootup.
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                if not check_status_is_syncd(duthost, po_intf, port_info, lag_name):
+                    pytest.fail("{} member {}'s status {} is not synced with oper_status in state_db.".format(lag_name, po_intf))
+
+        # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                duthost.shutdown(po_intf)
+                # Retrieve lag_facts after shutdown interface
+                new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+                port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
+                pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf),
+                "{} member {}'s admin_status or oper_status in state_db is not down.".format(lag_name, po_intf))
+
+                # Retrieve lag_facts after no shutdown interface
+                duthost.no_shutdown(po_intf)
+                # Sometimes, it has to wait seconds for booting up interface
+                pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                    "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
+    finally:
+        # Recover interfaces in case of failure
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                if port_info['link']['up']:
+                        logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
+                        continue
+                else:
+                    logger.info("Interface {} of {} is down, no shutdown to recover it.".format(po_intf, lag_name))
+                    duthost.no_shutdown(po_intf)
+
+def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardown, enum_dut_portchannel_with_completeness_level, ignore_expected_loganalyzer_exceptions):
+    """
+    test port channel add/deletion and check interface status in state_db
+    """
+    dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
+    logger.info("Start test_lag_db_status test on dut {} for lag {}".format(dut_name, dut_lag))
+    duthost = get_duthost_with_name(duthosts, dut_name)
+    if duthost is None:
+        pytest.fail("Failed with duthost is not found for dut name {}.".format(dut_name))
+
+    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
+    # Test for each lag
+    if dut_lag == "unknown":
+        test_lags = lag_facts['names']
+    else:
+        pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
+        test_lags = [ dut_lag ]
+
+    # Check if status of interface is in sync with state_db after removing/adding member.
+    for lag_name in test_lags:
+        for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+            # 1 Remove port member from portchannel
+            asichost.config_portchannel_member(lag_name, po_intf, "del")
+
+            # 2 Shutdown this port to check if status is down
+            duthost.shutdown(po_intf)
+            pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf),
+                "{} member {}'s admin_status or oper_status in state_db is not down.".format(lag_name, po_intf))
+
+            # 3 Add this port back into portchannel and check if status is synced
+            asichost.config_portchannel_member(lag_name, po_intf, "add")
+
+            # 4 Retrieve lag_facts after shutdown interface and check if status is synced
+            new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+            port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
+            pytest_assert(wait_until(15, 1, 0, check_status_is_syncd, duthost, po_intf, port_info, lag_name), 
+                "{} member {}'s status is not synced with oper_status in state_db.".format(lag_name, po_intf))
+
+            # 5 No shutdown this port to check if status is up
+            duthost.no_shutdown(po_intf)
+            # Sometimes, it has to wait seconds for booting up interface
+            pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                "{} member {}'s admin_status or oper_status in state_db is not up.".format(lag_name, po_intf))


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add test_lag_db_status and test_lag_db_status_with_po_update back which were reverted in #6058.

#### How did you do it?
Enhance these two cases to support 202012 kvm testbed, use wait_until instead of checking interface status immediately after shutdown or no shutdown.

#### How did you verify/test it?
Verified `test_lag_db_status` and `test_lag_db_status_with_po_update` on these testbeds:

- kvm testbed with master image
- kvm testbed with 202012 image
- T0
- T1-lag
- Dualtor

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
