### PR TITLE
Fix test_tx_disable_channel so that it ends with 0 channel disabled

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -544,7 +544,7 @@ class TestSfpApi(PlatformApiTestBase):
 
             # Test all TX disable combinations for a four-channel transceiver (i.e., 0x0 through 0xF)
             # We iterate in reverse here so that we end with 0x0 (no channels disabled)
-            for expected_mask in range(0xF, 0x0, -1):
+            for expected_mask in range(0xF, -1, -1):
                 # Enable TX on all channels
                 ret = sfp.tx_disable_channel(platform_api_conn, i, 0xF, False)
                 self.expect(ret is True, "Failed to enable TX on all channels for transceiver {}".format(i))


### PR DESCRIPTION
### Description of PR
The the of tx_disable_channel is meant to end with 0 channel disabled.
However the iteration range (0xF, 0, -1) makes it ends with 1 channel disabled, so modify it as (0XF, -1, -1)

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
After running test_get_tx_disable_channel, due to the 1 disabled channel, the ports under test will link down.

#### How did you do it?
Modify the iteration range.

#### How did you verify/test it?
Run test_get_tx_disable_channel then do "show interfaces status" on DUT to check link status.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
