### PR TITLE
[test_macsec]: Disable log analyzer due to Fault Handling in MACsec testcases

### DIFF
--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -274,6 +274,7 @@ class TestFaultHandling():
     MKA_TIMEOUT = 6
     LACP_TIMEOUT = 90
 
+    @pytest.mark.disable_loganalyzer
     def test_link_flap(self, duthost, ctrl_links):
         # Only pick one link for link flap test
         assert ctrl_links
@@ -282,7 +283,6 @@ class TestFaultHandling():
             nbr["host"], nbr["port"])
         _, _, _, dut_egress_sa_table_orig, dut_ingress_sa_table_orig = get_appl_db(
             duthost, port_name, nbr["host"], nbr["port"])
-
 
         # Flap < 6 seconds
         # Not working on eos neighbour
@@ -342,6 +342,7 @@ class TestFaultHandling():
         assert wait_until(12, 1, 0, lambda: find_portchannel_from_member(
             port_name, get_portchannel(duthost))["status"] == "Up")
 
+    @pytest.mark.disable_loganalyzer
     def test_mismatch_macsec_configuration(self, duthost, unctrl_links,
                                            profile_name, default_priority, cipher_suite,
                                            primary_cak, primary_ckn, policy, send_sci, request):


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Some MACsec testcases have intentionally fault handling which will trigger some ERR log, so disable log analyzer in these testcases.

#### How did you do it?

Add log analyzer marker for testcases:
```
test_link_flap
test_mismatch_macsec_configuration
```

#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
