### PR TITLE
[pfcwd] Fix pfcwd_config TC teardown

### DIFF
--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -130,7 +130,7 @@ def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
     Returns:
         original value of default_pfcwd_status
     """
-    output = duthost.shell("cat /etc/sonic/init_cfg.json | grep default_pfcwd_status")['stdout']
+    output = duthost.shell("cat {} | grep default_pfcwd_status".format(filepath))['stdout']
     matched = re.search('"default_pfcwd_status": "(.*)"', output)
     if matched:
         original_value = matched.group(1)

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -90,7 +90,7 @@ def cfg_teardown(duthost):
         os.system("rm -rf {}".format(TMP_DIR))
     duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='class')
 def cfg_setup(setup_pfc_test, duthosts, rand_one_dut_hostname):
     """
     Class level automatic fixture. Prior to the test run, create all the templates
@@ -142,21 +142,7 @@ def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
 
     return original_value
 
-def mg_cfg_teardown(duthost, default_pfcwd_value):
-    """
-    Reset default_pfcwd_status to its orignial value after the case run
-
-    Args:
-        duthost (AnsibleHost): instance
-        default_pfcwd_value: value of default_pfcwd_status, enable or disable
-
-    Returns:
-        None
-    """
-    update_pfcwd_default_state(duthost, '/etc/sonic/init_cfg.json', default_pfcwd_value)
-    update_pfcwd_default_state(duthost, '/etc/sonic/config_db.json', default_pfcwd_value)
-
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='class')
 def mg_cfg_setup(duthosts, rand_one_dut_hostname):
     """
     Class level automatic fixture. Prior to the test run, enable default pfcwd configuration
@@ -175,10 +161,11 @@ def mg_cfg_setup(duthosts, rand_one_dut_hostname):
     original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "enable")
 
     yield
-    logger.info("--- Start running default pfcwd config test---")
 
     logger.info("--- Recover configuration ---")
-    mg_cfg_teardown(duthost, original_pfcwd_value)
+    if original_pfcwd_value == 'disable':
+        update_pfcwd_default_state(duthost, '/etc/sonic/init_cfg.json', 'disable')
+        config_reload(duthost, config_source='minigraph')
 
 @pytest.fixture(scope='function', autouse=True)
 def stop_pfcwd(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Fixes:

- restored PFCWD feature status in startup config

test_default_cfg_after_load_mg sets the field `default_pfcwd_status` in` /etc/sonic/init_cfg.json `and checks PFCWD feature status corresponds to the set value after load_minigraph.

On finish the test attempts to restore PFCWD status present before the test run, by: 

-  stopping the feature in running config, with the command `pfcwd stop` 
-  resetting startup config by setting the field `default_pfcwd_status=disable` in files` /etc/sonic/init_cfg.json` and `/etc/sonic/config_db.json`

Step 1 works well so the feature gets disabled, but step 2 does its job improperly, leaving the startup config with PFCWD enabled so PFCWD gets enabled on config reload / DUT reboot.

The issue with step 2 is that it assumes the only changed PFCWD-related part of config_db after `load_minigraph` is the field `default_pfcwd_status=enable`, the test sets it to disable assuming the value is taken into account on config reload. But actually it is wrong and after `load_minigraph` while `/etc/sonic/init_cfg.json` has `default_pfcwd_status=enable`, the config_db gets PFCWD config in the form of PFC_WD dict containing per-port feature config. Test does not take such config into account and leaves it as is, which causes PFCWD to get enabled on config reload. It may harm the regression test run when the tests after test_default_cfg_after_load_mg don't expect PFCWD to be enabled.

Resolved by setting `default_pfcwd_status=disable` in /etc/sonic/init_cfg.json and finally reloading minigraph, so config_db appears with a clear PFCWD config.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix pfcwd_config teardown
#### How did you do it?

#### How did you verify/test it?
Run `pfcwd/test_pfc_config:test_default_cfg_after_load_mg`:

```
Before test 
 $ cat /etc/sonic/config_db.json | grep default_pfcwd_status
            "default_pfcwd_status": "disable",
$ cat /etc/sonic/init_cfg.json | grep default_pfcwd_status
            "default_pfcwd_status": "disable"

After test:
admin@igk-4-dut:~$ cat /etc/sonic/init_cfg.json | grep default_pfcwd_status
            "default_pfcwd_status": "disable"
admin@igk-4-dut:~$ cat /etc/sonic/config_db.json | grep default_pfcwd_status
            "default_pfcwd_status": "disable",
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.127871-dirty-20220728.095752
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 746e05210
Build date: Thu Jul 28 14:13:30 UTC 2022
Built by: AzDevOps@sonic-build-workers-001UGB
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
