### PR TITLE
Move ignore logs from TC to conftest for sub ports suite

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -567,3 +567,12 @@ def teardown_test_class(duthost):
     """
     yield
     config_reload(duthost)
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(duthost, loganalyzer):
+    if loganalyzer and loganalyzer[duthost.hostname]:
+        ignore_regex_list = [
+            ".*ERR teamd[0-9]*#tlm_teamd.*process_add_queue: Can't connect to teamd after.*attempts. LAG 'PortChannel.*'",
+            ".*ERR swss[0-9]*#orchagent.*update: Failed to get port by bridge port ID.*"
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -477,12 +477,3 @@ class TestSubPorts(object):
                                         type_of_traffic='balancing',
                                         ttl=63)
 
-
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(duthost, loganalyzer):
-    if loganalyzer and loganalyzer[duthost.hostname]:
-        ignore_regex_list = [
-            ".*ERR teamd[0-9]*#tlm_teamd.*process_add_queue: Can't connect to teamd after.*attempts. LAG 'PortChannel.*'",
-            ".*ERR swss[0-9]*#orchagent.*update: Failed to get port by bridge port ID.*"
-        ]
-        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR https://github.com/sonic-net/sonic-mgmt/pull/5951 introduced 2 error log ignore while running sub_port_interfaces test suite. Sub port folder has 2 more cases that need those skip to be performed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable ignore for all sub port test suite
#### How did you do it?
Move ignore fixture from test to conftest scope
#### How did you verify/test it?
Run TC, all passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
