### PR TITLE
remove testing skipped modules in "platform_tests/api/test_module.py::TestModuleApi::test_get_presence" completely

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -108,10 +108,10 @@ class TestModuleApi(PlatformApiTestBase):
             if self.expect(presence is not None, "Unable to retrieve module {} presence".format(i)):
                 if self.expect(isinstance(presence, bool), "Module {} presence appears incorrect".format(i)):
                     name = module.get_name(platform_api_conn, i)
-                    if name in self.skip_mod_list:
-                        self.expect(presence is False, "Module {} is not present".format(i))
-                    else:
+                    if name not in self.skip_mod_list:
                         self.expect(presence is True, "Module {} is not present".format(i))
+                    else:
+                        logger.info("Skipping module {} since it is part of skip_mod_list".format(name))
         self.assert_expectations()
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):


### PR DESCRIPTION
in test_get_presence() there is a new check added by PR (https://github.com/sonic-net/sonic-mgmt/pull/2985):

                    name = module.get_name(platform_api_conn, i)
                    if name in self.skip_mod_list:
                        self.expect(presence is False, "Module {} is not present".format(i))
                    else:
                        self.expect(presence is True, "Module {} is not present".format(i))

I am seeing some issue with the above logic.
In our testbed where we share a physical chassis that uses the same Supervisor card but group different LCs for different "logical chassis" so for some "logical chassis" some LCs are added to "skip_mod_list" as they are not meant to be tested for that logical chassis.  Our expectation is that if it is marked as skipped, it is not meant for testing and no state of those skipped modules should be used for any validation logic.   We should always trust what the inventory marked as skipped and not try to look at whatever state the "skipped module" should be.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/6160)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tried it out on the same logical chassis that I observed the issue and with the testcase modified it passes just fine.

Here is what got captured inside the test log showing the skipped module names that should be skipped and were correctly skipped:
```
12/08/2022 18:46:32 __init__._fixture_func_decorator         L0059 INFO   | -------------------- fixture setup setup starts --------------------
12/08/2022 18:46:54 chassis.chassis_api                      L0018 INFO   | Executing chassis API: "get_num_modules", arguments: "[]", result: "18"
12/08/2022 18:46:54 __init__._fixture_func_decorator         L0066 INFO   | -------------------- fixture setup setup ends --------------------
12/08/2022 18:46:54 __init__._log_sep_line                   L0160 INFO   | ==================== platform_tests/api/test_module.py::TestModuleApi::test_get_presence[chassis -sup-3] call ====================
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 0, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 0, arguments: "[]", result: "SUPERVISOR0"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 1, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 1, arguments: "[]", result: "SUPERVISOR1"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module SUPERVISOR1 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 2, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 2, arguments: "[]", result: "LINE-CARD0"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module LINE-CARD0 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 3, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 3, arguments: "[]", result: "LINE-CARD1"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 4, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 4, arguments: "[]", result: "LINE-CARD2"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 5, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 5, arguments: "[]", result: "LINE-CARD3"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 6, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 6, arguments: "[]", result: "LINE-CARD4"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module LINE-CARD4 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 7, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 7, arguments: "[]", result: "LINE-CARD5"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module LINE-CARD5 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 8, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 8, arguments: "[]", result: "LINE-CARD6"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module LINE-CARD6 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 9, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 9, arguments: "[]", result: "LINE-CARD7"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module LINE-CARD7 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 10, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 10, arguments: "[]", result: "FABRIC-CARD0"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 11, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 11, arguments: "[]", result: "FABRIC-CARD1"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module FABRIC-CARD1 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 12, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 12, arguments: "[]", result: "FABRIC-CARD2"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 13, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 13, arguments: "[]", result: "FABRIC-CARD3"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module FABRIC-CARD3 since it is part of skip_mod_list
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 14, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 14, arguments: "[]", result: "FABRIC-CARD4"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 15, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 15, arguments: "[]", result: "FABRIC-CARD5"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 16, arguments: "[]", result: "True"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 16, arguments: "[]", result: "FABRIC-CARD6"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_presence", index: 17, arguments: "[]", result: "False"
12/08/2022 18:46:54 module.module_api                        L0018 INFO   | Executing module API: "get_name", index: 17, arguments: "[]", result: "FABRIC-CARD7"
12/08/2022 18:46:54 test_module.test_get_presence            L0117 INFO   | Skipping module FABRIC-CARD7 since it is part of skip_mod_list
12/08/2022 18:46:54 __init__._log_sep_line                   L0160 INFO   | ==================== platform_tests/api/test_module.py::TestModuleApi::test_get_presence[chassis -sup-3] teardown ====================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
