### PR TITLE
Add testcase to verify vlan header in bounced back traffic

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -223,7 +223,7 @@ def setup_mirror_session(rand_selected_dut, setup_uplink):
     uplink_port_id = setup_uplink
     yield uplink_port_id
 
-    cmd = "config mirror_session remove {}"
+    cmd = "config mirror_session remove {}".format(session_name)
     rand_selected_dut.shell(cmd=cmd)
 
 @pytest.mark.disable_loganalyzer

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -224,7 +224,7 @@ def setup_mirror_session(rand_selected_dut, setup_uplink):
     cmd = "config mirror_session remove {}"
     rand_selected_dut.shell(cmd=cmd)
 
-
+@pytest.mark.disable_loganalyzer
 def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, ptfadapter, tbinfo, setup_mirror_session, toggle_all_simulator_ports_to_rand_unselected_tor, tunnel_traffic_monitor):
     """
     A test case to verify the bounced back packet from Standby ToR to T1 doesn't have an unexpected vlan id (4095)

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -185,6 +185,7 @@ def setup_uplink(rand_selected_dut, tbinfo):
         cmds = [
             "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 1".format(up_portchannel), # Update min_links
             "config portchannel member del {} {}".format(up_portchannel, pc_members[1]),         # Remove 1 portchannel member
+            "systemctl unmask teamd",                                                            # Unmask the service
             "systemctl restart teamd"                                                            # Resart teamd
         ]
         rand_selected_dut.shell_cmds(cmds=cmds)
@@ -203,6 +204,7 @@ def setup_uplink(rand_selected_dut, tbinfo):
         cmds = [
             "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 2".format(up_portchannel), # Update min_links
             "config portchannel member add {} {}".format(up_portchannel, pc_members[1]),         # Add back portchannel member
+            "systemctl unmask teamd",                                                            # Unmask the service
             "systemctl restart teamd"                                                            # Resart teamd
         ]
         rand_selected_dut.shell_cmds(cmds=cmds)

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -10,6 +10,7 @@ import pytest
 import random
 import time
 import contextlib
+import scapy
 
 from ptf import mask
 from ptf import testutils
@@ -21,6 +22,7 @@ from tests.common.dualtor.dual_tor_utils import get_ptf_server_intf_index
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_unselected_tor            # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
+from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
 from tests.common.fixtures.ptfhost_utils import run_garp_service
@@ -32,6 +34,7 @@ pytestmark = [
     pytest.mark.topology("t0")
 ]
 
+logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_common_setup_teardown(
@@ -158,3 +161,89 @@ def test_decap_standby_tor(
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
         time.sleep(2)
         verify_downstream_packet_to_server(ptfadapter, exp_ptf_port_index, exp_pkt)
+
+
+@pytest.fixture
+def setup_uplink(rand_selected_dut, tbinfo):
+    """
+    Function level fixture.
+    1. Only keep 1 uplink up. Shutdown others to force the bounced back traffic is egressed from monitor port of mirror session
+    2. If there are more than 1 member in the LAG, update the LAG to have only one member
+    """
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    portchannels = mg_facts['minigraph_portchannels'].keys()
+    up_portchannel = random.choice(portchannels)
+    logger.info("Select uplink {} for testing".format(up_portchannel))
+    # Shutdown other uplinks except for the selected one
+    for pc in portchannels:
+        if  pc != up_portchannel:
+            cmd = "config interface shutdown {}".format(pc)
+            rand_selected_dut.shell(cmd)
+    # Update the LAG if it has more than one member
+    pc_members = mg_facts['minigraph_portchannels'][up_portchannel]['members']
+    if len(pc_members) > 1:
+        cmds = [
+            "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 1".format(up_portchannel), # Update min_links
+            "config portchannel member del {} {}".format(up_portchannel, pc_members[1]),         # Remove 1 portchannel member
+            "systemctl restart teamd"                                                            # Resart teamd
+        ]
+        rand_selected_dut.shell_cmds(cmds=cmds)
+        time.sleep(300)
+    up_member = pc_members[0]
+    
+    yield mg_facts['minigraph_ptf_indices'][up_member]
+
+    # Startup the uplinks that were shutdown
+    for pc in portchannels:
+        if  pc != up_portchannel:
+            cmd = "config interface startup {}".format(pc)
+            rand_selected_dut.shell(cmd)
+    # Restore the LAG
+    if len(pc_members) > 1:
+        cmds = [
+            "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 2".format(up_portchannel), # Update min_links
+            "config portchannel member add {} {}".format(up_portchannel, pc_members[1]),         # Add back portchannel member
+            "systemctl restart teamd"                                                            # Resart teamd
+        ]
+        rand_selected_dut.shell_cmds(cmds=cmds)
+        time.sleep(300)
+
+
+@pytest.fixture
+def setup_mirror_session(rand_selected_dut, setup_uplink):
+    """
+    A function level fixture to add/remove a dummy mirror session.
+    The mirror session is to trigger the issue. No packet is mirrored actually.
+    """
+    session_name = "dummy_session"
+    cmd = "config mirror_session add {} 25.192.243.243 20.2.214.125 8 100 1234 0".format(session_name)
+    rand_selected_dut.shell(cmd=cmd)
+    uplink_port_id = setup_uplink
+    yield uplink_port_id
+
+    cmd = "config mirror_session remove {}"
+    rand_selected_dut.shell(cmd=cmd)
+
+
+def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, ptfadapter, tbinfo, setup_mirror_session, toggle_all_simulator_ports_to_rand_unselected_tor, tunnel_traffic_monitor):
+    """
+    A test case to verify the bounced back packet from Standby ToR to T1 doesn't have an unexpected vlan id (4095)
+    The issue can happen if the bounced back packets egressed from the monitor port of mirror session
+    Find more details in CSP CS00012263713. 
+    """
+    pytest_require("dualtor" in tbinfo['topo']['name'], "Only run on dualtor testbed")
+    # Since we have only 1 uplink, the source port is also the dest port
+    src_port_id = dst_port_id = setup_mirror_session
+    _, server_ip = rand_selected_interface
+    # Construct the packet to server
+    pkt_to_server = testutils.simple_tcp_packet(
+        eth_dst=rand_selected_dut.facts["router_mac"],
+        ip_src="1.1.1.1",
+        ip_dst=server_ip['server_ipv4'].split('/')[0]
+    )
+    logging.info("Sending packet from ptf t1 interface {}".format(src_port_id))
+    inner_packet = pkt_to_server[scapy.all.IP].copy()
+    inner_packet[IP].ttl -= 1
+    with tunnel_traffic_monitor(rand_selected_dut, inner_packet=inner_packet, check_items=()):
+        testutils.send(ptfadapter, src_port_id, pkt_to_server)
+       

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -235,7 +235,7 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, p
     """
     pytest_require("dualtor" in tbinfo['topo']['name'], "Only run on dualtor testbed")
     # Since we have only 1 uplink, the source port is also the dest port
-    src_port_id = dst_port_id = setup_mirror_session
+    src_port_id = setup_mirror_session
     _, server_ip = rand_selected_interface
     # Construct the packet to server
     pkt_to_server = testutils.simple_tcp_packet(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6427 
This PR is to add a test case to fill a test gap in #6427 
We found that there will be an unexpected vlan header in the bounced back traffic from standby ToR after mirror session is added. 
This PR is to add a test case to verify that.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
This PR is to add a test case to fill a test gap in #6427 
Test steps
1. Random selected a ToR for testing
2. Toggle mux cable to the unselected ToR, so that the selected one is standby
3. Shutdown other uplinks, only keep one uplink up on the selected ToR. This is to ensure the monitor port of mirror session is the port where the bounced back traffic is egressed
4. Send packet to the selected ToR, verify there is no unexpected vlan id in the bounced back traffic

#### How did you verify/test it?
The test case is verified on a Arista-7260cx3 dualtor testbed.


#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
A dualtor specify test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
