### PR TITLE
Update check condition of thermalctld since Celestica only has 1 thermalctld process

### DIFF
--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -277,14 +277,22 @@ def restart_thermal_control_daemon(dut):
     # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may
     # use subprocess to call ethtool to do initialization.
     # So we check here thermalcltd must have at least 2 processes.
-    assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
+    # For mellanox, it has at least two processes, but for celestica(broadcom),
+    # it only has one thermalctld process
+    if dut.facts["asic_type"] == "mellanox":
+        assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
+    else:
+        assert len(output["stdout_lines"]) >= 1, "There should be at least 1 thermalctld process"
 
     restart_thermalctl_cmd = "docker exec -i pmon bash -c 'supervisorctl restart thermalctld'"
     output = dut.shell(restart_thermalctl_cmd)
     if output["rc"] == 0:
         output = dut.shell(find_thermalctld_pid_cmd)
         assert output["rc"] == 0, "Run command '{}' failed after restart of thermalctld on {}".format(find_thermalctld_pid_cmd, dut.hostname)
-        assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
+        if dut.facts["asic_type"] == "mellanox":
+            assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
+        else:
+            assert len(output["stdout_lines"]) >= 1, "There should be at least 1 thermalctld process"
         logging.info("thermalctld processes restarted successfully on {}".format(dut.hostname))
         return
     # try restore by config reload...


### PR DESCRIPTION

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
`test_thermal_control_fan_status` and `system_health.test_system_health.test_device_checker` both failed on celestica testbeds.
It's because they both calls `restart_thermal_control_daemon`, it asks for al least 2 thermalctld processes, but for celestica(broadcom) it only has 2 thermalctld process running.

#### How did you do it?
Add an if condition in the function `restart_thermal_control_daemon`, if it's mellanox, it should have at least 2 thermalctld processes, for other platforms, it asks for at least 1 thermalctld process.

#### How did you verify/test it?

system_health/test_system_health.py::test_service_checker[str-dx010-acs-4] PASSED                                                                                                                                   [ 20%]
system_health/test_system_health.py::test_service_checker_with_process_exit[str-dx010-acs-4] PASSED                                                                                                                 [ 40%]
system_health/test_system_health.py::test_device_checker[str-dx010-acs-4] SKIPPED                                                                                                                                   [ 60%]
system_health/test_system_health.py::test_external_checker[str-dx010-acs-4] PASSED                                                                                                                                  [ 80%]
system_health/test_system_health.py::test_system_health_config[str-dx010-acs-4-ignore_log_analyzer_by_vendor0] SKIPPED                                                                                              [100%]


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
