### PR TITLE
Update PFC xoff_2 threshold for td3/topo-any/50000_300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -841,9 +841,9 @@ qos_params:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 58276
-                    pkts_num_trig_ingr_drp: 58516
-                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 58576
+                    pkts_num_trig_ingr_drp: 58816
+                    pkts_num_margin: 50
                 hdrm_pool_size:
                     dscps: [3, 4]
                     ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update PFC xoff_2 threshold for qos parameter "td3/topo-any/50000_300m"
This PR is a follow-up of PR#6188

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Night test failure: 

#### How did you do it?
Manually run the testcase by using binary search for the correct value.

#### How did you verify/test it?
Now manually run the testcase for 10 times without failure.

#### Any platform specific information?
Only 7050cx3 platform with 50000_300m profile.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
