### PR TITLE
[dualtor][active-active] Enable `test_tor_failure`

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -27,7 +27,8 @@ __all__ = [
     "mux_status_from_nic_simulator",
     "toggle_active_all_ports_both_tors",
     "set_drop_active_active",
-    "TrafficDirection"
+    "TrafficDirection",
+    "ForwardingState"
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -55,5 +55,6 @@ def get_pdu_controller(conn_graph_facts, pdu):
     yield pdu_controller_helper
 
     for controller in controller_map.values():
-        controller.turn_on_outlet()
-        controller.close()
+        if controller:
+            controller.turn_on_outlet()
+            controller.close()

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -16,6 +16,7 @@ from tests.common.dualtor.dual_tor_common import cable_type
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 
 logger = logging.getLogger(__name__)
@@ -173,13 +174,17 @@ def test_active_tor_reboot_downstream(
 
     # reboot the upper ToR and verify the upper ToR forwarding state is changed to standby
     toggle_upper_tor_pdu()
-    if not wait_until(60, 5, 5, check_forwarding_state, ForwardingState.STANDBY, ForwardingState.ACTIVE):
+    pytest_assert(
+        wait_until(60, 5, 5, check_forwarding_state, ForwardingState.STANDBY, ForwardingState.ACTIVE),
         pytest.fail("Forwarding state check failed after reboot.")
+    )
 
     # verify the upper ToR changes back to active after the upper comes back from reboot
     wait_for_device_reachable(upper_tor_host)
-    if not wait_until(180, 5, 60, check_forwarding_state, ForwardingState.ACTIVE, ForwardingState.ACTIVE):
-        pytest.fail("Forwarding state check failed after the upper ToR comes back from reboot.")
+    pytest_assert(
+        wait_until(180, 5, 60, check_forwarding_state, ForwardingState.ACTIVE, ForwardingState.ACTIVE),
+        "Forwarding state check failed after the upper ToR comes back from reboot."
+    )
     verify_tor_states(
         expected_active_host=[upper_tor_host, lower_tor_host],
         expected_standby_host=None,

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -8,8 +8,15 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable                                 # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, change_mac_addresses                                      # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                                                            # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import ForwardingState
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                                                                    # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type 
+from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.dual_tor_common import ActiveActivePortID
+from tests.common.utilities import wait_until
+
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +35,11 @@ def toggle_pdu_outlet(controller):
 @pytest.fixture(scope='module')
 def toggle_upper_tor_pdu(upper_tor_host, get_pdu_controller):
     pdu_controller = get_pdu_controller(upper_tor_host)
-    return lambda: toggle_pdu_outlet(pdu_controller)
+    if pdu_controller is None:
+        # restart the kernel instantly through system request if there is no pdu information present
+        return lambda: upper_tor_host.shell("nohup sh -c 'sleep 2; echo b > /proc/sysrq-trigger;' > /dev/null &")
+    else:
+        return lambda: toggle_pdu_outlet(pdu_controller)
 
 
 @pytest.fixture(scope='module')
@@ -37,11 +48,12 @@ def toggle_lower_tor_pdu(lower_tor_host, get_pdu_controller):
     return lambda: toggle_pdu_outlet(pdu_controller)
 
 
+@pytest.mark.enable_active_active
 @pytest.mark.disable_loganalyzer
 def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,
-    wait_for_device_reachable
+    wait_for_device_reachable, cable_type
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
@@ -52,9 +64,17 @@ def test_active_tor_reboot_upstream(
         action=toggle_upper_tor_pdu, stop_after=60
     )
     wait_for_device_reachable(upper_tor_host)
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
+
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host
+        )
+    elif cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=[upper_tor_host, lower_tor_host],
+            expected_standby_host=None,
+            cable_type=cable_type
     )
 
 
@@ -119,3 +139,53 @@ def test_standby_tor_reboot_downstream_active(
         expected_active_host=upper_tor_host,
         expected_standby_host=lower_tor_host
     )
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+@pytest.mark.disable_loganalyzer
+def test_active_tor_reboot_downstream(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_upper_tor_pdu, wait_for_device_reachable, cable_type,
+    tunnel_traffic_monitor, mux_status_from_nic_simulator
+):
+    def check_forwarding_state(upper_tor_forwarding_state, lower_tor_forwarding_state):
+        mux_status = mux_status_from_nic_simulator()
+        logging.debug(
+            "Check forwarding state, upper ToR: %s, lower ToR: %s",
+            upper_tor_forwarding_state,
+            lower_tor_forwarding_state
+        )
+        logging.debug("Mux status from nic_simulator:\n%s", mux_status)
+        for port in mux_status:
+            if ((mux_status[port][ActiveActivePortID.UPPER_TOR] != upper_tor_forwarding_state) or
+                (mux_status[port][ActiveActivePortID.LOWER_TOR] != lower_tor_forwarding_state)):
+                logging.debug("Port %s mux status is not expected", port)
+                return False
+        return True
+
+    # verify all ToRs are in active state
+    verify_tor_states(
+        expected_active_host=[upper_tor_host, lower_tor_host],
+        expected_standby_host=None,
+        cable_type=cable_type
+    )
+
+    # reboot the upper ToR and verify the upper ToR forwarding state is changed to standby
+    toggle_upper_tor_pdu()
+    if not wait_until(60, 5, 5, check_forwarding_state, ForwardingState.STANDBY, ForwardingState.ACTIVE):
+        pytest.fail("Forwarding state check failed after reboot.")
+
+    # verify the upper ToR changes back to active after the upper comes back from reboot
+    wait_for_device_reachable(upper_tor_host)
+    if not wait_until(180, 5, 60, check_forwarding_state, ForwardingState.ACTIVE, ForwardingState.ACTIVE):
+        pytest.fail("Forwarding state check failed after the upper ToR comes back from reboot.")
+    verify_tor_states(
+        expected_active_host=[upper_tor_host, lower_tor_host],
+        expected_standby_host=None,
+        cable_type=cable_type
+    )
+
+    # verify the server receives packets with no disrupts, no tunnel traffic
+    with tunnel_traffic_monitor(upper_tor_host, existing=False):
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Cover ToR reboot upstream/downstream dualtor IO scenario.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Enable one testcase:
* test_active_tor_reboot_upstream
Add one testcase:
* test_active_tor_reboot_downstream

#### How did you verify/test it?
```
dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream[active-active] PASSED                                                                                                                                                                                [100%]
dualtor_io/test_tor_failure.py::test_active_tor_reboot_upstream[active-active] PASSED                                                                                                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
