### PR TITLE
Add topology mark for test_fwutil.py

### DIFF
--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -5,6 +5,10 @@ import json
 
 from fwutil_common import call_fwutil, show_firmware, upload_platform, find_pattern
 
+pytestmark = [
+    pytest.mark.topology("any")
+]
+
 DEVICES_PATH="/usr/share/sonic/device"
 
 def test_fwutil_show(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The topology mark is missing from the test_fwutil.py. The script could be
skipped unintentionally when topology requirement is specified.

#### How did you do it?
This change added the "any" topology mark.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
