### PR TITLE
Ingoring local asic ping of ipv6 interfaces when one side is down

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -1015,9 +1015,14 @@ class TestFPLinkFlap(LinkFlap):
                              dev=nbrhosts[ports["portB"]['nbr_vm']]['host'], size=256, ttl=2, ttl_change=0)
                 check_packet(eos_ping, ports, 'portD', 'portB', dst_ip_fld='nbr_lb', src_ip_fld='nbr_lb',
                              dev=nbrhosts[ports["portB"]['nbr_vm']]['host'], size=256, ttl=2)
-                check_packet(sonic_ping, ports, "portB", "portA", dst_ip_fld='my_ip', src_ip_fld='my_ip',
-                             dev=ports['portA']['asic'], size=256, ttl=2,
-                             ttl_change=0)
+                if version == 4:
+                    check_packet(sonic_ping, ports, "portB", "portA", dst_ip_fld='my_ip', src_ip_fld='my_ip',
+                                dev=ports['portA']['asic'], size=256, ttl=2,
+                                ttl_change=0)
+                else:
+                    logging.info(
+                        "Ingoring local asic ping of ipv6 interfaces when one side is down - "
+                            "get error: ping: bind icmp socket: Cannot assign requested address")
 
             # Make sure VM connected to portA can't ping portA
             with pytest.raises(AssertionError):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Ingoring local asic ping of ipv6 interfaces when one side is down
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Local asic ping of ipv6 interfaces fails when one side is down.  We get the error message "ping: bind icmp socket: Cannot assign requested address"

#### How did you do it?
We ignore local asic ping of ipv6 interfaces if version is not v4.

#### How did you verify/test it?
Tested  test_front_panel_linkflap_port muli asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
