### PR TITLE
Skip fwutil install test if no path is available

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -212,6 +212,8 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
     chassis = init_versions["chassis"].keys()[0] # Only one chassis
     paths = get_install_paths(duthost, fw, init_versions, chassis, component)
     current = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+    if component not in paths:
+        pytest.skip("No available firmware to install on {}. Skipping".format(component))
 
     allure.step("Upload firmware to DUT")
     generate_config(duthost, paths, init_versions)
@@ -229,8 +231,6 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
     if component is None:
         command += " all fw"
     else:
-        if component not in paths:
-            pytest.skip("No available firmware to install on {}. Skipping".format(component))
         command += " chassis component {} fw".format(component)
 
     if basepath is not None:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In fwutil test, if the component path is not available, the install test should be skipped.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Sometimes there may be only one available version for a specific component defined in the firmware.json file, in this case, there will be no entry of the specific component in the 'paths' list and the install test will fail because of key error in line 224 of fwutil_common.py when trying to get the reboot type.
In current logic, the test should be skipped if the paths is not available(line 232), so need to fix it to skip the install test before we get the key error.

#### How did you do it?
Move the skip logic in line 232 up ahead.
#### How did you verify/test it?
By manual and automation.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
