### PR TITLE
Use config_reload when recovering from internal interfaces that are in down state

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -36,6 +36,11 @@ def __recover_interfaces(dut, fanouthosts, result, wait_time):
             action = 'config_reload'
             continue
 
+        # If internal port is down, do 'config_reload' to recover.
+        if '-IB' in pn or '-Rec' in pn or '-BP' in pn:
+            action = 'config_reload'
+            continue
+
         fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut.hostname, port)
         if fanout and fanout_port:
             fanout.no_shutdown(fanout_port)


### PR DESCRIPTION


If internal interfaces on a linecard are down as part of sanity_check, then to recover
we should just do 'config reload' as there are no peers for this that can be bounced.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If internal ports  (inband, Recycle, or Internal) on a multi-asic box are down, then we should do a 'config reload' as part of recovery in sanity check. There are no external peers for these ports that can be bounced to bring this ports up

#### How did you do it?
When iterating through down interfaces, if they have '-IB', or '-Rec' or '-Int' then set the recovery method as config_reload

#### How did you verify/test it?
Tested against a multi-asic linecard in a T2 chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
