### PR TITLE
Skip all admin down ports for non-Mellanox device

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2481,7 +2481,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
         else:
             if is_mellanox_device(duthost):
                 buffer_items_to_check = buffer_items_to_check_dict["down"][key_name]
-            elif is_broadcom_device(duthost) and (asic_type in ['td2', 'td3'] or speed <= '10000'):
+            elif is_broadcom_device(duthost):
                 buffer_items_to_check = [(None, None, None)]
             else:
                 if key_name == KEY_2_LOSSLESS_QUEUE:

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2481,15 +2481,8 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
         else:
             if is_mellanox_device(duthost):
                 buffer_items_to_check = buffer_items_to_check_dict["down"][key_name]
-            elif is_broadcom_device(duthost):
-                buffer_items_to_check = [(None, None, None)]
             else:
-                if key_name == KEY_2_LOSSLESS_QUEUE:
-                    buffer_items_to_check = [('BUFFER_PG_TABLE', '3-4', profile_wrapper.format(expected_profile))]
-                else:
-                    buffer_items_to_check.extend(
-                        [('BUFFER_PG_TABLE', '2-4', profile_wrapper.format(expected_profile)),
-                        ('BUFFER_PG_TABLE', '6', profile_wrapper.format(expected_profile))])
+                buffer_items_to_check = [(None, None, None)]
 
         for table, ids, expected_profile in buffer_items_to_check:
             logging.info("Checking buffer item {}:{}:{}".format(table, port, ids))


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skip all admin down ports for Broadcom device

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
There was no BUFFER_PROFILE_TABLE for admin down ports

#### How did you do it?
Skip all admin down ports for Broadcom device

#### How did you verify/test it?
Verify the original failure case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
