### PR TITLE
Fix cEOS duplicated mac address issue on Ubuntu 22.04

### DIFF
--- a/ansible/roles/vm_set/library/ceos_network.py
+++ b/ansible/roles/vm_set/library/ceos_network.py
@@ -103,7 +103,7 @@ class CeosNetwork(object):
             int_if (str): Internal interface of the veth pair. It is added to docker namespace.
         """
         logging.info("=== Create veth pair %s and %s. Add %s to docker with Pid %s as %s ===" %
-            (ext_if, t_int_if, int_if, self.pid, t_int_if))
+            (ext_if, t_int_if, t_int_if, self.pid, int_if))
 
         if CeosNetwork.intf_exists(ext_if) and CeosNetwork.intf_not_exists(int_if, self.pid):
             CeosNetwork.cmd("ip link del %s" % ext_if)

--- a/ansible/roles/vm_set/library/ceos_network.py
+++ b/ansible/roles/vm_set/library/ceos_network.py
@@ -50,9 +50,8 @@ OVS_FP_BRIDGE_TEMPLATE = 'br-%s-%d'
 FP_TAP_TEMPLATE = '%s-t%d'
 BP_TAP_TEMPLATE = '%s-back'
 MGMT_TAP_TEMPLATE = '%s-m'
+TMP_TAP_TEMPLATE = '%s-%d'
 INT_TAP_TEMPLATE = 'eth%d'
-
-config_module_logging('ceos_network')
 
 
 class CeosNetwork(object):
@@ -78,34 +77,37 @@ class CeosNetwork(object):
         """
         # create mgmt link
         mp_name = MGMT_TAP_TEMPLATE % (self.vm_name)
-        self.add_veth_if_to_docker(mp_name, INT_TAP_TEMPLATE % 0)
+        self.add_veth_if_to_docker(mp_name, TMP_TAP_TEMPLATE % (self.vm_name, 0), INT_TAP_TEMPLATE % 0)
         self.add_if_to_bridge(mp_name, self.mgmt_br_name)
 
         # create fp link
         for i in range(self.max_fp_num):
             fp_name = FP_TAP_TEMPLATE % (self.vm_name, i)
             fp_br_name = OVS_FP_BRIDGE_TEMPLATE % (self.vm_name, i)
-            self.add_veth_if_to_docker(fp_name, INT_TAP_TEMPLATE % (i + 1))
+            self.add_veth_if_to_docker(fp_name, TMP_TAP_TEMPLATE % (self.vm_name, (i + 1)), INT_TAP_TEMPLATE % (i + 1))
             self.add_if_to_ovs_bridge(fp_name, fp_br_name)
 
         # create backplane
-        self.add_veth_if_to_docker(BP_TAP_TEMPLATE % (self.vm_name), INT_TAP_TEMPLATE % (self.max_fp_num + 1))
+        self.add_veth_if_to_docker(
+            BP_TAP_TEMPLATE % (self.vm_name),
+            TMP_TAP_TEMPLATE % (self.vm_name, (self.max_fp_num + 1)),
+            INT_TAP_TEMPLATE % (self.max_fp_num + 1))
 
-
-    def add_veth_if_to_docker(self, ext_if, int_if):
+    def add_veth_if_to_docker(self, ext_if, t_int_if, int_if):
         """Create a pair of veth interfaces and add one of them to namespace of docker.
 
         Args:
             ext_if (str): External interface of the veth pair. It remains in host.
+            t_int_if (str): Name of peer interface of ext_if. It is firstly created in host with ext_if. Then it
+                is added to docker namespace and renamed to int_if.
             int_if (str): Internal interface of the veth pair. It is added to docker namespace.
         """
-        logging.info("=== Create veth pair %s and %s. Add %s to docker with Pid %s ===" %
-            (ext_if, int_if, int_if, self.pid))
+        logging.info("=== Create veth pair %s and %s. Add %s to docker with Pid %s as %s ===" %
+            (ext_if, t_int_if, int_if, self.pid, t_int_if))
 
         if CeosNetwork.intf_exists(ext_if) and CeosNetwork.intf_not_exists(int_if, self.pid):
             CeosNetwork.cmd("ip link del %s" % ext_if)
 
-        t_int_if = int_if + '_t'
         if CeosNetwork.intf_not_exists(ext_if):
             CeosNetwork.cmd("ip link add %s type veth peer name %s" % (ext_if, t_int_if))
 
@@ -288,7 +290,9 @@ class CeosNetwork(object):
                     # Result is unexpected, need to retry
                     continue
         # Reached max retry, fail with exception
-        raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
+        msg = 'ret_code=%d, error message: "%s" cmd: "%s"' % \
+            (ret_code, err, '%s | %s' % (cmdline, grep_cmd) if grep_cmd else cmdline)
+        raise Exception(msg)
 
     @staticmethod
     def get_ovs_br_ports(bridge):
@@ -357,6 +361,8 @@ def main():
     mgmt_bridge = module.params['mgmt_bridge']
     fp_mtu = module.params['fp_mtu']
     max_fp_num = module.params['max_fp_num']
+
+    config_module_logging('ceos_net_' + vm_name)
 
     try:
         cnet = CeosNetwork(name, vm_name, mgmt_bridge, fp_mtu, max_fp_num)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If deploy a topology using cEOS, one of the step is to create veth interfaces
for the cEOS docker containers.

For example, the current steps to create backplane interfaces:

1.1 Create veth pair in host for container VM0100
      ip link add VM0100-back type veth peer name eth5
1.2 Add the eth5 interface to network namespace of container VM0100

2.1 Create veth pair in host for another container VM0101
      ip link add VM0101-back type veth peer name eth5
2.2 Add the eth5 interface to network namespace of container VM0101

As we can see that after step 1.2, eth5 is no longer in the host namespace.
Then in step 2.1 we can add another interface with same name eth5.

The problem is that on Ubuntu 22.04, mac address of eth5 created in step 2.1
will be the same as the eth5 interface created in step 1.1. Possibly
Ubuntu 22.04 is using a different algorithm for assigning mac address
to new veth interfaces. If interface name is same, then mac address
will be same too.

Because all the VMxxxx-back interfaces will be attached to a same
ovs bridge, their peer interfaces should not use same mac address.

#### How did you do it?
The fix is to create veth interfaces with unique name in host for all cEOS
containers in the beginning. Then all the interfaces in different 
cEOS have unique mac address.

#### How did you verify/test it?
Tested using 'testbed-cli.sh remove-topo' and 'testbed-cli.sh add-topo'

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
