### PR TITLE
[Chassis][Platform] Skip testing base MAC verification on Fabric Cards which do not have Base MAC assigned

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -174,6 +174,11 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
                 continue
+            # Need to skip FABRIC-CARDx as they do not have base_mac assigned
+            mod_name = module.get_name(platform_api_conn, i)
+            if "FABRIC-CARD" in mod_name:
+                logger.info("skipping get_base_mac for module {} which is a Fabric Card".format(mod_name))
+                continue
             base_mac = module.get_base_mac(platform_api_conn, i)
 	    if not self.expect(base_mac is not None, "Module {}: Failed to retrieve base MAC address".format(i)):
                 continue


### PR DESCRIPTION
### Description of PR

Summary: TestModuleApi.test_get_base_mac is failing on Chassis Fabric Line Cards
Fixes # (issue)
No issue filed yet for this but this is pretty obvious if one attempt to run this test on a chassis and when it iterate through the Fabric-card section, it will fail since no base mac is ever assigned to any Fabric Card.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To fix bug
#### How did you do it?

#### How did you verify/test it?
Run this test on a chassis based SUP which contains SUP, LC, and Fabric Cards and without my change you will observe it is failing for each Fabric Card of the chassis.  with my change you will see in the test log that the Fabric CArds were skipped for this test_get_base_mac()
