### PR TITLE
[VNET_VXLAN] Fixed VNET_VXLAN test in case of scale

### DIFF
--- a/tests/vxlan/test_vnet_route_leak.py
+++ b/tests/vxlan/test_vnet_route_leak.py
@@ -68,7 +68,7 @@ def configure_dut(request, minigraph_facts, duthosts, rand_one_dut_hostname, vne
         duthost.shell(DELETE_BACKUP_CONFIG_DB_CMD)
 
         cleanup_vnet_routes(duthost, vnet_test_params, num_routes)
-        cleanup_dut_vnets(duthost, minigraph_facts, vnet_config)
+        cleanup_dut_vnets(duthost, vnet_config)
         cleanup_vxlan_tunnels(duthost, vnet_test_params)
 
         logger.info("Restarting BGP and waiting for BGP sessions")

--- a/tests/vxlan/vnet_utils.py
+++ b/tests/vxlan/vnet_utils.py
@@ -147,13 +147,12 @@ def apply_dut_config_files(duthost, vnet_test_params, num_routes):
         logger.info("Skip applying config files on DUT")
 
 
-def cleanup_dut_vnets(duthost, mg_facts, vnet_config):
+def cleanup_dut_vnets(duthost, vnet_config):
     """
     Removes all VNET information from DUT
 
     Args:
         duthost: DUT host object
-        mg_facts: Minigraph facts
         vnet_config: Configuration generated from templates/vnet_config.j2
     """
     logger.info("Removing VNET information from DUT")


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed VNET_VXLAN test in case of scale

We should use by default expected packets number - 3
But in case of scale we should expect - 2

In PTF test we have logic which in case of scale send traffic only to 1 IP per route - now expected value aligned with PTF test code

Summary: Fixed VNET_VXLAN test in case of scale
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When run test_vnet_vxlan with scale - test fail in line: with RouteFlowCounterTestContext
Because we expect 3 packets but received 2 - it happen because in case of scale - PTF test send different number of packets

#### How did you do it?
Aligned expected packets number with PTF test.
Added method "get_expected_flow_counter_packets_number" which similar to logic inside in PTF test(when PTF test decide how much packets send)

#### How did you verify/test it?
Executed vxlan tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
