### PR TITLE
[tests/override_config_table] Add empty table removal test

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -161,6 +161,24 @@ def load_minigraph_with_golden_full_config(duthost, full_config):
         )
 
 
+def load_minigraph_with_golden_empty_table_removal(duthost):
+    """Test Golden Config with empty table removal.
+
+    Here we assume all config contain SYSLOG_SERVER table
+    """
+    empty_table_removal = {
+        "SYSLOG_SERVER": {
+        }
+    }
+    reload_minigraph_with_golden_config(duthost, empty_table_removal)
+
+    current_config = get_running_config(duthost)
+    pytest_assert(
+        current_config.get('SYSLOG_SERVER', None) is None,
+        "Empty table removal fail: {}".format(current_config['SYSLOG_SERVER'])
+    )
+
+
 def test_load_minigraph_with_golden_config(duthost, setup_env):
     """Test Golden Config override during load minigraph
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add E2E test for empty table removal in Golden Config
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
We should have an agreement on how Golden Config removes initial table config.
This test is to verify the empty table removal in the E2E test.
#### How did you do it?
Add E2E test for empty table removal in Golden Config.
#### How did you verify/test it?
kvm test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
