### PR TITLE
Fix portstat case

### DIFF
--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -72,16 +72,14 @@ def test_portstat_delete_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname
     logger.info('Verify that the file names are in the /tmp directory')
     uid = duthost.command('id -u')['stdout'].strip()
     for stats_file in stats_files:
-        pytest_assert(duthost.stat(path='/tmp/portstat-{uid}/{uid}-{filename}'\
-                      .format(uid=uid, filename=stats_file))['stat']['exists'])
+        pytest_assert(get_tmp_portstat_file_existing_status(duthost, uid, stats_file))
 
     logger.info('Run the command to be tested "{}"'.format(command))
     duthost.command(command)
 
     logger.info('Verify that the file names are not in the /tmp directory')
     for stats_file in stats_files:
-        pytest_assert(not duthost.stat(path='/tmp/portstat-{uid}/{uid}-{filename}'\
-                      .format(uid=uid, filename=stats_file))['stat']['exists'])
+        pytest_assert(not get_tmp_portstat_file_existing_status(duthost, uid, stats_file))
 
 
 @pytest.mark.parametrize('command',
@@ -100,21 +98,23 @@ def test_portstat_delete_tag(duthosts, enum_rand_one_per_hwsku_frontend_hostname
     logger.info('Verify that the file names are in the /tmp directory')
     uid = duthost.command('id -u')['stdout'].strip()
     for stats_file in stats_files:
-        pytest_assert(duthost.stat(path='/tmp/portstat-{uid}/{uid}-{filename}'\
-                      .format(uid=uid, filename=stats_file))['stat']['exists'])
+        pytest_assert(get_tmp_portstat_file_existing_status(duthost, uid, stats_file))
 
     full_delete_command = command + ' ' + file_to_delete
     logger.info('Run the command to be tested "{}"'.format(full_delete_command))
     duthost.command(full_delete_command)
 
     logger.info('Verify that the deleted file name is not in the directory')
-    pytest_assert(not duthost.stat(path='/tmp/portstat-{uid}/{uid}-{filename}'\
-                  .format(uid=uid, filename=file_to_delete))['stat']['exists'])
+    pytest_assert(not get_tmp_portstat_file_existing_status(duthost, uid, file_to_delete))
 
     logger.info('Verify that the remaining file names are in the directory')
     for stats_file in files_not_deleted:
-        pytest_assert(duthost.stat(path='/tmp/portstat-{uid}/{uid}-{filename}'\
-                      .format(uid=uid, filename=stats_file))['stat']['exists'])
+        pytest_assert(get_tmp_portstat_file_existing_status(duthost, uid, stats_file))
+
+
+def get_tmp_portstat_file_existing_status(duthost, uid, stats_file):
+     return duthost.stat(path='/tmp/cache/portstat/{uid}-{filename}'.format(
+         uid=uid, filename=stats_file))['stat']['exists']
 
 
 @pytest.mark.parametrize('command', ['portstat -a', 'portstat --all'])


### PR DESCRIPTION
There is a bug fix for "portstat -c -t filename" which changes the path of portstat status file, so  we need to update the relevant portstat test:
 https://github.com/sonic-net/sonic-utilities/pull/2232
 https://github.com/sonic-net/sonic-buildimage/pull/11244 
1. Orignal design: After running “portstat -c -t  filename”, status file will be created on the folder of /tmp/portstat-{uid}/{uid}-{filename}
2. New design: After running “portstat -c -t  filename”, status file will be created on the folder of /tmp/cache/portstat/{uid}-{filename}

Change-Id: Ia122a08b9a55a26fe6a299d74d2df1f1949c7ca3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix test issue, because there is a relevant bug fix for the product.

#### How did you do it?
Change the test as the new desgin.
1. Orignal design: After running “portstat -c -t  filename”, status file will be created on the folder of /tmp/portstat-{uid}/{uid}-{filename}
2. New design: After running “portstat -c -t  filename”, status file will be created on the folder of /tmp/cache/portstat/{uid}-{filename}

#### How did you verify/test it?
Run the tests on the image with bug fix

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
