### PR TITLE
[dualtor] Fix `test_orchagent_slb`

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -148,7 +148,6 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 check_res.append("outer packet ECN not same as inner packet ECN")
             return " ,".join(check_res)
 
-        @staticmethod
         def _check_queue(self, packet):
             """Check queue for encap packet."""
 
@@ -163,18 +162,17 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             else:
                 return "Not a valid IPinIP or IPv6inIP tunnel packet"
 
-            outer_dscp, outer_ecn = _disassemble_ip_tos(outer_tos)
-            inner_dscp, inner_ecn = _disassemble_ip_tos(inner_tos)
+            outer_dscp, _ = _disassemble_ip_tos(outer_tos)
+            inner_dscp, _ = _disassemble_ip_tos(inner_tos)
             logging.info("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
             check_res = []
-            if outer_dscp != inner_dscp:
-                check_res.append("outer packet DSCP not same as inner packet DSCP")
             exp_queue = derive_queue_id_from_dscp(outer_dscp)
+            logging.info("Expect queue: %s", exp_queue)
+            if not wait_until(60, 5, 0, queue_stats_check, self.standby_tor, exp_queue):
+                check_res.append("no expect counter in the expected queue %s" % exp_queue)
+            return " ,".join(check_res)
 
-            pytest_assert(wait_until(60, 5, 0, queue_stats_check, self.standby_tor, exp_queue))
-            return check_res
-
-        def __init__(self, standby_tor, active_tor=None, existing=True, inner_packet=None):
+        def __init__(self, standby_tor, active_tor=None, existing=True, inner_packet=None, check_items=("ttl", "tos", "queue")):
             """
             Init the tunnel traffic monitor.
 
@@ -206,6 +204,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 self.inner_packet = inner_packet
             self.exp_pkt = self._build_tunnel_packet(self.standby_tor_lo_addr, self.active_tor_lo_addr, inner_packet=self.inner_packet)
             self.rec_pkt = None
+            self.check_items = check_items
 
         def __enter__(self):
             # clear queue counters before IO to ensure _check_queue could get more precise result
@@ -235,17 +234,16 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 logging.info("Encapsulated packet:\n%s", dump_scapy_packet_show_output(self.rec_pkt))
                 if not self.existing:
                     raise RuntimeError("Detected tunnel traffic from host %s." % self.standby_tor.hostname)
-                ttl_check_res = self._check_ttl(self.rec_pkt)
-                tos_check_res = self._check_tos(self.rec_pkt)
-                queue_check_res = self._check_queue(self, self.rec_pkt)
-                check_res = []
-                if ttl_check_res:
-                    check_res.append(ttl_check_res)
-                if tos_check_res:
-                    check_res.append(tos_check_res)
-                if queue_check_res:
-                    check_res.append(queue_check_res)
-                if check_res:
-                    raise ValueError(", ".join(check_res) + ".")
+
+                check_result = []
+                for check_item in self.check_items:
+                    check_func = getattr(self, "_check_%s" % check_item, None)
+                    if check_func is not None:
+                        result = check_func(self.rec_pkt)
+                        if result:
+                            check_result.append(result)
+
+                if check_result:
+                    raise ValueError(", ".join(check_result) + ".")
 
     return TunnelTrafficMonitor

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -10,7 +10,6 @@ from scapy.all import IP, IPv6, Ether
 from tests.common.dualtor import dual_tor_utils
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.utilities import wait_until
-from tests.common.helpers.assertions import pytest_assert
 
 
 def derive_queue_id_from_dscp(dscp):

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -246,7 +246,12 @@ def test_orchagent_slb(
         else:
             tunnel_innner_pkt = pkt[scapyall.IPv6].copy()
             tunnel_innner_pkt[scapyall.IPv6].hlim -= 1
-        tunnel_monitor = tunnel_traffic_monitor(duthost, existing=is_tunnel_traffic_existed, inner_packet=tunnel_innner_pkt)
+        tunnel_monitor = tunnel_traffic_monitor(
+            duthost,
+            existing=is_tunnel_traffic_existed,
+            inner_packet=tunnel_innner_pkt,
+            check_items=["ttl", "queue"]
+        )
         server_traffic_monitor = ServerTrafficMonitor(
             duthost, ptfhost, vmhost, tbinfo, connection["test_intf"],
             conn_graph_facts, exp_pkt, existing=is_server_traffic_existed


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_orchagent_slb` fails because of the dscp check failure in the
`tunnel_traffic_monitor`, which is introduced by the PCBB change. So
with PCBB on, the outer packet DSCP differs from the inner one.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let's skip the dscp check for `test_orchagent_slb`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
