### PR TITLE
[dhcpv6_relay_test] Add dhcp6relay dual tor test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -117,6 +117,7 @@ class DHCPTest(DataplaneBaseTest):
         self.vlan_ip = self.test_params['vlan_ip']
         
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
+        self.uplink_mac = self.test_params['uplink_mac']
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
         # Shutdown and startup the client interface to generate a proper IPv6 link-local address
@@ -156,7 +157,7 @@ class DHCPTest(DataplaneBaseTest):
         return solicit_packet
 
     def create_dhcp_solicit_relay_forward_packet(self):
-        solicit_relay_forward_packet = Ether(src=self.relay_iface_mac)
+        solicit_relay_forward_packet = Ether(src=self.uplink_mac)
         solicit_relay_forward_packet /= IPv6()
         solicit_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -173,8 +174,9 @@ class DHCPTest(DataplaneBaseTest):
 
         return advertise_packet
 
+
     def create_dhcp_advertise_relay_reply_packet(self):
-        advertise_relay_reply_packet = Ether(dst=self.relay_iface_mac)
+        advertise_relay_reply_packet = Ether(dst=self.uplink_mac)
         advertise_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         advertise_relay_reply_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         advertise_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -190,7 +192,7 @@ class DHCPTest(DataplaneBaseTest):
         return request_packet
 
     def create_dhcp_request_relay_forward_packet(self):
-        request_relay_forward_packet = Ether(src=self.relay_iface_mac)
+        request_relay_forward_packet = Ether(src=self.uplink_mac)
         request_relay_forward_packet /= IPv6()
         request_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         request_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -208,7 +210,7 @@ class DHCPTest(DataplaneBaseTest):
         return reply_packet
 
     def create_dhcp_reply_relay_reply_packet(self):
-        reply_relay_reply_packet = Ether(dst=self.relay_iface_mac)
+        reply_relay_reply_packet = Ether(dst=self.uplink_mac)
         reply_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         reply_relay_reply_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         reply_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -226,7 +228,7 @@ class DHCPTest(DataplaneBaseTest):
         return relay_forward_packet
 
     def create_dhcp_relayed_relay_packet(self):
-        relayed_relay_packet = Ether(src=self.relay_iface_mac)
+        relayed_relay_packet = Ether(src=self.uplink_mac)
         relayed_relay_packet /= IPv6()
         relayed_relay_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet_inside = DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -237,7 +239,7 @@ class DHCPTest(DataplaneBaseTest):
         return relayed_relay_packet
 
     def create_dhcp_relay_relay_reply_packet(self):
-        relay_relay_reply_packet = Ether(dst=self.relay_iface_mac)
+        relay_relay_reply_packet = Ether(dst=self.uplink_mac)
         relay_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         relay_relay_reply_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         relay_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, hopcount = 1, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
@@ -275,7 +277,6 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(solicit_relay_forward_packet)
-        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")
@@ -310,6 +311,7 @@ class DHCPTest(DataplaneBaseTest):
         # Mask off fields we don't care about matching
         masked_packet = Mask(advertise_packet)
         masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        masked_packet.set_do_not_care_scapy(IPv6, "src") # dual tor uses relay_iface_ip as ip src
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 
@@ -330,7 +332,6 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(request_relay_forward_packet)
-        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")
@@ -353,7 +354,7 @@ class DHCPTest(DataplaneBaseTest):
         # Form and send DHCPv6 RELAY-REPLY encapsulating REPLY packet
         reply_relay_reply_packet = self.create_dhcp_reply_relay_reply_packet()
         reply_relay_reply_packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
-        testutils.send_packet(self, self.server_port_indices[0], reply_relay_reply_packet)
+        testutils.send_packet(self, self.server_port_indices[0], reply_relay_reply_packet, count=3)
 
     # Verify that the DHCPv6 REPLY would be received by our simulated client
     def verify_relayed_reply(self):
@@ -363,6 +364,7 @@ class DHCPTest(DataplaneBaseTest):
         # Mask off fields we don't care about matching
         masked_packet = Mask(reply_packet)
         masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        masked_packet.set_do_not_care_scapy(IPv6, "src") # dual tor uses relay_iface_ip as ip src
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 
@@ -382,7 +384,6 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(relayed_relay_forward_count)
-        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")
@@ -412,6 +413,7 @@ class DHCPTest(DataplaneBaseTest):
         # Mask off fields we don't care about matching
         masked_packet = Mask(relay_reply_packet)
         masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        masked_packet.set_do_not_care_scapy(IPv6, "src") # dual tor uses relay_iface_ip as ip src
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -115,7 +115,7 @@ class DHCPTest(DataplaneBaseTest):
         self.relay_linkaddr = '::'
 
         self.vlan_ip = self.test_params['vlan_ip']
-        
+
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
         self.uplink_mac = self.test_params['uplink_mac']
 
@@ -354,7 +354,7 @@ class DHCPTest(DataplaneBaseTest):
         # Form and send DHCPv6 RELAY-REPLY encapsulating REPLY packet
         reply_relay_reply_packet = self.create_dhcp_reply_relay_reply_packet()
         reply_relay_reply_packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
-        testutils.send_packet(self, self.server_port_indices[0], reply_relay_reply_packet, count=3)
+        testutils.send_packet(self, self.server_port_indices[0], reply_relay_reply_packet)
 
     # Verify that the DHCPv6 REPLY would be received by our simulated client
     def verify_relayed_reply(self):

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -275,6 +275,7 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(solicit_relay_forward_packet)
+        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")
@@ -329,6 +330,7 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(request_relay_forward_packet)
+        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")
@@ -380,6 +382,7 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(relayed_relay_forward_count)
+        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -204,8 +204,6 @@ def test_dhcp_relay_default(tbinfo, ptfhost, duthosts, rand_one_dut_hostname, du
     if testing_mode == DUAL_TOR_MODE:
         skip_release(duthost, ["201811", "201911"])
 
-    vlan_mac = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac']
-    logging.info(vlan_mac)
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,
@@ -225,12 +223,12 @@ def test_dhcp_relay_default(tbinfo, ptfhost, duthosts, rand_one_dut_hostname, du
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
-def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist):
+def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology after uplinks flap
        For each DHCP relay agent running on the DuT, with relay agent running, flap the uplinks,
        then test whether the DHCP relay agent relays packets properly.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    testing_mode, duthost, testbed_mode = testing_config
     skip_release(duthost, ["201811", "201911", "202106"])
 
     if testbed_mode == 'dual_testbed':
@@ -264,17 +262,18 @@ def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, du
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
+                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
-def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist):
+def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology when relay agent starts with uplinks down
        For each DHCP relay agent running on the DuT, bring the uplinks down, then restart the
        relay agent while the uplinks are still down. Then test whether the DHCP relay agent
        relays packets properly.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    testing_mode, duthost, testbed_mode = testing_config
     skip_release(duthost, ["201811", "201911", "202106"])
 
     if testbed_mode == 'dual_testbed':
@@ -318,5 +317,6 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_host
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
+                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -233,6 +233,9 @@ def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, du
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911", "202106"])
 
+    if testbed_mode == 'dual_testbed':
+        pytest.skip("skip the link flap testcase on dual tor testbeds")
+
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down
         for iface in dhcp_relay['uplink_interfaces']:
@@ -273,6 +276,9 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_host
     """
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911", "202106"])
+
+    if testbed_mode == 'dual_testbed':
+        pytest.skip("skip the uplinks down testcase on dual tor testbeds")
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Add dhcp6relay dual tor test

#### How did you do it?
Separated test into single/dual depending on testbed mode.
Modified upstream packets dst mac to be uplink mac, as dual tor testbed has different mac address for vlan interface and uplink interface.

#### How did you verify/test it?
Ran dhcp6relay test on dual tor testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
