### PR TITLE
static route scirpt issue fix and improve

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -22,7 +22,7 @@ bfd/test_bfd.py:
   skip:
     reason: "Test not supported for 201911 images or older, other than mlnx4600c and cosco-8102. Skipping the test"
     conditions:
-      - "(kernel_version <= '4.9.0') or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
+      - "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
 
 #######################################
 #####            bgp              #####
@@ -612,7 +612,7 @@ route/test_static_route.py:
   skip:
     reason: "Test not supported for 201911 images or older."
     conditions:
-      - "kernel_version <= '4.9.0'"
+      - "release in ['201811', '201911']"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:
   # This test case may fail due to a known issue https://github.com/sonic-net/sonic-buildimage/issues/4930.


### PR DESCRIPTION
### Description of PR

- fix test_static_route.py script failed to run on OS kernel version 4.1*.0 (a wrong version check, as string "4.10.0" will < "4.9")

- investigate/fix static route script failure issue found in nightly run test.
 
- background information 
  t0/m0 announce_routes.py wrongly announced vlan1000 subnets to DUT.
  So when we try to config static route "1.1.1.0/24 nexthop 192.168.0.2", this directly connected nexthop will be marked as a 
  recursive nexthop , thus traffic match this static route will be redirect to another interface which BGP routes come from.
  And finally cause script check failure with error message like:
  AssertionError: Received expected packet on port 68 for device 0, but it should have arrived on one of these ports: [52, 34, 6]
  
  - static route config cli
  sonic-db-cli CONFIG_DB hmset 'STATIC_ROUTE|1.1.1.0/24' nexthop 192.168.0.24

  - show ip route static
  S>  1.1.1.0/24 [1/0] via 192.168.0.24 (recursive), weight 1, 00:28:33  *                    via 10.0.0.65, Ethernet46, weight 1, 00:28:33

  - wrong announced bgp route
  192.168.0.0/25 via 10.0.0.65 dev Ethernet46 proto bgp src 10.1.0.32 metric 20

Summary:
- wrong announce route fixed by https://github.com/sonic-net/sonic-mgmt/pull/6374
- improve script to give a clear information when route conflicts

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

fixes #15499053