### PR TITLE
Skip test_chassis_fans.py::TestChassisFans::test_set_fans_led 

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -98,9 +98,9 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_serial:
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
   skip:
-    reason: "Unsupported platform API"
+    reason: "On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API. Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
   #test_set_fans_speed requires get_speed_tolerance to be implemented

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -92,16 +92,22 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_serial:
   #Fan tray serial numbers cannot be retrieved through software in cisco platform
   #there is no fan tray idprom
   skip:
-    reason: "Retrieving fan tray serial number is not supported in Cisco 8000 and mellanox platform"
+    reason: "Unsupported platform API"
     conditions:
-       - "asic_type in ['mellanox', 'cisco-8000']"
+      - "asic_type in ['mellanox']"
+    reason: "Retrieving fan tray serial number is not supported in Cisco 8000"
+    conditions:
+       - "asic_type in ['cisco-8000']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
   skip:
-    reason: "On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API. Unsupported platform API"
+    reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000']"
-
+      - "asic_type in ['mellanox']"
+    reason: "On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+      
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
   #test_set_fans_speed requires get_speed_tolerance to be implemented
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -97,7 +97,7 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_serial:
       - "asic_type in ['mellanox']"
     reason: "Retrieving fan tray serial number is not supported in Cisco 8000"
     conditions:
-       - "asic_type in ['cisco-8000']"
+      - "asic_type in ['cisco-8000']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
   skip:


### PR DESCRIPTION
### Description of PR
On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API. Hence skipping this test for Cisco-8000 platforms

Summary:
Fixes # (issue)

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API.

#### How did you do it?

#### How did you verify/test it?
Verified on Cisco-8000 platforms for T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
