### PR TITLE
[TestbedV2] Enable runtime switch off classical pr test jobs by AZP library

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,7 @@ stages:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
         TOPOLOGY: t0
+        MIN_WORKER: 2
         MAX_WORKER: 3
 
   - job: t0_2vlans_testbedv2
@@ -129,6 +130,8 @@ stages:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
         TOPOLOGY: t1-lag
+        MIN_WORKER: 2
+        MAX_WORKER: 3
 
   - job:
     displayName: "kvmtest-t1-lag"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ stages:
     pool: sonictest
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 400
+    condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -40,6 +41,7 @@ stages:
     pool: sonictest
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 400
+    condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -54,7 +56,7 @@ stages:
   - job: t0_testbedv2
     displayName: "kvmtest-t0 by TestbedV2"
     timeoutInMinutes: 540
-    condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
+    condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -64,7 +66,7 @@ stages:
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
     timeoutInMinutes: 540
-    condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
+    condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -109,6 +111,7 @@ stages:
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
     timeoutInMinutes: 400
+    condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -121,7 +124,7 @@ stages:
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
     timeoutInMinutes: 540
-    condition: and(succeeded(), eq(variables.RUN_TEST_BY_SCHEDULER, 'YES'))
+    condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable runtime switch off classical pr test jobs by AZP library

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable runtime switch off classical pr test jobs by AZP library
#### How did you do it?
Enable runtime switch off classical pr test jobs by AZP library

