### PR TITLE
Fix dhcp_relay configuration in vrf TC

### DIFF
--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -88,8 +88,17 @@
     },
 {%     elif k == 'VLAN' %}
     "VLAN": {
-        "Vlan1000": {"vlanid": "1000"},
-        "Vlan2000": {"vlanid": "2000"}
+        "Vlan1000": {
+            "dhcp_servers": [
+{%              for dhcp in cfg_t0['VLAN']['Vlan1000']['dhcp_servers'] %}
+                {{ dhcp | to_nice_json }}{% if not loop.last %},
+{% endif %}
+{% endfor %}
+
+            ],
+            "vlanid": "1000"},
+        "Vlan2000": {
+            "vlanid": "2000"}
     },
 {%     elif k == 'VLAN_INTERFACE' %}
     "VLAN_INTERFACE": {


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Vrf test case generate and applies `vrf/vrf_config_db.j2`, after reboot with this generated config_db.json dhcp_relay container is down and cant get up. This leads to fail of vrf TC's on loganalyzer due to below error. It looks like config_db is missing dhcp_servers under VLAN field. With this PR dhcp_relay is getting up as expected.
Fixes # (issue)
```
LogAnalyzerError: expected_match: 0
               expected_missing_match: 0
               match: 2
               
               Match Messages:
               Aug  7 15:21:16.816208 ERR monit[558]: 'container_checker' status failed (3) -- Expected containers not running: dhcp_relay
               
               Aug  7 15:22:16.841585 ERR monit[558]: 'container_checker' status failed (3) -- Expected containers not running: dhcp_relay
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Update vrf_config_db.j2 so that dhcp_relay could start up after config is applied.
#### How did you do it?

#### How did you verify/test it?
Run vrf/test_vrf.py, after config was applied dhcp_relay was able to start and was up.
```
CONTAINER ID   IMAGE                                COMMAND                  CREATED        STATUS          PORTS     NAMES
3da2544f227a   cfc3a0dd23ec                         "/usr/bin/docker_ini…"   17 hours ago   Up 3 minutes              dhcp_relay
aee89bb9b05a   docker-snmp:latest                   "/usr/local/bin/supe…"   18 hours ago   Up 34 seconds             snmp
7be979167ced   docker-sonic-telemetry:latest        "/usr/local/bin/supe…"   18 hours ago   Up 34 seconds             telemetry
b0c586a21135   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   18 hours ago   Up 34 seconds             mgmt-framework
64736ff88e17   docker-lldp:latest                   "/usr/bin/docker-lld…"   18 hours ago   Up 3 minutes              lldp
9dcc1107c08b   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   18 hours ago   Up 2 minutes              pmon
a900fa87a675   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   18 hours ago   Up 3 minutes              radv
adc43094dbaa   docker-syncd-bfn:latest              "/usr/local/bin/supe…"   18 hours ago   Up 3 minutes              syncd
42f9e6d70253   docker-teamd:latest                  "/usr/local/bin/supe…"   18 hours ago   Up 3 minutes              teamd
d6205613327a   docker-orchagent:latest              "/usr/bin/docker-ini…"   18 hours ago   Up 3 minutes              swss
cffaa769be10   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   18 hours ago   Up 3 minutes              bgp
a88d5b1e51d1   docker-database:latest               "/usr/local/bin/dock…"   18 hours ago   Up 3 minutes              database
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.138110-dirty-20220822.105016
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 2d4ab9e97
Build date: Mon Aug 22 15:29:52 UTC 2022
Built by: AzDevOps@sonic-build-workers-001ZAM
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
