### PR TITLE
[tests/configlet] Skip platforms having duplicate lanes for add_rack test

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -27,6 +27,21 @@ def check_image_version(duthost):
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 
+@pytest.fixture(scope="module", autouse=True)
+def bypass_duplicate_lanes_platform(duthost):
+    """Skips platform that has duplicate lanes in default config
+
+    Args:
+        duthost: DUT host object.
+
+    Returns:
+        None.
+    """
+    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s' or \
+            duthost.facts['platform'] == 'x86_64-dellemc_s5232f_c3538-r0':
+        pytest.skip("Temporary skip platform with duplicate lanes...")
+
+
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip platforms having duplicate lanes for add_rack test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
GCU feature will fail if there are duplicate lanes in config. AddRack test are using GCU apply-patch for test, so it will fail the operation when config cannot pass lane verification.
#### How did you do it?
Skip platforms having duplicate lanes for add_rack test
#### How did you verify/test it?
Manual test on specific platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
