### PR TITLE
Enable designating build id of KVM image

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -26,14 +26,18 @@ parameters:
   type: string
   default: ""
 
+- name: KVM_BUILD_ID
+  type: string
+  default: ""
+
 steps:
   - script: |
-      set -e
+      set -ex
 
       pip install PyYAML
 
       rm -f new_test_plan_id.txt
-      python ./.azure-pipelines/test_plan.py create -t ${{ parameters.TOPOLOGY }} -o new_test_plan_id.txt --min-worker ${{ parameters.MIN_WORKER }} --max-worker ${{ parameters.MAX_WORKER }} --test-set ${{ parameters.TEST_SET }} --deploy-mg-extra-params "${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}"
+      python ./.azure-pipelines/test_plan.py create -t ${{ parameters.TOPOLOGY }} -o new_test_plan_id.txt --min-worker ${{ parameters.MIN_WORKER }} --max-worker ${{ parameters.MAX_WORKER }} --test-set ${{ parameters.TEST_SET }} --deploy-mg-extra-params "${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}" --kvm-build-id ${{ parameters.KVM_BUILD_ID }}
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 
       echo "Created test plan $TEST_PLAN_ID"

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -48,7 +48,7 @@ class TestPlanManager(object):
         except Exception as e:
             raise Exception("Get token failed with exception: {}".format(repr(e)))
 
-    def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", min_worker=1, max_worker=2, pr_id="unknown", scripts=[],
+    def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="", min_worker=1, max_worker=2, pr_id="unknown", scripts=[],
                output=None):
         tp_url = "{}/test_plan".format(self.url)
         print("Creating test plan, topology: {}, name: {}, build info:{} {} {}".format(topology, test_plan_name, repo_name, pr_id, build_id))
@@ -83,7 +83,8 @@ class TestPlanManager(object):
             "extra_params": {
                 "pull_request_id": pr_id,
                 "build_id": build_id,
-                "source_repo": repo_name
+                "source_repo": repo_name,
+                "kvm_build_id": kvm_build_id
             },
             "priority": 10,
             "requester": "pull request"
@@ -255,6 +256,16 @@ if __name__ == "__main__":
         required=False,
         help="Deploy minigraph extra params"
     )
+    parser_create.add_argument(
+        "--kvm-build-id",
+        type=str,
+        nargs='?',
+        const='',
+        dest="kvm_build_id",
+        default="",
+        required=False,
+        help="KVM build id."
+    )
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
     parser_cancel = subparsers.add_parser("cancel", help="Cancel running test plan.")
@@ -338,6 +349,7 @@ if __name__ == "__main__":
                 args.topology,
                 test_plan_name=test_plan_name,
                 deploy_mg_extra_params=args.deploy_mg_extra_params,
+                kvm_build_id=args.kvm_build_id,
                 min_worker=args.min_worker,
                 max_worker=args.max_worker,
                 pr_id=pr_id,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
         TOPOLOGY: t0
         MIN_WORKER: 2
         MAX_WORKER: 3
-        KVM_BUILD_ID: variables.KVM_BUILD_ID
+        KVM_BUILD_ID: ${{ variables.KVM_BUILD_ID }}
 
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
@@ -82,7 +82,7 @@ stages:
         TEST_SET: t0-2vlans
         MAX_WORKER: 1
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-        KVM_BUILD_ID: variables.KVM_BUILD_ID
+        KVM_BUILD_ID: ${{ variables.KVM_BUILD_ID }}
 
   - job:
     pool:
@@ -143,7 +143,7 @@ stages:
         TOPOLOGY: t1-lag
         MIN_WORKER: 2
         MAX_WORKER: 3
-        KVM_BUILD_ID: variables.KVM_BUILD_ID
+        KVM_BUILD_ID: ${{ variables.KVM_BUILD_ID }}
 
   - job:
     displayName: "kvmtest-t1-lag"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,7 @@ stages:
         TOPOLOGY: t0
         MIN_WORKER: 2
         MAX_WORKER: 3
+        KVM_BUILD_ID: variables.KVM_BUILD_ID
 
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
@@ -81,6 +82,7 @@ stages:
         TEST_SET: t0-2vlans
         MAX_WORKER: 1
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        KVM_BUILD_ID: variables.KVM_BUILD_ID
 
   - job:
     pool:
@@ -141,6 +143,7 @@ stages:
         TOPOLOGY: t1-lag
         MIN_WORKER: 2
         MAX_WORKER: 3
+        KVM_BUILD_ID: variables.KVM_BUILD_ID
 
   - job:
     displayName: "kvmtest-t1-lag"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable designating build id of KVM image to avoid image issue keep affecting sonic-mgmt repo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enable designating build id of KVM image to avoid image issue keep affecting sonic-mgmt repo
#### How did you do it?
Enable designating build id of KVM image to avoid image issue keep affecting sonic-mgmt repo
#### How did you verify/test it?
Pipeline tests it.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
