### PR TITLE
Tolerate occasional HTTP exceptions, prolong default polling interval

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -10,6 +10,7 @@ import requests
 import yaml
 
 PR_TEST_SCRIPTS_FILE = "pr_test_scripts.yaml"
+TOLERATE_HTTP_EXCEPTION_TIMES = 20
 
 
 def get_test_scripts(topology):
@@ -134,10 +135,10 @@ class TestPlanManager(object):
         print("Result of cancelling test plan at {}:".format(tp_url))
         print(str(resp["data"]))
 
-    def poll(self, test_plan_id, interval=10, timeout=36000):
+    def poll(self, test_plan_id, interval=60, timeout=36000):
 
-        print("Polling progress and status of test plan at https://www.testbed-tools.org/scheduler/testplan/{}"\
-            .format(test_plan_id))
+        print("Polling progress and status of test plan at https://www.testbed-tools.org/scheduler/testplan/{}" \
+              .format(test_plan_id))
         print("Polling interval: {} seconds".format(interval))
         print("Max polling time: {} seconds".format(timeout))
 
@@ -146,14 +147,22 @@ class TestPlanManager(object):
             "Content-Type": "application/json"
         }
         start_time = time.time()
+        http_exception_times = 0
         while (time.time() - start_time) < timeout:
             raw_resp = {}
             try:
                 raw_resp = requests.get(poll_url, headers=headers, timeout=10)
                 resp = raw_resp.json()
             except Exception as exception:
-                raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
-                                .format(poll_url, str(raw_resp), str(exception)))
+                print("HTTP execute failure, url: {}, raw_resp: {}, exception: {}".format(poll_url, str(raw_resp),
+                                                                                          str(exception)))
+                http_exception_times = http_exception_times + 1
+                if http_exception_times >= TOLERATE_HTTP_EXCEPTION_TIMES:
+                    raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
+                                    .format(poll_url, str(raw_resp), str(exception)))
+                else:
+                    time.sleep(interval)
+                    continue
             if not resp["success"]:
                 raise Exception("Query test plan at {} failed with error: {}".format(poll_url, resp["errmsg"]))
 
@@ -166,18 +175,18 @@ class TestPlanManager(object):
 
             if status in ["FINISHED", "CANCELLED", "FAILED"]:
                 if result == "SUCCESS":
-                    print("Test plan is successfully {}. Elapsed {:.0f} seconds"\
-                        .format(status, time.time() - start_time))
+                    print("Test plan is successfully {}. Elapsed {:.0f} seconds" \
+                          .format(status, time.time() - start_time))
                     return
                 else:
-                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds"\
-                        .format(test_plan_id, status, result, time.time() - start_time))
-            print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds"\
-                .format(test_plan_id, status, resp_data.get("progress", 0) * 100, time.time() - start_time))
+                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds" \
+                                    .format(test_plan_id, status, result, time.time() - start_time))
+            print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds" \
+                  .format(test_plan_id, status, resp_data.get("progress", 0) * 100, time.time() - start_time))
             time.sleep(interval)
         else:
-            raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled"\
-                .format(poll_url))
+            raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled" \
+                            .format(poll_url))
 
 
 if __name__ == "__main__":
@@ -223,9 +232,9 @@ if __name__ == "__main__":
         "--interval",
         type=int,
         required=False,
-        default=10,
+        default=60,
         dest="interval",
-        help="Polling interval. Default 10 seconds."
+        help="Polling interval. Default 60 seconds."
     )
     parser_poll.add_argument(
         "--timeout",
@@ -236,7 +245,7 @@ if __name__ == "__main__":
         help="Max polling time. Default 36000 seconds (10 hours)."
     )
 
-    if len(sys.argv)==1:
+    if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
 
@@ -273,14 +282,14 @@ if __name__ == "__main__":
             build_id = os.environ.get("BUILD_BUILDID")
             job_name = os.environ.get("SYSTEM_JOBDISPLAYNAME")
 
-            name = "{repo}_{reason}_PR_{pr_id}_BUILD_{build_id}_JOB_{job_name}"\
+            name = "{repo}_{reason}_PR_{pr_id}_BUILD_{build_id}_JOB_{job_name}" \
                 .format(
-                    repo=repo,
-                    reason=reason,
-                    pr_id=pr_id,
-                    build_id=build_id,
-                    job_name=job_name
-                ).replace(' ', '_')
+                repo=repo,
+                reason=reason,
+                pr_id=pr_id,
+                build_id=build_id,
+                job_name=job_name
+            ).replace(' ', '_')
             tp.create(
                 args.topology,
                 name=name,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the issue that test plans are wrongly considered as failed by occasional HTTP exceptions.
Tolerate occasional HTTP exceptions, and prolong default polling interval.


Issue(https://dev.azure.com/mssonic/build/_build/results?buildId=138125&view=logs&j=673172eb-c6f4-5e55-a0ff-d94334eade0e&t=bfe2231b-2c96-50f4-f21e-47ec25de3854&l=97):
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 718 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 728 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 738 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 748 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 759 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 769 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 779 seconds
Test plan id: 217, status: PREPARE_TESTBED, progress: 0%, elapsed: 789 seconds
Operation failed with exception: Exception("HTTP execute failure, url: http://sonic-testbed2-scheduler-backend.azurewebsites.net/test_plan/217, raw_resp: {}, exception: HTTPConnectionPool(host='sonic-testbed2-scheduler-backend.azurewebsites.net'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the issue that test plans are wrongly considered as failed by occasional HTTP exceptions.
Tolerate occasional HTTP exceptions, and prolong default polling interval.
#### How did you do it?
Tolerate at most 20 HTTP exceptions, prolong the default polling interval to 60s
#### How did you verify/test it?
TestbedV2 pipeline will test it
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
