### PR TITLE
[dualtor][active-active] Add testcases to cover BGP shutdown/startup

### DIFF
--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -23,9 +23,19 @@ class CableType(object):
 def cable_type(request, active_active_ports, active_standby_ports):
     """Dualtor cable type."""
     cable_type = request.param
-    has_enable_active_active_marker = bool([_ for _ in request.node.iter_markers() if _.name == "enable_active_active"])
+    has_enable_active_active_marker = False
+    skip_active_standby_marker = False
+    for marker in request.node.iter_markers():
+        if marker.name == "enable_active_active":
+            has_enable_active_active_marker = True
+        elif marker.name == "skip_active_standby":
+            skip_active_standby_marker = True
+
     if ((not has_enable_active_active_marker) and (cable_type == CableType.active_active)):
         pytest.skip("Skip cable type 'active-active'")
+
+    if skip_active_standby_marker and cable_type == CableType.active_standby:
+        pytest.skip("Skip cable type 'active-standby'")
 
     if cable_type == CableType.active_active and not active_active_ports:
         pytest.skip("Skip as no mux ports of 'active-active' cable type")

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -321,7 +321,7 @@ class DualTorIO:
 
         # use the same dst ip to ensure that packets from one server are always forwarded
         # to the same active ToR by the server NiC
-        dst_ip = self.random_host_ip()
+        dst_ips = {vlan_intf: self.random_host_ip() for vlan_intf in vlan_src_intfs}
         for i in range(self.packets_per_server):
             for vlan_intf in vlan_src_intfs:
                 ptf_src_intf = self.tor_to_ptf_intf_map[vlan_intf]
@@ -331,7 +331,7 @@ class DualTorIO:
                 packet = tcp_tx_packet_orig.copy()
                 packet[scapyall.Ether].src = eth_src
                 packet[scapyall.IP].src = server_ip
-                packet[scapyall.IP].dst = dst_ip if self.cable_type == CableType.active_active else self.random_host_ip()
+                packet[scapyall.IP].dst = dst_ips[vlan_intf] if self.cable_type == CableType.active_active else self.random_host_ip()
                 packet.load = payload
                 packet[scapyall.TCP].chksum = None
                 packet[scapyall.IP].chksum = None

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -318,6 +318,10 @@ class DualTorIO:
         )
         tcp_tx_packet_orig = scapyall.Ether(str(tcp_tx_packet_orig))
         payload_suffix = "X" * 60
+
+        # use the same dst ip to ensure that packets from one server are always forwarded
+        # to the same active ToR by the server NiC
+        dst_ip = self.random_host_ip()
         for i in range(self.packets_per_server):
             for vlan_intf in vlan_src_intfs:
                 ptf_src_intf = self.tor_to_ptf_intf_map[vlan_intf]
@@ -327,7 +331,7 @@ class DualTorIO:
                 packet = tcp_tx_packet_orig.copy()
                 packet[scapyall.Ether].src = eth_src
                 packet[scapyall.IP].src = server_ip
-                packet[scapyall.IP].dst = self.random_host_ip()
+                packet[scapyall.IP].dst = dst_ip if self.cable_type == CableType.active_active else self.random_host_ip()
                 packet.load = payload
                 packet[scapyall.TCP].chksum = None
                 packet[scapyall.IP].chksum = None

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -148,7 +148,6 @@ def shutdown_bgp_sessions():
 
     def _shutdown_bgp_sessions(duthost):
         duthosts.append(duthost)
-        bgp_neighbors = duthost.get_bgp_neighbors()
         logger.info("Shutdown all BGP sessions on {}".format(duthost.hostname))
         duthost.shell("config bgp shutdown all")
 

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -139,3 +139,22 @@ def wait_for_device_reachable(localhost):
         logger.info("SSH started on {}".format((duthost.hostname)))
 
     return wait_for_device_reachable
+
+
+@pytest.fixture
+def shutdown_bgp_sessions():
+    """Shutdown all bgp sessions on a device."""
+    duthosts = []
+
+    def _shutdown_bgp_sessions(duthost):
+        duthosts.append(duthost)
+        bgp_neighbors = duthost.get_bgp_neighbors()
+        logger.info("Shutdown all BGP sessions on {}".format(duthost.hostname))
+        duthost.shell("config bgp shutdown all")
+
+    yield _shutdown_bgp_sessions
+
+    time.sleep(1)
+    for duthost in duthosts:
+        logger.info("Startup all BGP sessions on {}".format(duthost.hostname))
+        duthost.shell("config bgp startup all")

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -3,3 +3,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "enable_active_active: mark test to run with 'active_active' ports"
     )
+
+    config.addinivalue_line(
+        "markers", "skip_active_standby: mark test to skip running with 'active_standby' ports"
+    )

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -6,6 +6,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.tor_failure_utils import kill_bgpd                                                                                    # lgtm[py/unused-import]
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions                                                                        # lgtm[py/unused-import]
+from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions_on_duthost
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
@@ -146,7 +147,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
     toggle_all_simulator_ports_to_upper_tor,
     shutdown_bgp_sessions, cable_type
 ):
-    '''
+    """
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
     Expectation:
@@ -154,16 +155,11 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
         ToR A DBs indicate standby, ToR B DBs indicate active
         T1 switch receives packet from the initial standby ToR (B) and not the active ToR (A)
         Verify traffic interruption < threshold
-    '''
+    """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
-        )
-        verify_tor_states(
-            expected_active_host=lower_tor_host,
-            expected_standby_host=upper_tor_host,
-            cable_type=cable_type
         )
 
     if cable_type == CableType.active_active:
@@ -171,8 +167,51 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
+
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        cable_type=cable_type
+    )
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_active_tor_shutdown_bgp_sessions_downstream(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    cable_type, tunnel_traffic_monitor
+):
+    """
+    Case: T1 -> ToR -> Server (Upper ToR shutdown/startup BGP sessions)
+    Action: Shutdown all BGP sessions on the upper ToR
+    Expectation:
+        Verify ToR changes to standby after shutdown all BGP sessions.
+        Verify ToR comes back to active after startup all BGP sessions.
+        Verify server receives packets after startup all BGP sessions, no tunnel traffic.
+    """
+    # verify all ToRs are in active state
+    verify_tor_states(
+        expected_active_host=[upper_tor_host, lower_tor_host],
+        expected_standby_host=None,
+        cable_type=cable_type
+    )
+
+    # verify the upper ToR changes to standby after shutdown BGP sessions
+    with shutdown_bgp_sessions_on_duthost() as shutdown_bgp_sessions:
+        shutdown_bgp_sessions(upper_tor_host)
         verify_tor_states(
             expected_active_host=lower_tor_host,
             expected_standby_host=upper_tor_host,
             cable_type=cable_type
         )
+
+    # verify the upper ToR changes back to active after startup BGP sessions
+    verify_tor_states(
+        expected_active_host=[upper_tor_host, lower_tor_host],
+        expected_standby_host=None,
+        cable_type=cable_type
+    )
+
+    # verify the server receives packets with no disrupts, no tunnel traffic
+    with tunnel_traffic_monitor(upper_tor_host, existing=False):
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -162,7 +162,8 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
-            expected_standby_host=upper_tor_host
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
         )
 
     if cable_type == CableType.active_active:
@@ -171,7 +172,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
         verify_tor_states(
-            expected_active_host=[upper_tor_host, lower_tor_host],
-            expected_standby_host=None,
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
             cable_type=cable_type
         )

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -5,10 +5,13 @@ from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action,
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.tor_failure_utils import kill_bgpd                                                                                    # lgtm[py/unused-import]
+from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions                                                                        # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
-from tests.common.dualtor.dual_tor_common import cable_type 
+from tests.common.dualtor.dual_tor_common import cable_type                                                                                     # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import CableType
+
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -135,3 +138,40 @@ def test_active_tor_kill_bgpd_downstream_standby(
         expected_active_host=lower_tor_host,
         expected_standby_host=upper_tor_host
     )
+
+
+@pytest.mark.enable_active_active
+def test_active_tor_shutdown_bgp_sessions_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_bgp_sessions, cable_type
+):
+    '''
+    Case: Server -> ToR -> T1 (Active ToR BGP Down)
+    Action: Shutdown all BGP sessions on the active ToR
+    Expectation:
+        Verify packet flow after the active ToR (A) loses BGP sessions
+        ToR A DBs indicate standby, ToR B DBs indicate active
+        T1 switch receives packet from the initial standby ToR (B) and not the active ToR (A)
+        Verify traffic interruption < threshold
+    '''
+    if cable_type == CableType.active_standby:
+        send_server_to_t1_with_action(
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host
+        )
+
+    if cable_type == CableType.active_active:
+        send_server_to_t1_with_action(
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+        )
+        verify_tor_states(
+            expected_active_host=[upper_tor_host, lower_tor_host],
+            expected_standby_host=None,
+            cable_type=cable_type
+        )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add testcase to cover upstream I/O scenario if one ToR goes through BGP shutdown/startup.
* `test_active_tor_shutdown_bgp_sessions_upstream` 
* `test_active_tor_shutdown_bgp_sessions_downstream`

This PR depends on https://github.com/sonic-net/sonic-mgmt/pull/5984

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. Add fixture `shutdown_bgp_sessions` to shutdown/startup bgp sessions.
2. Use the same dst IP for upstream traffic if `cable_type` is `active-active`, this is to ensure those packets will be forwarded to the same ToR.

#### How did you verify/test it?
```
dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_upstream[active-standby] PASSED                                                                                                                                                              [ 25%]
dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_upstream[active-active] PASSED                                                                                                                                                               [ 50%]
dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_downstream[active-standby] SKIPPED                                                                                                                                                           [ 75%]
dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_downstream[active-active] PASSED                                                                                                                                                             [100%]

============================================================================================================ 3 passed, 1 skipped, 8 deselected in 1262.20 seconds ============================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->