### PR TITLE
Move skip check of test_passwd_hardening to tests_mark_conditions.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -418,6 +418,16 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
+#####       passw_hardening       #####
+#######################################
+passw_hardening/test_passw_hardening.py:
+  skip:
+    reason: "Password-hardening supported just in master version"
+    conditions:
+        - "release not in ['master']"
+        - https://github.com/sonic-net/sonic-mgmt/issues/6428
+
+#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:

--- a/tests/passw_hardening/conftest.py
+++ b/tests/passw_hardening/conftest.py
@@ -17,12 +17,6 @@ def set_default_passw_hardening_policies(duthosts, enum_rand_one_per_hwsku_hostn
 
     test_passw_hardening.config_and_review_policies(duthost, passw_hardening_ob_dis, test_passw_hardening.PAM_PASSWORD_CONF_DEFAULT_EXPECTED)
 
-@pytest.fixture(scope="module", autouse=True)
-def passw_version_required(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if not "master" in duthost.os_version:
-        pytest.skip("Password-hardening supported just in master version")
-
 @pytest.fixture(scope="function")
 def clean_passw_policies(duthosts, enum_rand_one_per_hwsku_hostname):
     yield


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
`test_passw_hardening` is unable to run on master image because https://github.com/sonic-net/sonic-buildimage/pull/12138 hasn't been merged.
But after running it on 202205 image which supports passw-harden(enabled in this PR https://github.com/sonic-net/sonic-buildimage/pull/12025), found an issue and raised here https://github.com/sonic-net/sonic-mgmt/issues/6428.

I think that it's better to skip test case in tests_mark_conditions.yaml instead of in test script.

#### How did you do it?
1. Move skip condition to tests_mark_conditions.yaml
2. Add an issue in skip condition. After it's been fixed, we can run this script.

#### How did you verify/test it?
Run passw_hardening/test_passw_hardening.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
