### PR TITLE
[m0] Add supoort of test_default_route and bgp_update_timer

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -429,7 +429,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     peer_count = getattr(request.module, "PEER_COUNT", 1)
     if "dualtor" in tbinfo["topo"]["name"]:
         setup_func = _setup_interfaces_dualtor
-    elif tbinfo["topo"]["type"] == "t0":
+    elif tbinfo["topo"]["type"] in ["t0", "m0"]:
         setup_func = _setup_interfaces_t0
     elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
         setup_func = _setup_interfaces_t1_or_t2

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -23,6 +23,8 @@ def get_upstream_neigh_type(topo):
         return 't2'
     elif 't2' in topo:
         return 't3'
+    elif 'm0' in topo:
+        return 'm1'
     else:
         return None
 

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -20,7 +20,7 @@ from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0')
+    pytest.mark.topology('t0')
 ]
 
 # Use original ports intead of sub interfaces for ptfadapter if it's t0-backend


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add support for m0 about some test cases.

#### How did you do it?
* Skip test_vlan for m0
* Add m0 support on test_default_route and bgp_update_timer

#### How did you verify/test it?
Run test cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
