### PR TITLE
Fixed dut_basic_facts ansible module to have support SONiC images which does not have attribute "is_supervisor"

### DIFF
--- a/ansible/library/dut_basic_facts.py
+++ b/ansible/library/dut_basic_facts.py
@@ -45,7 +45,9 @@ def main():
         results['num_asic'] = device_info.get_num_npus()
         results.update(device_info.get_sonic_version_info())
         results['kernel_version'] = results['kernel_version'].split('-')[0]
-        results['is_supervisor'] = device_info.is_supervisor()
+        results['is_supervisor'] = False
+        if hasattr(device_info, 'is_supervisor'):
+            results['is_supervisor'] = device_info.is_supervisor()
 
         # In case a image does not have /etc/sonic/sonic_release, guess release from 'build_version'
         if 'release' not in results or not results['release'] or results['release'] == 'none':


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed dut_basic_facts ansible module to have support SONiC images which does not have attribute "is_supervisor"

Previoulsy when we call dut_basic_facts ansible module on SONiC image which does not have attribute "is_supervisor"(for example: 202012) we received error: AttributeError(\"'module' object has no attribute 'is_supervisor'\"
Now issue fixed - script will work on all SONiC branches
Issue introduced in PR: https://github.com/sonic-net/sonic-mgmt/pull/5708

Summary: Fixed dut_basic_facts ansible module to have support SONiC images which does not have attribute "is_supervisor"
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix AttributeError(\"'module' object has no attribute 'is_supervisor'\"

#### How did you do it?
See code

#### How did you verify/test it?
Executed ansible module: dut_basic_facts

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
