### PR TITLE
Fix test_container_autorestart bgp issue

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -3,6 +3,7 @@ Test the auto-restart feature of containers
 """
 import logging
 import re
+import time
 from collections import defaultdict
 
 import pytest
@@ -417,6 +418,12 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     if restore_disabled_state:
         logger.info("Restore auto-restart state of container '{}' to 'disabled'".format(container_name))
         duthost.shell("sudo config feature autorestart {} disabled".format(feature_name))
+
+    if container_name == "syncd":
+        # During syncd TC bgp service reach start-limit-hit, but at the time when it is
+        # checked in is_hiting_start_limit bgp service have another state.
+        # Wait 100 seconds to stabilize bgp state
+        time.sleep(100)
 
     critical_proceses, bgp_check = postcheck_critical_processes_status(
         duthost, feature_autorestart_states, up_bgp_neighbors

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -323,7 +323,7 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     """
     # Check if all critical processes are running with timeout 100 sec, if not
     # then this timeout will help to stabilize service state and to spot
-    # start-limit-hit if it was exceded.
+    # start-limit-hit if it was exceeded.
     wait_until(
         100, POST_CHECK_INTERVAL_SECS, 0,
         check_all_critical_processes_status, duthost


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_containers_autorestart fails at testing `syncd` container due to `bgp` container is down:
```
  File "/var/user/jenkins/sonic-mgmt/tests/common/devices/multi_asic.py", line 530, in check_bgp_session_state_all_asics
    if not asic.check_bgp_session_state(neigh_ips, state):
  File "/var/user/jenkins/sonic-mgmt/tests/common/devices/sonic_asic.py", line 627, in check_bgp_session_state
    bgp_facts = self.bgp_facts()['ansible_facts']
  File "/var/user/jenkins/sonic-mgmt/tests/common/devices/sonic_asic.py", line 106, in bgp_facts
    return self.sonichost.bgp_facts(*module_args, **complex_args)
  File "/var/user/jenkins/sonic-mgmt/tests/common/devices/base.py", line 89, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
RunAnsibleModuleFail: run module bgp_facts failed, Ansible Results =>
{
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "instance_id": null, 
            "num_npus": 1
        }
    }, 
    "msg": "Command failed rc=1, out=, err=Error response from daemon: Container 3f7ccc997ebc7c50172c73c65cd260235025b1d612182a402d92df55f170b96c is not running\n"
}
```
This is happening due to BGP service reached `start-limit-hit` and cannot get started, although TC check whether service have reached `start-limit-hit` and reset it, at the time of check BGP state is different (it might be Active (running) or inactive (dead)) like in logs below:
```
10:12:39 base._run                                L0082 DEBUG  | /var/user/jenkins/sonic-mgmt/tests/common/devices/multi_asic.py::_run_on_asics#100: [igk-4-dut] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sudo systemctl status bgp.service | grep 'Active'", "end": "2022-09-15 10:15:14.177219", "_ansible_no_log": false, "stdout": "     Active: active (running) since Thu 2022-09-15 10:12:37 UTC; 2min 36s ago", "changed": true, "rc": 0, "start": "2022-09-15 10:15:14.136187", "stderr": "", "delta": "0:00:00.041032", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sudo systemctl status bgp.service | grep 'Active'", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["     Active: active (running) since Thu 2022-09-15 10:12:37 UTC; 2min 36s ago"], "warnings": ["Consider using 'become', 'become_method', and 'become_user' rather than running sudo"], "failed": false}
15:31:14 base._run                                L0082 DEBUG  | /var/user/jenkins/sonic-mgmt/tests/common/devices/multi_asic.py::_run_on_asics#100: [igk-2-dut] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sudo systemctl status bgp.service | grep 'Active'", "end": "2022-09-14 15:31:13.467312", "_ansible_no_log": false, "stdout": "     Active: deactivating (stop) since Wed 2022-09-14 15:31:12 UTC; 822ms ago", "changed": true, "rc": 0, "start": "2022-09-14 15:31:13.448487", "stderr": "", "delta": "0:00:00.018825", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sudo systemctl status bgp.service | grep 'Active'", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["     Active: deactivating (stop) since Wed 2022-09-14 15:31:12 UTC; 822ms ago"], "warnings": ["Consider using 'become', 'become_method', and 'become_user' rather than running sudo"], "failed": false}
```
Due to this `start-limit-hit` is not reset and bgp container cant get up, after waiting around `60-90 seconds`,
status of bgp service changes to - `Active: failed (Result: start-limit-hit) since Thu 2022-09-15 10:14:03 UTC; 2min ago`

As for `wait_until` cant be used due to bgp might be in running state or inactive at that time and that other features are checked also, this PR adds 100 sec sleep when syncd container is tested, so that bgp state stabilized and `start-limit-hit` could be spotted.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix test_containers_autorestart[syncd] test case from being failed.
#### How did you do it?

#### How did you verify/test it?
Run `autorestart/test_container_autorestart.py`  on t1 topo, syncd TC got passed, bgp container was up.

#### Any platform specific information?
```
SONiC Software Version: SONiC.master.138110-dirty-20220822.105016
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 2d4ab9e97
Build date: Mon Aug 22 15:29:52 UTC 2022
Built by: AzDevOps@sonic-build-workers-001ZAM
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
