### PR TITLE
[announce_routes] fix test_static_route_ecmp issue by announce_route optimization

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -206,8 +206,8 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
                     # Skip non podset 0 for T0
                     if podset != 0:
                         continue
-                    # Skip subnet 0 (vlan ip) for M0
-                    elif topo == "m0" and subnet == 0:
+                    # Skip subnet 0 (vlan ip)
+                    elif subnet == 0:
                         continue
                     elif tor != tor_index:
                         continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the mistake that vlan ip has been announced to ToR DUT by exabgp, which could cause the route issue in DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix the mistake that vlan ip has been announced to ToR DUT by exabgp, which could cause the route issue in DUT.

#### How did you do it?
Ignore the vlan ip when announcing routes.

#### How did you verify/test it?
Run test_static_route_ecmp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
