### PR TITLE
Add support of caching issue status for conditional mark

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -279,12 +279,14 @@ function run_group_tests()
 {
     echo "=== Running tests in groups ==="
     echo Running: pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
-    pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
+    pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} --cache-clear
 }
 
 function run_individual_tests()
 {
     EXIT_CODE=0
+
+    CACHE_CLEAR="--cache-clear"
 
     echo "=== Running tests individually ==="
     for test_script in ${TEST_CASES}; do
@@ -299,8 +301,13 @@ function run_individual_tests()
         fi
 
         echo Running: pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
-        pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
+        pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} ${CACHE_CLEAR}
         ret_code=$?
+
+        # Clear pytest cache for the first run
+        if [[ -n ${CACHE_CLEAR} ]]; then
+            CACHE_CLEAR=""
+        fi
 
         # If test passed, no need to keep its log.
         if [ ${ret_code} -eq 0 ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
The conditional mark may need to check Github or other issue tracking website to get the status of issue and then decide whether to skip a test.

The problem is that when there is issue accessing the remote issue tracking website, it takes some time for the HTTP request to timeout or stop retrying. If the skipping of lots of test cases is dependent on querying issue status, the overall test time is obviously increased unnecessarily.

#### How did you do it?
This change added support of caching the issue status, no matter the issue status querying is success or not, the result is always cached for later use. Then in a pytest session, we only need to query any issue only once regardless how many test cases are dependent on status of the issue.

This change also improved the run_tests.sh script to clear pytest cache before running the first script.

#### How did you verify/test it?
Verified using some dummy test scripts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
