### PR TITLE
[test sensors] validate key before the usage

### DIFF
--- a/tests/platform_tests/test_sensors.py
+++ b/tests/platform_tests/test_sensors.py
@@ -37,10 +37,11 @@ def test_sensors(duthosts, rand_one_dut_hostname, creds):
 
     # Prepare check list
     sensors_checks = creds['sensors_checks']
-    logging.info("Sensor checks:\n{}".format(to_json(sensors_checks[platform])))
 
     if platform not in sensors_checks.keys():
         pytest.skip("Skip test due to not support check sensors for current platform({})".format(platform))
+
+    logging.info("Sensor checks:\n{}".format(to_json(sensors_checks[platform])))
 
     # Gather sensor facts
     sensors_facts = duthost.sensors_facts(checks=sensors_checks[platform])['ansible_facts']


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR #6198 was introduced mistake. The usage of the key platform inside the dictionary sensors_checks, were before the validation if this key exists.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [X] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?
stabilize the test

#### How did you do it?
added the key validation in right place

#### How did you verify/test it?
test executed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
