### PR TITLE
[IP packet] Differentiate actions to IP packets with 0xffff checksum by ASIC type

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -288,13 +288,13 @@ ip/test_ip_packet.py:
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
   skip:
-    reason: "Broadcom and Cisco Asic will tolorate IP packets with 0xffff checksum"
+    reason: "Broadcom, Cisco and Marvell Asic will tolorate IP packets with 0xffff checksum"
     conditions:
       - "asic_type in ['broadcom', 'cisco-8000', 'marvell']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:
-    reason: "Mellanox, Marvell Asic will drop IP packets with 0xffff checksum"
+    reason: "Mellanox Asic will drop IP packets with 0xffff checksum"
     conditions:
       - "asic_type in ['mellanox']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -286,6 +286,18 @@ ip/test_ip_packet.py:
     conditions:
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
 
+ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
+  skip:
+    reason: "Broadcom and Cisco Asic will tolorate IP packets with 0xffff checksum"
+    conditions:
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell']"
+
+ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
+  skip:
+    reason: "Mellanox, Marvell Asic will drop IP packets with 0xffff checksum"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 #######################################
 #####            ipfwd            #####
 #######################################

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -204,8 +204,7 @@ class TestIPPacket(object):
         pytest_assert(max(rx_drp, rx_err) <= self.PKT_NUM_ZERO, "Dropped {} packets in rx, not in expected range".format(rx_err))
         pytest_assert(max(tx_drp, tx_err) <= self.PKT_NUM_ZERO, "Dropped {} packets in tx, not in expected range".format(tx_err))
         pytest_assert(match_cnt >= self.PKT_NUM_MIN, "DUT Forwarded {} packets, not in expected range".format(match_cnt))
-
-    @pytest.mark.xfail
+ 
     def test_forward_ip_packet_with_0xffff_chksum_tolerant(self, duthost, ptfadapter, common_param):
         # GIVEN a ip packet with checksum 0x0000(compute from scratch)
         # WHEN manually set checksum as 0xffff and send the packet to DUT
@@ -265,7 +264,6 @@ class TestIPPacket(object):
         pytest_assert(max(tx_drp, tx_err) <= self.PKT_NUM_ZERO, "Dropped {} packets in tx, not in expected range".format(tx_err))
         pytest_assert(match_cnt >= self.PKT_NUM_MIN, "DUT Forwarded {} packets, not in expected range".format(match_cnt))
 
-    @pytest.mark.xfail
     def test_forward_ip_packet_with_0xffff_chksum_drop(self, duthost, ptfadapter, common_param):
         # GIVEN a ip packet with checksum 0x0000(compute from scratch)
         # WHEN manually set checksum as 0xffff and send the packet to DUT
@@ -533,8 +531,8 @@ class TestIPPacket(object):
         tx_drp = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_err = TestIPPacket.sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
 
-
+        asic_type = duthost.facts['asic_type']
         pytest_assert(rx_ok >= self.PKT_NUM_MIN, "Received {} packets in rx, not in expected range".format(rx_ok))
-        pytest_assert(max(rx_drp, rx_err) >= self.PKT_NUM_MIN, "Dropped {} packets in rx, not in expected range".format(rx_err))
+        pytest_assert(max(rx_drp, rx_err) >= self.PKT_NUM_MIN if asic_type not in ["marvell"] else True, "Dropped {} packets in rx, not in expected range".format(rx_err))
         pytest_assert(tx_ok <= self.PKT_NUM_ZERO, "Forwarded {} packets in tx, not in expected range".format(tx_ok))
         pytest_assert(max(tx_drp, tx_err) <= self.PKT_NUM_ZERO, "Dropped {} packets in tx, not in expected range".format(tx_err))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. Different ASIC plaftform has different behavior to IP packets with 0xffff checksum
2. Marvell do not support dropcounters yet
#### How did you do it?
1. Use conditional mark to differentiate actions by ASIC type
2. Do not check dropcounters in Marvell platform, but check Rx_OK and Tx_OK
#### How did you verify/test it?
Run a test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
