### PR TITLE
Update change_mac.sh, delete the pointer.

### DIFF
--- a/ansible/roles/vm_set/files/change_mac.sh
+++ b/ansible/roles/vm_set/files/change_mac.sh
@@ -1,1 +1,18 @@
-../../test/files/helpers/change_mac.sh
+#!/bin/bash
+
+set -euo pipefail
+
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
+
+for INTF in ${INTF_LIST}; do
+    ADDR="$(cat /sys/class/net/${INTF}/address)"
+    PREFIX="$(cut -c1-15 <<< ${ADDR})"
+    SUFFIX="$(printf "%02x" ${INTF##eth})"
+    MAC="${PREFIX}${SUFFIX}"
+
+    echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
+    # bringing the device down/up to trigger ipv6 link local address change
+    ip link set dev ${INTF} down
+    ip link set dev ${INTF} address ${MAC}
+    ip link set dev ${INTF} up
+done


### PR DESCRIPTION
When I adding topology, sometimes this file cannot be pointed to '../../test/files/helpers/change_mac.sh'.
The reason shows "this file not found". 
It is really not necessary to add this pointer. It is better to apply the "change ptf mac function" into this file directly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sometimes the pointer will result in "No such file or directory"
#### How did you do it?
Delete the pointer. Not necessary.
#### How did you verify/test it?
add-topo
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
