### PR TITLE
[copp] Enhance the copp test case

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -39,7 +39,7 @@ class ControlPlaneBaseTest(BaseTest):
     TASK_TIMEOUT = 600  # Wait up to 10 minutes for tasks to complete
 
     DEFAULT_PRE_SEND_INTERVAL_SEC = 1
-    DEFAULT_SEND_INTERVAL_SEC = 10
+    DEFAULT_SEND_INTERVAL_SEC = 30
     DEFAULT_RECEIVE_WAIT_TIME = 3
 
     def __init__(self):


### PR DESCRIPTION
What is the motivation for this PR?
The CBS is large on Cisco platform, it would take couple of seconds to be exhausted out. If just sending pkt with 10s, the test result is not  accurate because part of them costs on the CBS.

How did you do it?
Change the duration of sending packet from 10s to 30s

How did you verify/test it?
Run copp test.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
