### PR TITLE
Best effort stopping PTF container

### DIFF
--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -61,6 +61,13 @@
     loop_control:
       loop_var: dut_name
 
+  - name: Stop ptf container ptf_{{ vm_set_name }}
+    docker_container:
+      name: ptf_{{ vm_set_name }}
+      state: stopped
+    become: yes
+    ignore_errors: yes
+
   - name: Remove ptf docker container ptf_{{ vm_set_name }}
     docker_container:
       name: "ptf_{{ vm_set_name }}"

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -55,6 +55,7 @@
       name: ptf_{{ vm_set_name }}
       state: stopped
     become: yes
+    ignore_errors: yes
 
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PR #6131 introduced code to stop PTF container before deleting it.
The step to stop PTF container may raise error if the PTF container
is already deleted. 

#### How did you do it?
This change added "ignore_errors: yes" to the step of stopping PTF 
container to address this issue.

This change also added step to stop PTF container firstly for the "remove-topo" procedure.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
