### PR TITLE
[t0-56-po2vlan] Fixed KeyError: u'PortChannel201' in tests which can run on t0 topo for support t0-56-po2vlan topology

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
@@ -62,6 +62,9 @@ class BcastTest(BaseTest):
             self.src_ports = list(range(0, 2)) + list(range(4, 6)) + list(range(8, 10)) + list(range(12, 18)) + list(range(20, 22)) + \
                              list(range(24, 26)) + list(range(28, 30)) + list(range(32, 34)) + list(range(36, 38)) + list(range(40, 46)) + \
                              list(range(48, 50)) + list(range(52, 54))
+        if self.test_params['testbed_type'] == 't0-56-po2vlan':
+            self.src_ports = [8, 10, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 44, 46, 48, 50, 52, 54] + \
+                             [12, 13, 14, 15, 40, 41, 42, 43]
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = list(range(0, 2)) + list(range(4, 18)) + list(range(20, 33)) + list(range(36, 43)) + list(range(48, 49)) + list(range(52, 59))
         if self.test_params['testbed_type'] == 't0-116':

--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -374,7 +374,7 @@ the remote host.
 
 - [get_ip_route_info](sonic_asic_methods/get_ip_route_info.md) - Returns route information for a destionation. The destination could an ip address or ip prefix.
 
-- [get_portchannel_and_members_in_ns](sonic_asic_methods/get_portchannel_and_members_in_ns.md) - Finds a portchannel present on ASIC interface's namspace and returns its name and members.
+- [get_portchannels_and_members_in_ns](sonic_asic_methods/get_portchannels_and_members_in_ns.md) - Finds a portchannel present on ASIC interface's namspace and returns its name and members.
 
 - [get_queue_oid](sonic_asic_methods/get_queue_oid.md) - Get the queue OID of given port and queue number.
 

--- a/docs/api_wiki/sonic_asic_methods/get_portchannel_and_members_in_ns.md
+++ b/docs/api_wiki/sonic_asic_methods/get_portchannel_and_members_in_ns.md
@@ -1,4 +1,4 @@
-# get_portchannel_and_members_in_ns
+# get_portchannels_and_members_in_ns
 
 - [Overview](#overview)
 - [Examples](#examples)
@@ -6,7 +6,7 @@
 - [Expected Output](#expected-output)
 
 ## Overview
-Finds a portchannel present on ASIC interface's namspace and returns its name and members.
+Finds a portchannels present on ASIC interface's namspace and returns their names and members.
 
 ## Examples
 ```
@@ -15,7 +15,7 @@ def test_fun(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, tbinfo):
 
     sonic_asic = duthost.asic_instance(asic_index=enum_frontend_asic_index)
 
-    pc_on_asic = sonic_asic.get_portchannel_and_members_in_ns(tbinfo)
+    pc_on_asic_dict = sonic_asic.get_portchannels_and_members_in_ns(tbinfo)
 ```
 
 ## Arguments
@@ -24,9 +24,9 @@ def test_fun(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, tbinfo):
     - Type: `Dictionary`
 
 ## Expected Output
-A tuple with the following ordered items:
+A dict with the following items:
 
-1. Name of portchannel found
-2. List of portchannel members
+1. Name of portchannel found as key
+2. List of portchannel members as value
 
-If no portchannels could be found, `None` is returned.
+If no portchannels could be found, `{}` is returned.

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -538,36 +538,35 @@ class SonicAsic(object):
             return True
         return False
 
-    def get_portchannel_and_members_in_ns(self, tbinfo):
+    def get_portchannels_and_members_in_ns(self, tbinfo):
         """
-        Get a portchannel and it's members in this namespace.
+        Get a portchannels and their members in this namespace.
 
         Args: tbinfo - testbed info
 
-        Returns: a tuple with (portchannel_name, port_channel_members)
+        Returns: a dict portchannels_data with (portchannel_name as key and port_channel_members as value)
 
         """
-        pc = None
-        pc_members = None
-
+        port_channels_data = {}
         mg_facts = self.sonichost.minigraph_facts(
             host = self.sonichost.hostname
         )['ansible_facts']
 
         if len(mg_facts['minigraph_portchannels'].keys()) == 0:
-            return None, None
+            return port_channels_data
 
         if self.namespace is DEFAULT_NAMESPACE:
-            pc = mg_facts['minigraph_portchannels'].keys()[0]
-            pc_members = mg_facts['minigraph_portchannels'][pc]['members']
+            for pc in mg_facts['minigraph_portchannels'].keys():
+                pc_members = mg_facts['minigraph_portchannels'][pc]['members']
+                port_channels_data[pc] = pc_members
         else:
             for k, v in mg_facts['minigraph_portchannels'].iteritems():
                 if v.has_key('namespace') and self.namespace == v['namespace']:
                     pc = k
                     pc_members = mg_facts['minigraph_portchannels'][pc]['members']
-                    break
+                    port_channels_data[pc] = pc_members
 
-        return pc, pc_members
+        return port_channels_data
 
     def get_bgp_statistic(self, stat):
         """

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -59,6 +59,9 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
     vlan_dict = mg_facts['minigraph_vlans']
     for vlan_iface_name, vlan_info_dict in vlan_dict.items():
+        # Filter(remove) PortChannel interfaces from VLAN members list
+        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
+
         # Gather information about the downlink VLAN interface this relay agent is listening on
         downlink_vlan_iface = {}
         downlink_vlan_iface['name'] = vlan_iface_name
@@ -77,7 +80,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
         # We choose the physical interface where our DHCP client resides to be index of first interface with alias (ignore PortChannel) in the VLAN
         client_iface = {}
-        for port in vlan_info_dict['members']:
+        for port in vlan_members:
             if port in mg_facts['minigraph_port_name_to_alias_map']:
                 break
         else:
@@ -109,7 +112,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
                     uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
 
         other_client_ports_indices = []
-        for iface_name in vlan_info_dict['members'] :
+        for iface_name in vlan_members:
             if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
                 pass
             else :

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -37,6 +37,11 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
     vlan_dict = mg_facts['minigraph_vlans']
     for vlan_iface_name, vlan_info_dict in vlan_dict.items():
+        # Filter(remove) PortChannel interfaces from VLAN members list
+        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
+        if not vlan_members:
+            continue
+
         # Gather information about the downlink VLAN interface this relay agent is listening on
         downlink_vlan_iface = {}
         downlink_vlan_iface['name'] = vlan_iface_name
@@ -55,7 +60,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
         # We choose the physical interface where our DHCP client resides to be index of first interface in the VLAN
         client_iface = {}
-        client_iface['name'] = vlan_info_dict['members'][0]
+        client_iface['name'] = vlan_members[0]
         client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
         client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
 

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -197,9 +197,19 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         for iface in interfaces["members"]:
             port_channel_members[iface] = port_channel
 
+    l2_port_channel_members = []
     for vlan_id in mg_facts["minigraph_vlans"]:
         for iface in mg_facts["minigraph_vlans"][vlan_id]["members"]:
-            vlan_members[iface] = vlan_id
+            # Add only physical interfaces to vlan_members dict(skip PortChannel interfaces)
+            if 'PortChannel' in iface:
+                physical_ifaces = mg_facts['minigraph_portchannels'][iface]["members"]
+                l2_port_channel_members.extend(physical_ifaces)
+            else:
+                vlan_members[iface] = vlan_id
+
+    # Remove physical interfaces related to L2 PortChannel from port_channel_members dict(case with t0-56-po2vlan topo)
+    for po_member in set(l2_port_channel_members):
+        port_channel_members.pop(po_member)
 
     rif_members = {item["attachto"]: item["attachto"] for item in mg_facts["minigraph_interfaces"]}
     # Compose list of sniff ports

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -14,9 +14,23 @@ def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
     # Copy VLAN information file to PTF-docker
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    # Filter expected_vlans and minigraph_vlans to support t0-56-po2vlan topology
+    expected_vlans = []
+    minigraph_vlans = {}
+    for vlan in mg_facts['minigraph_vlan_interfaces']:
+        vlan_name = vlan['attachto']
+        if len(mg_facts['minigraph_vlans'][vlan_name]['members']) > 1:
+            expected_vlans.append(vlan)
+            vlan_members = []
+            for vl_m in mg_facts['minigraph_vlans'][vlan_name]['members']:
+                if 'PortChannel' not in vl_m:
+                    vlan_members.append(vl_m)
+            minigraph_vlans[vlan_name] = {'name': vlan_name, 'members': vlan_members}
+
     extra_vars = {
-        'minigraph_vlan_interfaces': mg_facts['minigraph_vlan_interfaces'],
-        'minigraph_vlans':           mg_facts['minigraph_vlans'],
+        'minigraph_vlan_interfaces': expected_vlans,
+        'minigraph_vlans':           minigraph_vlans,
         'minigraph_port_indices':    mg_facts['minigraph_ptf_indices'],
         'minigraph_portchannels':    mg_facts['minigraph_portchannels']
     }

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -66,7 +66,16 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     int_facts = asichost.interface_facts()['ansible_facts']
 
-    portchannel, portchannel_members = asichost.get_portchannel_and_members_in_ns(tbinfo)
+    port_channels_data = asichost.get_portchannels_and_members_in_ns(tbinfo)
+    portchannel = None
+    portchannel_members = None
+    for portchannel in port_channels_data:
+        logging.info('Trying to get PortChannel: {} for test'.format(portchannel))
+        if int_facts['ansible_interface_facts'][portchannel].get('ipv4'):
+            portchannel_members = port_channels_data[portchannel]
+            break
+
+    pytest_assert(portchannel and portchannel_members, 'Can not get PortChannel interface for test')
 
     tmp_portchannel = "PortChannel999"
     # Initialize portchannel_ip and portchannel_members

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -113,6 +113,21 @@ def setup_pfc_test(
     vlan_nw = None
 
     if mg_facts['minigraph_vlans']:
+        # Filter VLANs with one interface inside only(PortChannel interface in case of t0-56-po2vlan topo)
+        unexpected_vlans = []
+        for vlan, vlan_data in mg_facts['minigraph_vlans'].items():
+            if len(vlan_data['members']) < 2:
+               unexpected_vlans.append(vlan)
+
+        # Update minigraph_vlan_interfaces with only expected VLAN interfaces
+        expected_vlan_ifaces = []
+        for vlan in unexpected_vlans:
+            for mg_vl_iface in mg_facts['minigraph_vlan_interfaces']:
+                if vlan != mg_vl_iface['attachto']:
+                    expected_vlan_ifaces.append(mg_vl_iface)
+        if expected_vlan_ifaces:
+            mg_facts['minigraph_vlan_interfaces'] = expected_vlan_ifaces
+
         # gather all vlan specific info
         vlan_addr = mg_facts['minigraph_vlan_interfaces'][0]['addr']
         vlan_prefix = mg_facts['minigraph_vlan_interfaces'][0]['prefixlen']

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -189,7 +189,9 @@ class TrafficPorts(object):
         """
         temp_ports = dict()
         vlan_details = self.vlan_info.values()[0]
-        vlan_members = vlan_details['members']
+        # Filter(remove) PortChannel interfaces from VLAN members list
+        vlan_members = [port for port in vlan_details['members'] if 'PortChannel' not in port]
+
         vlan_type = vlan_details.get('type')
         vlan_id = vlan_details['vlanid']
         rx_port = self.pfc_wd_rx_port if isinstance(self.pfc_wd_rx_port, list) else [self.pfc_wd_rx_port]

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -166,7 +166,10 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         # Config save and reload if specified
         if config_reload_test:
             duthost.shell('config save -y')
-            config_reload(duthost, wait=350)
+            if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
+                config_reload(duthost, wait=400)
+            else:
+                config_reload(duthost, wait=350)
             #FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -166,10 +166,7 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         # Config save and reload if specified
         if config_reload_test:
             duthost.shell('config save -y')
-            if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
-                config_reload(duthost, wait=400)
-            else:
-                config_reload(duthost, wait=350)
+            config_reload(duthost, wait=350)
             #FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)
@@ -198,6 +195,22 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
 
 def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    # Filter VLANs with one interface inside only(PortChannel interface in case of t0-56-po2vlan topo)
+    unexpected_vlans = []
+    for vlan, vlan_data in mg_facts['minigraph_vlans'].items():
+        if len(vlan_data['members']) < 2:
+            unexpected_vlans.append(vlan)
+
+    # Update minigraph_vlan_interfaces with only expected VLAN interfaces
+    expected_vlan_ifaces = []
+    for vlan in unexpected_vlans:
+        for mg_vl_iface in mg_facts['minigraph_vlan_interfaces']:
+            if vlan != mg_vl_iface['attachto']:
+                expected_vlan_ifaces.append(mg_vl_iface)
+    if expected_vlan_ifaces:
+        mg_facts['minigraph_vlan_interfaces'] = expected_vlan_ifaces
+
     vlan_intf = mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]
     prefix_len = vlan_intf['prefixlen']
 
@@ -214,7 +227,7 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
         vlan = mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]['attachto']]
         vlan_ports = vlan['members']
         vlan_id = vlan['vlanid']
-        vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports]
+        vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports if 'PortChannel' not in port]
         nexthop_devs = vlan_ptf_ports
         # backend topology use ethx.x(e.g. eth30.1000) during servers and T0 in ptf
         # in other topology use ethx(e.g. eth30)

--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -38,7 +38,7 @@ def ports_for_test(cfg_facts):
 
     # Select 3 ports for test
     ports = cfg_facts['VLAN_MEMBER']['Vlan{}'.format(vlan)]
-    port_names = ports.keys()
+    port_names = [port_name for port_name in ports.keys() if 'PortChannel' not in port_name]
     selected_ports = [port_names[0], port_names[1], port_names[-1]]
 
     # Generate port info for selected ports


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>


### Description of PR
Many tests supports t0 topology and they should be able to run on t0-56-po2vlan topology - but they fail with error: KeyError: u'PortChannel201'
It happen because topology t0-56-po2vlan has 2 VLANs and tests expect that topology will have only 1 VLAN and second VLAN has PortChannel interface which are member of second VLAN(in regular t0 topo - all PortChannels are L3 interfaces)
Added fix(remove additional VLAN/PortChannel from list of VLANs/Interfaces) for tests to support t0-56-po2vlan topology

Summary: Fixed KeyError: u'PortChannel201' in tests which can run on t0 topo for support t0-56-po2vlan topology
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fixed KeyError: u'PortChannel201' in tests which can run on t0 topo for support t0-56-po2vlan topology

#### How did you do it?
In most cases removed extra VLAN/PortChannel from VLANs/PortChannels list and all t0 tests can pass on t0-56-po2vlan topology in the same way as on regular t0

#### How did you verify/test it?
Executed tests which were modified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
