### PR TITLE
[sanity check] Fix and improve recovery

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -98,7 +98,7 @@ def __neighbor_vm_recover_bgpd(node=None, results=None):
     results[nbr_host.hostname] = result
 
 
-def __recover_neighbor_bgp(duthost, nbrhosts, tbinfo):
+def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
     logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
@@ -122,7 +122,7 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
             elif result['check_item'] == 'services':
                 action = __recover_services(dut, result)
             elif result['check_item'] == 'bgp':
-                action = __recover_neighbor_bgp(dut, nbrhosts, tbinfo)
+                action = neighbor_vm_restore(dut, nbrhosts, tbinfo)
             elif result['check_item'] in [ 'processes', 'mux_simulator' ]:
                 action = 'config_reload'
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1655,7 +1655,7 @@ def collect_db_dump(request, duthosts):
     if request.config.getoption("--collect_db_data"):
         collect_db_dump_on_duts(request, duthosts)
 
-def dut_reload(duts_data, node=None, results=None):
+def __dut_reload(duts_data, node=None, results=None):
     if node is None or results is None:
         logger.error('Missing kwarg "node" or "results"')
         return
@@ -1665,10 +1665,10 @@ def dut_reload(duts_data, node=None, results=None):
     config_reload(node)
 
 @pytest.fixture(scope="module", autouse=True)
-def check_dut_health_status(duthosts, request):
+def core_dump_and_config_check(duthosts, request):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.
-    If so, we will reload the running config before test case running.
+    If so, we will reload the running config after test case running.
     '''
     check_flag = True
     if hasattr(request.config.option, 'enable_macsec') and request.config.option.enable_macsec:
@@ -1691,6 +1691,7 @@ def check_dut_health_status(duthosts, request):
 
     if check_flag:
         for duthost in duthosts:
+            logger.info("Collecting core dumps before test on {}".format(duthost.hostname))
             duts_data[duthost.hostname] = {}
 
             if "20191130" in duthost.os_version:
@@ -1699,8 +1700,9 @@ def check_dut_health_status(duthosts, request):
                 pre_existing_core_dumps = duthost.shell('ls /var/core/')['stdout'].split()
             duts_data[duthost.hostname]["pre_core_dumps"] = pre_existing_core_dumps
 
-            # get running config before running
-            duts_data[duthost.hostname]["pre_running_config"] = json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
+            logger.info("Collecting running config before test on {}".format(duthost.hostname))
+            duts_data[duthost.hostname]["pre_running_config"] = \
+                json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
 
     yield
 
@@ -1711,6 +1713,7 @@ def check_dut_health_status(duthosts, request):
             cur_only_config[duthost.hostname] = {}
             new_core_dumps[duthost.hostname] = []
 
+            logger.info("Collecting core dumps after test on {}".format(duthost.hostname))
             if "20191130" in duthost.os_version:
                 cur_cores = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
             else:
@@ -1723,8 +1726,9 @@ def check_dut_health_status(duthosts, request):
             if new_core_dumps[duthost.hostname]:
                 core_dump_check_pass = False
 
-            # get running config after running
-            duts_data[duthost.hostname]["cur_running_config"] = json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
+            logger.info("Collecting running config after test on {}".format(duthost.hostname))
+            duts_data[duthost.hostname]["cur_running_config"] = \
+                json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
 
             pre_running_config_keys = set(duts_data[duthost.hostname]["pre_running_config"].keys())
             cur_running_config_keys = set(duts_data[duthost.hostname]["cur_running_config"].keys())
@@ -1740,24 +1744,46 @@ def check_dut_health_status(duthosts, request):
                 cur_only_config[duthost.hostname].update({key: duts_data[duthost.hostname]["cur_running_config"][key]})
 
             # Get common keys in pre running config and cur running config
-            common_config_keys = list(pre_running_config_keys & cur_running_config_keys)
+            EXCLUDE_CONFIG_KEYS = set(["FLEX_COUNTER_TABLE"])
+            common_config_keys = list(pre_running_config_keys & cur_running_config_keys - EXCLUDE_CONFIG_KEYS)
 
             # Check if the running config is modified after module running
             for key in common_config_keys:
-                if duts_data[duthost.hostname]["pre_running_config"][key] != duts_data[duthost.hostname]["cur_running_config"][key]:
-                    inconsistent_config[duthost.hostname].update({key: {"pre_value": duts_data[duthost.hostname]["pre_running_config"][key], "cur_value": duts_data[duthost.hostname]["cur_running_config"][key]}})
+                if duts_data[duthost.hostname]["pre_running_config"][key] != \
+                    duts_data[duthost.hostname]["cur_running_config"][key]:
+                    inconsistent_config[duthost.hostname].update(
+                        {
+                            key: {
+                                "pre_value": duts_data[duthost.hostname]["pre_running_config"][key],
+                                "cur_value": duts_data[duthost.hostname]["cur_running_config"][key]
+                                }
+                        }
+                    )
 
-            if pre_only_config[duthost.hostname] or cur_only_config[duthost.hostname] or inconsistent_config[duthost.hostname]:
+            if pre_only_config[duthost.hostname] or \
+                cur_only_config[duthost.hostname] or \
+                inconsistent_config[duthost.hostname]:
                 config_db_check_pass = False
 
         if not (core_dump_check_pass and config_db_check_pass):
-            check_result = {"core_dump_check": {"pass": core_dump_check_pass, "new_core_dumps": new_core_dumps},
-                            "config_db_check": {"pass": config_db_check_pass, "pre_only_config": pre_only_config, "cur_only_config": cur_only_config, "inconsistent_config": inconsistent_config}}
-            logger.warning("Check Dut health failed: Dut health check results {}, running module {}".format(json.dumps(check_result), module_name))
-            results = parallel_run(dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=300)
+            check_result = {
+                "core_dump_check": {
+                    "pass": core_dump_check_pass,
+                    "new_core_dumps": new_core_dumps
+                },
+                "config_db_check": {
+                    "pass": config_db_check_pass,
+                    "pre_only_config": pre_only_config,
+                    "cur_only_config": cur_only_config,
+                    "inconsistent_config": inconsistent_config
+                }
+            }
+            logger.warning("Core dump or config check failed for {}, results: {}"\
+                .format(module_name, json.dumps(check_result)))
+            results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=300)
             logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
         else:
-            logger.info("Dut is healthy after the module {} running.".format(module_name))
+            logger.info("Core dump and config check passed for {}".format(module_name))
 
 def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The sanity check could fail during recovery on single-asic platform when there are interfaces down. 

#### How did you do it?
This change fixed that issue by firstly checking if the DUT is multi-asic or not. This change also made some other improvements:
* If there are bgp session down, try to "no shutdown" bgp session on neighbors and then do a config reload.
* If there are interface down, previously the code will only run "no shutdown" of the corresponding port on fanout switch. This change added an extra "shutdown" step before "no shutdown".
* Exclude "FLEX_COUNTER_TABLE" from post test config comparison.
* Improve logs and function names for the fixture checking core dumps and comparing config after testing.

#### How did you verify/test it?
Tested in KVM and physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
