### PR TITLE
Added barefoot asic type to conditional mark of ip_packet TC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -432,12 +432,6 @@ ip/test_ip_packet.py:
     conditions:
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
 
-ip/test_ip_packet.py::TestIPPacket::test_drop_ip_packet_with_wrong_0xffff_chksum:
-  skip:
-    reason: "Barefoot Asic forwards ip packets with 0xffff checksum"
-    conditions:
-      - "asic_type in ['barefoot']"
-
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
   skip:
     reason: "Broadcom, Cisco, Barefoot and Marvell Asic will tolorate IP packets with 0xffff checksum"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -432,11 +432,17 @@ ip/test_ip_packet.py:
     conditions:
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
 
+ip/test_ip_packet.py::TestIPPacket::test_drop_ip_packet_with_wrong_0xffff_chksum:
+  skip:
+    reason: "Barefoot Asic forwards ip packets with 0xffff checksum"
+    conditions:
+      - "asic_type in ['barefoot']"
+
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
   skip:
-    reason: "Broadcom, Cisco and Marvell Asic will tolorate IP packets with 0xffff checksum"
+    reason: "Broadcom, Cisco, Barefoot and Marvell Asic will tolorate IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000', 'marvell'] and hwsku not in ['Arista-7280CR3-C40']"
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot'] and hwsku not in ['Arista-7280CR3-C40']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added barefoot asic type to conditional marks of ip_packet TC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Barefoot ASIC supports forwarding IP packets with 0xffff checksum. So was added barefoot ASIC type to conditional mark of ip_packet TC.  TCs that check dropping those packets will be skipped.
#### How did you do it?
Added barefoot asic type to tests_mark_conditions.yaml file for ip_packet TC
#### How did you verify/test it?
```
PASSED ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0x0000_chksum
PASSED ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant
PASSED ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_recomputed_0xffff_chksum
PASSED ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_recomputed_0x0000_chksum
PASSED ip/test_ip_packet.py::TestIPPacket::test_forward_normal_ip_packet
SKIPPED [1] ip/test_ip_packet.py: Broadcom, Cisco, Barefoot and Marvell Asic will tolorate IP packets with 0xffff checksum
SKIPPED [1] ip/test_ip_packet.py: Barefoot Asic forwards ip packets with 0xffff checksum
```
#### Any platform specific information?
SONiC Software Version: SONiC.master.140328-dirty-20220827.104720
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 8ccae96bf
Build date: Sat Aug 27 15:29:20 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
