### PR TITLE
[dualtor] Fix `test_active_tor_reboot_downstream`

### DIFF
--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -179,7 +179,7 @@ def test_active_tor_reboot_downstream(
     toggle_upper_tor_pdu()
     pytest_assert(
         wait_until(60, 5, 5, check_forwarding_state, ForwardingState.STANDBY, ForwardingState.ACTIVE),
-        pytest.fail("Forwarding state check failed after reboot.")
+        "Forwarding state check failed after reboot."
     )
 
     # verify the upper ToR changes back to active after the upper comes back from reboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the typo.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
```
dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream[active-active] PASSED                                                                                                                                                                                [100%]

================================================================================================================== 1 passed, 1 deselected in 481.46 seconds ==================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
