### PR TITLE
[dualtor][active-active] Enable `test_active_link_down_downstream_active`

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -54,24 +54,39 @@ def test_active_link_down_upstream(
         )
 
 
+@pytest.mark.enable_active_active
 def test_active_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
     toggle_all_simulator_ports_to_upper_tor,
-    shutdown_fanout_upper_tor_intfs
+    shutdown_fanout_upper_tor_intfs, cable_type
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR link.
     Verify switchover and disruption lasts < 1 second
     """
-    send_t1_to_server_with_action(
-        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
-    )
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host,
-        expected_standby_health='unhealthy'
-    )
+    if cable_type == CableType.active_standby:
+        send_t1_to_server_with_action(
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health='unhealthy'
+        )
+
+    if cable_type == CableType.active_active:
+        send_t1_to_server_with_action(
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health='unhealthy',
+            cable_type=cable_type,
+            skip_state_db=True
+        )
 
 
 def test_active_link_down_downstream_standby(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable `test_active_link_down_downstream_active` for `active-active` dualtor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
due to https://github.com/sonic-net/sonic-buildimage/issues/11737, before IO verification, add method `_probe_stale_servers` to ensure all `STALE` neighbors of mux servers that are learned from `garp_service` are changed into `REACHABLE` state.

#### How did you verify/test it?
```
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby] PASSED                                                                                                                                                                        [ 50%]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-active] PASSED                                                                                                                                                                         [100%]

========================================================================================================================= 2 passed in 846.24 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
