### PR TITLE
Added a test case for fast reboot from other vendor NOS to SONiC

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1327,8 +1327,13 @@ class ReloadTest(BaseTest):
             self.sender_thr.start()
 
         self.log("Rebooting remote side")
-        if self.reboot_type != 'service-warm-restart':
+        if self.reboot_type != 'service-warm-restart' and self.test_params['other_vendor_flag'] is False:
             stdout, stderr, return_code = self.dut_connection.execCommand("sudo " + self.reboot_type, timeout=30)
+
+        elif self.test_params['other_vendor_flag'] is True:
+            ignore_db_integrity_check = " -d"
+            stdout, stderr, return_code = self.dut_connection.execCommand("sudo " + self.reboot_type + ignore_db_integrity_check, timeout=30)
+
         else:
             self.restart_service()
             return

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -117,7 +117,7 @@ class AdvancedReboot:
         if self.rebootLimit is None:
             if self.kvmTest:
                 self.rebootLimit = 200 # Default reboot limit for kvm
-            elif 'warm-reboot' in self.rebootType:
+	    elif 'warm-reboot' in self.rebootType:
                 self.rebootLimit = 0
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -3,7 +3,6 @@ import ipaddress
 import itertools
 import json
 import logging
-import re
 import pytest
 import time
 import os

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -80,7 +80,8 @@ class AdvancedReboot:
         self.moduleIgnoreErrors = kwargs["allow_fail"] if "allow_fail" in kwargs else False
         self.allowMacJump = kwargs["allow_mac_jumping"] if "allow_mac_jumping" in kwargs else False
         self.advanceboot_loganalyzer = kwargs["advanceboot_loganalyzer"] if "advanceboot_loganalyzer" in kwargs else None
-        self.__dict__.update(kwargs)
+	self.other_vendor_nos = kwargs['other_vendor_nos'] if 'other_vendor_nos' in kwargs else False
+	self.__dict__.update(kwargs)
         self.__extractTestParam()
         self.rebootData = {}
         self.hostMaxLen = 0

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -3,6 +3,7 @@ import ipaddress
 import itertools
 import json
 import logging
+import re
 import pytest
 import time
 import os
@@ -605,6 +606,7 @@ class AdvancedReboot:
             "dut_hostname" : self.rebootData['dut_hostname'],
             "reboot_limit_in_seconds" : self.rebootLimit,
             "reboot_type" : self.rebootType,
+            "other_vendor_flag" :  self.other_vendor_nos,
             "portchannel_ports_file" : self.rebootData['portchannel_interfaces_file'],
             "vlan_ports_file" : self.rebootData['vlan_interfaces_file'],
             "ports_file" : self.rebootData['ports_file'],
@@ -644,8 +646,11 @@ class AdvancedReboot:
 
         self.__updateAndRestartArpResponder(rebootOper)
 
-
-        logger.info('Run advanced-reboot ReloadTest on the PTF host. TestCase: {}, sub-case: {}'.format(\
+        if rebootOper is None and self.other_vendor_nos is True:
+            logger.info('Run advanced-reboot ReloadTest on the PTF host. TestCase: {}, sub-case:'
+            ' Reboot from other vendor nos'.format(self.request.node.name))
+        else:
+            logger.info('Run advanced-reboot ReloadTest on the PTF host. TestCase: {}, sub-case: {}'.format(\
             self.request.node.name, str(rebootOper)))
         result = ptf_runner(
             self.ptfhost,

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -12,6 +12,7 @@ pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
+logger = logging.getLogger()
 
 def pytest_generate_tests(metafunc):
     input_sad_cases = metafunc.config.getoption("sad_case_list")
@@ -32,15 +33,30 @@ def pytest_generate_tests(metafunc):
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     advanceboot_loganalyzer, capture_interface_counters):
     '''
-    Fast reboot test case is run using advacned reboot test fixture
+    Fast reboot test case is run using advanced reboot test fixture
 
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot',\
-        advanceboot_loganalyzer=advanceboot_loganalyzer)
+        advanceboot_loganalyzer=advanceboot_loganalyzer, other_vendor_nos = False)
     advancedReboot.runRebootTestcase()
 
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request, get_advanced_reboot, verify_dut_health,
+    advanceboot_loganalyzer, capture_interface_counters):
+    '''
+    Fast reboot test from other vendor case is run using advanced reboot test fixture
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    advancedReboot = get_advanced_reboot(rebootType='fast-reboot', other_vendor_nos = True,\
+    advanceboot_loganalyzer=advanceboot_loganalyzer)
+    preboot_oper = flush_dbs(duthost)
+    advancedReboot.runRebootTestcase(preboot_setup = preboot_oper)
 
 @pytest.mark.device_type('vs')
 def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
@@ -129,3 +145,17 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
     add_fail_step_to_reboot('warm-reboot')
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_fail=True)
     advancedReboot.runRebootTestcase()
+
+def flush_dbs(duthost):
+    """
+    This Function will flush all unnecessary databases, to mimic reboot from other vendor
+    """
+    logger.info('Flushing databases from switch')
+    db_dic = { 0: 'Application DB',
+                        1: 'ASIC DB',
+                        2: 'Counters DB',
+                        5: 'Flex Counters DB',
+                        6: 'State DB'
+               }
+    for db in db_dic.keys():
+        duthost.shell('redis-cli -n {} flushdb'.format(db))

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -39,7 +39,7 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot',\
-        advanceboot_loganalyzer=advanceboot_loganalyzer, other_vendor_nos = False)
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
 
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -55,8 +55,9 @@ def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request
     duthost = duthosts[rand_one_dut_hostname]
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot', other_vendor_nos = True,\
     advanceboot_loganalyzer=advanceboot_loganalyzer)
-    preboot_oper = flush_dbs(duthost)
-    advancedReboot.runRebootTestcase(preboot_setup = preboot_oper)
+    # Before rebooting, we will flush all unnecessary databases, to mimic reboot from other vendor.
+    flush_dbs(duthost)
+    advancedReboot.runRebootTestcase()
 
 @pytest.mark.device_type('vs')
 def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
@@ -159,3 +160,4 @@ def flush_dbs(duthost):
                }
     for db in db_dic.keys():
         duthost.shell('redis-cli -n {} flushdb'.format(db))
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
A new test case was added to fast reboot script.
This test case mimics a fast reboot from other vendor NOS to SONiC, by flushing all DBs that are part of the boot process, so the boot will be initiated with clean DBs as if it was booting from other NOSes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The current flow doesn't support booting from other vendor nos, and by that, we cannot measure and determine the performance of the fast-reboot process in that specific sub-case. 
The new test case enables us to mimic the flow of booting from other nos and by verifying the performance of this kind of reboot.

#### How did you do it?
I added a new flag of "other_vendor_nos"  which was added to the original fast_reboot test case in False mode and in the new test case in True mode, and added this flag to the AdvancedReboot class. 
This flag will initiate pre-boot function, that flushes all relevant DBs. By flushing them, the fast reboot flow is initiated with clean DBs, as if the system boots from other vendor nos. 

#### How did you verify/test it?
I ran full regression on community testbeds,
ran the test on the regular fast boot mode and on the new mode and verified the reboot process succeed.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
t0

