### PR TITLE
[masic] Fix argument issue in verify_cacl, test_cacl_application

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -46,7 +46,7 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulato
 @pytest.fixture
 def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
     expected_dhcp_rules = []
-    if duthost_dualtor.hostname == lower_tor_host.hostname:    
+    if duthost_dualtor.hostname == lower_tor_host.hostname:
         mark_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
         mark_keys = mark_keys.split("\n")
         for key in mark_keys:

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -45,8 +45,8 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulato
 
 @pytest.fixture
 def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
-    expected_dhcp_rules = []
     if duthost_dualtor.hostname == lower_tor_host.hostname:
+        expected_dhcp_rules = []
         mark_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
         mark_keys = mark_keys.split("\n")
         for key in mark_keys:
@@ -55,7 +55,9 @@ def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
                 continue
             rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
             expected_dhcp_rules.append(rule)
-    return expected_dhcp_rules
+        return expected_dhcp_rules
+    else:
+        return
 
 @pytest.fixture(scope="module")
 def docker_network(duthost):
@@ -821,12 +823,12 @@ def test_cacl_application_dualtor(duthost_dualtor, tbinfo, localhost, creds, doc
     """
     verify_cacl(duthost_dualtor, tbinfo, localhost, creds, docker_network, expected_dhcp_rules_for_standby)
 
-def test_multiasic_cacl_application(duthosts, tbinfo, rand_one_dut_hostname, localhost, creds, docker_network, expected_dhcp_rules_for_standby, enum_frontend_asic_index):
+def test_multiasic_cacl_application(duthosts, tbinfo, rand_one_dut_hostname, localhost, creds,docker_network, enum_frontend_asic_index):
     """
     Test case to ensure caclmgrd is applying control plane ACLs properly on multi-ASIC platform.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    verify_cacl(duthost, tbinfo, localhost, creds, docker_network, expected_dhcp_rules_for_standby, enum_frontend_asic_index)
+    verify_cacl(duthost, tbinfo, localhost, creds, docker_network, enum_frontend_asic_index)
     verify_nat_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
 
 def test_cacl_scale_rules_ipv4(duthosts, rand_one_dut_hostname, collect_ignored_rules, clean_scale_rules):

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -45,8 +45,8 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulato
 
 @pytest.fixture
 def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
-    if duthost_dualtor.hostname == lower_tor_host.hostname:
-        expected_dhcp_rules = []
+    expected_dhcp_rules = []
+    if duthost_dualtor.hostname == lower_tor_host.hostname:    
         mark_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
         mark_keys = mark_keys.split("\n")
         for key in mark_keys:
@@ -55,9 +55,7 @@ def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
                 continue
             rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
             expected_dhcp_rules.append(rule)
-        return expected_dhcp_rules
-    else:
-        return
+    return expected_dhcp_rules
 
 @pytest.fixture(scope="module")
 def docker_network(duthost):
@@ -823,13 +821,13 @@ def test_cacl_application_dualtor(duthost_dualtor, tbinfo, localhost, creds, doc
     """
     verify_cacl(duthost_dualtor, tbinfo, localhost, creds, docker_network, expected_dhcp_rules_for_standby)
 
-def test_multiasic_cacl_application(duthosts, tbinfo, rand_one_dut_hostname, localhost, creds,docker_network, enum_frontend_asic_index):
+def test_multiasic_cacl_application(duthosts, tbinfo, rand_one_dut_hostname, localhost, creds, docker_network, expected_dhcp_rules_for_standby, enum_frontend_asic_index):
     """
     Test case to ensure caclmgrd is applying control plane ACLs properly on multi-ASIC platform.
     """
     duthost = duthosts[rand_one_dut_hostname]
     verify_cacl(duthost, tbinfo, localhost, creds, docker_network, enum_frontend_asic_index)
-    verify_nat_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
+    verify_nat_cacl(duthost, localhost, creds, docker_network, expected_dhcp_rules_for_standby, enum_frontend_asic_index)
 
 def test_cacl_scale_rules_ipv4(duthosts, rand_one_dut_hostname, collect_ignored_rules, clean_scale_rules):
     """


### PR DESCRIPTION
Signed-off-by: Wenyi Zhang<wenyizhang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR [Enhance test_cacl_application to support dualtor by ZhaohuiS · Pull Request #5895 · sonic-net/sonic-mgmt (github.com)](https://github.com/sonic-net/sonic-mgmt/pull/5895) introduced 2 fixture which should be intended to work for dualtor, while it added argument in verify_cacl, which is also used for test_multiasic_cacl_application, failing to add this argument in this test leads to an argument misleading at runtime, between expected_dhcp_rules_for_standby and enum_frontend_asic_index

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Fix issue seen on multi-asic seen after above PR merged

#### How did you do it?
Add argument expected_dhcp_rules_for_standby in test_cacl_application_dualtor, as the fixture take fixture duthost_dualtor that for non-dualtor, there is only 1 active_tor and returns empty list.

#### How did you verify/test it?
**Before:**
30/07/2022 07:12:07 __init__._log_sep_line                   L0160 INFO   | ==================== cacl/test_cacl_application.py::test_multiasic_cacl_application[3] call ====================
30/07/2022 07:12:07 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/azp/agent/_work/2/s/sonic-mgmt-int/tests/cacl/test_cacl_application.py", line 838, in test_multiasic_cacl_application
    verify_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
  File "/azp/agent/_work/2/s/sonic-mgmt-int/tests/cacl/test_cacl_application.py", line 745, in verify_cacl
    expected_iptables_rules, expected_ip6tables_rules = generate_expected_rules(duthost, docker_network, asic_index, expected_dhcp_rules_for_standby)
  File "/azp/agent/_work/2/s/sonic-mgmt-int/tests/cacl/test_cacl_application.py", line 416, in generate_expected_rules
    iptables_rules.extend(expected_dhcp_rules_for_standby)
TypeError: 'int' object is not iterable


**After:**
cacl/test_cacl_application.py::test_cacl_application_nondualtor PASSED                                                                                                                                                                             [  7%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[active_tor] SKIPPED                                                                                                                                                                   [ 15%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[standby_tor] SKIPPED                                                                                                                                                                  [ 23%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[active_tor-0] PASSED                                                                                                                                                                [ 30%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[standby_tor-0] PASSED                                                                                                                                                               [ 38%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[active_tor-1] PASSED                                                                                                                                                                [ 46%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[standby_tor-1] PASSED                                                                                                                                                               [ 53%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[active_tor-2] PASSED                                                                                                                                                                [ 61%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[standby_tor-2] PASSED                                                                                                                                                               [ 69%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[active_tor-3] PASSED                                                                                                                                                                [ 76%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[standby_tor-3] PASSED                                                                                                                                                               [ 84%]
cacl/test_cacl_application.py::test_cacl_scale_rules_ipv4 PASSED                                                                                                                                                                                   [ 92%]
cacl/test_cacl_application.py::test_cacl_scale_rules_ipv6 PASSED                                                                                                                                                                                   [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------------------------------
================================================================================================================ short test summary info =================================================================================================================
SKIPPED [2] cacl/test_cacl_application.py: test_cacl_application_dualtor is only supported on dualtor topology
========================================================================================================= 11 passed, 2 skipped in 895.93 seconds =========================================================================================================


#### Any platform specific information?
Fix for multi-asic dut

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
