### PR TITLE
Fix test route flap script issue in dual-tor env

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -22,7 +22,7 @@ bfd/test_bfd.py:
   skip:
     reason: "Test not supported for 201911 images or older, other than mlnx4600c and cosco-8102. Skipping the test"
     conditions:
-      - "(kernel_version <= '4.9.0') or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
+      - "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
 
 #######################################
 #####            bgp              #####
@@ -612,7 +612,7 @@ route/test_static_route.py:
   skip:
     reason: "Test not supported for 201911 images or older."
     conditions:
-      - "kernel_version <= '4.9.0'"
+      - "release in ['201811', '201911']"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:
   # This test case may fail due to a known issue https://github.com/sonic-net/sonic-buildimage/issues/4930.

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -149,7 +149,7 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
     vlan_cfgs = {}
     try:
         vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
-    except:
+    except KeyError:
         logger.info('missing vlan configurations in topology, will use dut_mac {} in testing'.format(dut_mac))
 
     if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -140,10 +140,10 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
     common_config = tbinfo['topo']['properties']['configuration_properties'].get('common', {})
     nexthop = common_config.get('nhipv4', NHIPV4)
 
-    # In dual-tor env, unicast upstream l3 packet destination mac should be vlan mac
+    # On dual-tor, unicast upstream l3 packet destination mac should be vlan mac
     # After routing, output packet source mac will be replaced with port-channel mac (same as dut_mac)
-    # And in dual-tor env, vlan mac is different with dut_mac mac. U0/L0 use same vlan mac for AR response
-    # in single tor env, vlan mac is same as dut_mac
+    # On dual-tor, vlan mac is different with dut_mac mac. U0/L0 use same vlan mac for AR response
+    # On single tor, vlan mac is same as dut_mac
     vlan_mac = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac']
     if not vlan_mac:
         raise ValueError("Topology has no mac from Vlan1000")

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -146,7 +146,12 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
     # On single tor, vlan mac (if exists) is same as dut_mac
     dut_mac = duthost.facts['router_mac']
     vlan_mac = dut_mac
-    vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+    vlan_cfgs = {}
+    try:
+        vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+    except:
+        logger.info('missing vlan configurations in topology, will use dut_mac {} in testing'.format(dut_mac))
+
     if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
         default_vlan_name = vlan_cfgs['default_vlan_config']
         if default_vlan_name:

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -142,12 +142,17 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
 
     # On dual-tor, unicast upstream l3 packet destination mac should be vlan mac
     # After routing, output packet source mac will be replaced with port-channel mac (same as dut_mac)
-    # On dual-tor, vlan mac is different with dut_mac mac. U0/L0 use same vlan mac for AR response
-    # On single tor, vlan mac is same as dut_mac
-    vlan_mac = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac']
-    if not vlan_mac:
-        raise ValueError("Topology has no mac from Vlan1000")
+    # On dual-tor, vlan mac is different with dut_mac. U0/L0 use same vlan mac for AR response
+    # On single tor, vlan mac (if exists) is same as dut_mac
     dut_mac = duthost.facts['router_mac']
+    vlan_mac = dut_mac
+    vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+    if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
+        default_vlan_name = vlan_cfgs['default_vlan_config']
+        if default_vlan_name:
+            for vlan in vlan_cfgs[default_vlan_name].values():
+                if 'mac' in vlan and vlan['mac']:
+                    vlan_mac = vlan['mac']
 
     #get dst_prefix_list and aspath
     routes = namedtuple('routes', ['route', 'aspath'])

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -153,6 +153,7 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
             for vlan in vlan_cfgs[default_vlan_name].values():
                 if 'mac' in vlan and vlan['mac']:
                     vlan_mac = vlan['mac']
+                    break;
 
     #get dst_prefix_list and aspath
     routes = namedtuple('routes', ['route', 'aspath'])

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -160,8 +160,7 @@ def test_route_flap(duthost, tbinfo, ptfhost, ptfadapter,
                     if 'mac' in vlan and vlan['mac']:
                         vlan_mac = vlan['mac']
                         break
-        if not vlan_mac:
-            raise Exception('dual-tor without vlan mac !!!')
+        pytest_assert(vlan_mac, 'dual-tor without vlan mac !!!')
     else:
        vlan_mac = dut_mac
 


### PR DESCRIPTION
### Description of PR
1. test_route_flap.py failure on dual-tor TB
2. root cause is ptf send upstream packets from eth0 to DUT with destination mac is dut_mac.
3. On Dual-tor, layer3 interface (Vlan1000) mac is different with dut mac, thus layer3 packet will not match routing and get flooded to vlan1000 member interfaces
4. And for script, packet compare will failed

Summary:
Fixes #5773 

### Type of change
script change
1. destination mac use vlan interface mac
2. expect packet source mac use dut mac

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Inv and fix script failure

#### How did you do it?
Script running and debugging

#### How did you verify/test it?
Script running on dual-tor and single tor, result passed.

----------------------------- live log collection ------------------------------
12:47:42 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
12:47:42 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
12:48:00 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
12:48:00 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
collected 1 item                                                               

route/test_route_flap.py::test_route_flap 


PASSED                         [100%]
