### PR TITLE
Fix Copper cable check

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -176,7 +176,7 @@ class TestSfpApi(PlatformApiTestBase):
                 compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")
                 if "CR" in compliance_code:
                    return False
-                extended_code = spec_compliance_dict.get("Extended Specification Complianc", " ")
+                extended_code = spec_compliance_dict.get("Extended Specification Compliance", " ")
                 if "CR" in extended_code:
                    return False
         return True

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -173,13 +173,12 @@ class TestSfpApi(PlatformApiTestBase):
                 if compliance_code == "Passive Cable":
                    return False
             else:
-                compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code")
-                if compliance_code == "40GBASE-CR4":
+                compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")
+                if "CR" in compliance_code:
                    return False
-                if compliance_code == "Extended":
-                    extended_code = spec_compliance_dict.get("Extended Specification Compliance")
-                    if "CR" in extended_code:
-                        return False
+                extended_code = spec_compliance_dict.get("Extended Specification Complianc", " ")
+                if "CR" in extended_code:
+                   return False
         return True
 
     def is_xcvr_resettable(self, xcvr_info_dict):


### PR DESCRIPTION
### Description of PR
Copper cable check is failing if the DAC cable supports 40G and 100G speed

- [ x] Bug fix

### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Check for "CR" in specification code and extended specification code to decide if copper cable or NOT.

![image](https://user-images.githubusercontent.com/45705344/189244885-53bc8d48-e7bc-4599-9bed-33303139abed.png)


Both bit 7 and 3 can be set for this particular DAC cable

![image](https://user-images.githubusercontent.com/45705344/189245028-88a62cec-d391-4ced-8f96-06582c8f81cd.png)


#### How did you verify/test it?
Run test_sfp.py with a 40G/100G DAC cable

#### Supported testbed topology if it's a new test case?


