### PR TITLE
[Qos]Fix the failure of testQosSaiHeadroomPoolSize

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -415,12 +415,12 @@ class TestQosSai(QosSaiBase):
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         testPortIps = dutConfig["testPortIps"]
 
+        if not 'hdrm_pool_size' in qosConfig.keys():
+            pytest.skip("Headroom pool size is not enabled on this DUT")
+
         if not dutConfig['dualTor']:
             qosConfig['hdrm_pool_size']['pgs'] = qosConfig['hdrm_pool_size']['pgs'][:2]
             qosConfig['hdrm_pool_size']['dscps'] = qosConfig['hdrm_pool_size']['dscps'][:2]
-
-        if not 'hdrm_pool_size' in qosConfig.keys():
-            pytest.skip("Headroom pool size is not enabled on this DUT")
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])


### PR DESCRIPTION
The test testQosSaiHeadroomPoolSize should be skipped when hdrm_pool_size is not defined in the qosConfig, the issue is introduced by PR #5947, after this PR, the hdrm_pool_size is used before checking if it is exist or not.

Change-Id: I9c4804d0b1e169aa680ec5ab27b55a417a74d977

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The test testQosSaiHeadroomPoolSize should be skipped when hdrm_pool_size is not defined in the qosConfig
Fixes # (issue) The test testQosSaiHeadroomPoolSize should be skipped when hdrm_pool_size is not defined in the qosConfig

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
The test testQosSaiHeadroomPoolSize should be skipped when hdrm_pool_size is not defined in the qosConfig
#### How did you do it?
Move the check if hdrm_pool_size is defined or not in the qosConfig before using hdrm_pool_size 
#### How did you verify/test it?
Run testQosSaiHeadroomPoolSize and it can skipped as expected
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
