### PR TITLE
Refine pr merge blocking logic, define whether a job is required by code

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -72,8 +72,6 @@ steps:
     GIT_API_TOKEN: $(GIT_API_TOKEN)
   displayName: "Run tests"
   timeoutInMinutes: 360
-  ${{ if eq(parameters.tbtype, 'multi-asic-t1-lag-pr') }}:
-    continueOnError: true
 
 - script: |
     # save dut state if test fails

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,10 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+# For every job:
+# continueOnError: false means it's a required test job and will block merge if it fails
+# continueOnError: true means it's an optional test job and will not block merge even though it fails(unless a required test job depends on its result)
+
 pr:
 - master
 trigger: none
@@ -26,7 +30,7 @@ stages:
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
-
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -42,7 +46,7 @@ stages:
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
-
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -57,6 +61,7 @@ stages:
     displayName: "kvmtest-t0 by TestbedV2"
     timeoutInMinutes: 540
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -68,6 +73,7 @@ stages:
     displayName: "kvmtest-t0-2vlans by TestbedV2"
     timeoutInMinutes: 540
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -86,6 +92,7 @@ stages:
     - t0_testbedv2
     - t0_2vlans_testbedv2
     condition: always()
+    continueOnError: false
     variables:
       resultOfPart1: $[ dependencies.t0_part1.result ]
       resultOfPart2: $[ dependencies.t0_part2.result ]
@@ -113,6 +120,7 @@ stages:
     displayName: "kvmtest-t1-lag classic"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -126,6 +134,7 @@ stages:
     displayName: "kvmtest-t1-lag by TestbedV2"
     timeoutInMinutes: 540
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -139,10 +148,10 @@ stages:
     - t1_lag_classic
     - t1_lag_testbedv2
     condition: always()
+    continueOnError: false
     variables:
       resultOfClassic: $[ dependencies.t1_lag_classic.result ]
       resultOfTestbedV2: $[ dependencies.t1_lag_testbedv2.result ]
-
     steps:
     - script: |
         if [ $(resultOfClassic) == "Succeeded" ] || [ $(resultOfTestbedV2) == "Succeeded" ]; then
@@ -157,7 +166,7 @@ stages:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
     timeoutInMinutes: 400
-
+    continueOnError: true
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -171,7 +180,7 @@ stages:
     pool: sonictest-dualtor
     displayName: "kvmtest-dualtor"
     timeoutInMinutes: 400
-
+    continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-template.yml
         parameters:
@@ -185,7 +194,7 @@ stages:
     pool: sonictest-ma
     displayName: "kvmtest-multi-asic-t1-lag"
     timeoutInMinutes: 400
-
+    continueOnError: true
     steps:
       - template: .azure-pipelines/run-test-template.yml
         parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Refine pr merge blocking logic, define whether a job is required by code,

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently, we have some required jobs for allowing merging a pull request, in https://github.com/sonic-net/sonic-mgmt/settings/branch_protection_rules/14689274
But it's implicit and requires an admin auth to modify.
So I refined the logic, now we can define whether a job is required by continueOnError: false/true.
continueOnError: false means it's a required test job and will block merge if it fails
continueOnError: true means it's an optional test job and will not block merge even though it fails(unless a required test job depends on its result)
#### How did you do it?
Refine assert logic and project setting.

#### How did you verify/test it?
The behavior is verified in https://github.com/sonic-net/sonic-mgmt/pull/6252
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
