### PR TITLE
[GCU Testing] Remove requirement to ignore BUFFER_PORT YANG models

### DIFF
--- a/tests/generic_config_updater/gu_utils.py
+++ b/tests/generic_config_updater/gu_utils.py
@@ -10,8 +10,6 @@ logger = logging.getLogger(__name__)
 
 CONTAINER_SERVICES_LIST = ["swss", "syncd", "radv", "lldp", "dhcp_relay", "teamd", "bgp", "pmon", "telemetry", "acms"]
 DEFAULT_CHECKPOINT_NAME = "test"
-YANG_IGNORED_OPTIONS    = "-i /BUFFER_PORT_INGRESS_PROFILE_LIST -i /BUFFER_PORT_EGRESS_PROFILE_LIST"
-
 
 def generate_tmpfile(duthost):
     """Generate temp file
@@ -33,7 +31,7 @@ def apply_patch(duthost, json_data, dest_file):
     """
     duthost.copy(content=json.dumps(json_data, indent=4), dest=dest_file)
 
-    cmds = 'config apply-patch {} {}'.format(YANG_IGNORED_OPTIONS, dest_file)
+    cmds = 'config apply-patch {}'.format(dest_file)
 
     logger.info("Commands: {}".format(cmds))
     output = duthost.shell(cmds, module_ignore_errors=True)
@@ -222,7 +220,7 @@ def rollback(duthost, cp=DEFAULT_CHECKPOINT_NAME):
         duthost: Device Under Test (DUT)
         cp: rollback filename
     """
-    cmds = 'config rollback {} {}'.format(YANG_IGNORED_OPTIONS, cp)
+    cmds = 'config rollback {}'.format(cp)
 
     logger.info("Commands: {}".format(cmds))
     output = duthost.shell(cmds, module_ignore_errors=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Previously, there were errors in /BUFFER_PORT_INGRESS_PROFILE_LIST and /BUFFER_PORT_EGRESS_PROFILE_LIST YANG models. Now, those YANG models are fixed and GCU apply-patch works without ignoring those YANG models. So we remove the old requirement to ignore those two YANG models

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
It's no longer necessary to ignore /BUFFER_PORT_INGRESS_PROFILE_LIST and /BUFFER_PORT_EGRESS_PROFILE_LIST YANG models
#### How did you do it?
Remove ignore statement
#### How did you verify/test it?
Verified on physical Mellanox DUT and virtual switch
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
