### PR TITLE
[masic] [PR check] add sanity check for multi-asic mgmt PR check

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -281,7 +281,7 @@ test_multi_asic_t1_lag_pr() {
 
     pushd $SONIC_MGMT_DIR/tests
     # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -u
     popd
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add sanity_check in multi-asic mgmt PR check

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add sanity_check in multi-asic mgmt PR check

#### How did you do it?
remove 'skip_sanity' option for multi_asic_t1_lag_pr

#### How did you verify/test it?
This is scheduled azp of multi-asic sanity_check enabled, it runs every 1 hour and has sanity check stable for 3 days: https://dev.azure.com/mssonic/build/_build?definitionId=560&_a=summary

#### Any platform specific information?
multi-asic PR check

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
