### PR TITLE
Fix for test_nhop_group_member_count failure #6356

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -41,7 +41,6 @@ class IPRoutes:
         Add IP route with ECMP paths
         """
         # add IP route, nhop to list
-        self.ip_nhops = []
         self.ip_nhops.append(self.IP_NHOP(ip_route, nhop_path_ips))
 
     def program_routes(self):


### PR DESCRIPTION

### Description of PR
test_nhop_group_member_count creates max nhop_group and verifies 0 resource availability.

Below snippet is from test_nhop_group_member_count proc, nhop.add_ip_route adds the routes (max entries), and appends to nhop instance in the for loop. nhop.program_routes() adds the routes to the switch.

Summary:
Issue:
A recent change [#6084](https://github.com/sonic-net/sonic-mgmt/pull/6084) in nhop.add_ip_route broke the test, every time a route/set-of-routes added the self.ip_nhops = [] is set to empty list, this clears all the old entries and only the last entries were added. When the nhop.program_routes() is called, only the last few entries were added. Because of this the maximum nhop group were never programmed to validate.

https://github.com/sonic-net/sonic-mgmt/pull/6084/files#diff-c81ec8d56736d28f2d61099fc2bbc3830f15af4dae4a58ec30ce7caaaaabf17a

try:
for i, indx_list in zip(range(nhop_group_count), ip_indices):
# get a list of unique group of next hop IPs
ips = [arplist.ip_mac_list[x].ip for x in indx_list]

        ip_route = "{}/31".format(ip_prefix + (2*i))
 
        # add IP route with the next hop group created
        nhop.add_ip_route(ip_route, ips)
 
    nhop.program_routes()

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request / NO
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sonic-mgmt test failure

#### How did you do it?

#### How did you verify/test it?
Ran sonic-mgmt ipfwd/test_nhop_group.py test_nhop_group_member_count with the fix

#### Any platform specific information?
Tested with T2, common across platforms


