### PR TITLE
Skipping tests which is not applicable for Fabric Card [Cisco-8000]

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -237,13 +237,13 @@ class TestModuleApi(PlatformApiTestBase):
             # Ensure that we were able to obtain the minimum required type codes
             asic_type = duthost.facts["asic_type"]
             module_type = module.get_type(platform_api_conn, i)
-            if module_type == 'FABRIC-CARD' and 'cisco-8000' in duthost.facts["asic_type"]:
+            if module_type == 'FABRIC-CARD' and 'cisco-8000' in asic_type:
                 logger.info("This check is not applicable for Fabric card on cisco-8000 based chassis")
             else:
                 self.expect(set(MINIMUM_REQUIRED_TYPE_CODES_LIST) <= set(syseeprom_type_codes_list), "Module {}: Minimum required TlvInfo type codes not provided".format(i))
 
             # Ensure the base MAC address is sane
-            if module_type == 'FABRIC-CARD' and 'cisco-8000' in duthost.facts["asic_type"]:
+            if module_type == 'FABRIC-CARD' and 'cisco-8000' in asic_type:
 		logger.info("This check is not applicable for Fabric card on cisco-8000 based chassis")
             else:
                 base_mac = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR]


### PR DESCRIPTION
### Description of PR
Skipping tests which is not applicable for Fabric Card [Cisco-8000]

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Skipping tests which is not applicable for Fabric Card [Cisco-8000]

#### How did you do it?

#### How did you verify/test it?
Verified on cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
