### PR TITLE
Let pytest return different value if sanity check failed

### DIFF
--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -13,7 +13,7 @@ PRINT_LOGS = {
     "mux_config": "show mux config",
 }
 
-# Check items for testbed infrastructure that are not 
+# Check items for testbed infrastructure that are not
 # controlled by the DUT
 INFRA_CHECK_ITEMS = [
     "mux_simulator"
@@ -32,3 +32,4 @@ RECOVER_METHODS = {
 
 STAGE_PRE_TEST = 'stage_pre_test'
 STAGE_POST_TEST = 'stage_post_test'
+SANITY_CHECK_FAILED_RC = 10

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -110,7 +110,7 @@ function setup_environment()
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
     export ANSIBLE_CONNECTION_PLUGINS=${BASE_PATH}/ansible/plugins/connection
-    export ANSIBLE_CLICONF_PLUGINS=${BASE_PATH}/ansible/cliconf_plugins 
+    export ANSIBLE_CLICONF_PLUGINS=${BASE_PATH}/ansible/cliconf_plugins
     export ANSIBLE_TERMINAL_PLUGINS=${BASE_PATH}/ansible/terminal_plugins
 
     # Kill pytest and ansible-playbook process
@@ -264,18 +264,21 @@ function pre_post_extra_params()
 function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
+    echo Running: pytest ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
     pytest ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m pretest
 }
 
 function cleanup_dut()
 {
     echo "=== Cleaning up DUT after tests ==="
+    echo Running: pytest ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
     pytest ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} $(pre_post_extra_params) -m posttest
 }
 
 function run_group_tests()
 {
     echo "=== Running tests in groups ==="
+    echo Running: pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
     pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
 }
 
@@ -295,6 +298,7 @@ function run_individual_tests()
             TEST_LOGGING_OPTIONS="--log-file ${LOG_PATH}/${test_dir}/${test_name}.log --junitxml=${LOG_PATH}/${test_dir}/${test_name}.xml"
         fi
 
+        echo Running: pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
         pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
         ret_code=$?
 
@@ -304,6 +308,11 @@ function run_individual_tests()
                 rm -f ${LOG_PATH}/${test_dir}/${test_name}.log
             fi
         else
+            if [ ${ret_code} -eq 10 ]; then     # rc 10 means sanity check failed
+                echo "=== Sanity check failed for $test_script. Skip rest of the scripts if there is any. ==="
+                return ${ret_code}
+            fi
+
             EXIT_CODE=1
             if [[ ${TEST_MAX_FAIL} != 0 ]]; then
                 return ${EXIT_CODE}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Usually when sanity check failed on a testbed, it means that the testbed is broken.
If we continue to run scripts in the same way on same testbed, rest of the scripts
will fail at sanity check too. There is no point to try rest of the scripts.

It would be better for pytest to return a different value if sanity check failed.

#### How did you do it?
Currently the pytest framework has a good set of return codes defined as below:

OK = 0 --> Tests passed.
TESTS_FAILED = 1 --> Tests failed.
INTERRUPTED = 2 --> pytest was interrupted.
INTERNAL_ERROR = 3 --> An internal error got in the way.
USAGE_ERROR = 4 --> pytest was misused.
NO_TESTS_COLLECTED = 5 --> pytest couldn’t find tests.

Reference: https://docs.pytest.org/en/7.1.x/reference/reference.html#exitcode

This change used a dirty hack to force pytest to return value "10" if sanity check
failed. The value is defined here:
    tests/common/plugins/sanity_check/constants.py::SANITY_CHECK_FAILED_RC

The idea is to set a variable `sanity_check_failed=True` in pytest config.cache
when sanity check is failed.

Then added a hook function `pytest_sessionfinish` to the sanity check plugin
to override pytest exit code if found `sanity_check_failure` from cache and
its value is evaluated to `True`.

This change also updated the run_tests.sh to take advantage of this new return code.
When sanity check failed and tests are running in invidual mode, the run_tests.sh
tool will skip rest of the scripts to fail early.

#### How did you verify/test it?
Tested on KVM testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
