### PR TITLE
Fixes the issue "psud expected restarted status is RUNNING but is STARTING"

### DIFF
--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -169,7 +169,7 @@ def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, enum_sup
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
-    wait_until(50, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
+    wait_until(50, 10, 5, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,


### PR DESCRIPTION
### Description of PR
This commit fixes a failure in the test_psud.py that checks whether PSUD was terminated and restarted properly.

Summary:
Fixes the issue "psud expected restarted status is RUNNING but is STARTING"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach

#### How did you do it?
The PSUD needed more time to turn off, so I added a delay

#### How did you verify/test it?
Tested my changes on the platform where it was previously failing and ensured that it passed.

#### Any platform specific information?
This is for the z9332f platform.
