### PR TITLE
Add wait time to fix check mux status failure

### DIFF
--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -102,7 +102,7 @@ def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_p
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
-    check_result = wait_until(10, 2, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(180, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)
 
@@ -120,6 +120,6 @@ def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, restore_mux_
         mux_active_dut = duthosts[1]
     mux_active_dut.shell('config muxcable mode active all')
 
-    check_result = wait_until(10, 2, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(180, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -102,7 +102,7 @@ def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_p
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
-    check_result = wait_until(180, 5, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)
 
@@ -120,6 +120,6 @@ def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, restore_mux_
         mux_active_dut = duthosts[1]
     mux_active_dut.shell('config muxcable mode active all')
 
-    check_result = wait_until(180, 5, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Mux toggle in simulator often fails because active standby status were not transferred timely 
Linkmgrd may use more than 10s when entering {LinkProberUnknown, MuxActive, LinkUp} state
#### How did you do it?
Add wait time to 60s, and add time interval to 5s
#### How did you verify/test it?
Run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
