### PR TITLE
Install python-is-python3 for test_copp

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -217,7 +217,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                     rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
-                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python-setuptools wget cmake \
+                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python-setuptools wget cmake python-is-python3 \
                     && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_copp` will hang and gets stuck at running ptf command `ptf --test-dir ptftests copp_tests.ARPTest ...` forever until pipeline timeout.
It's because `ptf_nn_agent` is not running on DUT. It failed with this message:
`ptf_nn_agent                     FATAL     can't find command '/usr/bin/python'`

#### How did you do it?
syncd is upgraded to bullseye and `/usr/bin/python` doesn't exist in bullseye, we have to use `python3` instead.
In test_copp script, it copys `ansible/roles/test/templates/ptf_nn_agent.conf.dut.j2` to dut as `ptf_nn_agent` config file.
In this is template config file, it still uses `/usr/bin/python `which causes ptf_nn_agent can't boot up.
copp ptf script stuck forever since it can't establish connection with DUT's `ptf_nn_agent`.

Install `python-is-python3` during install nano.

#### How did you verify/test it?
Run `test_copp`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
