### PR TITLE
Add delay in test_pcied.py for batch run test cases

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -47,8 +47,7 @@ def setup(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     daemon_en_status = check_pmon_daemon_enable_status(duthost, daemon_name)
     ## add delay for pcied ready
-    if "Wistron_sw_to3200k" in duthost.facts["hwsku"]:
-        time.sleep(60)
+    time.sleep(60)
 
     if daemon_en_status is False:
         pytest.skip("{} is not enabled in {}".format(daemon_name, duthost.facts['platform'], duthost.os_version))

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -46,6 +46,10 @@ expected_pcied_devices_status = "PASSED"
 def setup(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     daemon_en_status = check_pmon_daemon_enable_status(duthost, daemon_name)
+    ## add delay for pcied ready
+    if "Wistron_sw_to3200k" in duthost.facts["hwsku"]:
+        time.sleep(60)
+
     if daemon_en_status is False:
         pytest.skip("{} is not enabled in {}".format(daemon_name, duthost.facts['platform'], duthost.os_version))
 


### PR DESCRIPTION
in batch run, the pmon docker will restart before daemon test.

the test_pcied will be performed after docker restart.

and the pcied did not update data into redis db since the pcied is not
ready yet.

the pcied need 1 minute for main thread start to run so we delay 60 secs
in setup

Signed-off-by: RogerX87 <RogerX87@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
improve the result in batch run for wistron sw-to3200k
#### How did you do it?
add delay for test_pcied.py for wistron 3200K
#### How did you verify/test it?
run the batch run for platform test
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
