### PR TITLE
Add a new marker to selectively skip health check and conf restore

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1671,7 +1671,7 @@ def check_dut_health_status(duthosts, request):
     if hasattr(request.config.option, 'enable_macsec') and request.config.option.enable_macsec:
         check_flag = False
     for m in request.node.iter_markers():
-        if m.name == "pretest" or m.name == "posttest":
+        if m.name == "skip_check_dut_health":
             check_flag = False
 
     module_name = request.node.name

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -12,6 +12,7 @@ markers:
     topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc)
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
     supported_completeness_level: test supported levels of completeness (coverage) level (Debug, Basic, Confident, Thorough)
+    skip_check_dut_health: skip default execution of check_dut_health_status fixture
 
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -9,7 +9,8 @@ pytestmark = [
     pytest.mark.posttest,
     pytest.mark.topology('util'),
     pytest.mark.sanity_check(skip_sanity=True),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health
 ]
 
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.pretest,
     pytest.mark.topology('util'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Add generic new marker to skip execution of `check_dut_health_status` fixture.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
As part of PR https://github.com/sonic-net/sonic-mgmt/pull/5817, DUT health and config diff check is being ignored by tests that are hardcoded in conftest.py file.

In this PR, a new marker is introduced that will skip the fixture's execution.
Using this approach, the conftest.py file does not need explicit mention of test cases names. 

Any testcase can use this marker and skip this fixture without modifcation to conftest.py file.

This would help in limiting to using one marker (vs unique marker for every case to be skipped)
Keep conftest file's logic generic.

#### How did you do it?

#### How did you verify/test it?
Tested on physical testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
