### PR TITLE
Fix core dump error in 201911

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1654,13 +1654,13 @@ def collect_db_dump(request, duthosts):
 @pytest.fixture(scope="module", autouse=True)
 def verify_new_core_dumps(duthost):
     if "20191130" in duthost.os_version:
-        pre_existing_cores = duthost.shell('ls /var/core/ | grep -v python')['stdout'].split()
+        pre_existing_cores = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
     else:
         pre_existing_cores = duthost.shell('ls /var/core/')['stdout'].split()
 
     yield
     if "20191130" in duthost.os_version:
-        cur_cores = duthost.shell('ls /var/core/ | grep -v python')['stdout'].split()
+        cur_cores = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
     else:
         cur_cores = duthost.shell('ls /var/core/')['stdout'].split()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
DUT with osversion 201911 would report error if no previous core dumps
when execute 'ls /var/core/ | grep -v python'
#### How did you do it?
Change to 'ls /var/core/ | grep -v python || true'
#### How did you verify/test it?
Run a test in 201911
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
