### PR TITLE
Add muli-asics support to test_radv_restart

### DIFF
--- a/tests/radv/test_radv_restart.py
+++ b/tests/radv/test_radv_restart.py
@@ -18,13 +18,23 @@ def test_radv_swss(duthost):
     """
 
     # 1. check status of swss.service
-    swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
-        "stdout_lines"]
-    swss_status_dict_before = parse_service_status(swss_stdout_lines)
+    if duthost.is_multi_asic:
+        for asic in duthost.asics:
+            swss_stdout_lines = duthost.shell(
+                "systemctl show -p ActiveState -p ActiveEnterTimestamp swss@{}.service".format(asic.asic_index))[
+                "stdout_lines"]
+            swss_status_dict_before = parse_service_status(swss_stdout_lines)
+            # make sure swss is running
+            assert swss_status_dict_before is not None and swss_status_dict_before.get(
+                "ActiveState") == "active", "service swss is not running"
+    else:
+        swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
+            "stdout_lines"]
+        swss_status_dict_before = parse_service_status(swss_stdout_lines)
 
-    # make sure swss is running
-    assert swss_status_dict_before is not None and swss_status_dict_before.get(
-        "ActiveState") == "active", "service swss is not running"
+        # make sure swss is running
+        assert swss_status_dict_before is not None and swss_status_dict_before.get(
+            "ActiveState") == "active", "service swss is not running"
 
     # 2. restart radv.service
     duthost.shell("sudo systemctl restart radv.service")
@@ -39,12 +49,22 @@ def test_radv_swss(duthost):
         "ActiveState") == "active", "service radv is not running"
 
     # 4. check status of swss.service
-    swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
-        "stdout_lines"]
-    swss_status_dict = parse_service_status(swss_stdout_lines)
-    # make sure the ActiveSate is active
-    assert swss_status_dict is not None and swss_status_dict.get(
-        "ActiveState") == "active", "service swss is not running after restart radv.service"
+    if duthost.is_multi_asic:
+        for asic in duthost.asics:
+            swss_stdout_lines = duthost.shell(
+                "systemctl show -p ActiveState -p ActiveEnterTimestamp swss@{}.service".format(asic.asic_index))[
+                "stdout_lines"]
+            swss_status_dict = parse_service_status(swss_stdout_lines)
+            # make sure the ActiveSate is active
+            assert swss_status_dict is not None and swss_status_dict.get(
+                "ActiveState") == "active", "service swss is not running after restart radv.service"
+    else:
+        swss_stdout_lines = duthost.shell("systemctl show -p ActiveState -p ActiveEnterTimestamp swss.service")[
+            "stdout_lines"]
+        swss_status_dict = parse_service_status(swss_stdout_lines)
+        # make sure the ActiveSate is active
+        assert swss_status_dict is not None and swss_status_dict.get(
+            "ActiveState") == "active", "service swss is not running after restart radv.service"
 
     # 5. verify "Restarting radv causes swss service to restart" or not
     # compare ActiveEnterTimestamp of swss.service with radv.service, and compare ActiveEnterTimestamp of swss.service


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add muli-asic support to test_radv_restart
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Check of swss fails for a mult-asic card since the testcase does not support multi-asics
Add support for multi-asic to test_radv_restart

#### How did you do it?
Find out if duthost is multi-asic
If duthost is multi-asic, check swss service for each asic

#### How did you verify/test it?
Tested test_radv_restart on a muli asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
