### PR TITLE
[bugfix] skip vlan/test_vlan_ping.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -678,6 +678,12 @@ test_pretest.py::test_stop_pfcwd:
 #######################################
 #####            vlan             #####
 #######################################
+vlan/test_vlan_ping.py:
+  skip:
+    reason: "test_vlan_ping doesn't work on Broadcom platform"
+    conditions:
+      - "asic_type in ['broadcom']"
+
 vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:
   skip:
     reason: "Unsupported platform."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr #5708 , we skip the test cases in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml. There is a merge conflict and forget to skip vlan/test_vlan_ping.py when the asic_type is broadcom. In this pr, skip this module.

Summary:
Fixes # (5708)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In pr #5708 , we skip the test cases in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml. There is a merge conflict and forget to skip vlan/test_vlan_ping.py when the asic_type is broadcom. In this pr, skip this module.

#### How did you do it?
Add the condition to skip vlan/test_vlan_ping.py.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
