### PR TITLE
add simple wan topo support

### DIFF
--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -209,6 +209,7 @@ class ParseTestbedTopoinfo():
         else:
             asic_topo_filename = 'vars/topo_' + hwsku + '.yml'
         vm_topo_config = dict()
+        vm_topo_config['topo_type'] = None
         asic_topo_config = dict()
         po_map = [None] * 16   # maximum 16 port channel interfaces
 
@@ -230,6 +231,9 @@ class ParseTestbedTopoinfo():
         if 'dut_num' in topo_definition['topology']:
             dut_num = topo_definition['topology']['dut_num']
         vm_topo_config['dut_num'] = dut_num
+        
+        if topo_definition['topology'].has_key('topo_type'):
+            vm_topo_config['topo_type'] = topo_definition['topology']['topo_type']
 
         if 'VMs' in topo_definition['topology']:
             dut_asn = topo_definition['configuration_properties']['common']['dut_asn']

--- a/ansible/roles/eos/templates/wan-pub-leaf.j2
+++ b/ansible/roles/eos/templates/wan-pub-leaf.j2
@@ -1,0 +1,116 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -4,7 +4,7 @@
     <PeeringSessions>
 {% for index in range(vms_number) %}
 {% set vm=vms[index] %}
-{% if vm_topo_config['vm'][vm]['peer_ipv4'][dut_index|int] %}
+{% if (vm_topo_config['vm'][vm]['peer_ipv4'][dut_index|int] and vm_topo_config['topo_type'] != 'wan') %}
       <BGPSession>
         <MacSec>false</MacSec>
         <StartRouter>{{ inventory_hostname }}</StartRouter>
@@ -28,7 +28,7 @@
       </BGPSession>
 {% endif %}
 {% endif %}
-{% if vm_topo_config['vm'][vm]['peer_ipv6'][dut_index|int] %}
+{% if (vm_topo_config['vm'][vm]['peer_ipv6'][dut_index|int] and vm_topo_config['topo_type'] != 'wan') %}
       <BGPSession>
         <StartRouter>{{ inventory_hostname }}</StartRouter>
         <StartPeer>{{ vm_topo_config['vm'][vm]['bgp_ipv6'][dut_index|int] }}</StartPeer>
@@ -142,7 +142,7 @@
 {% endif %}
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if card_type is not defined or card_type != 'supervisor' %}
+{% if ((card_type is not defined or card_type != 'supervisor') and vm_topo_config['topo_type'] != 'wan') %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
         <a:Hostname>{{ inventory_hostname }}</a:Hostname>
@@ -191,7 +191,7 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
 {% for index in range( vms_number) %}
-{% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length > 0 %}
+{% if (vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length > 0 and vm_topo_config['topo_type'] != 'wan') %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['vm'][vms[index]]['bgp_asn'] }}</a:ASN>
         <a:Hostname>{{ vms[index] }}</a:Hostname>

--- a/ansible/vars/topo_wan-pub.yml
+++ b/ansible/vars/topo_wan-pub.yml
@@ -1,0 +1,67 @@
+topology:
+  topo_type: wan
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 28
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 29
+      vm_offset: 1
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+      ipv6:
+        - FC00:1::32/128
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: InternetBackboneRouter
+    swrole: leaf
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        dut_index: 0      
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        dut_index: 0
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64

--- a/ansible/vars/topo_wan-pub.yml
+++ b/ansible/vars/topo_wan-pub.yml
@@ -3,11 +3,11 @@ topology:
   VMs:
     ARISTA01T1:
       vlans:
-        - 28
+        - 0
       vm_offset: 0
     ARISTA02T1:
       vlans:
-        - 29
+        - 1
       vm_offset: 1
   DUT:
     loopback:

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -32,6 +32,7 @@ all:
           - dualtor-mixed
           - dualtor-mixed-56
           - dualtor-mixed-120
+          - wan-pub
       children:
         server_1:
     lab:

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -214,3 +214,20 @@
   inv_name: veos_vtb
   auto_recover: 'False'
   comment: Tests 8000e sonic device
+
+- conf-name: vms-kvm-wan-pub
+  group-name: vms6-1
+  topo: wan-pub
+  ptf_image_name: docker-ptf
+  ptf: ptf-01
+  ptf_ip: 10.250.0.102/24
+  ptf_ipv6: fec0::ffff:afa:2/64
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - vlab-01
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests virtual switch vm
+
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
This PR is for support simple WAN topo in SONiC mgmt. 
<!--
- Add new topo file--wan-pub, and simple logical to create topo according to this file
- A little changes on minigraph template, to generate dut configurations
- Add new EOS configuration template to generate neighbor devices configurations
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add new WAN topo supporting
#### How did you do it?
Through add new topo file and analysis logic, we can create this topo
#### How did you verify/test it?
after added new files and logical, I can create this topo and T0 topo successfully. Based on new topo LLDP testcases run smoothly 
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
