### PR TITLE
[test-gap] Test members in LACP lag

### DIFF
--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -177,7 +177,7 @@ class LagMemberTrafficTest(BaseTest,RouterUtility):
     def get_port_number(self, port_name):
         return int(''.join([i for i in port_name if i.isdigit()]))
 
-    def build_icmp_packet(self, vlan_id, src_ip, dst_ip, src_mac='00:22:00:00:00:02', dst_mac='ff:ff:ff:ff:ff:ff',
+    def build_icmp_packet(self, vlan_id, src_ip, dst_ip, src_mac, dst_mac,
                             ttl=64, icmp_type=8):
         pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
                                     eth_dst=dst_mac,

--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -153,3 +153,100 @@ class LacpTimingTest(BaseTest,RouterUtility):
         # Check that packet timing matches the expected value.
         current_pkt_timing = self.getMedianInterval(masked_exp_pkt)
         self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < 0.1, "Bad packet timing: %.2f seconds while expected timing is %d seconds from port %s out of %d intervals" % (current_pkt_timing, self.packet_timing, self.exp_iface, self.interval_count))
+
+class LagMemberTrafficTest(BaseTest,RouterUtility):
+    '''
+    @ summary: Verify traiffic in lag is okay.
+
+    @ param: dut_mac      -   mac of dut lag.
+    @ param: dut_vlan        -   information about vlan in dut.
+    @ param: ptf_lag         -   information about lag in ptf.
+    @ param: port_not_behind_lag     -   information about port not behind lag in ptf.
+    '''
+
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = testutils.test_params_get()
+
+    def setUp(self):
+        '''
+        @summary: Setup for the test
+        '''
+        self.dataplane = ptf.dataplane_instance
+
+    def get_port_number(self, port_name):
+        return int(''.join([i for i in port_name if i.isdigit()]))
+
+    def build_icmp_packet(self, vlan_id, src_ip, dst_ip, src_mac='00:22:00:00:00:02', dst_mac='ff:ff:ff:ff:ff:ff',
+                            ttl=64, icmp_type=8):
+        pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
+                                    eth_dst=dst_mac,
+                                    eth_src=src_mac,
+                                    dl_vlan_enable=False if vlan_id == 0 else True,
+                                    vlan_vid=vlan_id,
+                                    vlan_pcp=0,
+                                    ip_src=src_ip,
+                                    ip_dst=dst_ip,
+                                    ip_ttl=ttl,
+                                    icmp_type=icmp_type)
+        return pkt
+
+    def get_mask_pkt(self, pkt):
+        masked_exp_pkt = Mask(pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, 'id')
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, 'chksum')
+        masked_exp_pkt.set_do_not_care_scapy(scapy.ICMP, 'chksum')
+        return masked_exp_pkt
+
+    def send_and_verify_packets(self, send_pkt, exp_pkt, src_port, dst_ports):
+        self.dataplane.flush()
+        send(self, src_port, send_pkt)
+        verify_packet_any_port(self, exp_pkt, dst_ports)
+
+    def run_ptf_to_dut_traffic_test(self):
+        '''
+        @summary: send icmp request packet from ptf to dut and verify icmp reply packet in ptf
+        '''
+        for port_behind_lag in self.lag_ports:
+            src_mac = self.dataplane.get_mac(0, port_behind_lag)
+            dst_mac = self.dut_mac
+
+            src_ip = self.ptf_lag['ip'].split('/')[0]
+            dst_ip = self.dut_vlan['ip'].split('/')[0]
+
+            send_pkt = self.build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac, src_ip=src_ip, dst_ip=dst_ip, icmp_type=8)
+            exp_pkt = self.build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac, src_ip=dst_ip, dst_ip=src_ip, icmp_type=0)
+            masked_exp_pkt = self.get_mask_pkt(exp_pkt)
+            self.send_and_verify_packets(send_pkt, masked_exp_pkt, port_behind_lag, self.lag_ports)
+
+    def run_ptf_to_ptf_traffic_test(self):
+        '''
+        @summary: send icmp request packet from port behind lag to port not behind lag in ptf, and verify packet arrive successfully.
+        '''
+        for src_port in self.lag_ports:
+            dst_port = [ src_port ]
+            src_port = [ self.port_not_behind_lag['port_id'] ]
+            src_mac = self.dataplane.get_mac(0, src_port[0])
+            dst_mac = self.dataplane.get_mac(0, dst_port[0])
+            dst_ip=self.ptf_lag['ip'].split('/')[0]
+            src_ip=self.port_not_behind_lag['ip'].split('/')[0]
+
+            send_pkt = self.build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac, src_ip=src_ip, dst_ip=dst_ip, icmp_type=8)
+            masked_exp_pkt = self.get_mask_pkt(send_pkt)
+            self.send_and_verify_packets(send_pkt, masked_exp_pkt, src_port[0], self.lag_ports)
+
+            send_pkt = self.build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac, src_ip=dst_ip, dst_ip=src_ip, icmp_type=8)
+            masked_exp_pkt = self.get_mask_pkt(send_pkt)
+            self.send_and_verify_packets(send_pkt, masked_exp_pkt, self.lag_ports[0], src_port)
+
+    def runTest(self):
+        # Get test parameters
+        self.dut_mac = self.test_params['dut_mac']
+        self.dut_vlan = self.test_params['dut_vlan']
+        self.ptf_lag = self.test_params['ptf_lag']
+        self.port_not_behind_lag = self.test_params['port_not_behind_lag']
+        port_behind_lag_list = self.ptf_lag['port_list']
+        self.lag_ports = [ self.get_port_number(i) for i in port_behind_lag_list ]
+
+        self.run_ptf_to_dut_traffic_test()
+        self.run_ptf_to_ptf_traffic_test()

--- a/tests/common/devices/ptf.py
+++ b/tests/common/devices/ptf.py
@@ -48,4 +48,60 @@ class PTFHost(AnsibleHostBase):
         tf.flush()
         self.copy(src=tf.name, dest="/root/" + MACSEC_INFO_FILE)
 
+    def add_ip_to_dev(self, dev, ip):
+        """
+        @summary: add ip to dev
+
+        @param dev: device name
+        @param ip: ip to be added
+        """
+        self.command("ip addr add {} dev {}".format(ip, dev))
+
+    def create_lag(self, lag_name, lag_ip, lag_mode):
+        """
+        @summary: create a lag as intf, only if after running add_intf_to_lag and startup_lag the lag can work
+
+        @param lag_name: name of lag
+        @param lag_ip: ip of lag
+        @param lag_mode: mode of lag
+        """
+        self.command("ip link add {} type bond".format(lag_name))
+        self.command("ip link set {} type bond miimon 100 mode {}".format(lag_name, lag_mode))
+        self.add_ip_to_dev(lag_name, lag_ip)
+
+    def add_intf_to_lag(self, lag_name, intf_name):
+        """
+        @summary: set interface down and master lag
+
+        @param lag_name: name of lag
+        @param intf_name: mode of interface
+        """
+        self.set_dev_up_or_down(intf_name, False)
+        self.command("ip link set {} master {}".format(intf_name, lag_name))
+
+    def startup_lag(self, lag_name):
+        """
+        @summary: startup lag
+
+        @param lag_name: name of lag
+        """
+        self.set_dev_up_or_down(lag_name, True)
+
+    def set_dev_up_or_down(self, dev_name, is_up):
+        """
+        @summary: set device up or down
+
+        @param dev_name: name of devices
+        @param is_up: True -> set device up, False -> set device down
+        """
+        self.command("ip link set {} {}".format(dev_name, "up" if is_up else "down"))
+
+    def set_dev_no_master(self, dev_name):
+        """
+        @summary: set device no master
+
+        @param dev_name: name of device
+        """
+        self.command("ip link set {} nomaster".format(dev_name))
+
     # TODO: Add a method for running PTF script

--- a/tests/common/devices/ptf.py
+++ b/tests/common/devices/ptf.py
@@ -104,4 +104,7 @@ class PTFHost(AnsibleHostBase):
         """
         self.command("ip link set {} nomaster".format(dev_name))
 
+    def ptf_nn_agent(self):
+        self.command("supervisorctl restart ptf_nn_agent")
+
     # TODO: Add a method for running PTF script

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2036,6 +2036,31 @@ Totals               6450                 6449
 
         Args:
             port_channel_name: name of port channel
+
+        Returns:
+            port channel status, example:
+                    {
+                        "runner": {...
+                        },
+                        "setup": {...
+                        },
+                        "ports": {
+                            "Ethernet28": {
+                                "link_watches": {...
+                                },
+                                "runner": {...
+                                },
+                                "link": {...
+                                },
+                                "ifinfo": {...
+                                }
+                            },
+                            "Ethernet8": {...
+                            }
+                        },
+                        "team_device": {...
+                        }
+                    }
         """
         commond_output = self.command("docker exec -i teamd teamdctl {} state dump".format(port_channel_name))
         json_info = json.loads(commond_output["stdout"])

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1984,3 +1984,59 @@ Totals               6450                 6449
                     }
 
         return ip_ifaces
+
+    def remove_acl_table(self, acl_table):
+        """
+        Remove acl table
+
+        Args:
+            acl_table: name of acl table to be removed
+        """
+        self.command("config acl remove table {}".format(acl_table))
+
+    def del_member_from_vlan(self, vlan_id, member_name):
+        """
+        Del vlan member
+
+        Args:
+            vlan_id: id of vlan
+            member_name: interface deled from vlan
+        """
+        self.command("config vlan member del {} {}".format(vlan_id, member_name))
+
+    def add_member_to_vlan(self, vlan_id, member_name, is_tagged=True):
+        """
+        Add vlan member
+
+        Args:
+            vlan_id: id of vlan
+            member_name: interface added to vlan
+            is_tagged: True - add tagged member. False - add untagged member.
+        """
+        self.command("config vlan member add {} {} {}".format("" if is_tagged else "-u", vlan_id, member_name))
+
+    def remove_ip_from_port(self, port, ip=None):
+        """
+        Remove ip addresses from port. If get ip from running config successfully, ignore arg ip provided
+
+        Args:
+            port: port name
+            ip: IP address
+        """
+        ip_addresses = self.config_facts(host=self.hostname, source="running")["ansible_facts"].get("INTERFACE", {}).get(port, {})
+        if ip_addresses:
+            for ip in ip_addresses:
+                self.command("config interface ip remove {} {}".format(port, ip))
+        elif ip:
+            self.command("config interface ip remove {} {}".format(port, ip))
+
+    def get_port_channel_status(self, port_channel_name):
+        """
+        Collect port channel information by command docker teamdctl
+
+        Args:
+            port_channel_name: name of port channel
+        """
+        commond_output = self.command("docker exec -i teamd teamdctl {} state dump".format(port_channel_name))
+        json_info = json.loads(commond_output["stdout"])
+        return json_info

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2038,29 +2038,22 @@ Totals               6450                 6449
             port_channel_name: name of port channel
 
         Returns:
-            port channel status, example:
-                    {
-                        "runner": {...
+            port channel status, key information example:
+            {
+                "ports": {
+                    "Ethernet28": {
+                        "runner": {
+                            "selected": True,
+                            "state": "current"
                         },
-                        "setup": {...
-                        },
-                        "ports": {
-                            "Ethernet28": {
-                                "link_watches": {...
-                                },
-                                "runner": {...
-                                },
-                                "link": {...
-                                },
-                                "ifinfo": {...
-                                }
-                            },
-                            "Ethernet8": {...
-                            }
-                        },
-                        "team_device": {...
+                        "link": {
+                            "duplex": "full",
+                            "speed": 10,
+                            "up": True
                         }
                     }
+                }
+            }
         """
         commond_output = self.command("docker exec -i teamd teamdctl {} state dump".format(port_channel_name))
         json_info = json.loads(commond_output["stdout"])

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -1,0 +1,360 @@
+import pytest
+
+import time
+import logging
+import json
+
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.config_reload import config_reload
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0")
+]
+
+PTF_LAG_NAME = "bond1"
+DUT_LAG_NAME = "PortChannel1"
+ATTR_PORT_NOT_BEHIND_LAG = "port_not_behind_lag"
+ATTR_PORT_BEHIND_LAG = "port_behind_lag"
+TEST_DIR = "/tmp/acstests/"
+HWSKU_INTF_NUMBERS_DICT = {
+    "Mellanox-SN2700": 16,
+    "ACS-MSN4600C": 16,
+    "Mellanox-SN2700": 16,
+    "Mellanox-SN3800-D112C8": 16,
+    "Force10-S6000": 16
+}
+
+def add_member_to_vlan(duthost, vlan_id, member_name, params):
+    """
+    Add vlan member
+
+    Args:
+        duthost: DUT host object
+        vlan_id: id of vlan
+        member_name: interface added to vlan
+        params: additional params in command line
+    """
+    duthost.shell("config vlan member add {} {} {}".format(params, vlan_id, member_name))
+
+def remove_member_from_vlan(duthost, vlan_id, member_name):
+    """
+    Remove vlan member
+
+    Args:
+        duthost: DUT host object
+        vlan_id: id of vlan
+        member_name: interface removed from vlan
+    """
+    duthost.shell("config vlan member del {} {}".format(vlan_id, member_name))
+
+def restart_ptf_nn_agent(ptfhost):
+    """
+    Restart ptf_nn_agent
+
+    Args:
+        ptfhost: PTF host object
+    """
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+
+def remove_ip_from_port(duthost, port, ip=None):
+    """
+    Remove ip addresses from port
+
+    Args:
+        duthost: DUT host object
+        port: port name
+        ip: IP address
+    """
+    ip_addresses = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"].get("INTERFACE", {}).get(port, {})
+    if ip_addresses:
+        for ip in ip_addresses:
+            duthost.shell("config interface ip remove {} {}".format(port, ip))
+    elif ip:
+        duthost.shell("config interface ip remove {} {}".format(port, ip))
+
+def dut_teardown(duthost, dut_lag_map):
+    """
+    Restore dut configuration
+
+    Args:
+        duthost: DUT host object
+        dut_lag_map: imformation about lag in dut
+    """
+    try:
+        for dut_lag_member in dut_lag_map[DUT_LAG_NAME]:
+            duthost.shell("config portchannel member del {} {}".format(DUT_LAG_NAME, dut_lag_member))
+        add_member_to_vlan(duthost, 1000, dut_lag_member, "-u")
+
+        remove_member_from_vlan(duthost, dut_lag_map["vlan"]["id"], DUT_LAG_NAME)
+        duthost.shell("config portchannel del {}".format(DUT_LAG_NAME))
+        remove_member_from_vlan(duthost, dut_lag_map["vlan"]["id"], dut_lag_map[ATTR_PORT_NOT_BEHIND_LAG]["port_name"])
+        remove_ip_from_port(duthost, "Vlan{}".format(dut_lag_map["vlan"]["id"]), dut_lag_map["vlan"]["ip"])
+        add_member_to_vlan(duthost, 1000, dut_lag_map[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], "-u")
+        duthost.shell("config vlan del {}".format(dut_lag_map["vlan"]["id"]))
+    finally:
+        config_reload(duthost)
+
+def ptf_teardown(ptfhost, ptf_lag_map):
+    """
+    Restore ptf configuration
+
+    Args:
+        ptfhost: PTF host object
+        ptf_lag_map: imformation about lag in ptf
+    """
+    ptfhost.shell("ip link set {} nomaster".format(PTF_LAG_NAME))
+
+    for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
+        ptfhost.shell("ip link set {} nomaster".format(ptf_lag_member))
+        ptfhost.shell("ip link set {} up".format(ptf_lag_member))
+        
+    ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
+    ptfhost.shell("ip addr del {} dev {}".format(ptf_lag_map[ATTR_PORT_NOT_BEHIND_LAG]["ip"], ptf_lag_map[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]))
+    restart_ptf_nn_agent(ptfhost)
+
+def setup_dut_lag(duthost, dut_ports, vlan):
+    """
+    Setup dut lag
+
+    Args:
+        duthost: DUT host object
+        dut_ports: ports need to configure
+        vlan: information about vlan configuration
+
+    Returns:
+        information about dut lag
+    """
+    duthost.shell("config acl remove table EVERFLOW")
+    duthost.shell("config acl remove table EVERFLOWV6")
+    duthost.shell("config portchannel add {}".format(DUT_LAG_NAME))
+
+    lag_port_list = []
+    port_list_idx = 0
+    port_list = list(dut_ports[ATTR_PORT_BEHIND_LAG].values())
+    for _ in range(1, 10000):
+        port_name = port_list[port_list_idx]
+        remove_ip_from_port(duthost, port_name)
+        remove_member_from_vlan(duthost, "1000", port_name)
+        duthost.shell("config portchannel member add {} {}".format(DUT_LAG_NAME, port_name))
+        lag_port_list.append(port_name)
+        port_list_idx += 1
+
+        if len(lag_port_list) == len(dut_ports[ATTR_PORT_BEHIND_LAG]):
+            break
+
+    duthost.shell("config vlan add {}".format(vlan["id"]))
+    duthost.shell("config interface ip add Vlan{} {}".format(vlan["id"], vlan["ip"]))
+    add_member_to_vlan(duthost, vlan["id"], DUT_LAG_NAME, "-u")
+    remove_member_from_vlan(duthost, 1000, dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"])
+    remove_ip_from_port(duthost, dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"])
+    add_member_to_vlan(duthost, vlan["id"], dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], "-u")
+
+    lag_port_map = {}
+    lag_port_map[DUT_LAG_NAME] = lag_port_list
+    lag_port_map[ATTR_PORT_NOT_BEHIND_LAG] = dut_ports[ATTR_PORT_NOT_BEHIND_LAG]
+    lag_port_map["vlan"] = vlan
+    return lag_port_map
+
+def setup_ptf_lag(ptfhost, ptf_ports, vlan):
+    """
+    Setup ptf lag
+
+    Args:
+        ptfhost: PTF host object
+        ptf_ports: ports need to configure
+        vlan: information about vlan configuration
+
+    Returns:
+        information about ptf lag
+    """
+    ip_prefix = ".".join(vlan["ip"].split("/")[0].split(".")[0:3])
+    mask_len = vlan["ip"].split("/")[1]
+    lag_ip = "{}.2/{}".format(ip_prefix, mask_len)
+    port_not_behind_lag_ip = "{}.3/{}".format(ip_prefix, mask_len)
+
+    ptfhost.shell("ip link add {} type bond".format(PTF_LAG_NAME))
+    ptfhost.shell("ip link set {} type bond miimon 100 mode 802.3ad".format(PTF_LAG_NAME))
+    ptfhost.shell("ip address add {} dev {}".format(lag_ip, PTF_LAG_NAME))
+    
+    port_list = []
+    for _, port_name in ptf_ports[ATTR_PORT_BEHIND_LAG].items():
+        ptfhost.shell("ip link set {} down".format(port_name))
+        ptfhost.shell("ip link set {} master {}".format(port_name, PTF_LAG_NAME))
+        port_list.append(port_name)
+
+    lag_port_map = {}
+    lag_port_map[PTF_LAG_NAME] = {
+        "port_list": port_list,
+        "ip": lag_ip
+    }
+    lag_port_map[ATTR_PORT_NOT_BEHIND_LAG] = ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]
+    lag_port_map[ATTR_PORT_NOT_BEHIND_LAG]["ip"] = port_not_behind_lag_ip
+    
+    ptfhost.shell("ip link set dev {} up".format(PTF_LAG_NAME))
+    ptfhost.shell("ifconfig {} mtu 9100 up".format(PTF_LAG_NAME))
+    ptfhost.shell("ip addr add {} dev {}".format(port_not_behind_lag_ip, ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]))
+    restart_ptf_nn_agent(ptfhost)
+    time.sleep(10)
+
+    return lag_port_map
+
+def setup_dut_ptf(ptfhost, duthost, tbinfo):
+    """
+    Setup dut and ptf
+
+    Args:
+        ptfhost: PTF host object
+        duthost: DUT host object
+        tbinfo: fixture provides information about testbed
+    
+    Returns:
+        information about lag of ptf and dut
+    """
+    cfg_facts = duthost.config_facts(host = duthost.hostname, source="running")["ansible_facts"]
+    portchannel_members = []
+    for member in cfg_facts.get("PORTCHANNEL_MEMBER", {}).values():
+        portchannel_members += member.keys()
+    
+    config_vlan_members = cfg_facts["port_index_map"]
+    port_status = cfg_facts["PORT"]
+    duts_map = tbinfo["duts_map"]
+    dut_indx = duts_map[duthost.hostname]
+
+    host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+    ptf_ports_available_in_topo = {}
+    for key in host_interfaces:
+        ptf_ports_available_in_topo[host_interfaces[key]] = "eth{}".format(key)    
+
+
+    dut_hwsku = duthost.facts["hwsku"]
+    number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, 8)
+    dut_ports = {
+        ATTR_PORT_BEHIND_LAG: {},
+        ATTR_PORT_NOT_BEHIND_LAG: {}
+    }
+    sub_interface_ports = set([_.split(".")[0] for _ in cfg_facts.get("VLAN_SUB_INTERFACE", {}).keys()])
+    for port, port_id in config_vlan_members.items():
+        if ((port not in portchannel_members) and
+            (not port in sub_interface_ports) and
+            (port_status[port].get("admin_status", "down") == "up")):
+            if len(dut_ports[ATTR_PORT_BEHIND_LAG]) == number_of_lag_member:
+                dut_ports[ATTR_PORT_NOT_BEHIND_LAG] = {
+                    "port_id": port_id,
+                    "port_name": port
+                }
+                break
+            dut_ports[ATTR_PORT_BEHIND_LAG][port_id] = port
+
+    pytest_require(len(dut_ports[ATTR_PORT_BEHIND_LAG]) == number_of_lag_member and len(dut_ports[ATTR_PORT_NOT_BEHIND_LAG]), "No port for testing")
+
+    ptf_ports = {
+        ATTR_PORT_BEHIND_LAG: {},
+        ATTR_PORT_NOT_BEHIND_LAG: {}
+    }
+
+    for port_id in ptf_ports_available_in_topo:
+        if port_id in dut_ports[ATTR_PORT_BEHIND_LAG]:
+            ptf_ports[ATTR_PORT_BEHIND_LAG][port_id] = ptf_ports_available_in_topo[port_id]
+        elif port_id == dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_id"]:
+            ptf_ports[ATTR_PORT_NOT_BEHIND_LAG] = {
+                "port_id": port_id,
+                "port_name": ptf_ports_available_in_topo[port_id]
+            }
+
+    vlan = {
+        "id": 109,
+        "ip": "192.168.9.1/24"
+    }
+    dut_lag_map = setup_dut_lag(duthost, dut_ports, vlan)
+    ptf_lag_map = setup_ptf_lag(ptfhost, ptf_ports, vlan)
+    return dut_lag_map, ptf_lag_map
+
+@pytest.fixture(scope="module")
+def common_setup_teardown(ptfhost):
+    logger.info("########### Setup for lag testing ###########")
+
+    ptfhost.shell("mkdir -p {}".format(TEST_DIR))
+    # Copy PTF test into PTF-docker for test LACP DU
+    test_files = ["lag_test.py", "acs_base_test.py", "router_utils.py"]
+    for test_file in test_files:
+        src = "../ansible/roles/test/files/acstests/%s" % test_file
+        dst = TEST_DIR + test_file
+        ptfhost.copy(src=src, dest=dst)
+
+    yield ptfhost
+
+    ptfhost.file(path=TEST_DIR, state="absent")
+
+@pytest.fixture(scope="module")
+def ptf_dut_setup_and_teardown(duthost, ptfhost, tbinfo):
+    """
+    Setup and teardown of ptf and dut
+
+    Args:
+        duthost: DUT host object
+        ptfhost: PTF host object
+        tbinfo: fixture provides information about testbed
+    """
+    dut_lag_map, ptf_lag_map = setup_dut_ptf(ptfhost, duthost, tbinfo)
+
+    yield dut_lag_map, ptf_lag_map
+
+    dut_teardown(duthost, dut_lag_map)
+    ptf_teardown(ptfhost, ptf_lag_map)
+
+def get_port_channel_status(duthost, port_channel):
+    """
+    Get status of port channel by port channel name
+
+    Args:
+        duthost: DUT host object
+        port_channel: port channel name
+
+    Returns:
+        status of port channel
+    """
+    commond_output = duthost.shell("docker exec -i teamd teamdctl {} state dump".format(port_channel))
+    pytest_assert(commond_output["rc"] == 0, "Get status of {}".format(port_channel))
+    json_info = json.loads(commond_output["stdout"])
+    return json_info
+
+def test_lag_member_status(duthost, ptf_dut_setup_and_teardown):
+    """
+    Test ports' status of 16 members in a lag
+    """
+    port_channel_status = get_port_channel_status(duthost, DUT_LAG_NAME)
+    dut_hwsku = duthost.facts["hwsku"]
+    number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, 8)
+    pytest_assert(number_of_lag_member == len(port_channel_status["ports"]), "Number of lag member error")
+    for _, status in port_channel_status["ports"].items():
+        pytest_assert(status["runner"]["aggregator"]["selected"], "Status of lag member error")
+
+def run_lag_member_traffic_test(duthost, dut_vlan, ptf_lag_map, ptfhost):
+    """
+    Run lag member traffic test
+
+    Args:
+        duthost: DUT host object
+        dut_vlan: vlan information in dut
+        ptf_lag_map: information about lag in ptf
+        ptfhost: PTF host object
+    """
+    params = {
+        "dut_mac": duthost.facts["router_mac"],
+        "dut_vlan": dut_vlan,
+        "ptf_lag": ptf_lag_map[PTF_LAG_NAME],
+        ATTR_PORT_NOT_BEHIND_LAG: ptf_lag_map[ATTR_PORT_NOT_BEHIND_LAG]
+    }
+    ptf_runner(ptfhost, TEST_DIR, "lag_test.LagMemberTrafficTest", "/root/ptftests", params=params)
+
+def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_teardown):
+    """
+    Test traffic about 16 ports in a lag
+    """
+    ptfhost = common_setup_teardown
+    dut_lag_map, ptf_lag_map = ptf_dut_setup_and_teardown
+    run_lag_member_traffic_test(duthost, dut_lag_map["vlan"], ptf_lag_map, ptfhost)

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -4,6 +4,7 @@ import time
 import logging
 import json
 import ipaddress
+import sys
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.ptf_runner import ptf_runner
@@ -15,6 +16,12 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology("t0")
 ]
+
+# TODO: Remove this once we no longer support Python 2
+if sys.version_info.major == 3:
+    UNICODE_TYPE = str
+else:
+    UNICODE_TYPE = unicode
 
 PTF_LAG_NAME = "bond1"
 DUT_LAG_NAME = "PortChannel1"
@@ -161,7 +168,7 @@ def setup_ptf_lag(ptfhost, ptf_ports, vlan):
         information about ptf lag
     """
     ip_splits = vlan["ip"].split("/")
-    vlan_ip = ipaddress.ip_address(unicode(ip_splits[0]))
+    vlan_ip = ipaddress.ip_address(UNICODE_TYPE(ip_splits[0]))
     lag_ip = "{}/{}".format(vlan_ip + 1, ip_splits[1])
     port_not_behind_lag_ip = "{}/{}".format(vlan_ip + 2, ip_splits[1])
     # Add lag
@@ -329,7 +336,7 @@ def test_lag_member_status(duthost, ptf_dut_setup_and_teardown):
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
     pytest_assert(port_channel_status.has_key("ports") and number_of_lag_member == len(port_channel_status["ports"]), "get port status error")
     for _, status in port_channel_status["ports"].items():
-        pytest_assert(status["runner"]["aggregator"]["selected"], "status of lag member error")
+        pytest_assert(status["runner"]["selected"], "status of lag member error")
 
 def run_lag_member_traffic_test(duthost, dut_vlan, ptf_lag_map, ptfhost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md



Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->



Summary:
Fixes [#3604](https://github.com/sonic-net/sonic-mgmt/issues/3604)



### Type of change



<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->



- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)




### Back port request
- [ ] 201911
- [ ] 202012



### Approach
#### What is the motivation for this PR?
Mitigate test gap, verify 16 lag members in LACP is supported.



#### How did you do it?
Created a port channel with 16 members between DUT and PTF, and configure them in the same sub-net.



#### How did you verify/test it?
1. Verify the status of port channel members in DUT is selected as expected.
2. Send ICMP request packet from PTF to DUT and verify ICMP reply packet in PTF
3. Send ICMP request packet from port behind lag to port not behind lag in PTF, and verify packet arrive successfully.



#### Any platform specific information?



#### Supported testbed topology if it's a new test case?
T0 topology



### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->