### PR TITLE
Improve the timeout of PR testing to ensure logs are always collected

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -60,19 +60,21 @@ steps:
     mkdir -p $(Build.ArtifactStagingDirectory)/pipeline
     docker exec sonic-mgmt-2 bash -c "pushd /var/src/$parent_dir/ansible;./testbed-cli.sh -d $(Build.SourcesDirectory)/sonic-vm -m $(inventory) -t $(testbed_file) -k ${{ parameters.vmtype }} refresh-dut ${{ parameters.tbname }} password.txt -v"|tee $(Build.ArtifactStagingDirectory)/pipeline/refresh-dut.log && sleep 180
   displayName: "Setup testbed"
+  timeoutInMinutes: 25
 
 - script: |
     pwd
-    
+
     parent_dir=$(basename $PWD)
     docker exec -e GIT_USER_NAME=$GIT_USER_NAME -e GIT_API_TOKEN=$GIT_API_TOKEN sonic-mgmt-2 bash -c "/var/src/$parent_dir/tests/kvmtest.sh -en -T ${{ parameters.tbtype }} -d /var/src/$parent_dir ${{ parameters.tbname }} ${{ parameters.dut }} ${{ parameters.section }}"
   env:
     GIT_USER_NAME: $(GIT_USER_NAME)
     GIT_API_TOKEN: $(GIT_API_TOKEN)
   displayName: "Run tests"
+  timeoutInMinutes: 360
   ${{ if eq(parameters.tbtype, 'multi-asic-t1-lag-pr') }}:
-      continueOnError: true
-      
+    continueOnError: true
+
 - script: |
     # save dut state if test fails
     virsh_version=$(virsh --version)
@@ -97,7 +99,7 @@ steps:
     username=$(id -un)
     sudo chown -R $username.$username $(Build.ArtifactStagingDirectory)
   displayName: "Collect test logs"
-  condition: succeededOrFailed()
+  condition: always()
 
 - publish: $(Build.ArtifactStagingDirectory)/kvmdump
   artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype}}${{ parameters.section }}.memdump@$(System.JobAttempt)
@@ -107,15 +109,15 @@ steps:
 - publish: $(Build.ArtifactStagingDirectory)/logs
   artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}${{ parameters.section }}.log@$(System.JobAttempt)
   displayName: "Archive sonic kvm logs"
-  condition: succeededOrFailed()
+  condition: always()
 
 - publish: $(Build.ArtifactStagingDirectory)/pipeline
   artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}${{ parameters.section }}.pipeline@$(System.JobAttempt)
   displayName: "Archive pipeline logs"
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
     testRunTitle: kvmtest.${{ parameters.tbtype }}${{ parameters.section }}
-  condition: succeededOrFailed()
+  condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -39,7 +39,7 @@ stages:
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -76,7 +76,7 @@ stages:
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -88,8 +88,6 @@ stages:
 
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
-    pool:
-      vmImage: 'ubuntu-20.04'
     timeoutInMinutes: 540
     condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
     steps:
@@ -98,8 +96,6 @@ stages:
         TOPOLOGY: t1-lag
 
   - job:
-    pool:
-      vmImage: 'ubuntu-20.04'
     displayName: "kvmtest-t1-lag"
     dependsOn:
     - t1_lag_classic
@@ -122,7 +118,7 @@ stages:
   - job:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -136,7 +132,7 @@ stages:
   - job:
     pool: sonictest-dualtor
     displayName: "kvmtest-dualtor"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
 
     steps:
       - template: .azure-pipelines/run-test-template.yml
@@ -150,7 +146,7 @@ stages:
   - job:
     pool: sonictest-ma
     displayName: "kvmtest-multi-asic-t1-lag"
-    timeoutInMinutes: 360
+    timeoutInMinutes: 400
 
     steps:
       - template: .azure-pipelines/run-test-template.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently PR testing on t1-lag may be stuck and cancelled eventually
due to timeout. After the job is cancelled, the steps for collecting
logs were not executed too. It is difficult to troubleshoot the issue
without logs.

#### How did you do it?
Changes of this PR:
* Adjusted the timeout value for jobs and added timeout to the step
  for running tests. Timeout of the run test step is slightly smaller
  than timeout of the job. So that if the run test step is
  cancelled due to timeout, rest of the steps still have time to run.
* Condition of the steps collecting logs were also changed to "always()".
* Removed the agent pool specification for some jobs. They will use the
  the default agent pool.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
