### PR TITLE
[t0-56-po2vlan] Fixed KeyError:'PortChannel201' to support tests on t0-56-po2vlan topology

### DIFF
--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -134,6 +134,8 @@ def gather_facts(tbinfo, duthosts, enum_rand_one_per_hwsku_frontend_hostname, en
         pytest.fail("ARP table is not rebuilt in given time")
 
     used_intfs = set()
+    if tbinfo['topo']['name'] == 't0-56-po2vlan':
+        used_intfs.add('PortChannel201')  # specific LAG interface from t0-56-po2vlan topo, which can't be tested
     src = None  # Name of lag or interface that is is up
     dst = None  # Name of lag or interface that is is up
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -273,6 +273,8 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, con
     # We can't run single_lag test on vtestbed since there is no leaffanout
     if testcase == "single_lag" and is_vtestbed(duthosts[0]):
         pytest.skip("Skip single_lag test on vtestbed")
+    if 'PortChannel201' in enum_dut_portchannel_with_completeness_level:
+        pytest.skip("PortChannel201 is a specific configuration of t0-56-po2vlan topo, which is not supported by test")
 
     ptfhost = common_setup_teardown
 
@@ -293,6 +295,9 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, con
                 test_lags = [ dut_lag ]
 
             for lag_name in test_lags:
+                # specific LAG interface from t0-56-po2vlan topo, which can't be tested
+                if lag_name == 'PortChannel201':
+                    continue
                 if testcase in [ "single_lag",  "lacp_rate" ]:
                     try:
                         lag_facts['lags'][lag_name]['po_config']['runner']['min_ports']


### PR DESCRIPTION
…can run on t0 topo for support t0-56-po2vlan topology

Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

-->
### Description of PR
This PR is continuing the work of fixing started in #6341

Many tests support t0 topology and they should be able to run on t0-56-po2vlan topology - but they fail with error: KeyError: u'PortChannel201'
It happens because topology t0-56-po2vlan has 2 VLANs and tests expect that topology will have only 1 VLAN and the second VLAN has a PortChannel interface which is a member of the second VLAN(in regular t0 topo - all PortChannels are L3 interfaces)
Added fix(remove additional VLAN/PortChannel from list of VLANs/Interfaces) for tests to support t0-56-po2vlan topology

Summary: Fixed KeyError: u'PortChannel201' in tests which can run on t0 topo for support t0-56-po2vlan topology


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add support of t0-56-po2vlan topo for the test which can run on t0 topo

#### How did you do it?
Skipped the validation on the interfaces with extra Vlan/PortChannel. The rest interfaces can be tested as on regular t0 topo.

#### How did you verify/test it?
The test cases were executed after the change.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
