### PR TITLE
[chassis-packet]: Update linecard minigraph to include links to fabric asics that are present in supervisor

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -70,7 +70,18 @@
         vm_base: "{% if testbed_facts['vm_base'] != '' %}{{ testbed_facts['vm_base'] }}{% else %}''{% endif %}"
     when: testbed_name is defined
 
-  - topo_facts: topo={{ topo }} hwsku={{ hwsku }} asic_name={{ asic_name | default(None) }}
+    - name: find supervisor dut of testbed
+      set_fact:
+        sup_dut: "{{ item | default(None) }}"
+      when: hostvars[item]['card_type'] is defined and hostvars[item]['card_type'] == 'supervisor'
+      loop: "{{ testbed_facts['duts'] }}"
+
+    - name: Get asics_present of supervisor dut
+      set_fact:
+        asics_present: "{{ hostvars[sup_dut]['asics_present'] | default([]) }}"
+      when: sup_dut is defined and hostvars[sup_dut]['asics_present'] is defined
+
+  - topo_facts: topo={{ topo }} hwsku={{ hwsku }} asic_name={{ asic_name | default(None) }} asics_present={{ asics_present | default([]) }} card_type={{ card_type | default('fixed') }}
     delegate_to: localhost
 
   - name: get connection graph if defined for dut (ignore any errors)

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -195,7 +195,7 @@ class ParseTestbedTopoinfo():
                                 vmconfig[vm]['ipv6mask'][dut_index] = ip_mask if ip_mask else '128'
         return vmconfig
 
-    def get_topo_config(self, topo_name, hwsku, asic_name):
+    def get_topo_config(self, topo_name, hwsku, asic_name, asics_present, card_type):
         CLET_SUFFIX = "-clet"
 
         if 'ptf32' in topo_name:
@@ -288,6 +288,19 @@ class ParseTestbedTopoinfo():
         else:
             vm_topo_config['devices_interconnect_interfaces'] = []
 
+        #  In linecard, keep neigh_asic information to only asics_present on supervisor
+        if card_type != 'supervisor' and asics_present:
+            asic_names_present = []
+            for asic in asics_present:
+                asic_name = 'ASIC' + str(asic)
+                asic_names_present.append(asic_name)
+            for slot in asic_topo_config:
+                for asic in asic_topo_config[slot]:
+                    for neigh_asic in asic_topo_config[slot][asic]['neigh_asic'].keys():
+                        if neigh_asic not in asic_names_present:
+                            # If neigh_asic is not part of asics_present, delete it.
+                            del asic_topo_config[slot][asic]['neigh_asic'][neigh_asic]
+
         self.vm_topo_config = vm_topo_config
         self.asic_topo_config = asic_topo_config
         return vm_topo_config, asic_topo_config
@@ -299,6 +312,8 @@ def main():
             topo=dict(required=True, default=None),
             hwsku=dict(required=True, default=None),
             asic_name=dict(required=True, default=None),
+            asics_present=dict(type = 'list', required=True, default=[]),
+            card_type=dict(required=True, default=None),
         ),
         supports_check_mode=True
     )
@@ -306,9 +321,11 @@ def main():
     topo_name = m_args['topo']
     hwsku = m_args['hwsku']
     asic_name = m_args['asic_name']
+    asics_present = m_args['asics_present']
+    card_type = m_args['card_type']
     try:
         topoinfo = ParseTestbedTopoinfo()
-        vm_topo_config, asic_topo_config = topoinfo.get_topo_config(topo_name, hwsku, asic_name)
+        vm_topo_config, asic_topo_config = topoinfo.get_topo_config(topo_name, hwsku, asic_name, asics_present, card_type)
         module.exit_json(ansible_facts={'vm_topo_config': vm_topo_config,
                                         'asic_topo_config': asic_topo_config})
     except (IOError, OSError):


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sanity tests on packet chassis fails because the admin status and oper status of links from linecard asics to fabric asics that are not present do not match.
Supervisor can have max number of asics and asics that are present are included in asics_present field in inventory file.
Minigraph that is generated for supervisor and Linecard will include information of asics that are not present as well.
This PR is diff is to ensure that Linecard minigraph will include neigh asic information only of fabric asics that is present in supervisor.
#### How did you do it?
1. Find the supervisor dut name for the chassis testbed for which linecard is to be generated. If there is no supervisor in testbed, default value of None will be used.
2. Get the asics_present list of supervisor dut 
3. Pass the values of card_type and asics_present to topo_facts library
4. Based on card_type, if card_type is not supervisor and we have the list of asics that are present, then only keep the asics that are present in linecard minigraph.

#### How did you verify/test it?
- on packet chassis linecard, verified that the admin status on interfaces to fabric asics that are not present are down.
- on packet chassis supervisor - no change in minigraph, the swss/sycnd dockers will not be started on asics that are not present so admin status and oper status mismatch cannot occur.
- on voq chassis - no change in any minigraph
- on multi-asic device (non chassis) - no change in minigraph

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
