### PR TITLE
[dualtor][active-active] Enable `test_link_drop`

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -44,6 +44,8 @@ ACTIVE_ACTIVE_INTERFACES_TEMPLATE = "iaa-%s-%d"
 ACTIVE_ACTIVE_INTERFACE_PATTERN = "iaa-[\w-]+-\d+"
 SERVER_NIC_INTERFACE_TEMPLATE = "nic-%s-%d"
 SERVER_NIC_INTERFACE_PATTERN = "nic-[\w-]+-\d+"
+
+# gRPC settings
 GRPC_TIMEOUT = 0.5
 GRPC_SERVER_OPTIONS = [
     ('grpc.http2.min_ping_interval_without_data_ms', 1000),
@@ -96,6 +98,7 @@ class OVSCommand(object):
     OVS_VSCTL_LIST_PORTS_CMD = "ovs-vsctl list-ports {bridge_name}"
     OVS_OFCTL_DEL_FLOWS_CMD = "ovs-ofctl del-flows {bridge_name}"
     OVS_OFCTL_ADD_FLOWS_CMD = "ovs-ofctl add-flow {bridge_name} {flow}"
+    OVS_OFCTL_MOD_FLOWS_CMD = "ovs-ofctl mod-flows {bridge_name} {flow}"
     OVS_OFCTL_DEL_GROUPS_CMD = "ovs-ofctl -O OpenFlow13 del-groups {bridge_name}"
     OVS_OFCTL_ADD_GROUP_CMD = "ovs-ofctl -O OpenFlow13 add-group {bridge_name} {group}"
     OVS_OFCTL_MOD_GROUP_CMD = "ovs-ofctl -O OpenFlow13 mod-group {bridge_name} {group}"
@@ -115,6 +118,10 @@ class OVSCommand(object):
     @staticmethod
     def ovs_ofctl_add_flow(bridge_name, flow):
         return run_command(OVSCommand.OVS_OFCTL_ADD_FLOWS_CMD.format(bridge_name=bridge_name, flow=flow))
+
+    @staticmethod
+    def ovs_ofctl_mod_flow(bridge_name, flow):
+        return run_command(OVSCommand.OVS_OFCTL_MOD_FLOWS_CMD.format(bridge_name=bridge_name, flow=flow))
 
     @staticmethod
     def ovs_ofctl_add_group(bridge_name, group):
@@ -180,7 +187,7 @@ class OVSFlow(StrObj):
     def __init__(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
         self.in_port = in_port
         self.packet_filter = packet_filter
-        self.output_ports = set(output_ports)
+        self.output_ports = output_ports
         self.group = group
         self.priority = priority
         self._str_prefix = []
@@ -190,17 +197,65 @@ class OVSFlow(StrObj):
             self._str_prefix.append(str(self.packet_filter))
         self._str_prefix.append("in_port=%s" % self.in_port)
         self._str_prefix = ",".join(self._str_prefix)
+        self.drop = False
 
     def to_string(self):
         flow_parts = [self._str_prefix]
-        if self.output_ports:
-            flow_parts.append("actions=")
-            flow_parts.extend("output:%s" % _ for _ in self.output_ports)
+        if self.drop:
+            flow_parts.append("actions=drop")
+        elif self.output_ports:
+            output = ["output:%s" % _ for _ in self.output_ports]
+            flow_parts.append("actions=%s" % ",".join(output))
         elif self.group:
             flow_parts.append("actions=group:%s" % self.group.group_id)
         else:
             flow_parts.append("actions=drop")
         return ",".join(flow_parts)
+
+    def set_drop(self, recover=False):
+        if recover:
+            self.drop = False
+        else:
+            self.drop = True
+        self.reset()
+
+
+class OVSUpstreamFlow(OVSFlow):
+    """Object to represent an OVS upstream flow to output to both ToRs."""
+
+    __slots__ = ("drop_output",)
+
+    def __init__(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
+        super(OVSUpstreamFlow, self).__init__(in_port, packet_filter, output_ports, group, priority)
+        self.drop_output = [False, False]
+
+    def to_string(self):
+        flow_parts = [self._str_prefix]
+        has_output = False
+        if self.output_ports:
+            output = ["output:%s" % port for (portid, port) in enumerate(self.output_ports) if not self.drop_output[portid]]
+            has_output = bool(output)
+            if has_output:
+                flow_parts.append("actions=%s" % ",".join(output))
+        elif self.group:
+            flow_parts.append("actions=group:%s" % self.group.group_id)
+
+        if not has_output:
+            flow_parts.append("actions=drop")
+        return ",".join(flow_parts)
+
+    def get_drop(self, portid):
+        return self.drop_output[portid]
+
+    def set_drop(self, portid=None, recover=False):
+        is_drop = not recover
+  
+        if portid is None:
+            self.drop_output = [is_drop, is_drop]
+        else:
+            self.drop_output[portid] = is_drop
+
+        self.reset()
 
 
 class ForwardingState(object):
@@ -317,7 +372,13 @@ class OVSBridge(object):
         "upstream_ecmp_flow",
         "upstream_ecmp_group",
         "states_getter",
-        "states_setter"
+        "states_setter",
+        "downstream_flows",
+        "downstream_upper_tor_flow",
+        "downstream_lower_tor_flow",
+        "upstream_nic_flow",
+        "upstream_icmp_flow",
+        "upstream_arp_flow"
     )
 
     def __init__(self, bridge_name):
@@ -341,6 +402,10 @@ class OVSBridge(object):
         self.states_setter = {
             1: self.upstream_ecmp_flow.set_upper_tor_forwarding_state,
             0: self.upstream_ecmp_flow.set_lower_tor_forwarding_state
+        }
+        self.downstream_flows = {
+            1: self.downstream_upper_tor_flow,
+            0: self.downstream_lower_tor_flow
         }
 
     def _init_ports(self):
@@ -376,16 +441,16 @@ class OVSBridge(object):
         self._del_flows()
         self._del_groups()
         # downstream flows
-        self._add_flow(self.upper_tor_port, output_ports=[self.ptf_port, self.server_nic], priority=10)
-        self._add_flow(self.lower_tor_port, output_ports=[self.ptf_port, self.server_nic], priority=10)
+        self.downstream_upper_tor_flow = self._add_flow(self.upper_tor_port, output_ports=[self.ptf_port, self.server_nic], priority=10)
+        self.downstream_lower_tor_flow = self._add_flow(self.lower_tor_port, output_ports=[self.ptf_port, self.server_nic], priority=10)
 
         # upstream flows
         # upstream packet from server NiC should be directed to both ToRs
-        self._add_flow(self.server_nic, output_ports=[self.upper_tor_port, self.lower_tor_port], priority=9)
+        self.upstream_nic_flow = self._add_flow(self.server_nic, output_ports=[self.lower_tor_port, self.upper_tor_port], priority=9, upstream=True)
         # upstream icmp packet from ptf port should be directed to both ToRs
-        self._add_flow(self.ptf_port, packet_filter="icmp", output_ports=[self.upper_tor_port, self.lower_tor_port], priority=8)
+        self.upstream_icmp_flow = self._add_flow(self.ptf_port, packet_filter="icmp", output_ports=[self.lower_tor_port, self.upper_tor_port], priority=8, upstream=True)
         # upstream arp packet from ptf port should be directed to both ToRs
-        self._add_flow(self.ptf_port, packet_filter="arp", output_ports=[self.upper_tor_port, self.lower_tor_port], priority=7)
+        self.upstream_arp_flow = self._add_flow(self.ptf_port, packet_filter="arp", output_ports=[self.lower_tor_port, self.upper_tor_port], priority=7, upstream=True)
         # upstream packet from ptf port should be ECMP directed to active ToRs
         self.upstream_ecmp_group = self._add_upstream_ecmp_group(1, self.upper_tor_port, self.lower_tor_port)
         self.upstream_ecmp_flow = self._add_upstream_ecmp_flow(self.ptf_port, self.upstream_ecmp_group, priority=6)
@@ -404,8 +469,11 @@ class OVSBridge(object):
         self.upstream_ecmp_group = None
         self.groups.clear()
 
-    def _add_flow(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
-        flow = OVSFlow(in_port, packet_filter=packet_filter, output_ports=output_ports, group=group, priority=priority)
+    def _add_flow(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None, upstream=False):
+        if upstream:
+            flow = OVSUpstreamFlow(in_port, packet_filter=packet_filter, output_ports=output_ports, group=group, priority=priority)
+        else:
+            flow = OVSFlow(in_port, packet_filter=packet_filter, output_ports=output_ports, group=group, priority=priority)
         logging.info("Add flow to bridge %s: %s", self.bridge_name, flow)
         OVSCommand.ovs_ofctl_add_flow(self.bridge_name, flow)
         self.flows.append(flow)
@@ -441,6 +509,70 @@ class OVSBridge(object):
             logging.info("Query bridge %s forwarding state for ports %s: %s", self.bridge_name, portids, tuple(ForwardingState.STATE_LABELS[_] for _ in states))
             return states
 
+    def set_drop(self, portids, directions, recover):
+        """Set drop on a link."""
+        logging.info("Set drop on bridge %s: portids=%s, directions=%s, recover=%s" % (self.bridge_name, portids, directions, recover))
+        with self.lock:
+            result = []
+            for portid, direction in zip(portids, directions):
+                downstream_flow = self.downstream_flows[portid]
+                forwarding_state_getter = self.states_getter[portid]
+                forwarding_state_setter = self.states_setter[portid]
+                if recover:
+                    # recover both upstream and downstream flows
+                    # recover downstream
+                    if downstream_flow.drop:
+                        downstream_flow.set_drop(recover=recover)
+                        OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, downstream_flow)
+
+                    # recover upstream
+                    # recover upstream traffic from server NiC
+                    if self.upstream_nic_flow.get_drop(portid):
+                        self.upstream_nic_flow.set_drop(portid=portid, recover=recover)
+                        OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_nic_flow)
+                    # recover upstream icmp traffic(heartbeats) from ptf
+                    if self.upstream_icmp_flow.get_drop(portid):
+                        self.upstream_icmp_flow.set_drop(portid=portid, recover=recover)
+                        OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_icmp_flow)
+                    # recover upstream arp traffic from ptf
+                    if self.upstream_arp_flow.get_drop(portid):
+                        self.upstream_arp_flow.set_drop(portid=portid, recover=recover)
+                        OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_arp_flow)
+
+                    forwarding_state = forwarding_state_getter()
+                    if forwarding_state == ForwardingState.STANDBY:
+                        forwarding_state_setter(ForwardingState.ACTIVE)
+                        OVSCommand.ovs_ofctl_mod_groups(self.bridge_name, self.upstream_ecmp_group)
+                else:
+                    if direction == 0:
+                        # downstream
+                        if not downstream_flow.drop:
+                            downstream_flow.set_drop()
+                            OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, downstream_flow)
+                    elif direction == 1:
+                        # upstream
+                        # drop upstream traffic from server NiC
+                        if not self.upstream_nic_flow.get_drop(portid):
+                            self.upstream_nic_flow.set_drop(portid)
+                            OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_nic_flow)
+                        # drop upstream icmp traffic(heartbeats) from ptf
+                        if not self.upstream_icmp_flow.get_drop(portid):
+                            self.upstream_icmp_flow.set_drop(portid)
+                            OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_icmp_flow)
+                        # drop upstream arp traffic from ptf
+                        if not self.upstream_arp_flow.get_drop(portid):
+                            self.upstream_arp_flow.set_drop(portid)
+                            OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, self.upstream_arp_flow)
+
+                        forwarding_state = forwarding_state_getter()
+                        # use set forwarding state to standby to simulator link drop
+                        if forwarding_state == ForwardingState.ACTIVE:
+                            forwarding_state_setter(ForwardingState.STANDBY)
+                            OVSCommand.ovs_ofctl_mod_groups(self.bridge_name, self.upstream_ecmp_group)
+                    else:
+                        raise ValueError("Invalid direction %s, please use 0 for downstream and 1 for upstream" % (direction))
+                result.append(True)
+            return result
 
 def validate_request_certificate(response):
     """Decorator to validate client certificate."""
@@ -538,6 +670,17 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
     def QueryServerVersion(self, request, context):
         # TODO: add QueryServerVersion implementation
         return nic_simulator_grpc_service_pb2.ServerVersionReply()
+
+    @validate_request_certificate(nic_simulator_grpc_service_pb2.DropReply())
+    def SetDrop(self, request, context):
+        logging.debug("SetDrop: request to server %s from client %s\n", self.nic_addr, context.peer())
+        portids, directions, recover = request.portid, request.direction, request.recover
+        response = nic_simulator_grpc_service_pb2.DropReply(
+            portid=portids,
+            success=self.ovs_bridge.set_drop(portids, directions, recover)
+        )
+        logging.debug("SetDrop: response to client %s from server %s\n%s", context.peer(), self.nic_addr, response)
+        return response
 
     def _run_server(self, binding_port):
         """Run the gRPC server."""
@@ -641,6 +784,30 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
 
     def QueryOperationPortState(self, request, context):
         return nic_simulator_grpc_mgmt_service_pb2.ListOfOperationReply()
+
+    def SetDrop(self, request, context):
+        nic_addresses = request.nic_addresses
+        drop_requests = request.drop_requests
+        logging.debug("SetDrop[mgmt]: request set drop: %s\n", request)
+        set_drop_responses = []
+        for nic_address, drop_request in zip(nic_addresses, drop_requests):
+            client_stub = self._get_client_stub(nic_address)
+            try:
+                set_drop_response = client_stub.SetDrop(
+                    drop_request,
+                    timeout=10
+                )
+                set_drop_responses.append(set_drop_response)
+            except Exception as e:
+                context.set_code(grpc.StatusCode.ABORTED)
+                context.set_details("Error in SetDrop to %s: %s" % (nic_address, repr(e)))
+                return nic_simulator_grpc_mgmt_service_pb2.ListOfDropReply()
+        response = nic_simulator_grpc_mgmt_service_pb2.ListOfDropReply(
+            nic_addresses=nic_addresses,
+            drop_replies=set_drop_responses
+        )
+        logging.debug("SetDrop[mgmt]: response of set drop: %s\n", response)
+        return response
 
     def start(self):
         self.server = grpc.server(

--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -237,8 +237,6 @@ class OVSUpstreamFlow(OVSFlow):
             has_output = bool(output)
             if has_output:
                 flow_parts.append("actions=%s" % ",".join(output))
-        elif self.group:
-            flow_parts.append("actions=group:%s" % self.group.group_id)
 
         if not has_output:
             flow_parts.append("actions=drop")

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
@@ -8,6 +8,8 @@ service DualTorMgmtService {
   rpc SetAdminForwardingPortState(ListOfAdminRequest) returns (ListOfAdminReply) {}
   
   rpc QueryOperationPortState(ListOfOperationRequest) returns (ListOfOperationReply) {}
+
+  rpc SetDrop(ListOfDropRequest) returns (ListOfDropReply) {}
 }
 
 message ListOfAdminRequest {
@@ -28,4 +30,14 @@ message ListOfOperationRequest {
 message ListOfOperationReply {
   repeated string nic_addresses = 1;
   repeated OperationReply operation_replies = 2;
+}
+
+message ListOfDropRequest {
+  repeated string nic_addresses = 1;
+  repeated DropRequest drop_requests = 2;
+}
+
+message ListOfDropReply {
+  repeated string nic_addresses = 1;
+  repeated DropReply drop_replies = 2;
 }

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2.py
@@ -3,7 +3,6 @@
 # source: nic_simulator_grpc_mgmt_service.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
-from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -15,14 +14,266 @@ _sym_db = _symbol_database.Default()
 import nic_simulator_grpc_service_pb2 as nic__simulator__grpc__service__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%nic_simulator_grpc_mgmt_service.proto\x1a nic_simulator_grpc_service.proto\"R\n\x12ListOfAdminRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12%\n\x0e\x61\x64min_requests\x18\x02 \x03(\x0b\x32\r.AdminRequest\"M\n\x10ListOfAdminReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\"\n\radmin_replies\x18\x02 \x03(\x0b\x32\x0b.AdminReply\"^\n\x16ListOfOperationRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12-\n\x12operation_requests\x18\x02 \x03(\x0b\x32\x11.OperationRequest\"Y\n\x14ListOfOperationReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12*\n\x11operation_replies\x18\x02 \x03(\x0b\x32\x0f.OperationReply2\xf5\x01\n\x12\x44ualTorMgmtService\x12I\n\x1dQueryAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12G\n\x1bSetAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12K\n\x17QueryOperationPortState\x12\x17.ListOfOperationRequest\x1a\x15.ListOfOperationReply\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor.FileDescriptor(
+  name='nic_simulator_grpc_mgmt_service.proto',
+  package='',
+  syntax='proto3',
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_pb=b'\n%nic_simulator_grpc_mgmt_service.proto\x1a nic_simulator_grpc_service.proto\"R\n\x12ListOfAdminRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12%\n\x0e\x61\x64min_requests\x18\x02 \x03(\x0b\x32\r.AdminRequest\"M\n\x10ListOfAdminReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\"\n\radmin_replies\x18\x02 \x03(\x0b\x32\x0b.AdminReply\"^\n\x16ListOfOperationRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12-\n\x12operation_requests\x18\x02 \x03(\x0b\x32\x11.OperationRequest\"Y\n\x14ListOfOperationReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12*\n\x11operation_replies\x18\x02 \x03(\x0b\x32\x0f.OperationReply\"O\n\x11ListOfDropRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12#\n\rdrop_requests\x18\x02 \x03(\x0b\x32\x0c.DropRequest\"J\n\x0fListOfDropReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12 \n\x0c\x64rop_replies\x18\x02 \x03(\x0b\x32\n.DropReply2\xa8\x02\n\x12\x44ualTorMgmtService\x12I\n\x1dQueryAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12G\n\x1bSetAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12K\n\x17QueryOperationPortState\x12\x17.ListOfOperationRequest\x1a\x15.ListOfOperationReply\"\x00\x12\x31\n\x07SetDrop\x12\x12.ListOfDropRequest\x1a\x10.ListOfDropReply\"\x00\x62\x06proto3'
+  ,
+  dependencies=[nic__simulator__grpc__service__pb2.DESCRIPTOR,])
 
 
 
-_LISTOFADMINREQUEST = DESCRIPTOR.message_types_by_name['ListOfAdminRequest']
-_LISTOFADMINREPLY = DESCRIPTOR.message_types_by_name['ListOfAdminReply']
-_LISTOFOPERATIONREQUEST = DESCRIPTOR.message_types_by_name['ListOfOperationRequest']
-_LISTOFOPERATIONREPLY = DESCRIPTOR.message_types_by_name['ListOfOperationReply']
+
+_LISTOFADMINREQUEST = _descriptor.Descriptor(
+  name='ListOfAdminRequest',
+  full_name='ListOfAdminRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfAdminRequest.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='admin_requests', full_name='ListOfAdminRequest.admin_requests', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=75,
+  serialized_end=157,
+)
+
+
+_LISTOFADMINREPLY = _descriptor.Descriptor(
+  name='ListOfAdminReply',
+  full_name='ListOfAdminReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfAdminReply.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='admin_replies', full_name='ListOfAdminReply.admin_replies', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=159,
+  serialized_end=236,
+)
+
+
+_LISTOFOPERATIONREQUEST = _descriptor.Descriptor(
+  name='ListOfOperationRequest',
+  full_name='ListOfOperationRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfOperationRequest.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='operation_requests', full_name='ListOfOperationRequest.operation_requests', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=238,
+  serialized_end=332,
+)
+
+
+_LISTOFOPERATIONREPLY = _descriptor.Descriptor(
+  name='ListOfOperationReply',
+  full_name='ListOfOperationReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfOperationReply.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='operation_replies', full_name='ListOfOperationReply.operation_replies', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=334,
+  serialized_end=423,
+)
+
+
+_LISTOFDROPREQUEST = _descriptor.Descriptor(
+  name='ListOfDropRequest',
+  full_name='ListOfDropRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfDropRequest.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='drop_requests', full_name='ListOfDropRequest.drop_requests', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=425,
+  serialized_end=504,
+)
+
+
+_LISTOFDROPREPLY = _descriptor.Descriptor(
+  name='ListOfDropReply',
+  full_name='ListOfDropReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='nic_addresses', full_name='ListOfDropReply.nic_addresses', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='drop_replies', full_name='ListOfDropReply.drop_replies', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=506,
+  serialized_end=580,
+)
+
+_LISTOFADMINREQUEST.fields_by_name['admin_requests'].message_type = nic__simulator__grpc__service__pb2._ADMINREQUEST
+_LISTOFADMINREPLY.fields_by_name['admin_replies'].message_type = nic__simulator__grpc__service__pb2._ADMINREPLY
+_LISTOFOPERATIONREQUEST.fields_by_name['operation_requests'].message_type = nic__simulator__grpc__service__pb2._OPERATIONREQUEST
+_LISTOFOPERATIONREPLY.fields_by_name['operation_replies'].message_type = nic__simulator__grpc__service__pb2._OPERATIONREPLY
+_LISTOFDROPREQUEST.fields_by_name['drop_requests'].message_type = nic__simulator__grpc__service__pb2._DROPREQUEST
+_LISTOFDROPREPLY.fields_by_name['drop_replies'].message_type = nic__simulator__grpc__service__pb2._DROPREPLY
+DESCRIPTOR.message_types_by_name['ListOfAdminRequest'] = _LISTOFADMINREQUEST
+DESCRIPTOR.message_types_by_name['ListOfAdminReply'] = _LISTOFADMINREPLY
+DESCRIPTOR.message_types_by_name['ListOfOperationRequest'] = _LISTOFOPERATIONREQUEST
+DESCRIPTOR.message_types_by_name['ListOfOperationReply'] = _LISTOFOPERATIONREPLY
+DESCRIPTOR.message_types_by_name['ListOfDropRequest'] = _LISTOFDROPREQUEST
+DESCRIPTOR.message_types_by_name['ListOfDropReply'] = _LISTOFDROPREPLY
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
 ListOfAdminRequest = _reflection.GeneratedProtocolMessageType('ListOfAdminRequest', (_message.Message,), {
   'DESCRIPTOR' : _LISTOFADMINREQUEST,
   '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
@@ -51,18 +302,75 @@ ListOfOperationReply = _reflection.GeneratedProtocolMessageType('ListOfOperation
   })
 _sym_db.RegisterMessage(ListOfOperationReply)
 
-_DUALTORMGMTSERVICE = DESCRIPTOR.services_by_name['DualTorMgmtService']
-if _descriptor._USE_C_DESCRIPTORS == False:
+ListOfDropRequest = _reflection.GeneratedProtocolMessageType('ListOfDropRequest', (_message.Message,), {
+  'DESCRIPTOR' : _LISTOFDROPREQUEST,
+  '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
+  # @@protoc_insertion_point(class_scope:ListOfDropRequest)
+  })
+_sym_db.RegisterMessage(ListOfDropRequest)
 
-  DESCRIPTOR._options = None
-  _LISTOFADMINREQUEST._serialized_start=75
-  _LISTOFADMINREQUEST._serialized_end=157
-  _LISTOFADMINREPLY._serialized_start=159
-  _LISTOFADMINREPLY._serialized_end=236
-  _LISTOFOPERATIONREQUEST._serialized_start=238
-  _LISTOFOPERATIONREQUEST._serialized_end=332
-  _LISTOFOPERATIONREPLY._serialized_start=334
-  _LISTOFOPERATIONREPLY._serialized_end=423
-  _DUALTORMGMTSERVICE._serialized_start=426
-  _DUALTORMGMTSERVICE._serialized_end=671
+ListOfDropReply = _reflection.GeneratedProtocolMessageType('ListOfDropReply', (_message.Message,), {
+  'DESCRIPTOR' : _LISTOFDROPREPLY,
+  '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
+  # @@protoc_insertion_point(class_scope:ListOfDropReply)
+  })
+_sym_db.RegisterMessage(ListOfDropReply)
+
+
+
+_DUALTORMGMTSERVICE = _descriptor.ServiceDescriptor(
+  name='DualTorMgmtService',
+  full_name='DualTorMgmtService',
+  file=DESCRIPTOR,
+  index=0,
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_start=583,
+  serialized_end=879,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='QueryAdminForwardingPortState',
+    full_name='DualTorMgmtService.QueryAdminForwardingPortState',
+    index=0,
+    containing_service=None,
+    input_type=_LISTOFADMINREQUEST,
+    output_type=_LISTOFADMINREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='SetAdminForwardingPortState',
+    full_name='DualTorMgmtService.SetAdminForwardingPortState',
+    index=1,
+    containing_service=None,
+    input_type=_LISTOFADMINREQUEST,
+    output_type=_LISTOFADMINREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='QueryOperationPortState',
+    full_name='DualTorMgmtService.QueryOperationPortState',
+    index=2,
+    containing_service=None,
+    input_type=_LISTOFOPERATIONREQUEST,
+    output_type=_LISTOFOPERATIONREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='SetDrop',
+    full_name='DualTorMgmtService.SetDrop',
+    index=3,
+    containing_service=None,
+    input_type=_LISTOFDROPREQUEST,
+    output_type=_LISTOFDROPREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_DUALTORMGMTSERVICE)
+
+DESCRIPTOR.services_by_name['DualTorMgmtService'] = _DUALTORMGMTSERVICE
+
 # @@protoc_insertion_point(module_scope)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2_grpc.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2_grpc.py
@@ -29,6 +29,11 @@ class DualTorMgmtServiceStub(object):
                 request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.SerializeToString,
                 response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.FromString,
                 )
+        self.SetDrop = channel.unary_unary(
+                '/DualTorMgmtService/SetDrop',
+                request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.SerializeToString,
+                response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.FromString,
+                )
 
 
 class DualTorMgmtServiceServicer(object):
@@ -52,6 +57,12 @@ class DualTorMgmtServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def SetDrop(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DualTorMgmtServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -69,6 +80,11 @@ def add_DualTorMgmtServiceServicer_to_server(servicer, server):
                     servicer.QueryOperationPortState,
                     request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.FromString,
                     response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.SerializeToString,
+            ),
+            'SetDrop': grpc.unary_unary_rpc_method_handler(
+                    servicer.SetDrop,
+                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.FromString,
+                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -128,5 +144,22 @@ class DualTorMgmtService(object):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/QueryOperationPortState',
             nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.SerializeToString,
             nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def SetDrop(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/SetDrop',
+            nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.SerializeToString,
+            nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
@@ -10,6 +10,8 @@ service DualToRActive {
   rpc QueryLinkState(LinkStateRequest) returns (LinkStateReply) {}
 
   rpc QueryServerVersion(ServerVersionRequest) returns (ServerVersionReply) {}
+
+  rpc SetDrop(DropRequest) returns (DropReply) {}
 }
 
 message AdminRequest {
@@ -46,4 +48,15 @@ message ServerVersionRequest {
 
 message ServerVersionReply {
   string version = 1;
+}
+
+message DropRequest {
+  repeated int32 portid = 1;
+  repeated int32 direction = 2;
+  bool recover = 3;
+}
+
+message DropReply {
+  repeated int32 portid = 1;
+  repeated bool success = 2;
 }

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2.py
@@ -3,7 +3,6 @@
 # source: nic_simulator_grpc_service.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
-from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -14,18 +13,398 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n nic_simulator_grpc_service.proto\"-\n\x0c\x41\x64minRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"+\n\nAdminReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10OperationRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eOperationReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10LinkStateRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eLinkStateReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\'\n\x14ServerVersionRequest\x12\x0f\n\x07version\x18\x01 \x01(\t\"%\n\x12ServerVersionReply\x12\x0f\n\x07version\x18\x01 \x01(\t2\xc8\x02\n\rDualToRActive\x12=\n\x1dQueryAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12;\n\x1bSetAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12?\n\x17QueryOperationPortState\x12\x11.OperationRequest\x1a\x0f.OperationReply\"\x00\x12\x36\n\x0eQueryLinkState\x12\x11.LinkStateRequest\x1a\x0f.LinkStateReply\"\x00\x12\x42\n\x12QueryServerVersion\x12\x15.ServerVersionRequest\x1a\x13.ServerVersionReply\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor.FileDescriptor(
+  name='nic_simulator_grpc_service.proto',
+  package='',
+  syntax='proto3',
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_pb=b'\n nic_simulator_grpc_service.proto\"-\n\x0c\x41\x64minRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"+\n\nAdminReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10OperationRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eOperationReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10LinkStateRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eLinkStateReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\'\n\x14ServerVersionRequest\x12\x0f\n\x07version\x18\x01 \x01(\t\"%\n\x12ServerVersionReply\x12\x0f\n\x07version\x18\x01 \x01(\t\"A\n\x0b\x44ropRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x11\n\tdirection\x18\x02 \x03(\x05\x12\x0f\n\x07recover\x18\x03 \x01(\x08\",\n\tDropReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x0f\n\x07success\x18\x02 \x03(\x08\x32\xef\x02\n\rDualToRActive\x12=\n\x1dQueryAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12;\n\x1bSetAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12?\n\x17QueryOperationPortState\x12\x11.OperationRequest\x1a\x0f.OperationReply\"\x00\x12\x36\n\x0eQueryLinkState\x12\x11.LinkStateRequest\x1a\x0f.LinkStateReply\"\x00\x12\x42\n\x12QueryServerVersion\x12\x15.ServerVersionRequest\x1a\x13.ServerVersionReply\"\x00\x12%\n\x07SetDrop\x12\x0c.DropRequest\x1a\n.DropReply\"\x00\x62\x06proto3'
+)
 
 
 
-_ADMINREQUEST = DESCRIPTOR.message_types_by_name['AdminRequest']
-_ADMINREPLY = DESCRIPTOR.message_types_by_name['AdminReply']
-_OPERATIONREQUEST = DESCRIPTOR.message_types_by_name['OperationRequest']
-_OPERATIONREPLY = DESCRIPTOR.message_types_by_name['OperationReply']
-_LINKSTATEREQUEST = DESCRIPTOR.message_types_by_name['LinkStateRequest']
-_LINKSTATEREPLY = DESCRIPTOR.message_types_by_name['LinkStateReply']
-_SERVERVERSIONREQUEST = DESCRIPTOR.message_types_by_name['ServerVersionRequest']
-_SERVERVERSIONREPLY = DESCRIPTOR.message_types_by_name['ServerVersionReply']
+
+_ADMINREQUEST = _descriptor.Descriptor(
+  name='AdminRequest',
+  full_name='AdminRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='AdminRequest.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='state', full_name='AdminRequest.state', index=1,
+      number=2, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=36,
+  serialized_end=81,
+)
+
+
+_ADMINREPLY = _descriptor.Descriptor(
+  name='AdminReply',
+  full_name='AdminReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='AdminReply.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='state', full_name='AdminReply.state', index=1,
+      number=2, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=83,
+  serialized_end=126,
+)
+
+
+_OPERATIONREQUEST = _descriptor.Descriptor(
+  name='OperationRequest',
+  full_name='OperationRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='OperationRequest.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=128,
+  serialized_end=162,
+)
+
+
+_OPERATIONREPLY = _descriptor.Descriptor(
+  name='OperationReply',
+  full_name='OperationReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='OperationReply.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='state', full_name='OperationReply.state', index=1,
+      number=2, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=164,
+  serialized_end=211,
+)
+
+
+_LINKSTATEREQUEST = _descriptor.Descriptor(
+  name='LinkStateRequest',
+  full_name='LinkStateRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='LinkStateRequest.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=213,
+  serialized_end=247,
+)
+
+
+_LINKSTATEREPLY = _descriptor.Descriptor(
+  name='LinkStateReply',
+  full_name='LinkStateReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='LinkStateReply.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='state', full_name='LinkStateReply.state', index=1,
+      number=2, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=249,
+  serialized_end=296,
+)
+
+
+_SERVERVERSIONREQUEST = _descriptor.Descriptor(
+  name='ServerVersionRequest',
+  full_name='ServerVersionRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='version', full_name='ServerVersionRequest.version', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=298,
+  serialized_end=337,
+)
+
+
+_SERVERVERSIONREPLY = _descriptor.Descriptor(
+  name='ServerVersionReply',
+  full_name='ServerVersionReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='version', full_name='ServerVersionReply.version', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=339,
+  serialized_end=376,
+)
+
+
+_DROPREQUEST = _descriptor.Descriptor(
+  name='DropRequest',
+  full_name='DropRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='DropRequest.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='direction', full_name='DropRequest.direction', index=1,
+      number=2, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recover', full_name='DropRequest.recover', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=378,
+  serialized_end=443,
+)
+
+
+_DROPREPLY = _descriptor.Descriptor(
+  name='DropReply',
+  full_name='DropReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='portid', full_name='DropReply.portid', index=0,
+      number=1, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='success', full_name='DropReply.success', index=1,
+      number=2, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=445,
+  serialized_end=489,
+)
+
+DESCRIPTOR.message_types_by_name['AdminRequest'] = _ADMINREQUEST
+DESCRIPTOR.message_types_by_name['AdminReply'] = _ADMINREPLY
+DESCRIPTOR.message_types_by_name['OperationRequest'] = _OPERATIONREQUEST
+DESCRIPTOR.message_types_by_name['OperationReply'] = _OPERATIONREPLY
+DESCRIPTOR.message_types_by_name['LinkStateRequest'] = _LINKSTATEREQUEST
+DESCRIPTOR.message_types_by_name['LinkStateReply'] = _LINKSTATEREPLY
+DESCRIPTOR.message_types_by_name['ServerVersionRequest'] = _SERVERVERSIONREQUEST
+DESCRIPTOR.message_types_by_name['ServerVersionReply'] = _SERVERVERSIONREPLY
+DESCRIPTOR.message_types_by_name['DropRequest'] = _DROPREQUEST
+DESCRIPTOR.message_types_by_name['DropReply'] = _DROPREPLY
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
 AdminRequest = _reflection.GeneratedProtocolMessageType('AdminRequest', (_message.Message,), {
   'DESCRIPTOR' : _ADMINREQUEST,
   '__module__' : 'nic_simulator_grpc_service_pb2'
@@ -82,26 +461,95 @@ ServerVersionReply = _reflection.GeneratedProtocolMessageType('ServerVersionRepl
   })
 _sym_db.RegisterMessage(ServerVersionReply)
 
-_DUALTORACTIVE = DESCRIPTOR.services_by_name['DualToRActive']
-if _descriptor._USE_C_DESCRIPTORS == False:
+DropRequest = _reflection.GeneratedProtocolMessageType('DropRequest', (_message.Message,), {
+  'DESCRIPTOR' : _DROPREQUEST,
+  '__module__' : 'nic_simulator_grpc_service_pb2'
+  # @@protoc_insertion_point(class_scope:DropRequest)
+  })
+_sym_db.RegisterMessage(DropRequest)
 
-  DESCRIPTOR._options = None
-  _ADMINREQUEST._serialized_start=36
-  _ADMINREQUEST._serialized_end=81
-  _ADMINREPLY._serialized_start=83
-  _ADMINREPLY._serialized_end=126
-  _OPERATIONREQUEST._serialized_start=128
-  _OPERATIONREQUEST._serialized_end=162
-  _OPERATIONREPLY._serialized_start=164
-  _OPERATIONREPLY._serialized_end=211
-  _LINKSTATEREQUEST._serialized_start=213
-  _LINKSTATEREQUEST._serialized_end=247
-  _LINKSTATEREPLY._serialized_start=249
-  _LINKSTATEREPLY._serialized_end=296
-  _SERVERVERSIONREQUEST._serialized_start=298
-  _SERVERVERSIONREQUEST._serialized_end=337
-  _SERVERVERSIONREPLY._serialized_start=339
-  _SERVERVERSIONREPLY._serialized_end=376
-  _DUALTORACTIVE._serialized_start=379
-  _DUALTORACTIVE._serialized_end=707
+DropReply = _reflection.GeneratedProtocolMessageType('DropReply', (_message.Message,), {
+  'DESCRIPTOR' : _DROPREPLY,
+  '__module__' : 'nic_simulator_grpc_service_pb2'
+  # @@protoc_insertion_point(class_scope:DropReply)
+  })
+_sym_db.RegisterMessage(DropReply)
+
+
+
+_DUALTORACTIVE = _descriptor.ServiceDescriptor(
+  name='DualToRActive',
+  full_name='DualToRActive',
+  file=DESCRIPTOR,
+  index=0,
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_start=492,
+  serialized_end=859,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='QueryAdminForwardingPortState',
+    full_name='DualToRActive.QueryAdminForwardingPortState',
+    index=0,
+    containing_service=None,
+    input_type=_ADMINREQUEST,
+    output_type=_ADMINREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='SetAdminForwardingPortState',
+    full_name='DualToRActive.SetAdminForwardingPortState',
+    index=1,
+    containing_service=None,
+    input_type=_ADMINREQUEST,
+    output_type=_ADMINREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='QueryOperationPortState',
+    full_name='DualToRActive.QueryOperationPortState',
+    index=2,
+    containing_service=None,
+    input_type=_OPERATIONREQUEST,
+    output_type=_OPERATIONREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='QueryLinkState',
+    full_name='DualToRActive.QueryLinkState',
+    index=3,
+    containing_service=None,
+    input_type=_LINKSTATEREQUEST,
+    output_type=_LINKSTATEREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='QueryServerVersion',
+    full_name='DualToRActive.QueryServerVersion',
+    index=4,
+    containing_service=None,
+    input_type=_SERVERVERSIONREQUEST,
+    output_type=_SERVERVERSIONREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='SetDrop',
+    full_name='DualToRActive.SetDrop',
+    index=5,
+    containing_service=None,
+    input_type=_DROPREQUEST,
+    output_type=_DROPREPLY,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_DUALTORACTIVE)
+
+DESCRIPTOR.services_by_name['DualToRActive'] = _DUALTORACTIVE
+
 # @@protoc_insertion_point(module_scope)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2_grpc.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2_grpc.py
@@ -39,6 +39,11 @@ class DualToRActiveStub(object):
                 request_serializer=nic__simulator__grpc__service__pb2.ServerVersionRequest.SerializeToString,
                 response_deserializer=nic__simulator__grpc__service__pb2.ServerVersionReply.FromString,
                 )
+        self.SetDrop = channel.unary_unary(
+                '/DualToRActive/SetDrop',
+                request_serializer=nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
+                response_deserializer=nic__simulator__grpc__service__pb2.DropReply.FromString,
+                )
 
 
 class DualToRActiveServicer(object):
@@ -74,6 +79,12 @@ class DualToRActiveServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def SetDrop(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DualToRActiveServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -101,6 +112,11 @@ def add_DualToRActiveServicer_to_server(servicer, server):
                     servicer.QueryServerVersion,
                     request_deserializer=nic__simulator__grpc__service__pb2.ServerVersionRequest.FromString,
                     response_serializer=nic__simulator__grpc__service__pb2.ServerVersionReply.SerializeToString,
+            ),
+            'SetDrop': grpc.unary_unary_rpc_method_handler(
+                    servicer.SetDrop,
+                    request_deserializer=nic__simulator__grpc__service__pb2.DropRequest.FromString,
+                    response_serializer=nic__simulator__grpc__service__pb2.DropReply.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -194,5 +210,22 @@ class DualToRActive(object):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryServerVersion',
             nic__simulator__grpc__service__pb2.ServerVersionRequest.SerializeToString,
             nic__simulator__grpc__service__pb2.ServerVersionReply.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def SetDrop(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualToRActive/SetDrop',
+            nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
+            nic__simulator__grpc__service__pb2.DropReply.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -8,7 +8,8 @@ __all__ = [
     'CableType',
     'mux_config',
     'active_standby_ports',
-    'active_active_ports'
+    'active_active_ports',
+    'ActiveActivePortID'
 ]
 
 
@@ -17,6 +18,12 @@ class CableType(object):
     active_active = "active-active"
     active_standby = "active-standby"
     default_type = "active-standby"
+
+
+class ActiveActivePortID(object):
+    """Port id for active-active."""
+    UPPER_TOR = 1
+    LOWER_TOR = 0
 
 
 @pytest.fixture(params=[CableType.active_standby, CableType.active_active])

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -12,11 +12,18 @@ from tests.common.dualtor.mux_simulator_control import set_drop # lgtm[py/unused
 from tests.common.dualtor.mux_simulator_control import set_output # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import simulator_flap_counter # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import set_drop_active_active   # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import TrafficDirection
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
-from tests.common.dualtor.dual_tor_common import cable_type 
+from tests.common.dualtor.dual_tor_common import ActiveActivePortID
+from tests.common.dualtor.dual_tor_common import active_active_ports
+from tests.common.dualtor.dual_tor_common import active_standby_ports
+from tests.common.dualtor.dual_tor_common import cable_type
+from tests.common.dualtor.dual_tor_common import CableType
+
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -32,17 +39,31 @@ def _set_drop_factory(set_drop_func, direction, tor_mux_intfs):
 
 
 @pytest.fixture(scope="function")
-def drop_flow_upper_tor(set_drop, set_output, tor_mux_intfs):
+def drop_flow_upper_tor(set_drop, set_output, active_standby_ports):
     """Drop the flow to the upper ToR."""
     direction = "upper_tor"
-    return _set_drop_factory(set_drop, direction, tor_mux_intfs)
+    return _set_drop_factory(set_drop, direction, active_standby_ports)
 
 
 @pytest.fixture(scope="function")
-def drop_flow_lower_tor(set_drop, set_output, tor_mux_intfs):
+def drop_flow_lower_tor(set_drop, set_output, active_standby_ports):
     """Drop the flow to the lower ToR."""
     direction = "lower_tor"
-    return _set_drop_factory(set_drop, direction, tor_mux_intfs)
+    return _set_drop_factory(set_drop, direction, active_standby_ports)
+
+
+@pytest.fixture(scope="function")
+def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_active):
+    direction = TrafficDirection.UPSTREAM
+    portid = ActiveActivePortID.UPPER_TOR
+
+    def _drop_flow_upper_tor_active_active():
+        logging.debug("Start set drop for upper ToR at %s", time.time())
+        for port in active_active_ports:
+            logging.debug("Set drop on port %s, portid %s, direction %s" % (port, portid, direction))
+            set_drop_active_active(port, portid, direction)
+
+    return _drop_flow_upper_tor_active_active
 
 
 @pytest.fixture(scope="function")
@@ -80,55 +101,97 @@ def check_simulator_flap_counter(
             raise ValueError(error_str)
 
 
+@pytest.mark.enable_active_active
 def test_active_link_drop_upstream(
     upper_tor_host,
     lower_tor_host,
     send_server_to_t1_with_action,
     toggle_all_simulator_ports_to_upper_tor,
-    drop_flow_upper_tor
+    drop_flow_upper_tor,
+    drop_flow_upper_tor_active_active,
+    cable_type
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the active ToR.
     Verify the switchover and disruption last < 1 second.
     """
-    send_server_to_t1_with_action(
-        upper_tor_host,
-        verify=True,
-        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3,
-        action=drop_flow_upper_tor
-    )
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host,
-        expected_standby_health="unhealthy"
-    )
+    if cable_type == CableType.active_standby:
+        send_server_to_t1_with_action(
+            upper_tor_host,
+            verify=True,
+            delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=3,
+            action=drop_flow_upper_tor
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_active:
+        send_server_to_t1_with_action(
+            upper_tor_host,
+            verify=True,
+            delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=1,
+            action=drop_flow_upper_tor_active_active
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type,
+            skip_state_db=True
+        )
 
 
+@pytest.mark.enable_active_active
 def test_active_link_drop_downstream_active(
     upper_tor_host,
     lower_tor_host,
     send_t1_to_server_with_action,
     toggle_all_simulator_ports_to_upper_tor,
-    drop_flow_upper_tor
+    drop_flow_upper_tor,
+    drop_flow_upper_tor_active_active,
+    cable_type
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
     servers and the active ToR.
     Verify the switchover and disruption last < 1 second.
     """
-    send_t1_to_server_with_action(
-        upper_tor_host,
-        verify=True,
-        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3,
-        action=drop_flow_upper_tor
-    )
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host,
-        expected_standby_health="unhealthy"
-    )
+    if cable_type == CableType.active_standby:
+        send_t1_to_server_with_action(
+            upper_tor_host,
+            verify=True,
+            delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=3,
+            action=drop_flow_upper_tor
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_active:
+        send_t1_to_server_with_action(
+            upper_tor_host,
+            verify=True,
+            delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            allowed_disruption=1,
+            action=drop_flow_upper_tor_active_active
+        )
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type,
+            skip_state_db=True
+        )
 
 
 def test_active_link_drop_downstream_standby(

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -5,23 +5,23 @@ import tabulate
 import time
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host # lgtm[py/unused-import]
-from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action # lgtm[py/unused-import]
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import set_drop # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import set_output # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import simulator_flap_counter # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor # lgtm[py/unused-import]
-from tests.common.dualtor.nic_simulator_control import set_drop_active_active   # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action                 # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action                 # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import set_drop                                 # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import set_output                               # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter                   # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import set_drop_active_active                   # lgtm[py/unused-import]
 from tests.common.dualtor.nic_simulator_control import TrafficDirection
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service            # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
-from tests.common.dualtor.dual_tor_common import active_active_ports
-from tests.common.dualtor.dual_tor_common import active_standby_ports
-from tests.common.dualtor.dual_tor_common import cable_type
+from tests.common.dualtor.dual_tor_common import active_active_ports                            # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import active_standby_ports                           # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import cable_type                                     # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import CableType
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable `test_link_drop` on mux ports of cable type `active-active`

#### How did you do it?
1. Add rpc call `SetDrop` for `nic_simulator` to drop flow, both upstream/downstream
2. Add fixture `set_drop_active_active` to call `nic_simulator` rpc call `SetDrop` to simulate link drop.
3. Enable two testcases: `test_active_link_drop_upstream` and `test_active_link_drop_downstream_active`

#### How did you verify/test it?
```
dualtor_io/test_link_drop.py::test_active_link_drop_upstream[active-standby] PASSED                                                                                                                                                                                    [ 25%]
dualtor_io/test_link_drop.py::test_active_link_drop_upstream[active-active] PASSED                                                                                                                                                                                     [ 50%]
dualtor_io/test_link_drop.py::test_active_link_drop_downstream_active[active-standby] PASSED                                                                                                                                                                           [ 75%]
dualtor_io/test_link_drop.py::test_active_link_drop_downstream_active[active-active] PASSED                                                                                                                                                                            [100%]

======================================================================================================================== 4 passed in 1516.40 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
