### PR TITLE
[portchannel]: Added multi-asic support to db testcases

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -367,10 +367,15 @@ def teardown(duthost):
         config_reload(duthost, config_source="minigraph")
     return
 
+def get_lag_namespace_id(duthost, lag_name):
+    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    return (lag_facts['lags'][lag_name]['po_namespace_id'])
 
-def get_oper_status_from_db(duthost, port_name):
+def get_oper_status_from_db(duthost, port_name, lag_name):
     """Get netdev_oper_status from state_db for interface"""
-    cmd = "redis-cli -n 6 hget \"PORT_TABLE|{}\" netdev_oper_status".format(port_name)
+    namespace_id = get_lag_namespace_id(duthost, lag_name)
+    namespace_prefix = 'sudo docker exec database' + str(namespace_id) if namespace_id else ''
+    cmd = "{} redis-cli -n 6 hget \"PORT_TABLE|{}\" netdev_oper_status".format(namespace_prefix, port_name)
     status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
     # If PORT_TABLE in STATE_DB doesn't have key netdev_oper_status,
     # check oper_status in APPL_DB instead. This scenario happens on 202012.
@@ -379,9 +384,11 @@ def get_oper_status_from_db(duthost, port_name):
         status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
     return status
 
-def get_admin_status_from_db(duthost, port_name):
+def get_admin_status_from_db(duthost, port_name, lag_name):
     """Get netdev_oper_status from state_db for interface"""
-    cmd = "redis-cli -n 6 hget \"PORT_TABLE|{}\" admin_status".format(port_name)
+    namespace_id = get_lag_namespace_id(duthost, lag_name)
+    namespace_prefix = 'sudo docker exec database' + str(namespace_id) if namespace_id else ''
+    cmd = "{} redis-cli -n 6 hget \"PORT_TABLE|{}\" admin_status".format(namespace_prefix, port_name)
     status = duthost.shell(cmd, module_ignore_errors=False)['stdout']
     # If PORT_TABLE in STATE_DB doesn't have key admin_status,
     # check admin_status in APPL_DB instead. This scenario happens on 202012.
@@ -393,7 +400,7 @@ def get_admin_status_from_db(duthost, port_name):
 def check_status_is_syncd(duthost, po_intf, port_info, lag_name):
     """Check if interface's status is synced with the netdev_oper_status in state_db"""
     port_status = port_info['link']['up'] if port_info['link'] else False
-    status_from_db = True if str(get_oper_status_from_db(duthost, po_intf)) == 'up' else False
+    status_from_db = True if str(get_oper_status_from_db(duthost, po_intf, lag_name)) == 'up' else False
     return status_from_db == port_status
 
 def check_link_is_up(duthost, po_intf, port_info, lag_name):
@@ -401,14 +408,14 @@ def check_link_is_up(duthost, po_intf, port_info, lag_name):
     new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
     port_info = new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
     port_status = port_info['link']['up'] if port_info['link'] else False
-    oper_status_from_db = True if str(get_oper_status_from_db(duthost, po_intf)) == 'up' else False
-    admin_status_from_db = True if str(get_admin_status_from_db(duthost, po_intf)) == 'up' else False
+    oper_status_from_db = True if str(get_oper_status_from_db(duthost, po_intf, lag_name)) == 'up' else False
+    admin_status_from_db = True if str(get_admin_status_from_db(duthost, po_intf, lag_name)) == 'up' else False
     return port_status and oper_status_from_db and admin_status_from_db
 
-def check_link_is_down(duthost, po_intf):
+def check_link_is_down(duthost, po_intf, lag_name):
     """Check if interface's status and the netdev_oper_status in state_db are both up"""
-    oper_status = get_oper_status_from_db(duthost, po_intf)
-    admin_status = get_admin_status_from_db(duthost, po_intf)
+    oper_status = get_oper_status_from_db(duthost, po_intf, lag_name)
+    admin_status = get_admin_status_from_db(duthost, po_intf, lag_name)
 
     return str(oper_status) == 'down' and str(admin_status) == 'down'
 
@@ -439,15 +446,23 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
         # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
         for lag_name in test_lags:
             for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
-                duthost.shutdown(po_intf)
+                namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+                if namespace_id:
+                    duthost.asic_instance_from_namespace('asic'+str(namespace_id)).shutdown_interface(po_intf)
+                else:
+                    duthost.shutdown(po_intf)
                 # Retrieve lag_facts after shutdown interface
                 new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
                 port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
-                pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf),
+                pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf, lag_name),
                 "{} member {}'s admin_status or oper_status in state_db is not down.".format(lag_name, po_intf))
 
                 # Retrieve lag_facts after no shutdown interface
-                duthost.no_shutdown(po_intf)
+                namespace_id = new_lag_facts['lags'][lag_name]['po_namespace_id']
+                if namespace_id:
+                    duthost.asic_instance_from_namespace('asic'+str(namespace_id)).startup_interface(po_intf)
+                else:
+                    duthost.no_shutdown(po_intf)
                 # Sometimes, it has to wait seconds for booting up interface
                 pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
                     "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
@@ -461,7 +476,11 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
                         continue
                 else:
                     logger.info("Interface {} of {} is down, no shutdown to recover it.".format(po_intf, lag_name))
-                    duthost.no_shutdown(po_intf)
+                    namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+                    if namespace_id:
+                        duthost.asic_instance_from_namespace('asic'+str(namespace_id)).startup_interface(po_intf)
+                    else:
+                        duthost.no_shutdown(po_intf)
 
 def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardown, enum_dut_portchannel_with_completeness_level, ignore_expected_loganalyzer_exceptions):
     """
@@ -489,8 +508,12 @@ def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardo
             asichost.config_portchannel_member(lag_name, po_intf, "del")
 
             # 2 Shutdown this port to check if status is down
-            duthost.shutdown(po_intf)
-            pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf),
+            namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+            if namespace_id:
+                duthost.asic_instance_from_namespace('asic'+str(namespace_id)).shutdown_interface(po_intf)
+            else:
+                duthost.shutdown(po_intf)
+            pytest_assert(wait_until(15, 1, 0, check_link_is_down, duthost, po_intf, lag_name),
                 "{} member {}'s admin_status or oper_status in state_db is not down.".format(lag_name, po_intf))
 
             # 3 Add this port back into portchannel and check if status is synced
@@ -503,7 +526,12 @@ def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardo
                 "{} member {}'s status is not synced with oper_status in state_db.".format(lag_name, po_intf))
 
             # 5 No shutdown this port to check if status is up
-            duthost.no_shutdown(po_intf)
+            namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+            if namespace_id:
+                duthost.asic_instance_from_namespace('asic'+str(namespace_id)).startup_interface(po_intf)
+            else:
+                duthost.no_shutdown(po_intf)
+
             # Sometimes, it has to wait seconds for booting up interface
             pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
                 "{} member {}'s admin_status or oper_status in state_db is not up.".format(lag_name, po_intf))


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Added support for multi-asic systems for newly added db related test cases.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
Test script change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The newly added db test cases handled single asic systems but were lacking handling of multi-asic systems.

#### How did you do it?
Added support to get namespace id corresponding to interface and use that information to run config and shut/no shut command in namespace.

#### How did you verify/test it?
Run test_lag_2.py for single and multi-asic DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0/T1/T2

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

=========================== short test summary info ============================
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1054]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1051]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1050]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1053]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1052]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1056]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1049]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc2|PortChannel1058]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel1011]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel1015]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel1019]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel105]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel107]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel103]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel101]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc1|PortChannel109]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel1010]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel1012]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel1016]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel104]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel106]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel102]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel1020]
PASSED pc/test_lag_2.py::test_lag_db_status[sfd-vt2-lc0|PortChannel108]
========================= 24 passed in 2230.07 seconds =========================