### PR TITLE
enhance ser test for 2022 OS image

### DIFF
--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -361,16 +361,23 @@ def get_asic_name():
     stdout, _ = run_cmd("lspci")
     output = stdout.decode("utf-8")
     if ("Broadcom Limited Device b960" in output or
-        "Broadcom Limited Broadcom BCM56960" in output):
+        "Broadcom Limited Broadcom BCM56960" in output or
+        "Broadcom Inc. and subsidiaries Device b960" in output or
+        "Broadcom Inc. and subsidiaries Broadcom BCM56960" in output):
         asic = "th"
-    elif "Broadcom Limited Device b971" in output:
+    elif ("Broadcom Limited Device b971" in output or
+          "Broadcom Inc. and subsidiaries Device b971" in output):
         asic = "th2"
     elif ("Broadcom Limited Device b850" in output or
-          "Broadcom Limited Broadcom BCM56850" in output):
+          "Broadcom Limited Broadcom BCM56850" in output or
+          "Broadcom Inc. and subsidiaries Device b850" in output or
+          "Broadcom Inc. and subsidiaries Broadcom BCM56850" in output):
         asic = "td2"
-    elif "Broadcom Limited Device b870" in output:
+    elif ("Broadcom Limited Device b870" in output or
+          "Broadcom Inc. and subsidiaries Device b870" in output):
         asic = "td3"
-    elif "Broadcom Limited Device b980" in output:
+    elif ("Broadcom Limited Device b980" in output or
+          "Broadcom Inc. and subsidiaries Device b980" in output):
         asic = "th3"
 
     return asic
@@ -795,7 +802,7 @@ class SerTest(object):
                     if VERBOSE:
                         print('--- mem {} error inject is slow: {}'.format(mem, speed))
                 self.mem_injection_speed[mem] = speed
-                if stdout.find('SER correction for it is not currently supported') > -1:
+                if stdout.decode().find('SER correction for it is not currently supported') > -1:
                     print("memory %s does not support ser" % mem)
                     self.mem_ser_unsupported.append(mem)
                 else:


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enhance ser test for latest OS image (202205)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
SER test case failed on the latest (202205 based) OS image

#### How did you do it?
Enhance the SER test case
1: modify the check condition of lspci, since the output of lspci is different between 2020 OS image and 2022 OS image
2: decode the data of bcmcmd's output before using the find function, since different behavior between python2 and python3

#### How did you verify/test it?
verified on testbeds based on ASIC type TD3, TH, TH2, all passed
vms24-dual-t0-7050-1
vms24-t0-7260-2
vms7-t0-dx010-4

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
