### PR TITLE
[ptftest]: Cast dict_keys to list

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -200,7 +200,7 @@ class IpinIPTunnelTest(BaseTest):
         """
         dst_ports = self.indice_to_portchannel.keys()
         # Select the first ptf indice as src port
-        src_port = dst_ports[0]
+        src_port = list(dst_ports)[0]
         # Step 1. verify no packet is received from standby_tor to server
         for i in range(0, PACKET_NUM_FOR_NEGATIVE_CHECK):
             inner_pkt = self.generate_packet_to_server('src-ip')

--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -198,9 +198,9 @@ class IpinIPTunnelTest(BaseTest):
         """
         Send packet from ptf (T1) to standby ToR, and verify
         """
-        dst_ports = self.indice_to_portchannel.keys()
+        dst_ports = list(self.indice_to_portchannel.keys())
         # Select the first ptf indice as src port
-        src_port = list(dst_ports)[0]
+        src_port = dst_ports[0]
         # Step 1. verify no packet is received from standby_tor to server
         for i in range(0, PACKET_NUM_FOR_NEGATIVE_CHECK):
             inner_pkt = self.generate_packet_to_server('src-ip')


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The ptftest `ip_in_ip_tunnel_test.py` fails because dict_keys objects are not subscriptable in Python3

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
