### PR TITLE
update PFC xoff1/xoff2 threshold for th2\topo-t1-64-lag\100000_300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -1344,14 +1344,14 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 4490
-                    pkts_num_trig_ingr_drp: 4978
+                    pkts_num_trig_pfc: 19994
+                    pkts_num_trig_ingr_drp: 20481
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 4490
-                    pkts_num_trig_ingr_drp: 4978
+                    pkts_num_trig_pfc: 19994
+                    pkts_num_trig_ingr_drp: 20481
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
update PFC xoff1/xoff2 threshold for th2\topo-t1-64-lag\100000_300m

Summary:
update PFC xoff1/xoff2 threshold for th2\topo-t1-64-lag\100000_300m


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
below QoS testcase failed for qos parameter "th2\topo-t1-64-lag\100000_300m":
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_1]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_2]

#### How did you do it?
find correct threshold, update qos parameters, make testcase pass.

#### How did you verify/test it?
manually run testcase on local

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
