### PR TITLE
Removed the superfluous pdb trace command from the get_healthy_psu_nu…

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -164,7 +164,6 @@ def get_healthy_psu_num(duthost):
     PSUUTIL_CMD = "sudo psuutil status"
     healthy_psus = 0
     psuutil_status_output = duthost.command(PSUUTIL_CMD)
-    pdb.set_trace()
 
     psus_status = psuutil_status_output["stdout_lines"][2:]
     for iter in psus_status:


### PR DESCRIPTION
…m function in test_platform_info

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR removes the unnecessary set_trace() call that was only intended for debug purposes. This is the only change made.

Summary:
Cleans up the code.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
To remove a function call intended only for debug purposes.

#### How did you do it?
N/A

#### How did you verify/test it?
N/A

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
