### PR TITLE
fix platform_tests/test_service_warm_restart test

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -678,12 +678,15 @@ class AdvancedReboot:
                 wait = self.readyTimeout
             )
 
+    def disable_service_warmrestart(self):
+        for service in self.service_list:
+            self.duthost.shell('sudo config warm_restart disable {}'.format(service))
+
     def __restorePrevDockerImage(self):
         """Restore previous docker image.
         """
         for service_name, data in self.service_data.items():
             if data['image_path_on_dut'] is None:
-                self.duthost.shell('sudo config warm_restart disable {}'.format(service_name))
                 continue
 
             #  We don't use sonic-installer rollback-docker CLI here because:
@@ -726,13 +729,15 @@ class AdvancedReboot:
             logger.info('Run the post reboot check script')
             self.__runScript([self.postRebootCheckScript], self.duthost)
 
-        if not self.stayInTargetImage:
-            logger.info('Restoring previous image')
-            if self.rebootType != 'service-warm-restart':
-                self.__restorePrevImage()
-            else:
+        if self.rebootType != 'service-warm-restart' and not self.stayInTargetImage:
+            self.__restorePrevImage()
+
+        if self.rebootType == 'service-warm-restart':
+            self.disable_service_warmrestart()
+            if not self.stayInTargetImage:
                 self.__restorePrevDockerImage()
-        else:
+        
+        if self.stayInTargetImage:
             logger.info('Stay in new image')
 
 @pytest.fixture

--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -22,48 +22,74 @@ def check_image_version(duthost):
     """
     skip_release(duthost, ["201811", "201911", "202012", "202106"])
 
+def get_builtin_services(duthost):
+    spm_data = duthost.show_and_parse('spm list')
+    return {item['name'] for item in spm_data if item['status'] == 'Built-In'}
+    
+def get_running_services(duthost):
+    services = duthost.shell('docker ps --format \{\{.Names\}\}')['stdout_lines']
+    return services
+
+def get_ignored_services(request):
+    ignored_services = request.config.getoption("--ignore_service")
+    return ignored_services.split(',') if ignored_services else []
+
+class ServiceMatchRules:
+    services_warmboot_unsupported = ['database', 'syncd']
+
+    def __init__(self, duthost, request):
+        feature_info = duthost.show_and_parse('show feature status')
+        self.feature_data = {info['feature']:info for info in feature_info}
+
+        self.ignored_services = get_ignored_services(request)
+        self.builtin_services = get_builtin_services(duthost)
+        self.running_services = get_running_services(duthost)
+    
+    def is_running(self, s):
+        return s in self.running_services
+
+    def is_not_ignored(self, s):
+        return s not in self.ignored_services
+
+    def is_built_in(self, s):
+        return s in self.builtin_services
+
+    def is_feature_enabled(self, s):
+        return self.feature_data[s]['state'] not in ['disabled', 'always_disabled']
+    
+    def is_warmboot_supported(self, s):
+        return s not in ServiceMatchRules.services_warmboot_unsupported
+
+    
+def select_services_to_warmrestart(duthost, request):
+
+    all_services = [feature_data['feature'] for feature_data in duthost.show_and_parse('show feature status')]
+
+    rules = ServiceMatchRules(duthost, request)
+
+    not_running_services = [service for service in all_services if not rules.is_running(service)]
+    if not_running_services:
+        logging.info('skipping test for not running services: {}'.format(not_running_services))
+
+    all_checks = [
+        rules.is_built_in,
+        rules.is_warmboot_supported,
+        rules.is_not_ignored,
+        rules.is_running,
+        rules.is_feature_enabled
+    ]
+
+    def passes_all_checks(service):
+        return all(rule(service) for rule in all_checks )
+    
+    return [service for service in all_services if passes_all_checks(service)]
+    
 
 def test_service_warm_restart(request, duthosts, rand_one_dut_hostname, verify_dut_health, get_advanced_reboot,
     advanceboot_loganalyzer, capture_interface_counters):
     duthost = duthosts[rand_one_dut_hostname]
 
-    # Get built-in service
-    spm_data = duthost.show_and_parse('spm list')
-    built_in_repo_set = {item['repository'] for item in spm_data if item['status'] == 'Built-In'}
-    built_in_service_set = set()
-    for built_in_repo in built_in_repo_set:
-        service_name = duthost.shell('docker ps --filter "ancestor={}" --format \{{\{{.Names\}}\}}'.format(built_in_repo))['stdout']
-        service_name = service_name.strip()
-        if service_name:
-            built_in_service_set.add(service_name)
-        else:
-            logging.info('service with docker repo {} is not enabled or running, skip warm restart for it'.format(built_in_repo))
-
-    feature_list = duthost.show_and_parse('show feature status')
-    ignored_services = request.config.getoption("--ignore_service")
-    candidate_service_list = []
-    for feature_data in feature_list:
-        if feature_data['feature'] in ['database', 'syncd']:
-            # Features that do not support warm restart
-            continue
-
-        if feature_data['feature'] not in built_in_service_set:
-            # There is no guarantee that non built-in feature support warm restart, so ignore them
-            logging.info('Feature {} is not a built-in feature, skip warm restart for it.'.format(feature_data['feature']))
-            continue
-
-        if ignored_services:
-            ignored_services = ignored_services.split(',')
-            if feature_data['feature'] in ignored_services:
-                logging.info("Feature {} is ignored by user, skip warm restart for it.".format(feature_data['feature']))
-                continue
-
-        if feature_data['state'] == 'disabled' or feature_data['state'] == 'always_disabled':
-            logging.info("Feature {} is not enabled, skip warm restart for it.".format(feature_data['feature']))
-            continue
-
-        candidate_service_list.append(feature_data['feature'])
-
+    candidate_service_list = select_services_to_warmrestart(duthost, request)
     pytest_require(candidate_service_list, 'Skip service warm restart test because candidate_service_list is empty')
 
     advancedReboot = get_advanced_reboot(rebootType='service-warm-restart',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: disabled warm-restart for services on test finish
Fixes # (issue)
- fixed https://github.com/sonic-net/sonic-mgmt/issues/6445
- refactored the code responsible for selection of services to check warm-restart for
All details of service selection were put into main test body, making test scenario difficult to understand. Moved service selection code into separate func `select_services_to_warmrestart`. Implemented `select_services_to_warmrestart` based on selection rules making easy to understand which serviced get selected for testing

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
