### PR TITLE
[dualtor][active-active] Fix tor switch testcases

### DIFF
--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -181,6 +181,7 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,
                                     action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                             expected_standby_host=upper_tor_host,
+                            expected_standby_health="unhealthy",
                             cable_type=cable_type)
 
 @pytest.mark.enable_active_active
@@ -206,6 +207,7 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,
                                     action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                             expected_standby_host=upper_tor_host,
+                            expected_standby_health="unhealthy",
                             cable_type=cable_type)
 
 @pytest.mark.enable_active_active
@@ -231,4 +233,5 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
                                     action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                             expected_standby_host=upper_tor_host,
+                            expected_standby_health="unhealthy",
                             cable_type=cable_type)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix those three testcases:
1. test_tor_switch_upstream
2. test_tor_switch_downstream_active
3. test_tor_switch_downstream_standby

As those testcases have wrong expected standby health, which should be unhealthy.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Change the expected standby health to `unhealthy`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
