### PR TITLE
ignored route sync error logs for VxLAN tests which toggle DUT interfaces

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -694,6 +694,14 @@ class Test_VxLAN:
                    qlen=1000,
                    log_file="/tmp/vxlan-tests.{}.{}.{}.log".format(tcname, encap_type, datetime.now().strftime('%Y-%m-%d-%H:%M:%S')))
 
+
+@pytest.fixture
+def ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend([".*Unaccounted_ROUTE_ENTRY_TABLE_entries.*"])
+    return
+
 class Test_VxLAN_route_tests(Test_VxLAN):
     def test_vxlan_single_endpoint(self, setUp, encap_type):
         '''
@@ -1084,6 +1092,7 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
         apply_config_in_swss(self.setup['duthost'], tc11_config, "vnet_route_tc11_"+encap_type)
         self.dump_self_info_and_run_ptf("tc11", encap_type, True, packet_count=1000)
 
+@pytest.mark.usefixtures("ignore_route_sync_errlogs")
 class Test_VxLAN_underlay_ecmp(Test_VxLAN):
     @pytest.mark.parametrize("ecmp_path_count", [1, 2])
     def test_vxlan_modify_underlay_default(self, setUp, minigraph_facts, encap_type, ecmp_path_count):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: ignored route sync error logs for VxLAN tests which toggle DUT interfaces
Fixes # (issue)

There are 2 vxlan tests in class `Test_VxLAN_underlay_ecmp` which toggle interfaces and check if packets get encapsulated and forwarded via backup routes.
LogAnalyzer fails those tests because of unsynced route error logs produced by `routeCheck` monitoring service when tests toggle interfaces.
Added ignoring the related error logs for the tests which toggle interfaces.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To account expected error logs during VxLAN tests in class Test_VxLAN_underlay_ecmp
#### How did you do it?
Ignored route sync error logs for the mentioned tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
