### PR TITLE
Stop ptf container before removing it

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -50,6 +50,12 @@
       echo "-----------------------------" >> /tmp/ptf_network_{{ vm_set_name }}.log
     when: ptf_docker_info.exists
 
+  - name: Stop ptf container ptf_{{ vm_set_name }}
+    docker_container:
+      name: ptf_{{ vm_set_name }}
+      state: stopped
+    become: yes
+
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The `testbed-cli.sh` script supports an operation which is to restart
the ptf docker container. In our lab, we ran into issue that the test
server was stuck with below error after the ptf docker container
was removed:
`
Aug  9 04:25:58 server1 kernel: [329566.985211] watchdog: BUG: soft lockup - CPU#1 stuck for 23s! [swapper/1:0]
`
When the ptf docker is removed, we used the "force_kill" option. Not sure if this is too
brutal and caused issue to the server. This issue happens around once a week.
It is hard to reproduce and yet very annoying.

#### How did you do it?
This change added code to stop the ptf container before removing it. Need to
observe for some time to see if this change can fix the issue.

#### How did you verify/test it?
Tested using "testbed-cli.sh restart-ptf".

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
