### PR TITLE
Add `pytest.mark` to enable more test_normal_op tests 

### DIFF
--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -35,7 +35,7 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,
                           expected_standby_host=None,
                           cable_type=cable_type)
 
-
+@pytest.mark.enable_active_active
 def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,
                                      send_t1_to_server_with_action,
                                      toggle_all_simulator_ports_to_upper_tor,
@@ -56,7 +56,7 @@ def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,
                             expected_standby_host=None,
                             cable_type=cable_type)
 
-
+@pytest.mark.enable_active_active
 def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,
                                       send_t1_to_server_with_action,
                                       toggle_all_simulator_ports_to_upper_tor,
@@ -177,7 +177,7 @@ def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host,
                             expected_standby_host=None,
                             cable_type=cable_type)
 
-
+@pytest.mark.enable_active_active
 def test_tor_switch_upstream(upper_tor_host, lower_tor_host,
                              send_server_to_t1_with_action,
                              toggle_all_simulator_ports_to_upper_tor,
@@ -197,13 +197,13 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,
                         expected_standby_host=upper_tor_host)
     
     if cable_type == CableType.active_active:
-        send_server_to_t1_with_action(upper_tor_host, verify=True,
+        send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
                                     action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                             expected_standby_host=upper_tor_host,
                             cable_type=cable_type)
 
-
+@pytest.mark.enable_active_active
 def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,
                                       send_t1_to_server_with_action,
                                       toggle_all_simulator_ports_to_upper_tor,
@@ -229,7 +229,7 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,
                             expected_standby_host=upper_tor_host,
                             cable_type=cable_type)
 
-
+@pytest.mark.enable_active_active
 def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
                                        send_t1_to_server_with_action,
                                        toggle_all_simulator_ports_to_upper_tor,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Enable tests below for active-active interfaces. These tests were previously updated, but I didn't merge the change of `mark.enable_active_active` to actually enable them.   
```
test_normal_op_downstream_upper_tor
test_normal_op_downstream_lower_tor
test_tor_switch_upstream
test_tor_switch_downstream_active
test_tor_switch_downstream_standby
```

`config reload` tests remain disabled until further debugging. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To enable test cases that are ready for active-active interfaces. 

#### How did you do it?
Add `@pytest.mark.enable_active_active` mark.   
Adjust expected delay for `test_tor_switch_upstream`

#### How did you verify/test it?
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/ZHANGJ~1/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/ZHANGJ~1/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



dualtor_io/test_normal_op.py::test_normal_op_upstream[active-standby] | PASSED
-- | --
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-active] | PASSED
dualtor_io/test_normal_op.py::test_normal_op_downstream_upper_tor[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_normal_op_downstream_upper_tor[active-active] | PASSED
dualtor_io/test_normal_op.py::test_normal_op_downstream_lower_tor[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_normal_op_downstream_lower_tor[active-active] | PASSED
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_upstream[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_upstream[active-active] | SKIPPED
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_upstream[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_upstream[active-active] | SKIPPED
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_downstream_upper_tor[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_downstream_upper_tor[active-active] | SKIPPED
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-active] | SKIPPED
dualtor_io/test_normal_op.py::test_tor_switch_upstream[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_tor_switch_upstream[active-active] | PASSED
dualtor_io/test_normal_op.py::test_tor_switch_downstream_active[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_tor_switch_downstream_active[active-active] | PASSED
dualtor_io/test_normal_op.py::test_tor_switch_downstream_standby[active-standby] | PASSED
dualtor_io/test_normal_op.py::test_tor_switch_downstream_standby[active-active] | PASSED



</body>

</html>



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
