### PR TITLE
[ip]: Use correct packet for checksum test

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -334,22 +334,14 @@ class TestIPPacket(object):
         # THEN DUT recompute new checksum correctly and forward packet as expected.
 
         (peer_ip_ifaces_pair, rif_rx_ifaces, rif_support, ptf_port_idx, pc_ports_map, ptf_indices) = common_param
-        pkt = testutils.simple_ip_packet(
-            eth_dst=duthost.facts["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, ptf_port_idx),
-            pktlen=1246,
-            ip_src="10.250.40.40",
-            ip_dst="10.156.190.188",
-            ip_proto=47,
-            ip_tos=0x84,
-            ip_id=0,
-            ip_ihl=5,
-            ip_ttl=122,
-        )
-        pkt.payload.flags = 2
+        ip_layer_str = "4500005ecd064000802fffff646b2e0c646b36880000000000000000000000000000000000000000000000000000"
+        ip_layer_hex = ip_layer_str.decode("hex")
+        pkt = packet.Ether(dst=duthost.facts["router_mac"], src=ptfadapter.dataplane.get_mac(0, ptf_port_idx))
+        pkt /= packet.IP(ip_layer_hex)
+        
         exp_pkt = pkt.copy()
-        exp_pkt.payload.ttl = 121
-        exp_pkt.payload.chksum = 0x0001
+        exp_pkt.payload.ttl = 127
+        exp_pkt.payload.chksum = 0x0100
         exp_pkt = mask.Mask(exp_pkt)
         exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
         exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_forward_ip_packet_recomputed_0xffff_chksum uses a packet that does not have a checksum of 0xffff, causing the test to have false positives (i.e. passing when it should not)

#### How did you do it?
Use a packet with checksum 0xffff

#### How did you verify/test it?
- Run the test on a device where IP checksum recalculation is turned off. Verify it fails.
- Run the test on a device where IP checksum recalculation is turned on. Verify it passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
