### PR TITLE
Added topo mark for route stress TC

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -18,6 +18,9 @@ MAX_WAIT_TIME = 120
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
     logger.info("announce ipv4 and ipv6 routes")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
TC stress routes does not have topology mark added. That's why when we try to collect/run TC using topology mark --topology it has been skip

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To be able to collect/run ip ticket TC with --topology
#### How did you do it?
Add topology mark any
#### How did you verify/test it?
Run TC at T0/T1 topology. TC passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
