### PR TITLE
[chassis]: Fix bgp session check in container_checker and critical_process_mon tests

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -1,6 +1,7 @@
 """
 Test the feature of container_checker
 """
+import time
 import logging
 
 import pytest
@@ -27,8 +28,6 @@ pytestmark = [
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 30
 CONTAINER_RESTART_THRESHOLD_SECS = 180
-POST_CHECK_INTERVAL_SECS = 1
-POST_CHECK_THRESHOLD_SECS = 360
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -144,17 +143,7 @@ def post_test_check(duthost, up_bgp_neighbors):
       This function will return True if all critical processes are running and
       all BGP sessions are established. Otherwise it will return False.
     """
-    critical_proceses = wait_until(
-        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
-        check_all_critical_processes_status, duthost
-    )
-
-    bgp_check = wait_until(
-        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
-        duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"
-    )
-
-    return critical_proceses and bgp_check
+    return check_all_critical_processes_status(duthost) and duthost.check_bgp_session_state_all_asics(up_bgp_neighbors, "established")
 
 
 def postcheck_critical_processes_status(duthost, up_bgp_neighbors):

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -27,6 +27,8 @@ pytestmark = [
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 30
 CONTAINER_RESTART_THRESHOLD_SECS = 180
+POST_CHECK_INTERVAL_SECS = 1
+POST_CHECK_THRESHOLD_SECS = 360
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -44,8 +46,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     up_bgp_neighbors = {}
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        bgp_neighbors = duthost.get_bgp_neighbors()
-        up_bgp_neighbors[duthost] = [ k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established" ]
+        up_bgp_neighbors[duthost] = duthost.get_bgp_neighbors_per_asic("established")
 
     yield
     for hostname in selected_rand_one_per_hwsku_hostname:
@@ -143,7 +144,17 @@ def post_test_check(duthost, up_bgp_neighbors):
       This function will return True if all critical processes are running and
       all BGP sessions are established. Otherwise it will return False.
     """
-    return check_all_critical_processes_status(duthost) and duthost.check_bgp_session_state(up_bgp_neighbors, "established")
+    critical_proceses = wait_until(
+        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
+        check_all_critical_processes_status, duthost
+    )
+
+    bgp_check = wait_until(
+        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
+        duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"
+    )
+
+    return critical_proceses and bgp_check
 
 
 def postcheck_critical_processes_status(duthost, up_bgp_neighbors):

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -3,6 +3,7 @@ Test the feature of monitoring critical processes on 20191130 image (Monit),
 202012 and newer images (Supervisor)
 """
 from collections import defaultdict
+import time
 import logging
 
 import pytest
@@ -153,16 +154,7 @@ def post_test_check(duthost, up_bgp_neighbors):
         This function will return True if all critical processes are running and
         all BGP sessions are established. Otherwise it will return False.
     """
-    critical_proceses = wait_until(
-        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
-        check_all_critical_processes_running, duthost
-    )
-
-    bgp_check = wait_until(
-        POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
-        duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"
-    )
-    return critical_proceses and bgp_check
+    return check_all_critical_processes_running(duthost) and duthost.check_bgp_session_state_all_asics(up_bgp_neighbors, "established")
 
 
 def postcheck_critical_processes_status(duthost, up_bgp_neighbors):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/5478 Added new functions to get bgp neighbors and check bgp sessions for each asic. This was done because bgp session neighbor IP can be same for asics in a Linecard as the neighbor IP will be loopback IP of neighbor LC's ASIC. 
container_checker and process monitoring should use the new functions to get bgp neighbors and check bgp sessions.

#### How did you do it?
Modify container_checker and process monitoring to use get_bgp_neighbors_per_asic() and check_bgp_session_state_all_asics()

#### How did you verify/test it?
Verified on chassis.

Verified on multi-asic VS:
```
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-radv] SKIPPED                                                                               [ 60%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-mgmt-framework] PASSED                                                                      [ 66%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-nat] SKIPPED                                                                                [ 73%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-teamd] PASSED                                                                               [ 80%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-dhcp_relay] SKIPPED                                                                         [ 86%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-swss] PASSED                                                                                [ 93%]
container_checker/test_container_checker.py::test_container_checker[vlab-08-1-syncd] PASSED                                                                               [100%]

------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/multi_asic_t1_lag/container_checker/test_container_checker.xml -------------------------------
============================================================================ short test summary info ============================================================================
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'macsec' is skipped for testing.
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'radv' is skipped for testing.
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'nat' is skipped for testing.
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'dhcp_relay' is skipped for testing.
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'sflow' is skipped for testing.
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Container 'mux' is skipped for testing.
==================================================================== 9 passed, 6 skipped in 1126.06 seconds =====================================================================
INFO:root:Can not get Allure report URL. Please check logs
sumeenak@d38f5615ba78:/var/src/sonic-mgmt/tests$
sumeenak@d38f5615ba78:/var/src/sonic-mgmt/tests$ ./run_tests.sh -i ../ansible/veos_vtb -d vlab-08 -n vms-kvm-four-asic-t1-lag -f vtestbed.yaml -k debug -l warning -m individual -q 1 -a False -O -r -e --allow_recover -E -c 'process_monitoring/test_critical_process_monitoring.py' -p logs/multi_asic_t1_lag -e --disable_loganalyzer -e --skip_sanity -u
=== Running tests individually ===
Running: pytest process_monitoring/test_critical_process_monitoring.py --inventory ../ansible/veos_vtb --host-pattern vlab-08 --testbed vms-kvm-four-asic-t1-lag --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --maxfail=1 --log-file logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.log --junitxml=logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.xml --allow_recover --disable_loganalyzer --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================== test session starts ==============================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, forked-1.3.0, metadata-1.11.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collected 1 item                                                                                                                                                                

process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes PASSED                                                                         [100%]

------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.xml --------------------------
========================================================================== 1 passed in 760.62 seconds ===========================================================================
INFO:root:Can not get Allure report URL. Please check logs
sumeenak@d38f5615ba78:/var/src/sonic-mgmt/tests$ ./run_tests.sh -i ../ansible/veos_vtb -d vlab-08 -n vms-kvm-four-asic-t1-lag -f vtestbed.yaml -k debug -l warning -m individual -q 1 -a False -O -r -e --allow_recover -E -c 'process_monitoring/test_critical_process_monitoring.py' -p logs/multi_asic_t1_lag -e --disable_loganalyzer -e --skip_sanity -u
=== Running tests individually ===
Running: pytest process_monitoring/test_critical_process_monitoring.py --inventory ../ansible/veos_vtb --host-pattern vlab-08 --testbed vms-kvm-four-asic-t1-lag --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --maxfail=1 --log-file logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.log --junitxml=logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.xml --allow_recover --disable_loganalyzer --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
======================================================================== test session starts ========================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, forked-1.3.0, metadata-1.11.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collected 1 item                                                                                                                                                    

process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes PASSED                                                             [100%]

------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/multi_asic_t1_lag/process_monitoring/test_critical_process_monitoring.xml --------------------
==================================================================== 1 passed in 742.79 seconds =====================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
