### PR TITLE
[dualtor-mixed] Set grpc config as insecure for testing

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -525,6 +525,42 @@
         shell: bash "/etc/sonic/apply_clet.sh"
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
+      - block:
+        - name: set the default grpc credential file path
+          set_fact:
+            grpc_credential_file: /tmp/grpc_secrets.json
+
+        - name: check if grpc credential file exists
+          stat:
+            path: "{{ grpc_credential_file }}"
+          register: stat_result
+
+        - block:
+          - name: collect initial grpc credentials
+            include_vars:
+              file: "{{ grpc_credential_file }}"
+              name: grpc_secrets
+
+          - name: use insecure grpc for testing
+            set_fact:
+              grpc_secrets: "{{ grpc_secrets | combine(new_item, recursive=true) }}"
+            vars:
+              new_item: "{ '{{ item.key }}': { 'config': 'insecure' } }"
+            with_dict: "{{ grpc_secrets }}"
+
+          - name: show new grpc setting
+            debug:
+              var: grpc_secrets
+
+          - name: save new grpc setting
+            copy:
+              content: "{{ grpc_secrets | to_nice_json }}"
+              dest: "{{ grpc_credential_file }}"
+
+          when: stat_result.stat.exists
+
+        when: "'dualtor-mixed' in topo"
+
       - name: execute cli "config save -y" to save current minigraph as startup-config
         become: true
         shell: config save -y

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -528,7 +528,7 @@
       - block:
         - name: set the default grpc credential file path
           set_fact:
-            grpc_credential_file: /tmp/grpc_secrets.json
+            grpc_credential_file: /etc/sonic/grpc_secrets.json
 
         - name: check if grpc credential file exists
           stat:
@@ -537,9 +537,13 @@
 
         - block:
           - name: collect initial grpc credentials
-            include_vars:
-              file: "{{ grpc_credential_file }}"
-              name: grpc_secrets
+            slurp:
+              path: "{{ grpc_credential_file }}"
+            register: grpc_credential_content
+
+          - name: parse initial grpc credentials
+            set_fact:
+              grpc_secrets: "{{ grpc_credential_content.content | b64decode | from_json }}"
 
           - name: use insecure grpc for testing
             set_fact:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -556,6 +556,13 @@
             copy:
               content: "{{ grpc_secrets | to_nice_json }}"
               dest: "{{ grpc_credential_file }}"
+            become: true
+
+          - name: restart the pmon service
+            service:
+              name: pmon
+              state: restarted
+            become: true
 
           when: stat_result.stat.exists
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Use `insecure` config for grpc connections from `ycabled` in tests.

#### How did you do it?
Modify `/etc/sonic/grpc_secrets.json`

#### How did you verify/test it?
This depends on https://github.com/sonic-net/sonic-platform-daemons/pull/298

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
