### PR TITLE
[test_platform_info] Do not disable thermal algorithm

### DIFF
--- a/tests/platform_tests/files/valid_policy.json
+++ b/tests/platform_tests/files/valid_policy.json
@@ -1,6 +1,6 @@
 {
     "thermal_control_algorithm": {
-        "run_at_boot_up": "false",
+        "run_at_boot_up": "true",
         "fan_speed_when_suspend": "60"
     },
     "info_types": [


### PR DESCRIPTION
Change-Id: I9ff2962307b34fa419fadbf869154e051d98c863

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_thermal_control_fan_status loads tests/platform_tests/files/valid_policy.json as the thermal control configuration file before running test.  tests/platform_tests/files/valid_policy.json will disable kernel thermal algorithm which could cause ASIC overheat during the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Fix thermal shutdown issue found during test_thermal_control_fan_status 

#### How did you do it?

Change tests/platform_tests/files/valid_policy.json so that it won't disable thermal algorithm.

#### How did you verify/test it?

Run the test case

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
