### PR TITLE
Modify skip condition due to replacement of asic about Nokia-7215

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -564,7 +564,7 @@ platform_tests/broadcom:
   skip:
     reason: "Marvell devices does not support platform_tests/broadcom"
     conditions:
-      - "asic_type in ['marvell']"
+      - "'marvell' in asic_type"
 
 #######################################
 #####  cli/test_show_platform.py  #####
@@ -611,7 +611,7 @@ platform_tests/mellanox:
   skip:
     reason: "Marvell devices does not support platform_tests/mellanox"
     conditions:
-      - "asic_type in ['marvell']"
+      - "'marvell' in asic_type"
 
 #######################################
 #####    test_platform_info.py    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Asic of Nokia-7215 was replaced by https://github.com/sonic-net/sonic-buildimage/pull/12148, which will cause skip failure about Nokia-7215

#### How did you do it?
Modify skip conditions.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
