### PR TITLE
making the change for port alias

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -201,7 +201,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
-                port_alias_to_name_map["etp%d" % (i + 1)] = "Ethernet%d" % (i * 4)
+                port_alias_to_name_map["etp%d" % i ] = "Ethernet%d" % (i * 4)
         elif hwsku in ["8800-LC-48H-O", "88-LC0-36FH-MO"]:
             for i in range(0, 48, 1):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
PR Description:
As per the new requirement, port alias on the device should start from etp0 to etp63.
Currently it starts from etp1 to etp64.

This change is to make sure it starts from etp0.