### PR TITLE
Improve debug capability for testcase [test_ecn_during_decap_on_active]

### DIFF
--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -351,9 +351,9 @@ def test_ecn_during_decap_on_active(
     exp_ecn = exp_tos & 3
     with stop_garp(ptfhost):
         tor.shell("portstat -c")
+        tor.shell("show arp")
         ptfadapter.dataplane.flush()
-        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=1000)
-        time.sleep(1)
+        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
         tor.shell("portstat -j")
         verify_ecn_on_received_packet(ptfadapter, exp_pkt, exp_ptf_port_index, exp_ecn)
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -350,8 +350,11 @@ def test_ecn_during_decap_on_active(
     exp_tos = encapsulated_packet[IP].payload[IP].tos
     exp_ecn = exp_tos & 3
     with stop_garp(ptfhost):
+        tor.shell("portstat -c")
         ptfadapter.dataplane.flush()
-        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
+        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=1000)
+        time.sleep(1)
+        tor.shell("portstat -j")
         verify_ecn_on_received_packet(ptfadapter, exp_pkt, exp_ptf_port_index, exp_ecn)
 
 def test_ecn_during_encap_on_standby(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Improve debug capability for testcase: test_ecn_during_decap_on_active

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
The testcase(test_ecn_during_decap_on_active) results are not stable.
Sometime it will fail due to not receiving expected packets. And there is no useful debug information in log file.

#### How did you do it?
Add "portstat -c" before sending packets and add "portstat -j" after sending packets.
Add "show arp" to quickly identify which is the RX/TX port.

#### How did you verify/test it?
Manually run the testcase without Python error.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A