### PR TITLE
[bugfix] Fix getting core dump error in 201911.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1691,7 +1691,7 @@ def check_dut_health_status(duthosts, request):
             duts_data[duthost.hostname] = {}
 
             if "20191130" in duthost.os_version:
-                pre_existing_core_dumps = duthost.shell('ls /var/core/ | grep -v python')['stdout'].split()
+                pre_existing_core_dumps = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
             else:
                 pre_existing_core_dumps = duthost.shell('ls /var/core/')['stdout'].split()
             duts_data[duthost.hostname]["pre_core_dumps"] = pre_existing_core_dumps
@@ -1709,7 +1709,7 @@ def check_dut_health_status(duthosts, request):
             new_core_dumps[duthost.hostname] = []
 
             if "20191130" in duthost.os_version:
-                cur_cores = duthost.shell('ls /var/core/ | grep -v python')['stdout'].split()
+                cur_cores = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
             else:
                 cur_cores = duthost.shell('ls /var/core/')['stdout'].split()
             duts_data[duthost.hostname]["cur_core_dumps"] = cur_cores


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
DUT with osversion 201911 would report error if no previous core dumps
when execute 'ls /var/core/ | grep -v python'

refer to：https://github.com/sonic-net/sonic-mgmt/pull/6210

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
DUT with osversion 201911 would report error if no previous core dumps
when execute 'ls /var/core/ | grep -v python'

refer to：https://github.com/sonic-net/sonic-mgmt/pull/6210

#### How did you do it?
Change to 'ls /var/core/ | grep -v python || true'

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
