### PR TITLE
[20191130] [masic] skip test_memory_exhaustion testcase in 20191130 for multi-asic platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -702,3 +702,12 @@ platform_tests/test_reload_config.py:
 platform_tests/test_sequential_restart.py::test_restart_syncd:
   skip:
     reason: "Restarting syncd is not supported yet"
+
+#######################################
+####  test_memory_exhaustion.py   #####
+#######################################
+platform_tests/test_memory_exhaustion.py:
+  skip:
+    reason: "Unsupported release 20191130"
+    conditions: 
+      - is_multi_asic==True and release in ['201911']

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -709,5 +709,5 @@ platform_tests/test_sequential_restart.py::test_restart_syncd:
 platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Unsupported release 20191130"
-    conditions: 
-      - is_multi_asic==True and release in ['201911']
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Currently passing platforms mentioned https://github.com/sonic-net/sonic-buildimage/issues/10339, as well as multi-asic platform, is passing with 20201231 image, 20191130 is still failing on this test for multi-asic platform. Root cause is still being investigated as both 201911 and 202012 has panic_on_oom set to 2 to compulsorily panic the system if OOM happens. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
