### PR TITLE
[masic] Add sanity and don't fail on single test for official multi-asic vs pipeline

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -282,7 +282,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -u -c "$tests" -p logs/$tgname -e --disable_loganalyzer
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -u -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
     popd
 }
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -92,6 +92,7 @@ RUNTEST_CLI_COMMON_OPTS="\
 -e --allow_recover \
 -e --completeness_level=confident"
 
+# the following option is for multi-asic testing pipeline, to not fail on 1st test failure
 MULTI_ASIC_CLI_OPTIONS=`echo $RUNTEST_CLI_COMMON_OPTS | sed 's/-q 1//g'`
 
 if [ -n "$exit_on_error" ]; then

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -270,7 +270,7 @@ test_multi_asic_t1_lag() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $MULTI_ASIC_CLI_OPTIONS -c "$tests" -p logs/$tgname -e --disable_loganalyzer
+    ./run_tests.sh $MULTI_ASIC_CLI_OPTIONS -u -c "$tests" -p logs/$tgname -e --disable_loganalyzer
     popd
 }
 
@@ -281,7 +281,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -u -c "$tests" -p logs/$tgname -e --disable_loganalyzer
     popd
 }
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -92,6 +92,8 @@ RUNTEST_CLI_COMMON_OPTS="\
 -e --allow_recover \
 -e --completeness_level=confident"
 
+MULTI_ASIC_CLI_OPTIONS=`echo $RUNTEST_CLI_COMMON_OPTS | sed 's/-q 1//g'`
+
 if [ -n "$exit_on_error" ]; then
     RUNTEST_CLI_COMMON_OPTS="$RUNTEST_CLI_COMMON_OPTS -E"
 fi
@@ -268,7 +270,7 @@ test_multi_asic_t1_lag() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
+    ./run_tests.sh $MULTI_ASIC_CLI_OPTIONS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e -u
     popd
 }
 
@@ -279,7 +281,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e -u
     popd
 }
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -270,7 +270,7 @@ test_multi_asic_t1_lag() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $MULTI_ASIC_CLI_OPTIONS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e -u
+    ./run_tests.sh $MULTI_ASIC_CLI_OPTIONS -c "$tests" -p logs/$tgname -e --disable_loganalyzer
     popd
 }
 
@@ -281,7 +281,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e -u
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer
     popd
 }
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -282,7 +282,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -u -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
     popd
 }
 


### PR DESCRIPTION
Make run test of test_multi_asic_t1_lag to not stop on first test failure, and add sanity, for official multi-asic vs azp run.
This will not change multi-asic PR check.
pipeline here:
https://dev.azure.com/mssonic/build/_build?definitionId=342&_a=summary

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. Add sainity check for multi-asic scheduled azp run, run more tests listed in test_multi_asic_t1_lag and do not stop at 1st failure test
2. This will not change multi-asic PR check


#### How did you do it?
remove 'skip_sanity' in run_tests command

#### How did you verify/test it?

#### Any platform specific information?
multi-asic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
