### PR TITLE
Adding innovium(Marvell) specific changes on nhg numbers in ipfwd module

### DIFF
--- a/tests/common/innovium_data.py
+++ b/tests/common/innovium_data.py
@@ -1,0 +1,2 @@
+def is_innovium_device(dut):
+    return dut.facts["asic_type"] == "innovium"

--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.innovium_data import is_innovium_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import skip_release
 
@@ -277,6 +278,10 @@ def test_nhop(request, duthost, tbinfo):
         default_max_nhop_paths = 10
         polling_interval = 1
         sleep_time = 380
+    elif is_innovium_device(duthost):
+        default_max_nhop_paths = 3
+        polling_interval = 10
+        sleep_time = 120
     else:
         default_max_nhop_paths = 32
         polling_interval = 10
@@ -295,7 +300,7 @@ def test_nhop(request, duthost, tbinfo):
     switch_capability = dict(zip(it, it))
     max_nhop = switch_capability.get("MAX_NEXTHOP_GROUP_COUNT")
     max_nhop = nhop_group_limit if max_nhop == None else int(max_nhop)
-    if is_cisco_device(duthost):
+    if is_cisco_device(duthost) or is_innovium_device(duthost):
         crm_stat = get_crm_info(duthost, asic)
         nhop_group_count = crm_stat["available"]
     else:


### PR DESCRIPTION
### Description of PR
Signed-off-by: kbabujp [kbabujp@marvell.com](mailto:kbabujp@marvell.com)

Adding innovium(Marvell) specific changes on nh numbers in ipfwd module

Summary:
* For innovium(Marvell) chip, change the default number of NH to be used in the NHG

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Changes to Pass IPFWD module test in innovium(Marvell) chip

#### How did you do it?
Modified the default number of NH to be used in the NHG

#### How did you verify/test it?
Running all the IPFWD module test passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

