### PR TITLE
Add build id and source repo in `.azure-pipelines/test_plan.py`

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -78,7 +78,9 @@ class TestPlanManager(object):
                 }
             },
             "extra_params": {
-                "pull_request_id": pr_id
+                "pull_request_id": pr_id,
+                "build_id": build_id,
+                "source_repo": repo_name
             },
             "priority": 10,
             "requester": "pull request"
@@ -272,6 +274,7 @@ if __name__ == "__main__":
             reason = os.environ.get("BUILD_REASON")
             build_id = os.environ.get("BUILD_BUILDID")
             job_name = os.environ.get("SYSTEM_JOBDISPLAYNAME")
+            repo_name = os.environ.get("BUILD_REPOSITORY_NAME")
 
             name = "{repo}_{reason}_PR_{pr_id}_BUILD_{build_id}_JOB_{job_name}"\
                 .format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
`build_id` and `source_repo` were added into extra_params in db, so when we create a test plan, we add these two parameters into extra_params. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`build_id` and `source_repo` were added into extra_params in db, so when we create a test plan, we add these two parameters into extra_params. 

#### How did you do it?
Get the build id and source repo from environment variables, and when creating a new test plan, add them into extra_params.

#### How did you verify/test it?
In db, the new created test plan have build id and source repo in extra_params 
'{"pull_request_id": "6201", "build_id": "138044", "source_repo": "sonic-net/sonic-mgmt"}'

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
