### PR TITLE
[TestbedV2]Convert t1-lag pr test to TestbedV2

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -1,0 +1,116 @@
+t0:
+  - arp/test_arp_dualtor.py
+  - arp/test_neighbor_mac.py
+  - arp/test_neighbor_mac_noptf.py
+  - bgp/test_bgp_fact.py
+  - bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved
+  - bgp/test_bgp_speaker.py
+  - bgp/test_bgpmon.py
+  - bgp/test_bgp_update_timer.py
+  - container_checker/test_container_checker.py
+  - cacl/test_cacl_application.py
+  - cacl/test_cacl_function.py
+  - cacl/test_ebtables_application.py
+  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcpv6_relay.py
+  - generic_config_updater/test_aaa.py
+  - generic_config_updater/test_bgpl.py
+  - generic_config_updater/test_bgp_prefix.py
+  - generic_config_updater/test_bgp_speaker.py
+  - generic_config_updater/test_cacl.py
+  - generic_config_updater/test_dhcp_relay.py
+  - generic_config_updater/test_eth_interface.py
+  - generic_config_updater/test_ipv6.py
+  - generic_config_updater/test_lo_interface.py
+  - generic_config_updater/test_monitor_config.py
+  - generic_config_updater/test_ntp.py
+  - generic_config_updater/test_portchannel_interface.py
+  - generic_config_updater/test_syslog.py
+  - generic_config_updater/test_vlan_interface.py
+  - iface_namingmode/test_iface_namingmode.py
+  - lldp/test_lldp.py
+  - monit/test_monit_status.py
+  - ntp/test_ntp.py
+  - pc/test_po_cleanup.py
+  - pc/test_po_update.py
+  - platform_tests/test_advanced_reboot.py::test_warm_reboot
+  - platform_tests/test_cpu_memory_usage.py
+  - process_monitoring/test_critical_process_monitoring.py
+  - radv/test_radv_ipv6_ra.py
+  - route/test_default_route.py
+  - route/test_static_route.py
+  - show_techsupport/test_techsupport_no_secret.py
+  - snmp/test_snmp_cpu.py
+  - snmp/test_snmp_default_route.py
+  - snmp/test_snmp_interfaces.py
+  - snmp/test_snmp_lldp.py
+  - snmp/test_snmp_loopback.py
+  - snmp/test_snmp_pfc_counters.py
+  - snmp/test_snmp_queue.py
+  - ssh/test_ssh_ciphers.py
+  - ssh/test_ssh_limit.py
+  - syslog/test_syslog.py
+  - system_health/test_system_status.py
+  - tacacs/test_accounting.py
+  - tacacs/test_authorization.py
+  - tacacs/test_jit_user.py
+  - tacacs/test_ro_disk.py
+  - tacacs/test_ro_user.py
+  - tacacs/test_rw_user.py
+  - telemetry/test_telemetry.py
+  - test_features.py
+  - test_interfaces.py
+  - test_procdockerstatsd.py
+
+t0-2vlans:
+  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcpv6_relay.py
+
+t0-sonic:
+  - bgp/test_bgp_fact.py
+  - macsec/test_macsec.py
+
+dualtor:
+  - arp/test_arp_dualtor.py
+
+t1-lag:
+  - bgp/test_bgp_allow_list.py
+  - bgp/test_bgp_bbr.py
+  - bgp/test_bgp_bounce.py
+  - bgp/test_bgp_fact.py
+  - bgp/test_bgp_multipath_relax.py
+  - bgp/test_bgp_update_timer.py
+  - bgp/test_bgpmon.py
+  - bgp/test_traffic_shift.py
+  - configlet/test_add_rack.py
+  - container_checker/test_container_checker.py
+  - http/test_http_copy.py
+  - ipfwd/test_mtu.py
+  - lldp/test_lldp.py
+  - monit/test_monit_status.py
+  - pc/test_lag_2.py
+  - platform_tests/test_cpu_memory_usage.py
+  - process_monitoring/test_critical_process_monitoring.py
+  - route/test_default_route.py
+  - scp/test_scp_copy.py
+  - test_interfaces.py
+
+multi-asic-t1-lag:
+  - bgp/test_bgp_fact.py
+  - snmp/test_snmp_default_route.py
+  - snmp/test_snmp_loopback.py
+  - snmp/test_snmp_pfc_counters.py
+  - snmp/test_snmp_queue.py
+  - tacacs/test_accounting.py
+  - tacacs/test_authorization.py
+  - tacacs/test_jit_user.py
+  - tacacs/test_ro_disk.py
+  - tacacs/test_ro_user.py
+  - tacacs/test_rw_user.py
+
+multi-asic-t1-lag-pr:
+  - bgp/test_bgp_fact.py
+
+t2:
+  - test_vs_chassis_setup.py
+  - voq/test_voq_init.py

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -21,7 +21,7 @@ steps:
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 
       echo "Created test plan $TEST_PLAN_ID"
-      echo "Check $TESTBED_TOOLS_URL/$TEST_PLAN_ID for test plan status"
+      echo "Check https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID for test plan status"
       echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -31,7 +31,6 @@ steps:
     displayName: Trigger test
 
   - script: |
-      set -x
       echo "Polling Test plan"
       echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient(We will improve the indication in a short time)"
       echo "If the progress keeps as 0 for more than 1 hour, please cancel and retry this pipeline"

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -1,0 +1,55 @@
+parameters:
+- name: TOPOLOGY
+  type: string
+
+- name: POLL_INTERVAL
+  type: number
+  default: 10
+
+- name: POLL_TIMEOUT
+  type: number
+  default: 36000
+
+steps:
+  - script: |
+      set -e
+
+      pip install PyYAML
+
+      rm -f new_test_plan_id.txt
+      python ./.azure-pipelines/test_plan.py create -t ${{ parameters.TOPOLOGY }} -o new_test_plan_id.txt
+      TEST_PLAN_ID=`cat new_test_plan_id.txt`
+
+      echo "Created test plan $TEST_PLAN_ID"
+      echo "Check $TESTBED_TOOLS_URL/$TEST_PLAN_ID for test plan status"
+      echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
+    env:
+      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+      TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)
+      CLIENT_ID: $(TESTBED_TOOLS_MSAL_CLIENT_ID)
+      CLIENT_SECRET: $(TESTBED_TOOLS_MSAL_CLIENT_SECRET)
+    displayName: Trigger test
+
+  - script: |
+      set -x
+      echo "Polling Test plan"
+      echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient(We will improve the indication in a short time)"
+      echo "If the progress keeps as 0 for more than 1 hour, please cancel and retry this pipeline"
+      echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to jianquanye@microsoft.com"
+      echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
+      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID)
+    env:
+      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+    displayName: Running test
+    timeoutInMinutes: 500
+
+  - script: |
+      echo "Try to cancel test plan $TEST_PLAN_ID, cancelling finished test plan has no effect."
+      python ./.azure-pipelines/test_plan.py cancel -i $(TEST_PLAN_ID)
+    condition: always()
+    env:
+      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+      TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)
+      CLIENT_ID: $(TESTBED_TOOLS_MSAL_CLIENT_ID)
+      CLIENT_SECRET: $(TESTBED_TOOLS_MSAL_CLIENT_SECRET)
+    displayName: Cancel running test plan

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -1,0 +1,278 @@
+from __future__ import print_function, division
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import requests
+import yaml
+
+PR_TEST_SCRIPTS_FILE = "pr_test_scripts.yaml"
+
+
+def get_test_scripts(topology):
+    _self_path = os.path.abspath(__file__)
+    pr_test_scripts_file = os.path.join(os.path.dirname(_self_path), PR_TEST_SCRIPTS_FILE)
+    with open(pr_test_scripts_file) as f:
+        pr_test_scripts = yaml.safe_load(f)
+        return pr_test_scripts.get(topology, [])
+
+
+class TestPlanManager(object):
+
+    def __init__(self, url, tenant_id=None, client_id=None, client_secret=None):
+        self.url = url
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        if self.tenant_id and self.client_id and self.client_secret:
+            self._get_token()
+
+    def _get_token(self):
+        token_url = "https://login.microsoftonline.com/{}/oauth2/v2.0/token".format(self.tenant_id)
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": "api://sonic-testbed-tools-prod/.default"
+        }
+        try:
+            resp = requests.post(token_url, headers=headers, data=payload, timeout=10).json()
+            self.token = resp["access_token"]
+        except Exception as e:
+            raise Exception("Get token failed with exception: {}".format(repr(e)))
+
+    def create(self, topology, name="my_test_plan", pr_id="unknown", scripts=[], output=None):
+        tp_url = "{}/test_plan".format(self.url)
+        print("Creating test plan, topology: {}, name: {}, pr_id: {}".format(topology, name, pr_id))
+        print("Test scripts to be covered in this test plan:")
+        print(json.dumps(scripts, indent=4))
+
+        payload = json.dumps({
+            "name": name,
+            "testbed": {
+                "platform": "kvm",
+                "topology": topology,
+                "min": 1,
+                "max": 2
+            },
+            "test_option": {
+                "stop_on_failure": True,
+                "retry_times": 2,
+                "test_cases": {
+                    "features": [],
+                    "scripts": scripts,
+                    "features_exclude": [],
+                    "scripts_exclude": []
+                },
+                "common_params": [
+                ],
+                "specified_params": {
+                }
+            },
+            "extra_params":{
+                "pull_request_id": pr_id
+            },
+            "priority": 10,
+            "requester": "pull request"
+        })
+        headers = {
+            "Authorization": "Bearer {}".format(self.token),
+            "scheduler-site": "PRTest",
+            "Content-Type": "application/json"
+        }
+        resp = requests.post(tp_url, headers=headers, data=payload, timeout=10).json()
+        if not resp["success"]:
+            raise Exception("Create test plan failed with error: {}".format(resp["errmsg"]))
+
+        print("Result of creating test plan: {}".format(str(resp["data"])))
+
+        if output:
+            print("Store new test plan id to file {}".format(output))
+            with open(output, "w") as f:
+                f.write(str(resp["data"]))
+
+        return resp["data"]
+
+    def cancel(self, test_plan_id):
+
+        tp_url = "{}/test_plan/{}".format(self.url, test_plan_id)
+        cancel_url = "{}/cancel".format(tp_url)
+
+        print("Cancelling test plan at {}".format(cancel_url))
+
+        payload = json.dumps({})
+        headers = {
+            "Authorization": "Bearer {}".format(self.token),
+            "scheduler-site": "PRTest",
+            "Content-Type": "application/json"
+        }
+
+        resp = requests.post(cancel_url, headers=headers, data=payload, timeout=10).json()
+        if not resp["success"]:
+            raise Exception("Cancel test plan failed with error: {}".format(resp["errmsg"]))
+
+        print("Result of cancelling test plan at {}:".format(tp_url))
+        print(str(resp["data"]))
+
+    def poll(self, test_plan_id, interval=10, timeout=36000):
+
+        print("Polling progress and status of test plan at https://www.testbed-tools.org/scheduler/testplan/{}"\
+            .format(test_plan_id))
+        print("Polling interval: {} seconds".format(interval))
+        print("Max polling time: {} seconds".format(timeout))
+
+        poll_url = "{}/test_plan/{}".format(self.url, test_plan_id)
+        headers = {
+            "Content-Type": "application/json"
+        }
+        start_time = time.time()
+        while (time.time() - start_time) < timeout:
+            resp = requests.get(poll_url, headers=headers, timeout=10).json()
+            if not resp["success"]:
+                raise Exception("Query test plan at {} failed with error: {}".format(poll_url, resp["errmsg"]))
+
+            resp_data = resp.get("data", None)
+            if not resp_data:
+                raise Exception("No valid data in response: {}".format(str(resp)))
+
+            status = resp_data.get("status", None)
+            result = resp_data.get("result", None)
+
+            if status in ["FINISHED", "CANCELLED"]:
+                if result == "SUCCESS":
+                    print("Test plan is successfully {}. Elapsed {:.0f} seconds"\
+                        .format(status, time.time() - start_time))
+                    return
+                else:
+                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds"\
+                        .format(test_plan_id, status, result, time.time() - start_time))
+            print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds"\
+                .format(test_plan_id, status, resp_data.get("progress", 0) * 100, time.time() - start_time))
+            time.sleep(interval)
+        else:
+            raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled"\
+                .format(poll_url))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Tool for managing test plan.")
+
+    subparsers = parser.add_subparsers(
+        title="action",
+        help="Action to perform on test plan",
+        dest="action"
+    )
+
+    parser_create = subparsers.add_parser("create", help="Create new test plan.")
+    parser_create.add_argument(
+        "-t", "--topology",
+        type=str,
+        dest="topology",
+        required=True,
+        help="The test topology to be used."
+    )
+    parser_create.add_argument(
+        "-o", "--output",
+        type=str,
+        dest="output",
+        required=False,
+        help="Output id of created test plan to the specified file."
+    )
+
+    parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
+    parser_cancel = subparsers.add_parser("cancel", help="Cancel running test plan.")
+
+    for p in [parser_poll, parser_cancel]:
+        p.add_argument(
+            "-i", "--test-plan-id",
+            type=int,
+            dest="test_plan_id",
+            required=True,
+            help="Test plan id."
+        )
+
+    parser_poll.add_argument(
+        "--interval",
+        type=int,
+        required=False,
+        default=10,
+        dest="interval",
+        help="Polling interval. Default 10 seconds."
+    )
+    parser_poll.add_argument(
+        "--timeout",
+        type=int,
+        required=False,
+        default=36000,
+        dest="timeout",
+        help="Max polling time. Default 36000 seconds (10 hours)."
+    )
+
+    if len(sys.argv)==1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    auth_env = ["TENANT_ID", "CLIENT_ID", "CLIENT_SECRET"]
+    required_env = ["TESTBED_TOOLS_URL"]
+
+    if args.action in ["create", "cancel"]:
+        required_env.extend(auth_env)
+
+    env = {
+        "testbed_tools_url": os.environ.get("TESTBED_TOOLS_URL"),
+        "tenant_id": os.environ.get("TENANT_ID"),
+        "client_id": os.environ.get("CLIENT_ID"),
+        "client_secret": os.environ.get("CLIENT_SECRET"),
+    }
+    env_missing = [k.upper() for k, v in env.items() if k.upper() in required_env and not v]
+    if env_missing:
+        print("Missing required environment variables: {}".format(env_missing))
+        sys.exit(1)
+
+    try:
+        tp = TestPlanManager(
+            env["testbed_tools_url"],
+            env["tenant_id"],
+            env["client_id"],
+            env["client_secret"])
+
+        if args.action == "create":
+            pr_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+            repo = os.environ.get("BUILD_REPOSITORY_PROVIDER")
+            reason = os.environ.get("BUILD_REASON")
+            build_id = os.environ.get("BUILD_BUILDID")
+            job_name = os.environ.get("SYSTEM_JOBDISPLAYNAME")
+
+            name = "{repo}_{reason}_PR_{pr_id}_BUILD_{build_id}_JOB_{job_name}"\
+                .format(
+                    repo=repo,
+                    reason=reason,
+                    pr_id=pr_id,
+                    build_id=build_id,
+                    job_name=job_name
+                ).replace(' ', '_')
+            tp.create(
+                args.topology,
+                name=name,
+                pr_id=pr_id,
+                scripts=get_test_scripts(args.topology),
+                output=args.output
+            )
+        elif args.action == "poll":
+            tp.poll(args.test_plan_id, args.interval, args.timeout)
+        elif args.action == "cancel":
+            tp.cancel(args.test_plan_id)
+        sys.exit(0)
+    except Exception as e:
+        print("Operation failed with exception: {}".format(repr(e)))
+        sys.exit(3)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -71,11 +71,12 @@ class TestPlanManager(object):
                     "scripts_exclude": []
                 },
                 "common_params": [
+                    "--completeness_level=confident"
                 ],
                 "specified_params": {
                 }
             },
-            "extra_params":{
+            "extra_params": {
                 "pull_request_id": pr_id
             },
             "priority": 10,

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -71,7 +71,8 @@ class TestPlanManager(object):
                     "scripts_exclude": []
                 },
                 "common_params": [
-                    "--completeness_level=confident"
+                    "--completeness_level=confident",
+                    "--allow_recover"
                 ],
                 "specified_params": {
                 }
@@ -87,7 +88,13 @@ class TestPlanManager(object):
             "scheduler-site": "PRTest",
             "Content-Type": "application/json"
         }
-        resp = requests.post(tp_url, headers=headers, data=payload, timeout=10).json()
+        raw_resp = {}
+        try:
+            raw_resp = requests.post(tp_url, headers=headers, data=payload, timeout=10)
+            resp = raw_resp.json()
+        except Exception as exception:
+            raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
+                            .format(tp_url, str(raw_resp), str(exception)))
         if not resp["success"]:
             raise Exception("Create test plan failed with error: {}".format(resp["errmsg"]))
 
@@ -114,7 +121,13 @@ class TestPlanManager(object):
             "Content-Type": "application/json"
         }
 
-        resp = requests.post(cancel_url, headers=headers, data=payload, timeout=10).json()
+        raw_resp = {}
+        try:
+            raw_resp = requests.post(cancel_url, headers=headers, data=payload, timeout=10)
+            resp = raw_resp.json()
+        except Exception as exception:
+            raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
+                            .format(cancel_url, str(raw_resp), str(exception)))
         if not resp["success"]:
             raise Exception("Cancel test plan failed with error: {}".format(resp["errmsg"]))
 
@@ -134,7 +147,13 @@ class TestPlanManager(object):
         }
         start_time = time.time()
         while (time.time() - start_time) < timeout:
-            resp = requests.get(poll_url, headers=headers, timeout=10).json()
+            raw_resp = {}
+            try:
+                raw_resp = requests.get(poll_url, headers=headers, timeout=10)
+                resp = raw_resp.json()
+            except Exception as exception:
+                raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
+                                .format(poll_url, str(raw_resp), str(exception)))
             if not resp["success"]:
                 raise Exception("Query test plan at {} failed with error: {}".format(poll_url, resp["errmsg"]))
 

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -144,7 +144,7 @@ class TestPlanManager(object):
             status = resp_data.get("status", None)
             result = resp_data.get("result", None)
 
-            if status in ["FINISHED", "CANCELLED"]:
+            if status in ["FINISHED", "CANCELLED", "FAILED"]:
                 if result == "SUCCESS":
                     print("Test plan is successfully {}. Elapsed {:.0f} seconds"\
                         .format(status, time.time() - start_time))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ stages:
 - stage: Test
 
   variables:
+  - group: Testbed-Tools
   - name: inventory
     value: veos_vtb
   - name: testbed_file
@@ -76,6 +77,7 @@ stages:
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag"
     timeoutInMinutes: 360
+    condition: and(succeeded(), not(eq(variables.RUN_TEST_BY_SCHEDULER, 'YES')))
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -85,6 +87,16 @@ stages:
         ptf_name: ptf_vms6-2
         tbtype: t1-lag
         vmtype: ceos
+
+  - job:
+    displayName: "kvmtest-t1-lag by scheduler"
+    pool: sonictest
+    timeoutInMinutes: 540
+    condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
+    steps:
+    - template: .azure-pipelines/run-test-scheduler-template.yml
+      parameters:
+        TOPOLOGY: t1-lag
 
   - job:
     pool: sonictest-sonic-t0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
 
     steps:
     - script: |
-        if [ $(t1_lag_classic) == "Succeeded" ] || [ $(t1_lag_classic) == "Succeeded" ]; then
+        if [ $(resultOfClassic) == "Succeeded" ] || [ $(resultOfTestbedV2) == "Succeeded" ]; then
           echo "One or both of t1_lag_classic and t1_lag_testbedv2 passed."
           exit 0
         else

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,12 +73,10 @@ stages:
           exit 1
         fi
 
-  - job:
+  - job: t1_lag_classic
     pool: sonictest-t1-lag
-    displayName: "kvmtest-t1-lag"
+    displayName: "kvmtest-t1-lag classic"
     timeoutInMinutes: 360
-    condition: and(succeeded(), not(eq(variables.RUN_TEST_BY_SCHEDULER, 'YES')))
-
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -88,15 +86,38 @@ stages:
         tbtype: t1-lag
         vmtype: ceos
 
-  - job:
-    displayName: "kvmtest-t1-lag by scheduler"
-    pool: sonictest
+  - job: t1_lag_testbedv2
+    displayName: "kvmtest-t1-lag by TestbedV2"
+    pool:
+      vmImage: 'ubuntu-20.04'
     timeoutInMinutes: 540
     condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
         TOPOLOGY: t1-lag
+
+  - job:
+    pool:
+      vmImage: 'ubuntu-20.04'
+    displayName: "kvmtest-t1-lag"
+    dependsOn:
+    - t1_lag_classic
+    - t1_lag_testbedv2
+    condition: always()
+    variables:
+      resultOfClassic: $[ dependencies.t1_lag_classic.result ]
+      resultOfTestbedV2: $[ dependencies.t1_lag_testbedv2.result ]
+
+    steps:
+    - script: |
+        if [ $(t1_lag_classic) == "Succeeded" ] || [ $(t1_lag_classic) == "Succeeded" ]; then
+          echo "One or both of t1_lag_classic and t1_lag_testbedv2 passed."
+          exit 0
+        else
+          echo "Both t1_lag_classic and t1_lag_testbedv2 failed! Please check the detailed information."
+          exit 1
+        fi
 
   - job:
     pool: sonictest-sonic-t0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Convert t1-lag pr test to TestbedV2

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Convert the t1-lag pr test to TestbedV2, to reduce test time by distributing test cases on multi-instances.
Currently, the preparation of the testbed(add-topo, deploy-mg) is operated implicitly, before the testbed is ready, the progress of the test plan keeps 0. We will refine the progress indicator in a future release.
The conversion can be dynamically reverted by modifying an AZP library variable:
Testbed-Tools/RUN_TEST_BY_SCHEDULER : YES/NO
#### How did you do it?
Modify the pipeline yaml file.
After converting to TestbedV2, the AZP only create the test plan and poll the result of the test plan.
#### How did you verify/test it?
The pass result of this pr is the test result of this pr.
