### PR TITLE
[ansible/testbed] Support overwriting the env vars defined in groups_vars/all

### DIFF
--- a/ansible/group_vars/all/env.yml
+++ b/ansible/group_vars/all/env.yml
@@ -1,5 +1,7 @@
 # if your lab needs http(s) proxy to access Internet
-# Uncomment following section and provide correct http(s) proxy
+# Uncomment following section and provide correct http(s) proxy for all inventories.
+# If you want to provide http(s) proxy for a specific inveotory,
+# please use group_vars/{{ inv_name }}/env.yml (e.g. /group_vars/veos_vtb/env.yml)
 #proxy_env:
 #  http_proxy: http://10.252.0.99:3128
 #  https_proxy: http://10.252.0.99:3128

--- a/ansible/group_vars/veos_vtb/env.yml
+++ b/ansible/group_vars/veos_vtb/env.yml
@@ -1,0 +1,5 @@
+# Uncomment following section and provide correct http(s) proxy for veos_vtb
+#proxy_env:
+#  http_proxy: http://10.252.0.99:3128
+#  https_proxy: http://10.252.0.99:3128
+#  no_proxy: 127.0.0.1,localhost

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -295,7 +295,7 @@ function add_topo
   fi
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-        -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e inv_name="$inv_name" -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
         -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
         -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6"  -e netns_mgmt_ip="$netns_mgmt_ip" \
         $ansible_options $@
@@ -334,7 +334,7 @@ function remove_topo
   fi
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-      -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+      -e inv_name="$inv_name" -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
       -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
       -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" -e netns_mgmt_ip="$netns_mgmt_ip" \
       -e remove_keysight_api_server="$remove_keysight_api_server" \

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -16,10 +16,11 @@
 #  Every topology contains a ptf container which will be used as placeholder for the injected interfaces from VMs, or direct connections to PTF host
 #
 # To add a topology please use following command
-# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_add_vm_topology.yml --vault-password-file=~/.password -l server_3 -e vm_set_name=first -e dut_name=str-msn2700-01 -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e ptf_imagename="docker_ptf"
+# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_add_vm_topology.yml --vault-password-file=~/.password -l server_3 -e inv_name=veos_vtb -e vm_set_name=first -e dut_name=str-msn2700-01 -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e ptf_imagename="docker_ptf"
 #
 # Parameters
 # -l server_3                - this playbook have to be limited to run only on one server
+# -e inv_name=veos_vtb       - the inventory name of testbed
 # -e vm_set_name=first       - the name of vm_set
 # -e duts_name=str-msn2700-01 - the name of target duts
 # -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
@@ -33,6 +34,12 @@
 - hosts: servers:&vm_host
   gather_facts: no
   pre_tasks:
+
+  # Overwrite the default values in group_vars/all/env.yml
+  - name: Load inventory specified environment variables
+    include_vars: "group_vars/{{ inv_name }}/env.yml"
+    ignore_errors: true
+
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
     when: "{{ play_hosts|length }} != 1"

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -3,10 +3,11 @@
 # For additional details see playbook testbed_add_vm_topology.yml
 #
 # To remove a topology please use following command
-# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_remove_vm_topology.yml --vault-password-file=~/.password -l server_3 -e vm_set_name=first -e -e duts_name=str-msn2700-01 -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e ptf_imagename="docker_ptf"
+# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_remove_vm_topology.yml --vault-password-file=~/.password -l server_3 -e inv_name=veos_vtb  -e vm_set_name=first -e -e duts_name=str-msn2700-01 -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e ptf_imagename="docker_ptf"
 #
 # Parameters
 # -l server_3                - this playbook have to be limited to run only on one server
+# -e inv_name=veos_vtb       - the inventory name of testbed
 # -e vm_set_name=first       - the name of vm_set
 # -e duts_name=str-msn2700-01 - the name of target dut
 # -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
@@ -19,6 +20,12 @@
   vars_files:
     - vars/docker_registry.yml
   pre_tasks:
+  
+  # Overwrite the default values in group_vars/all/env.yml
+  - name: Load inventory specified environment variables
+    include_vars: "group_vars/{{ inv_name }}/env.yml"
+    ignore_errors: true
+  
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
     when: "{{ play_hosts|length }} != 1"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Summary:
Support overwriting the environment variables defined in `group_vars/all/env.yml` when add/remove topo.

Variables defined in `group_vars/all/env.yml` will be applied to all inventories when add/remove topo. If you want to provide some environment variables for a specific inventory, you can add it to `group_vars/{your-inventory-name}/env.yml` now. It'll overwrite the values in `group_vars/all/env.yml`.

BTW, you don't have to add an `env.yml` for every inventory directory, `ansible` will skip the overwrite task if file doesn't exist.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Support overwriting the environment variables defined in group_vars/all when add/remove topo

#### How did you do it?

Updated `ansible/testbed-cli.sh` and ansible playbooks for add/remove topo.

#### How did you verify/test it?

Verified on virtual testbeds and physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
