### PR TITLE
Add support of starting ceos containers in batch

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -103,6 +103,7 @@
 
 - hosts: servers:&eos
   gather_facts: no
+  serial: "{{ eos_batch_size | default(0) | int }}"
   pre_tasks:
     - block:
         - name: Check that variable topo is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently all the cEOS containers are started in one batch in parallel
during add-topo. We observed that a few of the cEOS container may
fail to start while preparing a KVM testbed for the t1-lag topology.
Management IP of the cEOS containers cannot become reachable.
Preparing KVM testbed for t0 topology is much more stable.

The t1-lag topology has 24 cEOS containers and the t0 only has 4.
We suspect that starting all the 24 cEOS containers in a single batch
in parallel may cause CPU bust burden and caused this issue.

#### How did you do it?
This change introduced a "serial" configuration for the playbook 
starting the eos neighbors.

Reference:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html#setting-the-batch-size-with-serial

By default, value passed to the "serial" setting is 0. The default
behavior will be the same.

While running the `testbed-cli.sh` tool, we can optionally pass value
to variable `eos_batch_size` to customize the batch size. For example:

```
  testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k ceos add-topo vms-kvm-t1-lag password.txt -e eos_batch_size=12
```

This fix is still not idea. By default, the playbook of the "eos" role
is applied to all the eos hosts under the server. Not just the eos hosts
used by current topology. For eos with hostname not in the "VM_targets"
list, they will simply be skipped.

When the batch size is specified, ansible will process all the eos hosts
under the server in batches, including the eos hosts not used by the
current topology. This also means that in each batch, we can't be sure that
all the eos hosts in this batch are for the current topology. The eos
hosts used by the current topology may not be divided evenly in batches.

Since this change does not affect the default behavior. Let's see if
this enhancement is able to improve the stability of deploying a t1-lag
topology.

#### How did you verify/test it?
Tested deploying t1-lag testbed using `testbed-cli.sh` and extra `-e eos_batch_size=12` argument.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
