### PR TITLE
Increasing the timeout in wait_for_marker function to avoid errors in auto-restart cases

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -194,7 +194,7 @@ class AnsibleLogAnalyzer:
         syslogger.info('\n')
         self.flush_rsyslogd()
 
-    def wait_for_marker(self, marker, timeout=60, polling_interval=10):
+    def wait_for_marker(self, marker, timeout=120, polling_interval=10):
         '''
         @summary: Wait the marker to appear in the /var/log/syslog file
         @param marker:         Marker to be placed into log files.


### PR DESCRIPTION
Increasing the timeout in wait_for_marker function to avoid errors in auto-restart cases

This issue discussed in https://github.com/sonic-net/sonic-mgmt/issues/6280

### Description of PR
Increasing timeout to 120 to avoid errors seen in auto-restart cases

Summary:
To fix the issue report in https://github.com/sonic-net/sonic-mgmt/issues/6280
Increasing timeout in wait_for_marker function to fix "cannot find marker end-LogAnalyzer-test_containers_autorestart" errors

### Type of change
- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [*] 201911
- [*] 202012

### Approach
#### What is the motivation for this PR?
Increasing the timeout to avoid errors seen in auto-restart cases
#### How did you do it?

#### How did you verify/test it?
Ran the auto-restart tests and all passed without errors.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
