### PR TITLE
[test_bfd_multihop] add missing import of fixture

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -3,6 +3,8 @@ import random
 import time
 import json
 
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
+
 pytestmark = [
     pytest.mark.topology('t1')
 ]


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR #6032 mistake was introduced.
No import for the fixture.
As a result, the bfd_multihop test failed with error:
_@pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
  def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):
**E       fixture 'toggle_all_simulator_ports_to_rand_selected_tor_m' not found**_

Added missed import of fixture.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?
Stabilize the test

#### How did you do it?
Added missed import of fixture.

#### How did you verify/test it?
Test executed and passed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
