### PR TITLE
Enable `tunnel_qos_remap` on two T1 SKUs

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -179,6 +179,15 @@
       restart_pmon: no
     when: "'dualtor' in topo"
 
+  - name: gather hwsku for LeafRouter that supports dualtor deployment
+    set_fact:
+      hwsku_list_dualtor_t1: "['ACS-MSN4600C', 'Arista-7260CX3-C64']"
+  
+  - name: enable tunnel_qos_remap for T1 in dualtor deployment
+    set_fact:
+      enable_tunnel_qos_remap: true
+    when: "('leafrouter' == (vm_topo_config['dut_type'] | lower)) and (hwsku in hwsku_list_dualtor_t1)"
+
   - name: set default vm file path
     set_fact:
       vm_file: veos

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -41,6 +41,13 @@
             <a:Value>Gemini</a:Value>
           </a:DeviceProperty>
 {% endif %}
+{% if ('t1' in topo) and (enable_tunnel_qos_remap|default('false')|bool) %}
+          <a:DeviceProperty>
+            <a:Name>DownstreamRedundancyTypes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+          </a:DeviceProperty>
+{% endif %}
 {% if dhcp_servers %}
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to enable `tunnel_qos_remap` on two T1 SKUs 'ACS-MSN4600C' and 'Arista-7260CX3-C64'.

The change is done by adding property DownstreamRedundancyTypes in minigraph.xml.
```
           <a:DeviceProperty>
            <a:Name>DownstreamRedundancyTypes</a:Name>
            <a:Reference i:nil="true"/>
            <a:Value>Gemini</a:Value>
          </a:DeviceProperty>
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to enable `tunnel_qos_remap` on two T1 SKUs 'ACS-MSN4600C' and 'Arista-7260CX3-C64'.

#### How did you do it?
Add an attribute `DownstreamRedundancyTypes` in minigraph template.

#### How did you verify/test it?
Verified by generating minigraph file locally,

#### Any platform specific information?
'ACS-MSN4600C' and 'Arista-7260CX3-C64'

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
