### PR TITLE
Fix get mux status called error in toggle mux

### DIFF
--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -4,8 +4,6 @@ import logging
 import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports
-from tests.common.dualtor.mux_simulator_control import get_mux_status
 from tests.common.utilities import wait_until
 
 

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -78,7 +78,7 @@ def check_mux_status(duthosts, active_side):
         return False
 
 
-def validate_check_result(check_result, duthosts):
+def validate_check_result(check_result, duthosts, get_mux_status):
     """If check_result is False, collect some log and fail the test.
 
     Args:
@@ -106,11 +106,11 @@ def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_p
 
     check_result = wait_until(10, 2, 2, check_mux_status, duthosts, active_side)
 
-    validate_check_result(check_result, duthosts)
+    validate_check_result(check_result, duthosts, get_mux_status)
 
 
 @pytest.mark.parametrize("active_side", [UPPER_TOR, LOWER_TOR])
-def test_toggle_mux_from_cli(duthosts, active_side, restore_mux_auto_mode):
+def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, restore_mux_auto_mode):
 
     logger.info('Reset muxcable mode to auto for all ports on all DUTs')
     duthosts.shell('config muxcable mode auto all')
@@ -124,4 +124,4 @@ def test_toggle_mux_from_cli(duthosts, active_side, restore_mux_auto_mode):
 
     check_result = wait_until(10, 2, 2, check_mux_status, duthosts, active_side)
 
-    validate_check_result(check_result, duthosts)
+    validate_check_result(check_result, duthosts, get_mux_status)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fixture can't be called directly when toggle mux failed
#### How did you do it?
Call fixture as a parameter
#### How did you verify/test it?
Run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
