### PR TITLE
Fix testcase failure: testQosSaiPfcXoffLimit[None-xoff_1]

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -825,9 +825,9 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 58617
-                    pkts_num_trig_ingr_drp: 58626
-                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 58576
+                    pkts_num_trig_ingr_drp: 58816
+                    pkts_num_margin: 50
                 xoff_2:
                     dscp: 4
                     ecn: 1

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -826,7 +826,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 58617
-                    pkts_num_trig_ingr_drp: 58857
+                    pkts_num_trig_ingr_drp: 58626
                     pkts_num_margin: 4
                 xoff_2:
                     dscp: 4

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -825,8 +825,8 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 58276
-                    pkts_num_trig_ingr_drp: 58516
+                    pkts_num_trig_pfc: 58617
+                    pkts_num_trig_ingr_drp: 58857
                     pkts_num_margin: 4
                 xoff_2:
                     dscp: 4


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Testcase failure: testQosSaiPfcXoffLimit[None-xoff_1]

Summary:
Fixes  testcase failure testQosSaiPfcXoffLimit[None-xoff_1]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
The testcase failed on nightly test.

#### How did you verify/test it?
Manually run the testcase by using binary search for the correct value.
Now manually run the testcase for 10 times without failure.

#### Any platform specific information?
Only 7050cx3 platform with 50000_300m profile.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
