### PR TITLE
[Bugfix] Fix the error to get option `enable_macsec`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1668,7 +1668,7 @@ def check_dut_health_status(duthosts, request):
     If so, we will reload the running config before test case running.
     '''
     check_flag = True
-    if request.config.getoption("enable_macsec"):
+    if request.config.option.enable_macsec:
         check_flag = False
     for m in request.node.iter_markers():
         if m.name == "pretest" or m.name == "posttest":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1668,7 +1668,7 @@ def check_dut_health_status(duthosts, request):
     If so, we will reload the running config before test case running.
     '''
     check_flag = True
-    if request.config.option.enable_macsec:
+    if hasattr(request.config.option, 'enable_macsec') and request.config.option.enable_macsec:
         check_flag = False
     for m in request.node.iter_markers():
         if m.name == "pretest" or m.name == "posttest":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After merged into 202012, there is an error caused by `request.config.getoption('enable_macsec')`, because in 202012 branch, there is no option named `enable_macsec` in 202012.  So we use `request.config.option.enable_macsec` to best effort getting option "enable_macsec".

Summary:
Fixes # ([5817](https://github.com/sonic-net/sonic-mgmt/pull/5817))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
After merged into 202012, there is an error caused by `request.config.getoption('enable_macsec')`, because in 202012 branch, there is no option named `enable_macsec` in 202012.  So we use `request.config.option.enable_macsec` to best effort getting option "enable_macsec".

#### How did you do it?
Change from `request.config.getoption('enable_macsec')` to `request.config.option.enable_macsec`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
