### PR TITLE
Align dip_sip test with the changes done in PR#6084

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1226,6 +1226,10 @@ def pytest_generate_tests(metafunc):
         tbname, tbinfo = get_tbinfo(metafunc)
         duts_selected = [tbinfo["duts"][0]]
 
+    possible_asic_enums = ["enum_asic_index", "enum_frontend_asic_index", "enum_backend_asic_index", "enum_rand_one_asic_index", "enum_rand_one_frontend_asic_index"]
+    enums_asic_fixtures = set(metafunc.fixturenames).intersection(possible_asic_enums)
+    assert len(enums_asic_fixtures) < 2, "The number of asic_enum fixtures should be 1 or zero, the following fixtures conflict one with each other".format(enums_asic_fixtures)
+
     if "enum_asic_index" in metafunc.fixturenames:
         asic_fixture_name = "enum_asic_index"
         asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_ALL)

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -81,7 +81,7 @@ def run_test_ipv4(ptfadapter, facts):
     testutils.verify_packet_any_port(ptfadapter, exp_pkt, facts['dst_port_ids'], timeout=WAIT_EXPECTED_PACKET_TIMEOUT)
 
 
-def test_dip_sip(tbinfo, ptfadapter, gather_facts, enum_frontend_asic_index):
+def test_dip_sip(tbinfo, ptfadapter, gather_facts, enum_rand_one_frontend_asic_index):
     ptfadapter.reinit()
     run_test_ipv4(ptfadapter, gather_facts)
     run_test_ipv6(ptfadapter, gather_facts)


### PR DESCRIPTION
Community PR https://github.com/sonic-net/sonic-mgmt/pull/6084 has changed the asic enum from enum_frontend_asic_index to enum_rand_one_frontend_asic_index. However, the usage of enum_frontend_asic_index in test_dip_sip was not changed. The purpose of this change is:
1. Align test_dip_sip with the changes in [PR#6084.](https://github.com/sonic-net/sonic-mgmt/pull/6084)
2. Add an assertion when two conflicting fixtures are being used. This would allow faster debug when similar issues will pop-up in the future.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Align dip_sip test with the changes done in PR#6084

#### How did you do it?
Change the fixture in dip sip test from enum_frontend_asic_index to enum_rand_one_frontend_asic_index

#### How did you verify/test it?
By running the dip sip test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
