### PR TITLE
[snmp] fix transceiver info with nested dictionary

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -754,7 +754,8 @@ def redis_hgetall(duthost, db_id, key):
     content = output['stdout'].strip()
     if not content:
         return {}
-
+    # fix to make literal_eval() work with nested dictionaries
+    content = content.replace("'{", '"{').replace("}'", '}"')
     return ast.literal_eval(content)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: TC `snmp/test_snmp_phy_entity.py::test_transceiver_info` was failing due to inability to convert string to nested dictionary due to same single quotes being used around and inside the nested dictionary. By converting single quotes around nested dictionaries to double quotes, **literal_eval()** doesn't treat quotes as a string separator, and stops returning **SyntaxError**
```
    def parse(source, filename='<unknown>', mode='exec'):
        """
        Parse the source into an AST node.
        Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
        """
>       return compile(source, filename, mode, PyCF_ONLY_AST)
E         File "<unknown>", line 1
E           {'cmis_rev': '3.0', 'host_electrical_interface': 'N/A', 'active_apsel_hostlane1': 'N/A', 'supported_min_tx_power': 'N/A', 'cable_length': '1.0', 'supported_max_laser_freq': 'N/A', 'vendor_rev': '  ', 'encoding': 'N/A', 'nominal_bit_rate': '0', 'media_lane_assignment_option': 'N/A', 'supported_min_laser_freq': 'N/A', 'media_lane_count': '0', 'active_firmware': '0.0', 'media_interface_technology': 'Copper cable unequalized', 'active_apsel_hostlane7': 'N/A', 'connector': 'No separable connector', 'active_apsel_hostlane4': 'N/A', 'ext_rateselect_compliance': 'N/A', 'host_lane_count': '8', 'cable_type': 'Length Cable Assembly(m)', 'active_apsel_hostlane6': 'N/A', 'host_lane_assignment_option': '1', 'active_apsel_hostlane3': 'N/A', 'inactive_firmware': 'N/A', 'active_apsel_hostlane8': 'N/A', 'hardware_rev': '0.0', 'supported_max_tx_power': 'N/A', 'media_interface_code': 'Copper cable', 'active_apsel_hostlane5': 'N/A', 'active_apsel_hostlane2': 'N/A', 'specification_compliance': 'passive_copper_media_interface', 'application_advertisement': '{1: {'host_electrical_interface_id': '400G CR8', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '200GBASE-CR4 (Clause 136)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 3: {'host_electrical_interface_id': '100GBASE-CR4 (Clause 92)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 4: {'host_electrical_interface_id': '50GBASE-CR (Clause 126)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255}, 5: {'host_electrical_interface_id': 'IB HDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 6: {'host_electrical_interface_id': '25GBASE-CR CA-L (Clause 110)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 1, 'host_lane_count': 1, 'host_lane_assignment_options': 255}, 7: {'host_electrical_interface_id': 'IB EDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1}}', 'dom_capability': 'N/A', 'is_replaceable': 'True'}
E                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ^
E       SyntaxError: invalid syntax 
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Update TC `snmp/test_snmp_phy_entity.py::test_transceiver_info` to work with strings containing nested dictionaries. 
Transceiver_info returns a dictionary with transceiver facts, example:
`{'cmis_rev': '3.0','nominal_bit_rate': '0'}`
With new stable SONiC, transceiver facts **specification_compliance** and **application_advertisement** can return nested dictionaries as a string, examples:
`{'cmis_rev': '3.0', 'application_advertisement': '{1: {'host_electrical_interface_id': '400G CR8'}}'}`
`{'cmis_rev': '3.0', 'specification_compliance': '{'10/40G Ethernet Compliance Code': 'Extended'}'}`
Single quotes around and inside nested dictionaries create **SyntaxError**. This fix changes single quotes around nested dictionaries to double quotes. As a result, facts without nested dictionaries don't change, but facts with nested dictionaries change the format to make **literal_eval()** work without SyntaxError, examples:
`{'cmis_rev': '3.0', 'application_advertisement': "{1: {'host_electrical_interface_id': '400G CR8'}}"}`
`{'cmis_rev': '3.0', 'specification_compliance': "{'10/40G Ethernet Compliance Code': 'Extended'}"}`
#### How did you do it?
I changed quotes around nested dictionaries to avoid SyntaxError
#### How did you verify/test it?
Run `snmp/test_snmp_phy_entity.py::test_transceiver_info` on t0 topology
```
snmp/test_snmp_phy_entity.py::test_transceiver_info PASSED 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->