### PR TITLE
A fix for the get_target_speed issue on test_psu_fans

### DIFF
--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -57,7 +57,8 @@ class TestPsuFans(PlatformApiTestBase):
             else:
                 if self.num_psus == 0:
                     pytest.skip("No psus found on device")
-
+                else:
+                    logging.info("Number of PSUs on device: {}".format(self.num_psus))
     #
     # Helper functions
     #
@@ -249,11 +250,16 @@ class TestPsuFans(PlatformApiTestBase):
     def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        total_psu_fans = 0
         psus_skipped = 0
 
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
             fans_skipped = 0
+            total_psu_fans += num_fans
+
+            if num_fans == 0:
+                continue
 
             for i in range(num_fans):
                 speed_target_val = 25
@@ -280,6 +286,9 @@ class TestPsuFans(PlatformApiTestBase):
 
         if psus_skipped == self.num_psus:
             pytest.skip("skipped as all PSU fans' speed is not controllable")
+
+        if total_psu_fans == 0:
+            pytest.skip("skipped as there are no PSU fans available")
 
         self.assert_expectations()
 


### PR DESCRIPTION
### Description of PR

This is a partial fix for the test_get_target_speed issue on test_psu_fans. Specifically, this fixes the issue where the test cannot differentiate between devices that have PSU fans that behave as intended and those that don't even have PSU fans.

In the case of the latter, the changes in this commit skip the test instead of misleadingly marking them as having passed.

The actual problem with the test is that the platform.json for the devices where it has been failing, is incomplete.
The platform.json file does not have 'controllable' field under psu: fan -- this would make the default controllable status 'True'. However, the source code in fan.py renders the fan speed unable to be set if it is a PSU fan. Therefore, vendors need to set the 'controllable' field to False in the platform.json

Summary:
Fixes platform_tests.api.test_psu_fans.TestPsuFans] test_get_fans_target_speed 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
The actual motivation for this specific PR is to ensure that tests that are being skipped in actuality, are being marked as such instead of being marked as having passed.

#### How did you do it?
By getting a total count of the fans in all PSUs and skipping the test if that number is 0.

#### How did you verify/test it?
Tested code changes on the 7260 platform where it was previously passing, and verified that the test was now being skipped.

#### Any platform specific information?
Celestica dx010 and Dell S6000 platforms need to update their platform.json files.
