### PR TITLE
[test_macsec]: Disable log analyzer due to intentionally link flap in MACsec testcases

### DIFF
--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -384,6 +384,7 @@ class TestInteropProtocol():
     Macsec interop with other protocols
     '''
 
+    @pytest.mark.disable_loganalyzer
     def test_port_channel(self, duthost, profile_name, ctrl_links):
         '''Verify lacp
         '''
@@ -403,6 +404,7 @@ class TestInteropProtocol():
         assert wait_until(20, 1, 0, lambda: find_portchannel_from_member(
             ctrl_port, get_portchannel(duthost))["status"] == "Up")
 
+    @pytest.mark.disable_loganalyzer
     def test_lldp(self, duthost, ctrl_links, profile_name):
         '''Verify lldp
         '''
@@ -431,6 +433,7 @@ class TestInteropProtocol():
             assert wait_until(1, 1, LLDP_TIMEOUT,
                             lambda: nbr["name"] in get_lldp_list(duthost))
 
+    @pytest.mark.disable_loganalyzer
     def test_bgp(self, duthost, ctrl_links, upstream_links, profile_name):
         '''Verify BGP neighbourship
         '''


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Some MACsec testcases have intentionally link flap which will trigger some ERR log, so disable log analyzer in these testcases.

#### How did you do it?
Add log analyzer marker for testcases:
```
test_port_channel
test_lldp
test_bgp
```
#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
