### PR TITLE
Adding Innovium(Marvell) specific change for port_utils.py and combined_drop_counters.yml

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -225,6 +225,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "RA-B6920-4S":
             for i in range(1,129):
                 port_alias_to_name_map["hundredGigE%d" % i] = "Ethernet%d" % i
+        elif hwsku in ["Wistron_sw_to3200k_32x100","Wistron_sw_to3200k"]:
+            for i in range(0, 256, 8):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         else:
             for i in range(0, 128, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i

--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -26,6 +26,8 @@ l2_l3:
     - "x86_64-accton_as9516.*"
     - "x86_64-accton_wedge100bf.*"
     - "x86_64-8.*"
+    - "x86_64-cel_midstone-r0"
+    - "x86_64-wistron_sw_to3200k-r0"
 
 acl_l2:
     - "x86_64-mlnx"


### PR DESCRIPTION
Adding Innovium(Marvell) specific change for port_utils.py and combined_drop_counters.yml

### Description of PR
Adding changes to run PTF tests on Wistron Platform and also adding combined drop counter details

Summary:
* Adding Wistron hwsku details in port_utils.py
* Adding hwsku info in combined drop counter 

### Type of change

- [ ] Bug fix
- [*] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [*] 202012

### Approach
#### What is the motivation for this PR?
Need to add this change to run PTF test on Innovium(Marvell) supported hwsku
#### How did you do it?

#### How did you verify/test it?
Running PTF test with this change on Wistron platform passes
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
