### PR TITLE
[dualtor] Fix pdu host unavailable issue

### DIFF
--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -46,7 +46,10 @@ def toggle_upper_tor_pdu(upper_tor_host, get_pdu_controller):
 @pytest.fixture(scope='module')
 def toggle_lower_tor_pdu(lower_tor_host, get_pdu_controller):
     pdu_controller = get_pdu_controller(lower_tor_host)
-    return lambda: toggle_pdu_outlet(pdu_controller)
+    if pdu_controller is None:
+        return lambda: lower_tor_host.shell("nohup sh -c 'sleep 2; echo b > /proc/sysrq-trigger;' > /dev/null &")
+    else:
+        return lambda: toggle_pdu_outlet(pdu_controller)
 
 
 @pytest.mark.enable_active_active


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the issue that pdu information is missing on some testbeds:
```
AttributeError: 'NoneType' object has no attribute 'dut_hostname'
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
For those testbeds without pdu information available, use system request to reboot.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
