### PR TITLE
Restore tacacs_server after the module tacacs/test_accounting.py running.

### DIFF
--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -2,7 +2,7 @@ import os
 import logging
 import yaml
 import pytest
-from .utils import setup_tacacs_client, setup_tacacs_server, cleanup_tacacs
+from .utils import setup_tacacs_client, setup_tacacs_server, cleanup_tacacs, restore_tacacs_server
 
 logger = logging.getLogger(__name__)
 TACACS_CREDS_FILE='tacacs_creds.yaml'
@@ -15,19 +15,18 @@ def tacacs_creds(creds_all_duts):
     creds_all_duts.update(hardcoded_creds)
     return creds_all_duts
 
-
 @pytest.fixture(scope="module")
 def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     logger.info('tacacs_creds: {}'.format(str(tacacs_creds)))
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     tacacs_server_ip = ptfhost.mgmt_ip
-    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    default_tacacs_server = setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
     cleanup_tacacs(ptfhost, tacacs_creds, duthost)
-
+    restore_tacacs_server(duthost, default_tacacs_server, tacacs_server_ip)
 
 @pytest.fixture(scope="module")
 def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -2,7 +2,7 @@ import os
 import logging
 import yaml
 import pytest
-from .utils import setup_tacacs_client, setup_tacacs_server, cleanup_tacacs, restore_tacacs_server
+from .utils import setup_tacacs_client, setup_tacacs_server, cleanup_tacacs, restore_tacacs_servers
 
 logger = logging.getLogger(__name__)
 TACACS_CREDS_FILE='tacacs_creds.yaml'
@@ -20,13 +20,13 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_cre
     logger.info('tacacs_creds: {}'.format(str(tacacs_creds)))
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     tacacs_server_ip = ptfhost.mgmt_ip
-    default_tacacs_server = setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    default_tacacs_servers = setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
     cleanup_tacacs(ptfhost, tacacs_creds, duthost)
-    restore_tacacs_server(duthost, default_tacacs_server, tacacs_server_ip)
+    restore_tacacs_servers(duthost, default_tacacs_servers, tacacs_server_ip)
 
 @pytest.fixture(scope="module")
 def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -45,14 +45,14 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     """setup tacacs client"""
 
     # configure tacacs client
-    default_tacacs_server = []
+    default_tacacs_servers = []
     duthost.shell("sudo config tacacs passkey %s" % tacacs_creds[duthost.hostname]['tacacs_passkey'])
 
     # get default tacacs servers
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     for tacacs_server in config_facts.get('TACPLUS_SERVER', {}):
         duthost.shell("sudo config tacacs delete %s" % tacacs_server)
-        default_tacacs_server.append(tacacs_server)
+        default_tacacs_servers.append(tacacs_server)
     duthost.shell("sudo config tacacs add %s" % tacacs_server_ip)
     duthost.shell("sudo config tacacs authtype login")
 
@@ -66,11 +66,11 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
 
     # setup local user
     setup_local_user(duthost, tacacs_creds)
-    return default_tacacs_server
+    return default_tacacs_servers
 
-def restore_tacacs_server(duthost, default_tacacs_server, tacacs_server_ip):
+def restore_tacacs_servers(duthost, default_tacacs_servers, tacacs_server_ip):
     duthost.shell("sudo config tacacs delete %s" % tacacs_server_ip)
-    for tacacs_server in default_tacacs_server:
+    for tacacs_server in default_tacacs_servers:
         duthost.shell("sudo config tacacs add %s" % tacacs_server)
 
 def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path, path_to_be_fix = None):

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -45,12 +45,14 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     """setup tacacs client"""
 
     # configure tacacs client
+    default_tacacs_server = []
     duthost.shell("sudo config tacacs passkey %s" % tacacs_creds[duthost.hostname]['tacacs_passkey'])
 
     # get default tacacs servers
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     for tacacs_server in config_facts.get('TACPLUS_SERVER', {}):
         duthost.shell("sudo config tacacs delete %s" % tacacs_server)
+        default_tacacs_server.append(tacacs_server)
     duthost.shell("sudo config tacacs add %s" % tacacs_server_ip)
     duthost.shell("sudo config tacacs authtype login")
 
@@ -64,6 +66,12 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
 
     # setup local user
     setup_local_user(duthost, tacacs_creds)
+    return default_tacacs_server
+
+def restore_tacacs_server(duthost, default_tacacs_server, tacacs_server_ip):
+    duthost.shell("sudo config tacacs delete %s" % tacacs_server_ip)
+    for tacacs_server in default_tacacs_server:
+        duthost.shell("sudo config tacacs add %s" % tacacs_server)
 
 def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path, path_to_be_fix = None):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `tacacs/test_accounting.py`, the fixture `check_tacacs` use the function `setup_tacacs_client` to delete the default tacacs server, and set the ptf mgmt ip as tacacs sever ip. But it doesn't restore this config when the module finish running. We want to keep the config in consistent before and after the testcase running, so fix it. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In module `tacacs/test_accounting.py`, the fixture `check_tacacs` use the function `setup_tacacs_client` to delete the default tacacs server, and set the ptf mgmt ip as tacacs sever ip. But it doesn't restore this config when the module finish running. We want to keep the config in consistent before and after the testcase running, so fix it. 

#### How did you do it?
Get the default tacacs server and put them into a list, when the module finish running, delete the ptf mgmt ipand restore the default tacacs server ip. 

#### How did you verify/test it?
Running the test cases in this module and compare the tacacs server ip before and after running. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
