### PR TITLE
[mpls] skip MPLS TCs on Barefoot platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -326,6 +326,15 @@ macsec/test_macsec.py:
       - "platform not in ['x86_64-arista_7280cr3mk_32d4', 'x86_64-kvm_x86_64-r0']"
 
 #######################################
+#####            mpls             #####
+#######################################
+mpls/test_mpls.py:
+  skip:
+    reason: "MPLS TCs are not supported on Barefoot plarforms"
+    conditions:
+      - "asic_type in ['barefoot']"
+
+#######################################
 #####           nat               #####
 #######################################
 nat:


### PR DESCRIPTION
**Description of PR**
 Skip MPLS test-cases on Barefoot platforms due to MPLS not being supported by Barefoot.

**Summary:**
Update `tests_mark_conditions.yaml` to skip MPLS TCs on Barefoot platforms.

Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

**Back port request**
 - [ ] 201911
 - [ ] 202012

**Approach**
**What is the motivation for this PR?**
On May 6th [basic MPLS tests](https://github.com/Azure/sonic-mgmt/commit/3522391ef97a532ee22f784f84acab4d5437901a) were added. There is no support for MPLS TCs by Barefoot yet. This fix skips the following unsupported tests for barefoot devices:

- mpls/test_mpls.py::TestBasicMpls::test_pop_label
- mpls/test_mpls.py::TestBasicMpls::test_swap_label
- mpls/test_mpls.py::TestBasicMpls::test_push_label
- mpls/test_mpls.py::TestBasicMpls::test_swap_labelstack

**How did you do it?**
I added MPLS conditional mark to skip `mpls/test_mpls.py` on Barefoot platforms

**How did you verify/test it?**
Run 4 `mpls/test_mpls.py` tests on t1 topology after adding conditional mark. Got skip cases:
`('mpls/test_mpls.py', 185, u'Skipped: MPLS TCs are not supported on Barefoot plarforms')`

**Any platform specific information?**

**Supported testbed topology if it's a new test case?**

**Documentation**

**Notes**
This is re-opening of the [closed PR](https://github.com/sonic-net/sonic-mgmt/pull/5833) due to fork deletion