### PR TITLE
Shutdown Ethernet0 after the module test_neighbor_mac.py running. 

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -41,6 +41,7 @@ class TestNeighborMac:
 
         logger.info("Restore the DUT interface config, remove IP address")
         self.__configureInterfaceIp(duthost, action="remove")
+        self.__shutdownInterface(duthost)
 
     @pytest.fixture(params=[0, 1])
     def macIndex(self, request):
@@ -88,6 +89,24 @@ class TestNeighborMac:
             "config",
             "interface",
             "startup",
+            self.DUT_ETH_IF
+        ])
+
+    def __shutdownInterface(self, duthost):
+        """
+            Shutdown the interface on the DUT
+
+            Args:
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Returns:
+                None
+        """
+        logger.info("Configure the interface '{0}' as DOWN".format(self.DUT_ETH_IF))
+        duthost.shell(argv=[
+            "config",
+            "interface",
+            "shutdown",
             self.DUT_ETH_IF
         ])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
During the module test_neighbor_mac.py running, it start up Ethernet0. This cause the inconsistent in config db before and after the test case running. In this pr, we shutdown the Ethernet0 after the module running.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
During the module test_neighbor_mac.py running, it start up Ethernet0. This cause the inconsistent in config db before and after the test case running. In this pr, we shutdown the Ethernet0 after the module running.

#### How did you do it?
Shutdown Ethernet0 after the module running. 

#### How did you verify/test it?
Check the config db before and after the module running.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
