### PR TITLE
[image 20191130] [masic] skip power off reboot in 20191130 image for masic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -663,7 +663,7 @@ platform_tests/test_reboot.py::test_power_off_reboot:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"
     conditions:
-      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or ("is_multi_asic==True and release in ['201911'])""
+      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
 
 platform_tests/test_reboot.py::test_soft_reboot:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -663,7 +663,7 @@ platform_tests/test_reboot.py::test_power_off_reboot:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"
     conditions:
-      - "hwsku in ['Celestica-E1031-T48S4'] or 'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or ("is_multi_asic==True and release in ['201911'])""
 
 platform_tests/test_reboot.py::test_soft_reboot:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip test_power_off_reboot for multi-asic platform on 201911 image.
The test is currently failing in latest 20191130 image, but power off reboot does not have any issue, issue happens in `check_reboot_cause` which need vendor to provide sonic_platform package.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_reboot_power_off was skipped in 20191130.78 as no PSU controller provided in this version.

Starting 20191130.80 PSU controller is there, so test is not skipped. 

After a power off reboot, we want to ensure all critical services are up.
When checking reboot-cause, the output of ‘show reboot-cause’ performed on dut is ‘Unknown’, which is not as expected ‘Power off’ and caused step `check reboot cause` to fail.

The reason why ‘show reboot-cause’ fail to get reboot-cause is that:
•	systemd failed to find hardware reboot cause due to:
o	Sep 22 03:53:41.916464 str-n3164-acs-2 WARNING process-reboot-cause: sonic_platform package not installed. Unable to detect hardware reboot causes. 
•	Then it tried to get software reboot cause by reading from file /host/reboot-cause/reboot-cause.txt and gives ‘Unknown’

According to following code, vendor should provide sonic_platform package for this test to pass:
```
def find_hardware_reboot_cause():
    hardware_reboot_cause = None

    # Until all platform vendors have provided sonic_platform packages,
    # if there is no sonic_platform package installed, we only provide
    # software-related reboot causes.
    try:
        import sonic_platform

        platform = sonic_platform.platform.Platform()
```
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
