### PR TITLE
Fix test lag issue

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -449,7 +449,7 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
                 # Retrieve lag_facts after no shutdown interface
                 duthost.no_shutdown(po_intf)
                 # Sometimes, it has to wait seconds for booting up interface
-                pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                pytest_assert(wait_until(60, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
                     "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
     finally:
         # Recover interfaces in case of failure
@@ -505,5 +505,5 @@ def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardo
             # 5 No shutdown this port to check if status is up
             duthost.no_shutdown(po_intf)
             # Sometimes, it has to wait seconds for booting up interface
-            pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+            pytest_assert(wait_until(60, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
                 "{} member {}'s admin_status or oper_status in state_db is not up.".format(lag_name, po_intf))


### PR DESCRIPTION
Increase timeout to 60s for check_link_is_up. The reasons are as follows:
1. The motivation of test_lag_db_status and test_lag_db_status_with_po_update is to verify if interface status is synchronized with the status in db. Increasing timeout will make the test more stable.
2. For different platforms and different cables, the uptime of the interface is different. Now, 15s is not enough for some platforms and cables, so we need to set a litter bigger time.

Change-Id: If01b612f227898d112cbb3f9df6d6f08a6ee5138

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make test more stable

#### How did you do it?
Increase timeout to 60s for check_link_is_up

#### How did you verify/test it?
Run pc/test_lag_2.py

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
T0, T1-lag

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
