### PR TITLE
Add StartTimestamp column in TestReportPipeline table

### DIFF
--- a/test_reporting/collect_azp_results.py
+++ b/test_reporting/collect_azp_results.py
@@ -20,13 +20,27 @@ def get_tasks_results(buildid):
         dict: Dict of tasks' results
     """
     task_results = {
+        "start_time": "",
         "success_tasks": "",
         "failed_tasks": "",
         "cancelled_tasks": ""
     }
-    pipeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid) + "/timeline?api-version=5.1"
-    print("Collect task results from here:{}".format(pipeline_url))
-    build_records = requests.get(pipeline_url, auth=AUTH).json()["records"]
+
+    pipeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/"+ str(buildid)
+    print("Collect pipeline startTime from here:{}".format(pipeline_url))
+    api_result = requests.get(pipeline_url, auth=AUTH)
+    starttime_str = api_result.json()["startTime"]
+
+    # Convert the time format from 2022-08-09T03:00:32.7088577Z
+    # to 2022-08-09 03:00:32.7088577
+    starttime_str = starttime_str.replace("T", " ")
+    starttime_str = starttime_str.replace("Z", "")
+    task_results["start_time"] = starttime_str
+
+    timeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid) + "/timeline?api-version=5.1"
+    print("Collect task results from here:{}".format(timeline_url))
+    api_result = requests.get(timeline_url, auth=AUTH)
+    build_records = api_result.json()["records"]
     if not build_records:
         print("Failed to get build records for buildid {}".format(buildid))
         return

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -107,22 +107,23 @@
 
 ###############################################################################
 # PIPELINE TABLE SETUP                                                        #
-# 1. Create a TestReportPipeline table to store test metadata                 #
+# 1. Create a TestReportPipeline table to store pipeline task results         #
 # 2. Add a JSON mapping for the table                                         #
 ###############################################################################
-.create table TestReportPipeline (UploadTimestamp: datetime, TrackingId: string,
+.create table TestReportPipeline (StartTimestamp: datetime, UploadTimestamp: datetime, TrackingId: string,
                                   ReportId: string, TestbedName: string,
                                   OSVersion: string, SuccessTasks: string,
                                   FailedTasks: string, CancelledTasks: string)
 
-.create table TestReportPipeline ingestion json mapping 'FlatPipelineMappingV1' @'[{"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}},'
+.create table TestReportPipeline ingestion json mapping 'FlatPipelineMappingV1' @'[{"column":"StartTimestamp","Properties":{"path":"$.start_time"}},'
+                                                                                  '{"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}},'
                                                                                   '{"column":"TrackingId","Properties":{"path":"$.tracking_id"}},'
                                                                                   '{"column":"ReportId","Properties":{"path":"$.id"}},'
                                                                                   '{"column":"TestbedName","Properties":{"path":"$.testbed"}},'
                                                                                   '{"column":"OSVersion","Properties":{"path":"$.os_version"}},'
                                                                                   '{"column":"SuccessTasks","Properties":{"path":"$.success_tasks"}},'
                                                                                   '{"column":"FailedTasks","Properties":{"path":"$.failed_tasks"}},'
-                                                                                  '{"column":"CanceledTasks","Properties":{"path":"$.cancelled_tasks"}}]'
+                                                                                  '{"column":"CancelledTasks","Properties":{"path":"$.cancelled_tasks"}}]'
 
 ###############################################################################
 # EXPECTED TEST RUNS TABLE SETUP                                              #


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add StartTimestamp column in TestReportPipeline table

#### How did you do it?
Use another API to get the start time of pipeline and upload it to Kusto.

#### How did you verify/test it?
```
python3 collect_azp_results.py 8888
python3 report_uploader.py -c "test_result" -e "vms-t0-kvm.201911#132728" -t "vms-t0-kvm" -i "http://****/sonic-broadcom.bin" results SonicTestData
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
