### PR TITLE
[SAI Qualify] Remove hard coded port mapping config

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -59,8 +59,6 @@ SAISERVER_CONTAINER = "saiserver"
 SYNCD_CONATINER = "syncd"
 
 PORT_MAP_FILE_PATH = "/tmp/default_interface_to_front_map.ini"
-DX010_PORT_MAP = "--interface '0-0@eth20' --interface '0-1@eth21' --interface '0-2@eth22' --interface '0-3@eth23' --interface '0-4@eth24' --interface '0-5@eth25' --interface '0-6@eth26' --interface '0-7@eth27' --interface '0-8@eth4' --interface '0-9@eth5' --interface '0-10@eth6' --interface '0-11@eth7' --interface '0-12@eth8' --interface '0-13@eth9' --interface '0-14@eth10' --interface '0-15@eth11' --interface '0-16@eth0' --interface '0-17@eth1' --interface '0-18@eth2' --interface '0-19@eth3' --interface '0-20@eth12' --interface '0-21@eth13' --interface '0-22@eth14' --interface '0-23@eth15' --interface '0-24@eth16' --interface '0-25@eth17' --interface '0-26@eth18' --interface '0-27@eth19' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31'"
-
 
 SAI_TEST_CTNR_CHECK_TIMEOUT_IN_SEC = 140
 SAI_TEST_CTNR_RESTART_INTERVAL_IN_SEC = 35

--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -126,7 +126,6 @@ def run_case_from_ptf(duthost, dut_ip, ptfhost, test_case, test_interface_params
     if request.config.option.enable_sai_test:
         test_para = "--test-dir {}".format(SAI_TEST_SAI_CASE_DIR_ON_PTF)
         test_para += " \"--test-params=thrift_server='{}';port_config_ini='/tmp/sai_qualify/sai_test/resources/{}'\"".format(dut_ip, request.config.option.sai_port_config_file)
-        test_interface_params = DX010_PORT_MAP
     elif request.config.option.enable_ptf_sai_test:
         test_para = "--test-dir {}".format(SAI_TEST_PTF_SAI_CASE_DIR_ON_PTF)
         test_para += " \"--test-params=thrift_server='{}';port_config_ini='/tmp/sai_qualify/sai_test/resources/{}'\"".format(dut_ip, request.config.option.sai_port_config_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
SAI Test updated, it support the dynamic configuation on multi platforms.
The harded configueation for port mapping(port and host interfaces) can be removed

Summary:
Fixes # (issue)
SAI Test updated, it support the dynamic configuation on multi platforms.
The harded configueation for port mapping(port and host interfaces) can be removed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Test done:
pipeline testing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
