### PR TITLE
[TestbedProcessing] Add vm_host variables to generated creds.yml

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -152,7 +152,10 @@ def makeVMHostCreds(data, outfile):
     result = {
         "ansible_user": veos.get("vm_host_ansible").get("ansible_user"),
         "ansible_password": veos.get("vm_host_ansible").get("ansible_password"),
-        "ansible_become_pass": veos.get("vm_host_ansible").get("ansible_become_pass")
+        "ansible_become_pass": veos.get("vm_host_ansible").get("ansible_become_pass"),
+        "vm_host_user": veos.get("vm_host_ansible").get("ansible_user"),
+        "vm_host_password": veos.get("vm_host_ansible").get("ansible_password"),
+        "vm_host_become_password": veos.get("vm_host_ansible").get("ansible_become_pass")
     }
     with open(outfile, "w") as toWrite:
         toWrite.write("---\n")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updated creds.yml generation via TestbedProcessing to include vm_host_* variables

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
[PR 6303](https://github.com/sonic-net/sonic-mgmt/pull/6303) added vm_host_* variables to `ansible/group_vars/all/creds.yml` and `asnible/group_vars/vm_host/creds.yml`, as well as updated vm_topo add/remove/renumber  scrips to use vm_host_* credentials instead of ansible_* credentials.
 `asnible/group_vars/vm_host/creds.yml` is created as part of TestbedProcessing.py. Since vm_host variables are not added to it during file generation, credentials are collected from default `ansible/group_vars/all/creds.yml`, resulting in add_topo scripts failing due to incorrect login credentials. 
#### How did you do it?
Updated TestbedProcessing `makeVMHostCreds` function to include vm_host variables.
#### How did you verify/test it?
Added and removed topology.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
