### PR TITLE
[test gap] Add testcase to verify swss does not restart when radv restarts

### DIFF
--- a/tests/radv/test_radv_restart.py
+++ b/tests/radv/test_radv_restart.py
@@ -23,7 +23,8 @@ def test_radv_swss(duthost):
     swss_status_dict_before = parse_service_status(swss_stdout_lines)
 
     # make sure swss is running
-    assert swss_status_dict_before is not None and swss_status_dict_before.get("ActiveState") == "active"
+    assert swss_status_dict_before is not None and swss_status_dict_before.get(
+        "ActiveState") == "active", "service swss is not running"
 
     # 2. restart radv.service
     duthost.shell("sudo systemctl restart radv.service")
@@ -34,14 +35,16 @@ def test_radv_swss(duthost):
     radv_status_dict = parse_service_status(radv_stdout_lines)
 
     # make sure radv run successfully
-    assert radv_status_dict is not None and radv_status_dict.get("ActiveState") == "active"
+    assert radv_status_dict is not None and radv_status_dict.get(
+        "ActiveState") == "active", "service radv is not running"
 
     # 4. check status of swss.service
     swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
         "stdout_lines"]
     swss_status_dict = parse_service_status(swss_stdout_lines)
     # make sure the ActiveSate is active
-    assert swss_status_dict is not None and swss_status_dict.get("ActiveState") == "active"
+    assert swss_status_dict is not None and swss_status_dict.get(
+        "ActiveState") == "active", "service swss is not running after restart radv.service"
 
     # 5. verify "Restarting radv causes swss service to restart" or not
     # compare ActiveEnterTimestamp of swss.service with radv.service, and compare ActiveEnterTimestamp of swss.service
@@ -50,7 +53,7 @@ def test_radv_swss(duthost):
     datetime_swss_before = datetime.strptime(swss_status_dict_before.get("ActiveEnterTimestamp"), date_format)
     datetime_swss = datetime.strptime(swss_status_dict.get("ActiveEnterTimestamp"), date_format)
     datetime_radv = datetime.strptime(radv_status_dict.get("ActiveEnterTimestamp"), date_format)
-    assert datetime_swss < datetime_radv and datetime_swss == datetime_swss_before
+    assert datetime_swss < datetime_radv and datetime_swss == datetime_swss_before, "service swss also restarted while radv restarting"
 
 
 def parse_service_status(service_status_stdout_lines):
@@ -67,11 +70,10 @@ def parse_service_status(service_status_stdout_lines):
 
         {"ActiveState": "active",
          "ActiveEnterTimestamp": "Tue 2022-08-09 10:30:58 UTC"}
-
     """
 
     # check empty
-    if service_status_stdout_lines is None or len(service_status_stdout_lines) == 0:
+    if not service_status_stdout_lines:
         return None
 
     service_status_dict = {}

--- a/tests/radv/test_radv_restart.py
+++ b/tests/radv/test_radv_restart.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+import pytest
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
+    pytest.mark.topology('any')
+]
+
+
+# For this Test gap "Restarting radv causes swss service to restart"
+# see details at
+# https://github.com/sonic-net/sonic-mgmt/issues/6042
+def test_radv_swss(duthost):
+    """swss does not restart while radv restarting
+
+    Args:
+        duthost: AnsiblecHost instance for DUT
+    """
+
+    # 1. check status of swss.service
+    swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
+        "stdout_lines"]
+    swss_status_dict_before = parse_service_status(swss_stdout_lines)
+
+    # make sure swss is running
+    assert swss_status_dict_before is not None and swss_status_dict_before.get("ActiveState") == "active"
+
+    # 2. restart radv.service
+    duthost.shell("sudo systemctl restart radv.service")
+
+    # 3. check status of radv.service
+    radv_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp radv.service")[
+        "stdout_lines"]
+    radv_status_dict = parse_service_status(radv_stdout_lines)
+
+    # make sure radv run successfully
+    assert radv_status_dict is not None and radv_status_dict.get("ActiveState") == "active"
+
+    # 4. check status of swss.service
+    swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
+        "stdout_lines"]
+    swss_status_dict = parse_service_status(swss_stdout_lines)
+    # make sure the ActiveSate is active
+    assert swss_status_dict is not None and swss_status_dict.get("ActiveState") == "active"
+
+    # 5. verify "Restarting radv causes swss service to restart" or not
+    # compare ActiveEnterTimestamp of swss.service with radv.service, and compare ActiveEnterTimestamp of swss.service
+    # before and after radv.service restarts.
+    date_format = "%a %Y-%m-%d %H:%M:%S %Z"
+    datetime_swss_before = datetime.strptime(swss_status_dict_before.get("ActiveEnterTimestamp"), date_format)
+    datetime_swss = datetime.strptime(swss_status_dict.get("ActiveEnterTimestamp"), date_format)
+    datetime_radv = datetime.strptime(radv_status_dict.get("ActiveEnterTimestamp"), date_format)
+    assert datetime_swss < datetime_radv and datetime_swss == datetime_swss_before
+
+
+def parse_service_status(service_status_stdout_lines):
+    """parse the service status from array format into dictionary format
+
+    Args:
+        service_status_stdout_lines: "stdout_lines" field for the result of duthost.shell(). Type is array, each element is a string. For example:
+
+        ["ActiveState=active",
+        "ActiveEnterTimestamp=Tue 2022-08-09 10:30:58 UTC"]
+
+    Returns:
+        A dictionary which holds the service status. For example:
+
+        {"ActiveState": "active",
+         "ActiveEnterTimestamp": "Tue 2022-08-09 10:30:58 UTC"}
+
+    """
+
+    # check empty
+    if service_status_stdout_lines is None or len(service_status_stdout_lines) == 0:
+        return None
+
+    service_status_dict = {}
+    # parsing
+    for line in service_status_stdout_lines:
+        fields = line.split("=")
+        if len(fields) == 2:
+            service_status_dict[fields[0]] = fields[1]
+
+    return service_status_dict


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Service swss depends on service radv, so we want to confirm whether swss restarts while radv restarting. And our expect is that swss should not restart when radv restarts.

Summary:
Fixes # (6042)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Service swss depends on service radv, so we want to confirm whether swss restarts while radv restarting. And our expect is that swss should not restart when radv restarts.

#### How did you do it?

On a stable SONiC image device:
1. check the status of swss.service, make sure it's active.
2. restart radv.service and confirm it is successful.
3. get the status of swss.service again and compare it with that in step1, also make sure its run time is previous than radv.service.

#### How did you verify/test it?

Run Pytest script 'test_radv_restart.py' in Starlab device via 'run_tests.sh'.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
