### PR TITLE
update PFC xoff threshold for th2/topo-any/50000_300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -1572,14 +1572,14 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 4457
-                    pkts_num_trig_ingr_drp: 5140
+                    pkts_num_trig_pfc: 20034
+                    pkts_num_trig_ingr_drp: 20521
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 4457
-                    pkts_num_trig_ingr_drp: 5140
+                    pkts_num_trig_pfc: 20034
+                    pkts_num_trig_ingr_drp: 20521
                 hdrm_pool_size:
                     dscps: [3, 4]
                     ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update PFC xoff threshold for qos parameter "th2/topo-any/50000_300m"

Summary:
Update PFC xoff threshold for qos parameter "th2/topo-any/50000_300m"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Below QoS testcaes failed for qos parameter "th2/topo-any/50000_300m/xoff".
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_1]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_2]

#### How did you do it?
adjust threshold, to find correct value

#### How did you verify/test it?
manually run testcase on local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
