### PR TITLE
add snmp to plugin list so its init is run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.custom_fixtures',
                   'tests.common.dualtor',
                   'tests.decap',
+                  'tests.snmp',
                   'tests.common.plugins.allure_server',
                   'tests.common.plugins.conditional_mark')
 


### PR DESCRIPTION
Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Snmp module provided option percentage, but it can only be used when running this test alone. In order to use it in nightly alone with other tests, this module need to be added into the plugin list, so its init files can be run.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Running tests failed after adding this option, unrecognized options

#### How did you do it?
Add snmp to plugin

#### How did you verify/test it?
Run tests manually

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
