### PR TITLE
[dualtor] Fix `test_ipinip.py`

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -19,6 +19,7 @@ from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface
 from tests.common.dualtor.dual_tor_utils import get_ptf_server_intf_index
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_unselected_tor            # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
@@ -126,8 +127,7 @@ def test_decap_active_tor(
 
 
 def test_decap_standby_tor(
-    apply_standby_state_to_orchagent,
-    build_encapsulated_packet,
+    build_encapsulated_packet, request,
     rand_selected_interface, ptfadapter,
     tbinfo, rand_selected_dut, tunnel_traffic_monitor
 ):
@@ -139,6 +139,11 @@ def test_decap_standby_tor(
             if exp_pkt.pkt_match(packet):
                 return True
         return False
+
+    if is_t0_mocked_dualtor(tbinfo):
+        request.getfixturevalue('apply_standby_state_to_orchagent')
+    else:
+        request.getfixturevalue('toggle_all_simulator_ports_to_rand_unselected_tor')
 
     tor = rand_selected_dut
     encapsulated_packet = build_encapsulated_packet


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In dualtor nightly, the testcase after `test_ipinip.py` suffers from sanity check failure:
```
    {
        "check_item": "mux_simulator", 
        "failed": true, 
        "failed_reason": "Some ports doesn't have 'show mux status' output", 
        "hosts": [
            "str2-7050cx3-acs-06", 
            "str2-7050cx3-acs-07"
        ], 
        "action": "<not serializable>"
    }, 
```
This is because `test_ipinip.py::test_decap_standby_tor` uses dualtor mocking fixture `apply_standby_state_to_orchagent` to toggle to standby for dualtor testbed, which will clean up app db `MUX_CABLE_TABLE` in its teardown, so `show mux status` will be empty in such case.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
On a real dualtor testbed, use `toggle_all_simulator_ports_to_rand_unselected_tor` to make the selected ToR standby.

#### How did you verify/test it?
```
dualtor/test_ipinip.py::test_decap_active_tor PASSED                                                                                                                                                                                                                   [ 50%]
dualtor/test_ipinip.py::test_decap_standby_tor PASSED                                                                                                                                                                                                                  [100%]

========================================================================================================================= 2 passed in 232.87 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
