### PR TITLE
[test_macsec]: Improving the passing rate of MACsec testcases

### DIFF
--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -94,7 +94,7 @@ class TestDataPlane():
     BATCH_COUNT = 10
 
     def test_server_to_neighbor(self, duthost, ctrl_links, downstream_links, upstream_links, ptfadapter):
-        ptfadapter.dataplane.set_qlen(TestDataPlane.BATCH_COUNT * 10)
+        ptfadapter.dataplane.set_qlen(TestDataPlane.BATCH_COUNT * 100)
 
         down_link = downstream_links.values()[0]
         dut_macaddress = duthost.get_dut_iface_mac(ctrl_links.keys()[0])
@@ -138,7 +138,7 @@ class TestDataPlane():
                 testutils.send_packet(
                     ptfadapter, down_link["ptf_port_id"], pkt, TestDataPlane.BATCH_COUNT)
                 result = check_macsec_pkt(test=ptfadapter,
-                                          ptf_port_id=up_link["ptf_port_id"],  exp_pkt=exp_pkt, timeout=3)
+                                          ptf_port_id=up_link["ptf_port_id"],  exp_pkt=exp_pkt, timeout=30)
                 if result is None:
                     return
                 fail_message += result

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -396,13 +396,13 @@ class TestInteropProtocol():
         disable_macsec_port(duthost, ctrl_port)
         # Remove ethernet interface <ctrl_port> from PortChannel interface <pc>
         duthost.command("sudo config portchannel {} member del {} {}".format(getns_prefix(duthost, ctrl_port), pc["name"], ctrl_port))
-        assert wait_until(20, 1, 0, lambda: get_portchannel(
+        assert wait_until(90, 1, 0, lambda: get_portchannel(
             duthost)[pc["name"]]["status"] == "Dw")
 
         enable_macsec_port(duthost, ctrl_port, profile_name)
         # Add ethernet interface <ctrl_port> back to PortChannel interface <pc>
         duthost.command("sudo config portchannel {} member add {} {}".format(getns_prefix(duthost, ctrl_port), pc["name"], ctrl_port))
-        assert wait_until(20, 1, 0, lambda: find_portchannel_from_member(
+        assert wait_until(90, 1, 0, lambda: find_portchannel_from_member(
             ctrl_port, get_portchannel(duthost))["status"] == "Up")
 
     @pytest.mark.disable_loganalyzer
@@ -431,7 +431,7 @@ class TestInteropProtocol():
             wait_until(20, 3, 0,
                 lambda: duthost.iface_macsec_ok(ctrl_port) and
                         nbr["host"].iface_macsec_ok(nbr["port"]))
-            assert wait_until(1, 1, LLDP_TIMEOUT,
+            assert wait_until(LLDP_TIMEOUT, LLDP_ADVERTISEMENT_INTERVAL, 0,
                             lambda: nbr["name"] in get_lldp_list(duthost))
 
     @pytest.mark.disable_loganalyzer
@@ -504,6 +504,7 @@ class TestInteropProtocol():
 
 
 class TestDeployment():
+    @pytest.mark.disable_loganalyzer
     def test_config_reload(self, duthost, ctrl_links, policy, cipher_suite, send_sci):
         # Save the original config file
         duthost.shell("cp /etc/sonic/config_db.json config_db.json")


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Improving the passing rate of MACsec testcases.

#### How did you do it?
1. Increasing the timeout of portchannel recovering
2. Increasing the buffer size of dataplane test
3. Disabling log analyzer for config_reload

#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
