### PR TITLE
Fixed test_bgp_slb_neighbor_persistence_across_advanced_reboot - issue when run fast reboot after warm reboot

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -76,7 +76,7 @@ def test_bgp_slb_neighbor_persistence_across_advanced_reboot(
         neighbor.start_session()
         if not wait_until(40, 5, 10, verify_bgp_session, duthost, neighbor):
             pytest.fail("dynamic BGP session is not established")
-        reboot(duthost, localhost, reboot_type=reboot_type)
+        reboot(duthost, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True)
         if not wait_until(40, 5, 10, verify_bgp_session, duthost, neighbor):
             pytest.fail("dynamic BGP session is not established after %s" % reboot_type)
     finally:


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed test_bgp_slb_neighbor_persistence_across_advanced_reboot - issue when run fast reboot after warm reboot

Sometimes when run test test_bgp_slb_neighbor_persistence_across_advanced_reboot second test(fast-reboot) may fail because previous warm-reboot test not finished yet. Added fix: wait_warmboot_finalizer=True

Summary: Fixed test_bgp_slb_neighbor_persistence_across_advanced_reboot - issue when run fast reboot after warm reboot
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sometimes when run test test_bgp_slb_neighbor_persistence_across_advanced_reboot second test(fast-reboot) may fail because previous warm-reboot test not finished yet.

#### How did you do it?
Added fix: wait_warmboot_finalizer=True

#### How did you verify/test it?
Executed test tests/bgp/test_bgp_slb.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
