### PR TITLE
[sub-interface]Use OrderedDict instead of built-in dict for ptf and dut ports in get_port() function of sub-interface test

### DIFF
--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -753,7 +753,7 @@ def get_port(duthost, ptfhost, interface_num, port_type, ports_to_exclude=None, 
 
     config_vlan_members = cfg_facts['port_index_map']
     port_status = cfg_facts['PORT']
-    config_port_indices = {}
+    config_port_indices = OrderedDict()
     for port, port_id in config_vlan_members.items():
         if ((port not in portchannel_members) and
             (not (('port_in_lag' in port_type or exclude_sub_interface_ports) and port in sub_interface_ports)) and
@@ -766,7 +766,7 @@ def get_port(duthost, ptfhost, interface_num, port_type, ports_to_exclude=None, 
     pytest_require(len(config_port_indices) == interface_num, "No port for testing")
 
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
-    ptf_ports = {}
+    ptf_ports = OrderedDict()
     for port_id in config_port_indices:
         ptf_ports[port_id] = ptf_ports_available_in_topo[port_id]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The function get_port() in tests/sub_port_interfaces/sub_ports_helpers.py is using built-in dictionary to store the dut ports and ptf ports selected for the subinterface test. However, because there's no order in the built-in dict, sometimes the dut port could be paired with a wrong ptf port,  which will cause the test to fail.
In the function get_ports() the dut ports is returned in dict and the ptf ports is returned in list of the dict values, and they are zipped in the caller to do iteration. It is not guaranteed that when zipping, the dut port is paired with the correct ptf port.
For example in tests/sub_port_interfaces/conftest.py
```
@pytest.fixture
def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_type, tbinfo):
...
...
...
    for port, ptf_port, subnet in zip(config_port_indices.values(), ptf_ports, subnets):
        for vlan_id_dut, vlan_id_ptf, net in zip(vlan_ranges_dut, vlan_ranges_ptf, subnet.subnets(new_prefix=30)):
            hosts_list = [i for i in net.hosts()]
            sub_ports_config['{}.{}'.format(port, vlan_id_dut)] = {
                'ip': '{}/{}'.format(hosts_list[0], prefix),
                'neighbor_port': '{}.{}'.format(ptf_port, vlan_id_ptf),
                'neighbor_ip': '{}/{}'.format(hosts_list[1], prefix)
            }
...
...
...
```
So need to use OrderedDict instead of built-in dictitonary to store the selected dut ports and ptf port in get_ports().


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To fix a bug in the get_ports() function in tests/sub_port_interfaces/sub_ports_helpers.py.
#### How did you do it?
Use OrderedDict instead of built-in dictionary to store the selected dut ports and ptf port in get_ports().
#### How did you verify/test it?
Run sub-interface tests on on t0-64 and t1-lag setups with 202205 image and all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
