### PR TITLE
Add multi-asic and T2 topology support for bgpmon and bgp_traffic_shift suites

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -538,7 +538,7 @@ def bgpmon_setup_teardown(ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_ho
     # Start bgpmon on DUT
     logger.info("Starting bgpmon on DUT")
     asichost = duthost.asic_instance_from_namespace(connection['namespace'])
-    asichost.run_sonic_cfggen("-j {} -w".format(BGPMON_CONFIG_FILE))
+    asichost.write_to_config_db(BGPMON_CONFIG_FILE)
 
     logger.info("Starting bgp monitor session on PTF")
 

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -170,20 +170,20 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     def _is_ipv4_address(ip_addr):
         return ipaddress.ip_address(ip_addr).version == 4
 
-    def _duthost_cleanup_ip(duthost, namespace, ip):
+    def _duthost_cleanup_ip(asichost, ip):
         """
         Search if "ip" is configured on any DUT interface. If yes, remove it.
         """
 
-        for line in duthost.shell("ip addr show | grep 'inet '")['stdout_lines']:
+        for line in duthost.shell("{} ip addr show | grep 'inet '".format(asichost.ns_arg))['stdout_lines']:
             # Example line: '''    inet 10.0.0.2/31 scope global Ethernet104'''
             fields = line.split()
             intf_ip = fields[1].split("/")[0]
             if intf_ip == ip:
                 intf_name = fields[-1]
-                duthost.shell("config interface %s ip remove %s %s" % (namespace, intf_name, ip))
+                asichost.config_ip_intf(intf_name, ip, "remove")
 
-        ip_intfs = duthost.show_and_parse('show ip interface {}'.format(namespace))
+        ip_intfs = duthost.show_and_parse('show ip interface {}'.format(asichost.cli_ns_option))
 
         # For interface that has two IP configured, the output looks like:
         #       admin@vlab-03:~$ show ip int
@@ -223,7 +223,8 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         # Remove the specified IP from interfaces
         for ip_intf in ip_intfs:
             if ip_intf["ipv4 address/mask"].split("/")[0] == ip:
-                duthost.shell("config interface %s ip remove %s %s" % (namespace, ip_intf["interface"], ip))
+                asichost.config_ip_intf(ip_intf["interface"], ip, "remove")
+
 
     def _find_vlan_intferface(mg_facts):
         for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
@@ -385,7 +386,10 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
                 conn["loopback_ip"] = loopback_ip
-                conn["namespace"] = DEFAULT_NAMESPACE
+                if 'namespace' in mg_facts['minigraph_neighbors'][intf] and mg_facts['minigraph_neighbors'][intf]['namespace']:
+                    conn["namespace"] = mg_facts['minigraph_neighbors'][intf]['namespace']
+                else:
+                    conn["namespace"] = DEFAULT_NAMESPACE
                 if intf.startswith("PortChannel"):
                     member_intf = mg_facts["minigraph_portchannels"][intf]["members"][0]
                     conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_ptf_indices"][member_intf]
@@ -401,14 +405,15 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
             ptfhost.remove_ip_addresses()  # In case other case did not cleanup IP address configured on PTF interface
 
             for conn in connections:
-                namespace = '-n {}'.format(conn["namespace"]) if conn["namespace"] else ''
+                asichost = duthost.asic_instance_from_namespace(conn['namespace'])
 
                 # Find out if any other interface has the same IP configured. If yes, remove it
                 # Otherwise, there may be conflicts and test would fail.
-                _duthost_cleanup_ip(duthost, namespace, conn["local_addr"])
+                _duthost_cleanup_ip(asichost, conn["local_addr"])
 
                 # bind the ip to the interface and notify bgpcfgd
-                duthost.shell("config interface %s ip add %s %s" % (namespace, conn["local_intf"], conn["local_addr"]))
+                asichost.config_ip_intf(conn["local_intf"], conn["local_addr"], "add")
+
                 ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"], conn["neighbor_addr"]))
 
                 # add route to loopback address on PTF host
@@ -429,8 +434,8 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
 
         finally:
             for conn in connections:
-                namespace = '-n {}'.format(conn["namespace"]) if conn["namespace"] else ''
-                duthost.shell("config interface %s ip remove %s %s" % (namespace, conn["local_intf"], conn["local_addr"]))
+                asichost = duthost.asic_instance_from_namespace(conn['namespace'])
+                asichost.config_ip_intf(conn["local_intf"], conn["local_addr"], "remove")
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
                 ptfhost.shell(
                     "ip route del {}/32".format(conn["loopback_ip"]),
@@ -511,7 +516,8 @@ def backup_bgp_config(duthost):
         apply_default_bgp_config(duthost)
 
 @pytest.fixture(scope="module")
-def bgpmon_setup_teardown(ptfhost, duthost, localhost, setup_interfaces):
+def bgpmon_setup_teardown(ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, setup_interfaces):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     connection = setup_interfaces[0]
     dut_lo_addr = connection["loopback_ip"].split("/")[0]
     peer_addr = connection['neighbor_addr'].split("/")[0]
@@ -531,7 +537,8 @@ def bgpmon_setup_teardown(ptfhost, duthost, localhost, setup_interfaces):
                  dest=BGPMON_CONFIG_FILE)
     # Start bgpmon on DUT
     logger.info("Starting bgpmon on DUT")
-    duthost.command("sonic-cfggen -j {} -w".format(BGPMON_CONFIG_FILE))
+    asichost = duthost.asic_instance_from_namespace(connection['namespace'])
+    asichost.run_sonic_cfggen("-j {} -w".format(BGPMON_CONFIG_FILE))
 
     logger.info("Starting bgp monitor session on PTF")
 
@@ -560,16 +567,18 @@ def bgpmon_setup_teardown(ptfhost, duthost, localhost, setup_interfaces):
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (dut_lo_addr, duthost.facts["router_mac"], connection["neighbor_intf"]))
     ptfhost.shell("ip route add %s dev %s" % (dut_lo_addr + "/32", connection["neighbor_intf"]))
 
-    pt_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT),
+    pt_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
                   "Failed to start bgp monitor session on PTF")
     pt_assert(wait_until(20, 5, 0, duthost.check_bgp_session_state, [peer_addr]), 'BGP session {} on duthost is not established'.format(BGP_MONITOR_NAME))
 
-    yield
+    yield connection
     # Cleanup bgp monitor
-    duthost.shell("redis-cli -n 4 -c DEL 'BGP_MONITORS|{}'".format(peer_addr))
+    asichost.run_sonic_db_cli_cmd("CONFIG_DB DEL 'BGP_MONITORS|{}'".format(peer_addr))
+
     ptfhost.exabgp(name=BGP_MONITOR_NAME, state="absent")
     ptfhost.file(path=CUSTOM_DUMP_SCRIPT_DEST, state="absent")
     ptfhost.file(path=DUMP_FILE, state="absent")
     # Remove the route to DUT loopback IP  and the interface router mac
     ptfhost.shell("ip route del %s" % dut_lo_addr + "/32")
     ptfhost.shell("ip neigh flush to %s nud permanent" % dut_lo_addr)
+

--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -31,7 +31,8 @@ def get_default_route_ports(host, tbinfo):
         if route['protocol'] != 'bgp':
             continue
         for itfs in route['nexthops']:
-            ports.append(itfs['interfaceName'])
+            if 'interfaceName' in itfs and '-IB' not in itfs['interfaceName']:
+                ports.append(itfs['interfaceName'])
     port_indices = []
     for port in ports:
         if 'PortChannel' in port:
@@ -43,7 +44,29 @@ def get_default_route_ports(host, tbinfo):
     return port_indices
 
 @pytest.fixture
-def common_setup_teardown(duthost, ptfhost, tbinfo):
+def dut_with_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+    if tbinfo['topo']['type'] == 't2':
+        # For T2 setup, default route via eBGP is only advertised from T3 VM's which are connected to one of the
+        # linecards and not the other. So, can't use enum_rand_one_per_hwsku_frontend_hostname for T2.
+        dut_to_T3 = None
+        for a_dut in duthosts.frontend_nodes:
+            minigraph_facts = a_dut.get_extended_minigraph_facts(tbinfo)
+            minigraph_neighbors = minigraph_facts['minigraph_neighbors']
+            for key, value in minigraph_neighbors.items():
+                if 'T3' in value['name']:
+                    dut_to_T3 = a_dut
+                    break
+            if dut_to_T3:
+                break
+        if dut_to_T3 is None:
+            pytest.skip("Did not find any DUT in the DUTs (linecards) that are connected to T3 VM's")
+        return dut_to_T3
+    else:
+        duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+@pytest.fixture
+def common_setup_teardown(dut_with_default_route, tbinfo):
+    duthost = dut_with_default_route
     peer_addr = generate_ip_through_default_route(duthost)
     pytest_assert(peer_addr, "Failed to generate ip address for test")
     peer_addr = str(IPNetwork(peer_addr).ip)
@@ -64,7 +87,7 @@ def common_setup_teardown(duthost, ptfhost, tbinfo):
                  dest=BGPMON_CONFIG_FILE)
     yield local_addr, peer_addr, peer_ports, mg_facts['minigraph_bgp_asn']
     # Cleanup bgp monitor
-    duthost.shell("redis-cli -n 4 -c DEL 'BGP_MONITORS|{}'".format(peer_addr))
+    duthost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_MONITORS|{}'".format(peer_addr), asic_index='all')
     duthost.file(path=BGPMON_CONFIG_FILE, state='absent')
 
 def build_syn_pkt(local_addr, peer_addr):
@@ -102,14 +125,22 @@ def build_syn_pkt(local_addr, peer_addr):
     exp_packet.set_ignore_extra_bytes()
     return exp_packet
 
-def test_bgpmon(duthost, localhost, common_setup_teardown, ptfadapter, ptfhost):
+
+def test_bgpmon(dut_with_default_route, localhost, common_setup_teardown, ptfadapter, ptfhost):
     """
     Add a bgp monitor on ptf and verify that DUT is attempting to establish connection to it
     """
+
+    duthost = dut_with_default_route
+
     def bgpmon_peer_connected(duthost, bgpmon_peer):
         try:
-            bgp_summary = json.loads(duthost.shell('vtysh -c "show bgp summary json"')['stdout'])
-            return bgp_summary['ipv4Unicast']['peers'][bgpmon_peer]["state"] == "Established"
+            bgp_summary_all_asics = duthost.run_vtysh('-c "show bgp summary json"', asic_index='all')
+            for a_bgp_summary in bgp_summary_all_asics:
+                bgp_summary = json.loads(a_bgp_summary['stdout'])
+                if bgp_summary['ipv4Unicast']['peers'][bgpmon_peer]["state"] == "Established":
+                    return True
+            return False
         except Exception as e:
             logger.info('Unable to get bgp status')
             return False
@@ -120,7 +151,7 @@ def test_bgpmon(duthost, localhost, common_setup_teardown, ptfadapter, ptfhost):
     ptfadapter.dataplane.flush()
     # Load bgp monitor config
     logger.info("Configured bgpmon and verifying packet on {}".format(peer_ports))
-    duthost.command("sonic-cfggen -j {} -w".format(BGPMON_CONFIG_FILE))
+    duthost.run_sonic_cfggen("-j {} -w".format(BGPMON_CONFIG_FILE), asic_index='all')
     # Verify syn packet on ptf
     (rcvd_port_index, rcvd_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_packet, ports=peer_ports, timeout=BGP_CONNECT_TIMEOUT)
     #To establish the connection we set the PTF port that receive syn packet following properties
@@ -142,7 +173,7 @@ def test_bgpmon(duthost, localhost, common_setup_teardown, ptfadapter, ptfhost):
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
     ptfhost.shell("ip route add %s dev %s" % (local_addr + "/32", ptf_interface))
     try:
-        pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT),
+        pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
                       "Failed to start bgp monitor session on PTF")
         pytest_assert(wait_until(180, 5, 0, bgpmon_peer_connected, duthost, peer_addr),"BGPMon Peer connection not established")
     finally:
@@ -152,26 +183,28 @@ def test_bgpmon(duthost, localhost, common_setup_teardown, ptfadapter, ptfhost):
         ptfhost.shell("ip add del %s dev %s" % (peer_addr + "/24", ptf_interface))
         ptfhost.shell("ifconfig %s hw ether %s" % (ptf_interface, original_mac))
 
-def test_bgpmon_no_resolve_via_default(duthost, common_setup_teardown, ptfadapter):
+
+def test_bgpmon_no_resolve_via_default(dut_with_default_route, common_setup_teardown, ptfadapter):
     """
     Verify no syn for BGP is sent when 'ip nht resolve-via-default' is disabled.
     """
+    duthost = dut_with_default_route
     local_addr, peer_addr, peer_ports, asn = common_setup_teardown
     exp_packet = build_syn_pkt(local_addr, peer_addr)
     # Load bgp monitor config
     logger.info("Configured bgpmon and verifying no packet on {} when resolve-via-default is disabled".format(peer_ports))
     try:
         # Disable resolve-via-default
-        duthost.command("vtysh -c \"configure terminal\" \
-                        -c \"no ip nht resolve-via-default\"")
+        duthost.run_vtysh(" -c \"configure terminal\" -c \"no ip nht resolve-via-default\"", asic_index='all')
         # Flush dataplane
         ptfadapter.dataplane.flush()
-        duthost.command("sonic-cfggen -j {} -w".format(BGPMON_CONFIG_FILE))
+
+        duthost.run_sonic_cfggen("-j {} -w".format(BGPMON_CONFIG_FILE), asic_index='all')
+
         # Verify no syn packet is received
         pytest_assert(0 == testutils.count_matched_packets_all_ports(test=ptfadapter, exp_packet=exp_packet, ports=peer_ports, timeout=BGP_CONNECT_TIMEOUT),
                      "Syn packets is captured when resolve-via-default is disabled")
     finally:
         # Re-enable resolve-via-default
-        duthost.command("vtysh -c \"configure terminal\" \
-                        -c \"ip nht resolve-via-default\"")
+        duthost.run_vtysh("-c \"configure terminal\" -c \"ip nht resolve-via-default\"", asic_index='all')
 

--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -62,7 +62,7 @@ def dut_with_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             pytest.skip("Did not find any DUT in the DUTs (linecards) that are connected to T3 VM's")
         return dut_to_T3
     else:
-        duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        return duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
 @pytest.fixture
 def common_setup_teardown(dut_with_default_route,  tbinfo):

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -75,7 +75,6 @@ def get_traffic_shift_state(host):
 def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     mg_facts = dut_host.minigraph_facts(host=dut_host.hostname)['ansible_facts']
     asn = mg_facts['minigraph_bgp_asn']
-    neigh_host_items = neigh_hosts.items()
     all_routes = {}
 
     host_name_map = {}

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -383,21 +383,6 @@ class SonicAsic(object):
 
         return self.sonichost.command(cmdstr)
 
-    def run_sonic_cfggen(self, cmdstr):
-        """
-            Add -n option with ASIC instance on multi ASIC
-
-            Args:
-                cmdstr
-            Returns:
-                Output from the ansible command module
-        """
-        if not self.sonichost.is_multi_asic:
-            return self.sonichost.command("sonic-cfggen {}".format(cmdstr))
-
-        cmdstr = "sonic-cfggen -n {} {}".format(self.namespace, cmdstr)
-        return self.sonichost.command(cmdstr)
-
     def run_vtysh(self, cmdstr):
         """
             Add -n option with ASIC instance on multi ASIC

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -16,7 +16,7 @@ class SonicAsic(object):
     For example, passing asic_id, namespace, instance_id etc. to ansible module to deal with namespaces.
     """
 
-    _MULTI_ASIC_SERVICE_NAME = "{}@{}.service"   # service name, asic_id
+    _MULTI_ASIC_SERVICE_NAME = "{}@{}"   # service name, asic_id
     _MULTI_ASIC_DOCKER_NAME = "{}{}"     # docker name,  asic_id
 
     def __init__(self, sonichost, asic_index):
@@ -544,12 +544,13 @@ class SonicAsic(object):
                 if portchannel == pc:
                     return True
         return False
-    
+
     def write_to_config_db(self, dst_path):
         cmd = 'sonic-cfggen {} -j {} --write-to-db'.format(self.cli_ns_option, dst_path)
         return self.shell(cmd)
 
-    def get_portchannels_and_members_in_ns(self, tbinfo):
+    def get_portchannel_and_members_in_ns(self, tbinfo):
+
         """
         Get a portchannels and their members in this namespace.
 

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -549,7 +549,7 @@ class SonicAsic(object):
         cmd = 'sonic-cfggen {} -j {} --write-to-db'.format(self.cli_ns_option, dst_path)
         return self.shell(cmd)
 
-    def get_portchannel_and_members_in_ns(self, tbinfo):
+    def get_portchannels_and_members_in_ns(self, tbinfo):
 
         """
         Get a portchannels and their members in this namespace.

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -16,7 +16,7 @@ class SonicAsic(object):
     For example, passing asic_id, namespace, instance_id etc. to ansible module to deal with namespaces.
     """
 
-    _MULTI_ASIC_SERVICE_NAME = "{}@{}"   # service name, asic_id
+    _MULTI_ASIC_SERVICE_NAME = "{}@{}.service"   # service name, asic_id
     _MULTI_ASIC_DOCKER_NAME = "{}{}"     # docker name,  asic_id
 
     def __init__(self, sonichost, asic_index):
@@ -381,6 +381,21 @@ class SonicAsic(object):
 
         cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
 
+        return self.sonichost.command(cmdstr)
+
+    def run_sonic_cfggen(self, cmdstr):
+        """
+            Add -n option with ASIC instance on multi ASIC
+
+            Args:
+                cmdstr
+            Returns:
+                Output from the ansible command module
+        """
+        if not self.sonichost.is_multi_asic:
+            return self.sonichost.command("sonic-cfggen {}".format(cmdstr))
+
+        cmdstr = "sonic-cfggen -n {} {}".format(self.namespace, cmdstr)
         return self.sonichost.command(cmdstr)
 
     def run_vtysh(self, cmdstr):

--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -3,7 +3,7 @@ import json
 
 ZERO_ADDR = r'0.0.0.0/0'
 
-def generate_ips(num, prefix, exclude_ips):
+def generate_ips(num, prefix, exclude_ips, addr=False):
     """ Generate random ips within prefix """
     prefix = IPNetwork(prefix)
     exclude_ips.append(prefix.broadcast)
@@ -14,12 +14,16 @@ def generate_ips(num, prefix, exclude_ips):
         raise Exception("Not enough available IPs")
 
     generated_ips = []
+    generated_ips_wout_mask = []
     for available_ip in available_ips:
         if available_ip not in exclude_ips:
             generated_ips.append(str(available_ip) + '/' + str(prefix.prefixlen))
+            generated_ips_wout_mask.append(str(available_ip))
         if len(generated_ips) == num:
             break
 
+    if addr:
+        return generated_ips_wout_mask
     return generated_ips
 
 
@@ -50,7 +54,12 @@ def generate_ip_through_default_route(host, exclude_ips=None):
     """
     exclude_ips = exclude_ips if exclude_ips is not None else []
     for leading in range(11, 255):
-        ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips)[0]
-        if route_through_default_routes(host, ip_addr):
-            return ip_addr
+        if host.is_multi_asic:
+            # Workaround for https://github.com/sonic-net/sonic-buildimage/issues/10897
+            ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips, addr=True)
+        else:
+            ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips)
+        for ip in ip_addr:
+            if route_through_default_routes(host, ip):
+                return ip
     return None

--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -3,7 +3,7 @@ import json
 
 ZERO_ADDR = r'0.0.0.0/0'
 
-def generate_ips(num, prefix, exclude_ips, addr=False):
+def generate_ips(num, prefix, exclude_ips):
     """ Generate random ips within prefix """
     prefix = IPNetwork(prefix)
     exclude_ips.append(prefix.broadcast)
@@ -14,16 +14,11 @@ def generate_ips(num, prefix, exclude_ips, addr=False):
         raise Exception("Not enough available IPs")
 
     generated_ips = []
-    generated_ips_wout_mask = []
     for available_ip in available_ips:
         if available_ip not in exclude_ips:
-            generated_ips.append(str(available_ip) + '/' + str(prefix.prefixlen))
-            generated_ips_wout_mask.append(str(available_ip))
+            generated_ips.append(str(available_ip))
         if len(generated_ips) == num:
             break
-
-    if addr:
-        return generated_ips_wout_mask
     return generated_ips
 
 
@@ -54,12 +49,7 @@ def generate_ip_through_default_route(host, exclude_ips=None):
     """
     exclude_ips = exclude_ips if exclude_ips is not None else []
     for leading in range(11, 255):
-        if host.is_multi_asic:
-            # Workaround for https://github.com/sonic-net/sonic-buildimage/issues/10897
-            ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips, addr=True)
-        else:
-            ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips)
-        for ip in ip_addr:
-            if route_through_default_routes(host, ip):
-                return ip
+        ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips)[0]
+        if route_through_default_routes(host, ip_addr):
+            return ip_addr
     return None

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -70,6 +70,12 @@ bgp/test_bgpmon.py:
     conditions:
       - "'backend' in topo_name"
 
+bgp/test_bgp_gr_helper.py:
+  skip:
+    reason: 'bgp graceful restarted is not a supported feature for T2'
+    conditions:
+      - "'t2' in topo_name"
+
 #######################################
 #####            cacl             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add multi-asic and T2 topology support for bgpmon and bgp_traffic_shift suites
Added support for KVM
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Existing bgpmon and bgp_traffic_shift don't support multi_asic and multi-dut T2 topology.
Existing scripts do not support KVM

#### How did you do it?
Added multi-asic support by using SonicAsic instance asichost instead of SonicHost instance duthost.
  - Use methods in SonicAsic that work for both single asic and multi-asic DUT - like 'run_vtysh', 'command', 'run_sonic_db_cli_cmd' etc.
  - Added run_sonic_cfggen to run sonic_cfggen with namespace added to the command if multi-asic DUT.

bgpmon:
  - Since test depends on DUT with default route pointing to eBGP, for T2 topology, pick DUT from duthosts that has T3 VM's.
  - Use sonic-db-cli instead of redis-cli
  - Apply bgpmon config to all asics.
     - exabgp will be started only the ptf port on which we receive the first tcp message - so this is OK
  - Increased default timeout of 30secs to 60secs for waiting for tcp port for bgpmon to be open on the ptf.
     - this helps with larger T2 topologies running on slower testbed servers.

bgp_traffic_shift:
  - Use enum_rand_one_per_hwsku_frontend_hostname instead of duthost (first DUT in the testbed for T2 chassis) which 
    could be supervisor card.
  - For T2 topology, TSA command sets up policies where only loopback address on the iBGP peers on the same linecard 
    are exchanged between the asics. Also, since bgpmon is iBGP as well, routes learnt from other asics on other linecards 
    are also not going to be advertised to bgpmon. So, for T2 topology, we cannot validate all routes are send to bgpmon 
    on T2 and thus skip this validation.
  - When validating loopback routes only are annnouced to bgpmon, we have to validate only on nbrhosts that are 
     connected to the linecard chosen, and not all the nbrhosts which includes nbrs on the other linecards where we 
     have not done any traffic shift commands.

generators:
  - Added workaround for sonic-buildimage/issues/10897

tests_mark_conditions.yaml:
  - skipping test_bgp_gr_helper_routes_perserved since it is not supported fetature for T2
  
#### How did you verify/test it?
Tested the two suites on a muli asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
