### PR TITLE
[202012][loganalyzer] Ignore FDB flush unsupport error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -143,3 +143,6 @@ r, ".*ERR syncd[0-9]*#syncd.*updateSupportedBufferPoolCounters.*BUFFER_POOL_WATE
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14482841
 r, ".* ERR dhcp_relay#dhcpmon.*Invalid number of interfaces, downlink/south 1, uplink/north 0.*"
+
+# https://github.com/sonic-net/sonic-swss/pull/2401
+r, ".* ERR swss#orchagent: :- update: Unsupported FDB Flush: .*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This issue will cause some tests failed log analyzer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The message can be ignored till below PR merged.
https://github.com/sonic-net/sonic-swss/pull/2401
Raise this change because we do not have an agreement on whether the backporting is allowed. As PR owner said, this issue will affect warm-reboot. Some platforms which not supporting warm-reboot are suffered by this issue.

#### How did you do it?
Ignore the message.

#### How did you verify/test it?

```
crm/test_crm.py::test_crm_fdb_entry[str2-7215-acs-1-None] PASSED         [100%]

----------- generated xml file: /var/src/internal/tests/logs/tr.xml ------------
========================== 1 passed in 420.57 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
