### PR TITLE
Correct the error handling in EOS if wrong eos login occurred

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -209,7 +209,7 @@ class EosHost(AnsibleHostBase):
         res = self.localhost.shell(cli_cmd)
 
         if res["localhost"]["rc"] != 0:
-            raise Exception("Unable to execute template\n{}".format(res["stdout"]))
+            raise Exception("Unable to execute template\n{}".format(res["localhost"]["stdout"]))
 
     def get_route(self, prefix):
         cmd = 'show ip bgp' if ipaddress.ip_network(unicode(prefix)).version == 4 else 'show ipv6 bgp'


### PR DESCRIPTION
Signed-off-by: RogerX87 <RogerX87@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Correct the error message output if use wrong information for eos login
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Found the error handle cannot print correct message when we use wrong information to login EOS
#### How did you do it?
Correct the data
#### How did you verify/test it?
run the test with patched code, check the output
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
error log before modification:
[test_pfcwd_timer_accuracy_failed_1.log](https://github.com/sonic-net/sonic-mgmt/files/9652710/test_pfcwd_timer_accuracy_failed_1.log)
error log after modification:
[test_pfcwd_timer_accuracy_failed_2.log](https://github.com/sonic-net/sonic-mgmt/files/9652708/test_pfcwd_timer_accuracy_failed_2.log)


<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
