### PR TITLE
Added solution to configure minigraph from platform and hwsku files

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -4,9 +4,12 @@ import re
 import os
 import traceback
 import subprocess
+import json
+import ast
 from operator import itemgetter
 from itertools import groupby
 from collections import defaultdict
+from collections import OrderedDict
 
 try:
     from sonic_py_common import multi_asic
@@ -51,6 +54,8 @@ PORTMAP_FILE = 'port_config.ini'
 ALLOWED_HEADER = ['name', 'lanes', 'alias', 'index', 'asic_port_name', 'role', 'speed',
                   'coreid', 'coreportid', 'numvoq']
 
+PLATFORM_FILE = 'platform.json'
+HWSKU_FILE = 'hwsku.json'
 MACHINE_CONF = '/host/machine.conf'
 ONIE_PLATFORM_KEY = 'onie_platform'
 ABOOT_PLATFORM_KEY = 'aboot_platform'
@@ -92,6 +97,90 @@ class SonicPortAliasMap():
             return portconfig
         return None
 
+    def get_platform_path(self):
+        platform = self.get_platform_type()
+        if platform is None:
+            return None
+        platform_path = os.path.join(FILE_PATH, platform, PLATFORM_FILE)
+        if os.path.exists(platform_path):
+            return platform_path
+        return None
+
+    def get_hwsku_path(self):
+        platform = self.get_platform_type()
+        if platform is None:
+            return None
+        hwsku_path = os.path.join(FILE_PATH, platform, self.hwsku, HWSKU_FILE)
+        if os.path.exists(hwsku_path):
+            return hwsku_path
+        return None
+
+    def get_portmap_from_platform_hwsku(self, platform_file, hwsku_file, aliases, portmap, aliasmap, portspeed):
+        decoder = json.JSONDecoder(object_pairs_hook=OrderedDict)
+        brkout_pattern = r'(\d{1,3})x(\d{1,3}G)(\[\d{1,3}G\])?(\((\d{1,3})\))?'
+        with open(platform_file) as f:
+            data = json.load(f, object_pairs_hook=OrderedDict)
+            platform_dict = decoder.decode(json.dumps(data))
+        with open(hwsku_file) as f:
+            data = json.load(f)
+            hwsku_dict = ast.literal_eval(json.dumps(data))
+        for interface in platform_dict["interfaces"]:
+            if interface not in hwsku_dict["interfaces"]:
+                raise Exception("interface {} not in hwsku dict".format(interface))
+            lanes = platform_dict["interfaces"][interface]['lanes']
+            breakout_mode = hwsku_dict["interfaces"][interface]["default_brkout_mode"]
+            alias_list = platform_dict["interfaces"][interface]['breakout_modes'][breakout_mode]
+
+            # Asymmetric breakout mode
+            if re.search("\+", breakout_mode) is not None:
+                breakout_parts = breakout_mode.split("+")
+                match_list = [re.match(brkout_pattern, i).groups() for i in breakout_parts]
+            # Symmetric breakout mode
+            else:
+                match_list = [re.match(brkout_pattern, breakout_mode).groups()]
+
+            offset = 0
+            parent_intf_id = int(re.search("Ethernet(\d+)", interface).group(1))
+            for k in match_list:
+                if k is not None:
+                    num_lane_used, speed, assigned_lane = k[0], k[1], k[4]
+
+                    # In case of symmetric mode
+                    if assigned_lane is None:
+                        assigned_lane = len(lanes.split(","))
+
+                    parent_intf_id = int(offset)+int(parent_intf_id)
+                    alias_position = 0 + int(offset)//int(num_lane_used)
+
+                    step = int(assigned_lane)//int(num_lane_used)
+                    for i in range(0,int(assigned_lane), step):
+
+                        intf_name = "Ethernet" + str(parent_intf_id)
+                        alias = alias_list[alias_position]
+
+                        alias_indexes = platform_dict["interfaces"][interface]['index'].split(",")
+                        aliases.append((str(alias), alias_indexes[0]))
+
+                        portmap[intf_name] = str(alias)
+                        aliasmap[str(alias)] = intf_name
+                        if speed:
+                            speed_pat = re.search("^((\d+)G|\d+)$", speed.upper())
+                            if speed_pat is None:
+                                raise Exception('{} speed is not Supported...'.format(speed))
+                            speed_G, speed_orig = speed_pat.group(2), speed_pat.group(1)
+                            if speed_G:
+                                portspeed[alias] = str(int(speed_G)*1000)
+                            else:
+                                portspeed[alias] = speed_orig
+                        else:
+                            raise Exception('Regex return for speed is None...')
+
+                        parent_intf_id += step
+                        alias_position += 1
+
+                    parent_intf_id = 0
+                    offset = int(assigned_lane) + int(offset)
+
     def get_portmap(self, asic_id=None, include_internal=False,
                     hostname=None, switchid=None, slotid=None):
         aliases = []
@@ -108,7 +197,14 @@ class SonicPortAliasMap():
         num_voq_index = -1
         # default to Asic0 as minigraph.py parsing code has that assumption.
         asic_name = "Asic0" if asic_id is None else "asic" + str(asic_id)
-
+        # if platform.json and hwsku.json exist, than get portmap from hwsku
+        platform_file = self.get_platform_path()
+        hwsku_file = self.get_hwsku_path()
+        if platform_file and hwsku_file:
+            self.get_portmap_from_platform_hwsku(platform_file, hwsku_file, aliases, portmap, aliasmap, portspeed)
+            return (aliases, portmap, aliasmap, portspeed, front_panel_asic_ifnames, asic_if_names,
+                sysports)
+        # platform.json or hwsku.json does not exist so get portmap from port_config.ini
         filename = self.get_portconfig_path(slotid, asic_id)
         if filename is None:
             raise Exception("Something wrong when trying to find the portmap file, either the hwsku is not available or file location is not correct")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
New approach for reading necessary configuration parameters (lanes, alias, index, speed) and adding to config_db.json and minigraph.xml on SONiC from platform.json and hwsku.json .
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
port_config.ini file was deprecated, so we should add a new approach for the setup of port configuration with necessary configuration parameters from platform.json and hwsku.json files.
#### How did you do it?
Add opportunity to generate port configuration from platform.json and hwsku.json files if they exist.
#### How did you verify/test it?
Checked manually if port configuration is correct, run TC.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
