### PR TITLE
[conditional_marker]Add param to let user have chance to dynamic update the skip reason

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -46,6 +46,14 @@ def pytest_addoption(parser):
         help="Location of your custom inventory file. "
              "If it is not specified, and inv_name not in testbed.csv, 'lab' will be used")
 
+    parser.addoption(
+        '--dynamic_update_skip_reason',
+        action='store_true',
+        dest='dynamic_update_skip_reason',
+        default=False,
+        help="Dynamically update the skip reason based on the conditions, "
+             "by default it will not use the static reason specified in the mark conditions file")
+
 
 def load_conditions(session):
     """Load the content from mark conditions file
@@ -269,10 +277,13 @@ def update_issue_status(condition_str):
     return condition_str
 
 
-def evaluate_condition(condition, basic_facts):
+def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basic_facts):
     """Evaluate a condition string based on supplied basic facts.
 
     Args:
+        dynamic_update_skip_reason(bool): Dynamically update the skip reason based on the conditions, if it is true,
+            it will update the skip reason, else will not.
+        mark_details (dict): The mark detail infos specified in the mark conditions file.
         condition (str): A raw condition string that can be evaluated using python "eval()" function. The raw condition
             string may contain issue URLs that need further processing.
         basic_facts (dict): A one level dict with basic facts. Keys of the dict can be used as variables in the
@@ -286,7 +297,10 @@ def evaluate_condition(condition, basic_facts):
 
     condition_str = update_issue_status(condition)
     try:
-        return bool(eval(condition_str, basic_facts))
+        condition_result = bool(eval(condition_str, basic_facts))
+        if condition_result and dynamic_update_skip_reason:
+            mark_details['reason'].append(condition)
+        return condition_result
     except Exception as e:
         logger.error('Failed to evaluate condition, raw_condition={}, condition_str={}'.format(
             condition,
@@ -294,13 +308,16 @@ def evaluate_condition(condition, basic_facts):
         return False
 
 
-def evaluate_conditions(conditions, basic_facts, conditions_logical_operator):
+def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, basic_facts, conditions_logical_operator):
     """Evaluate all the condition strings.
 
     Evaluate a single condition or multiple conditions. If multiple conditions are supplied, apply AND or OR
     logical operation to all of them based on conditions_logical_operator(by default AND).
 
     Args:
+        dynamic_update_skip_reason(bool): Dynamically update the skip reason based on the conditions, if it is true,
+            it will update the skip reason, else will not.
+        mark_details (dict): The mark detail infos specified in the mark conditions file.
         conditions (str or list): Condition string or list of condition strings.
         basic_facts (dict): A one level dict with basic facts. Keys of the dict can be used as variables in the
             condition string evaluation.
@@ -309,16 +326,18 @@ def evaluate_conditions(conditions, basic_facts, conditions_logical_operator):
     Returns:
         bool: True or False based on condition strings evaluation result.
     """
+    if dynamic_update_skip_reason:
+        mark_details['reason'] = []
     if isinstance(conditions, list):
         # Apply 'AND' or 'OR' operation to list of conditions based on conditions_logical_operator(by default 'AND')
         if conditions_logical_operator == 'OR':
-            return any([evaluate_condition(c, basic_facts) for c in conditions])
+            return any([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts) for c in conditions])
         else:
-            return all([evaluate_condition(c, basic_facts) for c in conditions])
+            return all([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts) for c in conditions])
     else:
         if conditions is None or conditions.strip() == '':
             return True
-        return evaluate_condition(conditions, basic_facts)
+        return evaluate_condition(dynamic_update_skip_reason, mark_details, conditions, basic_facts)
 
 
 def pytest_collection(session):
@@ -364,7 +383,7 @@ def pytest_collection_modifyitems(session, config, items):
         return
     logger.info('Available basic facts that can be used in conditional skip:\n{}'.format(
         json.dumps(basic_facts, indent=2)))
-
+    dynamic_update_skip_reason = session.config.option.dynamic_update_skip_reason
     for item in items:
         longest_matches = find_longest_matches(item.nodeid, conditions)
 
@@ -374,7 +393,7 @@ def pytest_collection_modifyitems(session, config, items):
             for match in longest_matches:
                 # match is a dict which has only one item, so we use match.values()[0] to get its value.
                 for mark_name, mark_details in list(match.values())[0].items():
-
+                    conditions_logical_operator = mark_details.get('conditions_logical_operator', 'AND').upper()
                     add_mark = False
                     if not mark_details:
                         add_mark = True
@@ -384,13 +403,18 @@ def pytest_collection_modifyitems(session, config, items):
                             # Unconditionally add mark
                             add_mark = True
                         else:
-                            conditions_logical_operator = mark_details.get('conditions_logical_operator', 'AND').upper()
-                            add_mark = evaluate_conditions(mark_conditions, basic_facts, conditions_logical_operator)
+                            add_mark = evaluate_conditions(dynamic_update_skip_reason, mark_details, mark_conditions,
+                                                           basic_facts, conditions_logical_operator)
 
                     if add_mark:
                         reason = ''
                         if mark_details:
                             reason = mark_details.get('reason', '')
+                            if isinstance(reason, list):
+                                if conditions_logical_operator == "AND":
+                                    reason = " and\n".join(reason)
+                                else:
+                                    reason = " or\n".join(reason)
 
                         if mark_name == 'xfail':
                             strict = False


### PR DESCRIPTION
In the skip mark condition file, user can specify the skip reason, but sometimes user may need to use the skip reason to do some further process, then the skip reason is not realiable since user can specify any string in the skip reason, update the skip reason with the condition when the condition is true can reflect the real skip reason.
if the --dynamic_update_skip_reason is not specified in the pytest, it will not update the skip reason, so the default behavior of this file will not be changed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add param to let user have chance to dynamic update the skip reason
Fixes # (issue) Add param to let user have chance to dynamic update the skip reason

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add param to let user have chance to dynamic update the skip reason
#### How did you do it?
Add pytest arg --dynamic_update_skip_reason, if this arg is speicified, then the skip reason will be updated in the code based on the skip condition
#### How did you verify/test it?
Run the test case which is specified to be dynamically skipped inthe condition marker file. and the skip reason is updated after  --dynamic_update_skip_reason is specified. 
#### Any platform specific information?
NO
#### Supported testbed topology if it's a new test case?
NO
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
