### PR TITLE
Changed approach to getting sonic fanout shell creds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -521,8 +521,8 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
                     shell_user = creds.get('fanout_shell_user', admin_user)
                     shell_password = creds.get('fanout_shell_pass', admin_password)
                     if os_type == 'sonic':
-                        shell_user = creds['fanout_sonic_user']
-                        shell_password = creds['fanout_sonic_password']
+                        shell_user = creds.get('fanout_sonic_user', None)
+                        shell_password = creds.get('fanout_sonic_password', None)
 
                     fanout = FanoutHost(ansible_adhoc,
                                         os_type,


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6378

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Run test_link_flap TC
#### How did you do it?
Changed approach to getting fanout_sonic_user and fanout_sonic_password from creds object.
#### How did you verify/test it?
Run TC. TC are passed
```
PASSED platform_tests/link_flap/test_link_flap.py::test_link_flap
```
#### Any platform specific information?
SONiC.master.150398-dirty-20220919.163414
Distribution: Debian 11.5
Kernel: 5.10.0-12-2-amd64
Build commit: c1d2e88de
Build date: Mon Sep 19 16:39:46 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
