### PR TITLE
Fix exception that partiallySucceeded build result not found

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -107,7 +107,12 @@ def find_latest_build_id(branch, success_flag = "succeeded"):
 
     j = json.loads(resp.read().decode('utf-8'))
 
-    latest_build_id = int(j['value'][0]['id'])
+    value = j.get('value', [])
+
+    if len(value) > 0:
+        latest_build_id = int(value[0]['id'])
+    else:
+        latest_build_id = None
 
     return latest_build_id
 
@@ -132,7 +137,9 @@ def main():
     if args.buildid is None:
         buildid_succ = find_latest_build_id(args.branch, "succeeded")
         buildid_partial = find_latest_build_id(args.branch, "partiallySucceeded")
-        buildid = max(buildid_succ,buildid_partial)
+        if buildid_succ is None and buildid_partial is None:
+            raise Exception("Can't find 'Succeeded' or 'partiallySucceeded' build result.")
+        buildid = max(buildid_succ, buildid_partial)
     else:
         buildid = int(args.buildid)
 

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -9,6 +9,9 @@ from urllib.request import urlopen, urlretrieve
 _start_time = None
 _last_time = None
 artifact_size = 0
+NOT_FOUND_BUILD_ID = -999
+
+
 def reporthook(count, block_size, total_size):
     global _start_time, _last_time, artifact_size
     cur_time = int(time.time())
@@ -112,7 +115,7 @@ def find_latest_build_id(branch, success_flag = "succeeded"):
     if len(value) > 0:
         latest_build_id = int(value[0]['id'])
     else:
-        latest_build_id = None
+        latest_build_id = NOT_FOUND_BUILD_ID
 
     return latest_build_id
 
@@ -137,7 +140,7 @@ def main():
     if args.buildid is None:
         buildid_succ = find_latest_build_id(args.branch, "succeeded")
         buildid_partial = find_latest_build_id(args.branch, "partiallySucceeded")
-        if buildid_succ is None and buildid_partial is None:
+        if buildid_succ == NOT_FOUND_BUILD_ID and buildid_partial == NOT_FOUND_BUILD_ID:
             raise Exception("Can't find 'Succeeded' or 'partiallySucceeded' build result.")
         buildid = max(buildid_succ, buildid_partial)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If the partiallySucceeded or succeeded build result not found, getBuild will raise exception:
Traceback (most recent call last):
  File "sonic-mgmt/tests/scripts/getbuild.py", line 146, in <module>
    main()
  File "sonic-mgmt/tests/scripts/getbuild.py", line 134, in main
    buildid_partial = find_latest_build_id(args.branch, "partiallySucceeded")
  File "sonic-mgmt/tests/scripts/getbuild.py", line 110, in find_latest_build_id
    latest_build_id = int(j['value'][0]['id'])
IndexError: list index out of range

This PR refine the logic to only require one result from partiallySucceeded or succeeded build result.

#### How did you do it?
Tolerate build id not found in function: find_latest_build_id
#### How did you verify/test it?
TestbedV2 t1-lag pipeline will go through this step.

