### PR TITLE
Use parallel_run in test_traffic_shift.py, avoid endless waiting.

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -1,16 +1,16 @@
-import pytest
 import logging
-import ipaddr as ipaddress
-from bgp_helpers import parse_rib, get_routes_not_announced_to_bgpmon, remove_bgp_neighbors, restore_bgp_neighbors
-from tests.common.helpers.constants import DEFAULT_ASIC_ID
-from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.parallel import parallel_run
-from tests.common.utilities import wait_until
-from multiprocessing.dummy import Pool as ThreadPool
-from tests.common import config_reload
 import re
 
+import ipaddr as ipaddress
+import pytest
+
+from bgp_helpers import parse_rib, get_routes_not_announced_to_bgpmon, remove_bgp_neighbors, restore_bgp_neighbors
+from tests.common import config_reload
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.constants import DEFAULT_ASIC_ID
+from tests.common.helpers.parallel import parallel_run
 from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('t1', 't2')

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -1,9 +1,10 @@
 import pytest
 import logging
 import ipaddr as ipaddress
-from bgp_helpers import parse_rib, get_routes_not_announced_to_bgpmon,remove_bgp_neighbors,restore_bgp_neighbors
+from bgp_helpers import parse_rib, get_routes_not_announced_to_bgpmon, remove_bgp_neighbors, restore_bgp_neighbors
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until
 from multiprocessing.dummy import Pool as ThreadPool
 from tests.common import config_reload
@@ -12,7 +13,7 @@ import re
 from tests.common.platform.processes_utils import wait_critical_processes
 
 pytestmark = [
-    pytest.mark.topology('t1','t2')
+    pytest.mark.topology('t1', 't2')
 ]
 
 logger = logging.getLogger(__name__)
@@ -22,10 +23,13 @@ TS_MAINTENANCE = "System Mode: Maintenance"
 TS_INCONSISTENT = "System Mode: Not consistent"
 TS_NO_NEIGHBORS = "System Mode: No external neighbors"
 
+
 @pytest.fixture
 def traffic_shift_community(duthost):
-    community = duthost.shell('sonic-cfggen -y /etc/sonic/constants.yml -v constants.bgp.traffic_shift_community')['stdout']
+    community = duthost.shell('sonic-cfggen -y /etc/sonic/constants.yml -v constants.bgp.traffic_shift_community')[
+        'stdout']
     return community
+
 
 def verify_traffic_shift_per_asic(host, outputs, match_result, asic_index):
     prefix = "BGP{} : ".format(asic_index) if asic_index != DEFAULT_ASIC_ID else ''
@@ -35,12 +39,14 @@ def verify_traffic_shift_per_asic(host, outputs, match_result, asic_index):
     else:
         return False
 
+
 def verify_traffic_shift(host, outputs, match_result):
     for asic_index in host.get_frontend_asic_ids():
         if not verify_traffic_shift_per_asic(host, outputs, match_result, asic_index):
             return "ERROR"
 
     return match_result
+
 
 def get_traffic_shift_state(host):
     outputs = host.shell('TSC')['stdout_lines']
@@ -52,6 +58,7 @@ def get_traffic_shift_state(host):
         return TS_INCONSISTENT
     pytest.fail("TSC return unexpected state {}".format("ERROR"))
 
+
 def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
     """
     Parse the output of 'show ip bgp neigh received-routes' on eos, and store in a dict
@@ -61,18 +68,17 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "
+
     # Retrieve the routes on all VMs  in parallel by using a thread poll
-    neigh_host_items = neigh_hosts.items()
-    def parse_routes_process(neigh_host_item):
+    def parse_routes_process(node=None, results=None):
         """
         The process to parse routes on a VM.
         :param neigh_host_item: tuple of hostname and host_conf dict
         :return: no return value
         """
-        hostname = neigh_host_item[0]
-        host_conf = neigh_host_item[1]
-        host = host_conf['host']
-        peer_ips = host_conf['conf']['bgp']['peers'][asn]
+        hostname = node['host'].hostname
+        host = node['host']
+        peer_ips = node['conf']['bgp']['peers'][asn]
         for ip in peer_ips:
             if ipaddress.IPNetwork(ip).version == 4:
                 peer_ip_v4 = ip
@@ -114,13 +120,11 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
                     community = ""
         if entry:
             routes[entry] = community
-        all_routes[hostname] = routes
-    pool = ThreadPool()
-    # Run the parse routes process on all VMs in parallel.
-    pool.map(parse_routes_process, neigh_host_items)
-    pool.close()
-    pool.join()
+        results[hostname] = routes
+
+    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=120)
     return all_routes
+
 
 def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_ver):
     """
@@ -144,6 +148,7 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
                 logger.warn("{} not found on {}".format(route, hostname))
                 return False
     return True
+
 
 def verify_loopback_route_with_community(dut_host, neigh_hosts, ip_ver, community):
     logger.info("Verifying only loopback routes are announced to bgp neighbors")
@@ -171,12 +176,14 @@ def verify_loopback_route_with_community(dut_host, neigh_hosts, ip_ver, communit
                 return False
     return True
 
+
 def verify_only_loopback_routes_are_announced_to_neighs(dut_host, neigh_hosts, community):
     """
     Verify only loopback routes with certain community are announced to neighs in TSA
     """
     return verify_loopback_route_with_community(dut_host, neigh_hosts, 4, community) and \
-        verify_loopback_route_with_community(dut_host, neigh_hosts, 6, community)
+           verify_loopback_route_with_community(dut_host, neigh_hosts, 6, community)
+
 
 # API to check if the image has support for BGP_DEVICE_GLOBAL table in the configDB
 def check_tsa_persistence_support(duthost):
@@ -184,10 +191,12 @@ def check_tsa_persistence_support(duthost):
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
     namespace = duthost.get_namespace_from_asic_id(asic_index)
     sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")
-    tsa_in_configdb = duthost.shell('{} CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled"'.format(sonic_db_cmd), module_ignore_errors=False)['stdout_lines']    
+    tsa_in_configdb = duthost.shell('{} CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled"'.format(sonic_db_cmd),
+                                    module_ignore_errors=False)['stdout_lines']
     if not tsa_in_configdb:
         return False
     return True
+
 
 def test_TSA(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
@@ -200,13 +209,14 @@ def test_TSA(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_co
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
                       "DUT is not in maintenance state")
-        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost)==[],
+        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost) == [],
                       "Not all routes are announced to bgpmon")
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthost, nbrhosts, traffic_shift_community),
                       "Failed to verify routes on eos in TSA")
     finally:
         # Recover to Normal state
         duthost.shell("TSB")
+
 
 def test_TSB(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown):
     """
@@ -219,12 +229,13 @@ def test_TSB(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown):
     # Verify DUT is in normal state.
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
-    pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost)==[],
+    pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost) == [],
                   "Not all routes are announced to bgpmon")
     pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
                   "Not all ipv4 routes are announced to neighbors")
     pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
                   "Not all ipv6 routes are announced to neighbors")
+
 
 def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbinfo):
     """
@@ -232,7 +243,6 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
     """
     bgp_neighbors = {}
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
-
 
     try:
 
@@ -245,7 +255,8 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
         output = duthost.shell("TSC")['stdout_lines']
 
         # Verify DUT is in Normal state, and ASIC0 has no neighbors message.
-        pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")
+        pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index),
+                      "ASIC is not having no neighbors")
 
     finally:
         # Restore BGP neighbors
@@ -260,10 +271,11 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
                       "Not all BGP sessions are established on DUT")
 
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,duthost, nbrhosts, routes_4, 4),
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_4, 4),
                       "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,duthost, nbrhosts, routes_6, 6),
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_6, 6),
                       "Not all ipv6 routes are announced to neighbors")
+
 
 def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
@@ -282,7 +294,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
                       "DUT is not in maintenance state")
-        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost)==[],
+        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost) == [],
                       "Not all routes are announced to bgpmon")
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthost, nbrhosts, traffic_shift_community),
                       "Failed to verify routes on eos in TSA")
@@ -299,13 +311,15 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
 
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
-                    "DUT is not in normal state")
+                      "DUT is not in normal state")
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                    "Not all ipv4 routes are announced to neighbors")
+                      "Not all ipv4 routes are announced to neighbors")
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                    "Not all ipv6 routes are announced to neighbors")
+                      "Not all ipv6 routes are announced to neighbors")
 
-def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
+
+def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown,
+                                                traffic_shift_community):
     """
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
@@ -314,12 +328,13 @@ def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpm
         pytest.skip("TSA persistence not supported in the image")
 
     try:
-        config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True, traffic_shift_away=True)
+        config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True,
+                      traffic_shift_away=True)
 
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
                       "DUT is not in maintenance state")
-        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost)==[],
+        pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost) == [],
                       "Not all routes are announced to bgpmon")
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthost, nbrhosts, traffic_shift_community),
                       "Failed to verify routes on eos in TSA")
@@ -333,8 +348,8 @@ def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpm
 
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
-                    "DUT is not in normal state")
+                      "DUT is not in normal state")
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                  "Not all ipv4 routes are announced to neighbors")
+                      "Not all ipv4 routes are announced to neighbors")
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                  "Not all ipv6 routes are announced to neighbors")
+                      "Not all ipv6 routes are announced to neighbors")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use parallel_run in test_traffic_shift.py, avoid endless waiting.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_traffic_shift.py gets a large chance to stuck forever in t1-lag pr test, use parallel_run in test_traffic_shift.py to avoid endless waiting.
#### How did you do it?
use parallel_run in test_traffic_shift.py instead of join()
#### How did you verify/test it?
It's included in pr test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
