### PR TITLE
[202012][m0] Fix announce routes mistakes and add support for m0 topo in some test cases #6362 #6365

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -198,6 +198,9 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
                     # Skip non podset 0 for T0
                     if podset != 0:
                         continue
+                    # Skip subnet 0 (vlan ip) for M0
+                    elif topo == "m0" and subnet == 0:
+                        continue
                     elif tor != tor_index:
                         continue
 

--- a/ansible/vars/topo_m0.yml
+++ b/ansible/vars/topo_m0.yml
@@ -78,7 +78,7 @@ topology:
         Vlan1000:
           id: 1000
           intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
-          prefix: 192.168.0.1/21
+          prefix: 192.168.0.1/24
           prefix_v6: fc02:1000::1/64
           tag: 1000
 
@@ -90,7 +90,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 64
     failure_rate: 0
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -142,7 +142,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     vlan_ports = []
     vlan_mac = None
 
-    if topo == "t0":
+    if topo in ["t0", "m0"]:
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
                       for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
 
@@ -160,13 +160,13 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     upstream_port_id_to_router_mac_map = {}
     downstream_port_id_to_router_mac_map = {}
 
-    # For T0/dual ToR testbeds, we need to use the VLAN MAC to interact with downstream ports
+    # For M0/T0/dual ToR testbeds, we need to use the VLAN MAC to interact with downstream ports
     # For T1 testbeds, no VLANs are present so using the router MAC is acceptable
     downlink_dst_mac = vlan_mac if vlan_mac is not None else rand_selected_dut.facts["router_mac"]
 
     for interface, neighbor in mg_facts["minigraph_neighbors"].items():
         port_id = mg_facts["minigraph_ptf_indices"][interface]
-        if (topo == "t1" and "T0" in neighbor["name"]) or (topo == "t0" and "Server" in neighbor["name"]) or (topo == "m0" and "MX" in neighbor["name"]):
+        if (topo == "t1" and "T0" in neighbor["name"]) or (topo in ["t0", "m0"] and "Server" in neighbor["name"]):
             downstream_ports[neighbor['namespace']].append(interface)
             downstream_port_ids.append(port_id)
             downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
@@ -256,13 +256,13 @@ def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
 def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, ip_version):
     """Set up the ARP responder utility in the PTF container."""
     duthost = duthosts[rand_one_dut_hostname]
-    if setup["topo"] != "t0":
+    if setup["topo"] not in ["t0", "m0"]:
         def noop():
             pass
 
         yield noop
 
-        return  # Don't fall through to t0 case
+        return  # Don't fall through to t0/m0 case
 
     addr_list = [DOWNSTREAM_DST_IP[ip_version], DOWNSTREAM_IP_TO_ALLOW[ip_version], DOWNSTREAM_IP_TO_BLOCK[ip_version]]
 

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -208,8 +208,8 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand
 
     skip_containers = disabled_containers[:]
 
-    # Skip 'radv' container on devices whose role is not T0.
-    if tbinfo["topo"]["type"] != "t0":
+    # Skip 'radv' container on devices whose role is not T0/M0.
+    if tbinfo["topo"]["type"] not in ["t0", "m0"]:
         skip_containers.append("radv")
 
     pytest_require(service_name not in skip_containers,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -280,7 +280,7 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True):
                testdir="ptftests",
                # Special Handling for DHCP if we are using T1 Topo
                testname="copp_tests.{}Test".format((protocol+"TopoT1")
-                         if protocol in _TOR_ONLY_PROTOCOL and dut_type != "ToRRouter" else protocol),
+                         if protocol in _TOR_ONLY_PROTOCOL and dut_type not in ["ToRRouter", "MgmtToRRouter"] else protocol),
                platform="nn",
                qlen=100000,
                params=params,

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -523,13 +523,13 @@ class TestShowQueue():
             for intf in setup['default_interfaces']:
                 assert re.search(r'{}'.format(intf), show_queue_wm_ucast) is not None
 
-# Tests to be run in t0 topology
+# Tests to be run in t0/m0 topology
 
 class TestShowVlan():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_check_topo(self, tbinfo):
-        if tbinfo['topo']['type'] != 't0':
+        if tbinfo['topo']['type'] not in ['t0', 'm0']:
             pytest.skip('Unsupported topology')
 
     @pytest.fixture()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Manually cherry-pick these PR: https://github.com/sonic-net/sonic-mgmt/pull/6362 https://github.com/sonic-net/sonic-mgmt/pull/6365

#### How did you do it?
* Fix announce routes mistakes:
    * When generating routes, skip the first network
    * Change the vlan prefix and tor_subnet_size for m0
    * Modify test_acl due to topo change
* Add support for m0 topo in some test cases:
    * test_container_checker
    * test_copp
    * test_iface_namingmode

#### How did you verify/test it?
Deploy topo and run test cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
