### PR TITLE
Enhance test_cacl_application_dualtor in case of toggle mux cable failed

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -57,7 +57,7 @@ def expected_dhcp_rules_for_standby(duthost_dualtor):
             mark = duthost_dualtor.shell('/usr/bin/redis-cli -n 6 --raw hget "DHCP_PACKET_MARK|{}" "mark"'.format(interface_name), module_ignore_errors=False)['stdout']
             rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
             expected_dhcp_rules.append(rule)
-    logger.info("Generate expected dhcp rules for standby interfaces: {}".format(expected_dhcp_rules))
+    logger.info("Generated expected dhcp rules for standby interfaces: {}".format(expected_dhcp_rules))
     return expected_dhcp_rules
 
 @pytest.fixture(scope="module")

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -31,30 +31,33 @@ def ignore_hardcoded_cacl_rule_on_dualtor(tbinfo):
         ignored_iptable_rules += rules_to_ignore
 
 @pytest.fixture(scope="function", params=["active_tor", "standby_tor"])
-def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_upper_tor):
+def duthost_dualtor(request, upper_tor_host, lower_tor_host):
     which_tor = request.param
 
     # Add expected DHCP mark iptable rules for standby tor, not for active tor.
     if which_tor == 'standby_tor':
         dut = lower_tor_host
-        logger.info("Select standby tor, generate expected DHCP iptables rules for standby tor.")
+        logger.info("Select lower tor...")
     else:
-        logger.info("Select active tor, don't need to add expected DHCP mark rules.")
+        logger.info("Select upper tor...")
         dut = upper_tor_host
     return dut
 
 @pytest.fixture
-def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
+def expected_dhcp_rules_for_standby(duthost_dualtor):
     expected_dhcp_rules = []
-    if duthost_dualtor.hostname == lower_tor_host.hostname: 
-        mark_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
-        mark_keys = mark_keys.split("\n")
-        for key in mark_keys:
-            mark = duthost_dualtor.shell('/usr/bin/redis-cli -n 6 --raw hget "{}" "mark"'.format(key), module_ignore_errors=False)['stdout']
-            if not mark:
-                continue
+    mux_cable_int_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "MUX_CABLE_TABLE*"', module_ignore_errors=True)['stdout']
+    mux_cable_int_keys = mux_cable_int_keys.split("\n")
+    for mux_cable_int in mux_cable_int_keys:
+        interface_name = mux_cable_int.split("|")[1]
+        mux_status = duthost_dualtor.shell('/usr/bin/redis-cli -n 6 --raw hget "{}" "state"'.format(mux_cable_int), module_ignore_errors=False)['stdout']
+        if not mux_status:
+            continue
+        if mux_status == 'standby':
+            mark = duthost_dualtor.shell('/usr/bin/redis-cli -n 6 --raw hget "DHCP_PACKET_MARK|{}" "mark"'.format(interface_name), module_ignore_errors=False)['stdout']
             rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
             expected_dhcp_rules.append(rule)
+    logger.info("Generate expected dhcp rules for standby interfaces: {}".format(expected_dhcp_rules))
     return expected_dhcp_rules
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If some interfaces are not toggled to active status on upper tor because of some issues in toggle mux cable function, test_cacl_application_dualtor will fail since it thinks all interfaces are toggled successfully, it will add expected dhcp rules for all interfaces on standby tor, which is not in fact.

#### How did you do it?
Remove toggle_all_simulator_ports_to_upper_tor fixture, check MUX_CABLE_TABLE before adding dhcp rules, if the interface is standby, it will add one dhcp mask rule for this interface, otherwise it will not add dhcp rule for it, whatever on the upper tor or lower tor.

#### How did you verify/test it?
run `test_cacl_application::test_cacl_application_dualtor`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
