### PR TITLE
[dualtor][active-standby] Fix `test_link_drop`

### DIFF
--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -70,7 +70,7 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
 def check_simulator_flap_counter(
     simulator_flap_counter,
     toggle_all_simulator_ports_to_upper_tor,
-    tor_mux_intfs
+    active_standby_ports
 ):
     """Check the flap count for each server-facing interfaces."""
     def set_expected_counter_diff(diff):
@@ -78,7 +78,7 @@ def check_simulator_flap_counter(
         expected_diff.append(diff)
 
     expected_diff = []
-    tor_mux_intfs = [str(_) for _ in tor_mux_intfs]
+    tor_mux_intfs = [str(_) for _ in active_standby_ports]
     counters_before = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}
     yield set_expected_counter_diff
     counters_after = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Only check flap counters for active-standby ports.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
use fixture `active_standby_ports` to retrieve ports of `active-standby` cable type

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
