### PR TITLE
[swap_syncd] Avoid bgp idle check when bgp docker is already down

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -193,7 +193,6 @@ def _perform_swap_syncd_shutdown_check(duthost):
         if any([
             duthost.is_container_running("syncd"),
             duthost.is_container_running("swss"),
-            not duthost.is_bgp_state_idle()
         ]):
             return False
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
With the latest image, qos sai tests are failing during test setup with the following error. This is due to the changes introduced in sonic-net/sonic-buildimage#11000. Since swss docker is already stopped prior to this check, bgp docker is stopped and hence the show commands will no longer work

02/08/2022 13:14:58 utilities.wait_until                     L0113 ERROR  | Exception caught while checking ready_for_swap:Traceback (most recent call last):
  File "/azp/agent/_work/26/s/sonic-mgmt-int/tests/common/utilities.py", line 107, in wait_until
    check_result = condition(*args, **kwargs)
  File "/azp/agent/_work/26/s/sonic-mgmt-int/tests/common/system_utils/docker.py", line 186, in ready_for_swap
    not duthost.is_bgp_state_idle()
  File "/azp/agent/_work/26/s/sonic-mgmt-int/tests/common/devices/multi_asic.py", line 304, in is_bgp_state_idle
    return self.sonichost.is_bgp_state_idle()
  File "/azp/agent/_work/26/s/sonic-mgmt-int/tests/common/devices/sonic.py", line 1657, in is_bgp_state_idle
    bgp_summary = self.command("show ip bgp summary")["stdout_lines"]
  File "/azp/agent/_work/26/s/sonic-mgmt-int/tests/common/devices/base.py", line 89, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
RunAnsibleModuleFail: run module command failed, Ansible Results =>
{
    "changed": true, 
    "cmd": [
        "show", 
        "ip", 
        "bgp", 
        "summary"
    ], 
    "delta": "0:00:00.881363", 
    "end": "2022-08-02 13:14:58.004283", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "show ip bgp summary", 
            "_uses_shell": false, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "stdin_add_newline": true, 
            "strip_empty_ends": true, 
            "warn": true
        }
    }, 
    "msg": "non-zero return code", 
    "rc": 2, 
    "start": "2022-08-02 13:14:57.122920", 
    "stderr": "Usage: show ip [OPTIONS] COMMAND [ARGS]...\nTry \"show ip -h\" for help.\n\nError: No such command \"bgp\".", 
    "stderr_lines": [
        "Usage: show ip [OPTIONS] COMMAND [ARGS]...", 
        "Try \"show ip -h\" for help.", 
        "", 
        "Error: No such command \"bgp\"."
    ], 
    "stdout": "", 
    "stdout_lines": []
}

#### How did you do it?
Remove the bgp idle state check

#### How did you verify/test it?
Ran the qos sai testcase with the changes and it passed
