### PR TITLE
Fixed tests/qos/test_pfc_counters.py - issue with getting port name for MLNX fanout after merge PR: #6268

### DIFF
--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -90,7 +90,7 @@ def run_test(fanouthosts, duthost, conn_graph_facts, fanout_graph_facts, leaf_fa
             if peerdev_ans.get_fanout_os() == "nxos":
                 peer_port_name = nxos_to_linux_intf(peer_port)
             else:
-                peer_port_name = eos_to_linux_intf(peer_port)
+                peer_port_name = eos_to_linux_intf(peer_port, hwsku=fanout_hwsku)
 
             if is_pfc:
                 for priority in range(PRIO_COUNT):
@@ -134,7 +134,7 @@ def run_test(fanouthosts, duthost, conn_graph_facts, fanout_graph_facts, leaf_fa
                 if peerdev_ans.get_fanout_os() == "nxos":
                     peer_port_name = nxos_to_linux_intf(peer_port)
                 else:
-                    peer_port_name = eos_to_linux_intf(peer_port)
+                    peer_port_name = eos_to_linux_intf(peer_port, hwsku=fanout_hwsku)
 
                 if fanout_hwsku == "MLNX-OS":
                     cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (onyx_pfc_container_name, PFC_GEN_FILE_ABSULOTE_PATH, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
PR #6268 removed additional argument "hwsku=fanout_hwsku" when call method "eos_to_linux_intf" 
Changed call for method "eos_to_linux_intf" to have original logic as it was before PR #6268 eos_to_linux_intf(peer_port, hwsku=fanout_hwsku)

Summary: Fixed tests/qos/test_pfc_counters.py - issue with getting port name for MLNX fanout after merge PR: #6268
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fixed tests/qos/test_pfc_counters.py - issue with getting port name for MLNX fanout after merge PR: #6268

#### How did you do it?
Changed call for method "eos_to_linux_intf" to have original logic as it was before PR #6268 eos_to_linux_intf(peer_port, hwsku=fanout_hwsku)

#### How did you verify/test it?
Executed tests from file

#### Any platform specific information?
Mellanox fanout related

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
