### PR TITLE
[dualtor][active-active] Enable `test_heartbeat_failure.py`

### DIFF
--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -10,16 +10,20 @@ from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat       
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type 
+from tests.common.dualtor.dual_tor_common import CableType
+
 
 pytestmark = [
     pytest.mark.topology("dualtor")
 ]
 
 
+@pytest.mark.enable_active_active
 def test_active_tor_heartbeat_failure_upstream(
     toggle_all_simulator_ports_to_upper_tor,
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    shutdown_tor_heartbeat):
+    shutdown_tor_heartbeat, cable_type
+):
     """
     Send upstream traffic and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
@@ -28,16 +32,28 @@ def test_active_tor_heartbeat_failure_upstream(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
-    )
+
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
+        )
 
 
+@pytest.mark.enable_active_active
 def test_active_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor,
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    shutdown_tor_heartbeat):
+    shutdown_tor_heartbeat, cable_type
+):
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
@@ -46,10 +62,20 @@ def test_active_tor_heartbeat_failure_downstream_active(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
-    )
+
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
+        )
 
 
 def test_active_tor_heartbeat_failure_downstream_standby(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable `test_heartbeat_failure.py` for `active-active` mux ports.

#### How did you do it?

#### How did you verify/test it?
The test cases now fails because of https://github.com/sonic-net/sonic-buildimage/pull/11821

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
