### PR TITLE
skip test_tx_disable_channel for e1031

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -454,6 +454,12 @@ platform_tests/api/test_sfp.py::test_reset:
     conditions:
       - "platform in ['x86_64-cel_e1031-r0']"
 
+platform_tests/api/test_sfp.py::test_tx_disable_channel:
+  skip:
+    reason: "platform does not support"
+    conditions:
+      - "platform in ['x86_64-cel_e1031-r0']"
+
 platform_tests/broadcom/test_ser.py::test_ser:
   skip:
     reason: "platform does not support test_ser"


### PR DESCRIPTION
Signed-off-by: Xichen Lin <lukelin0907@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Platform does not support test_tx_disable_channel

#### How did you do it?
Skip the test

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
