### PR TITLE
Remove unuseful code for platform api

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -23,15 +23,9 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, local
                              timeout=5,
                              module_ignore_errors=True)
     if 'exception' in res:
-        # TODO: Remove this check once we no longer need to support Python 2
-        if request.cls.__name__ == "TestSfpApi" and duthost.facts.get("asic_type") == "mellanox" \
-                and duthost.sonic_release in ['202012', '202106']:
-            # On Mellanox platform, the SFP APIs are not migrated to python3 yet,
-            # thus we have to make it as an exception here.
-            py3_platform_api_available = False
-        else:
-            res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
-            py3_platform_api_available = not res['failed']
+
+        res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
+        py3_platform_api_available = not res['failed']
 
         supervisor_conf = [
             '[program:platform_api_server]',


### PR DESCRIPTION
On mellanox platform the SFP APIs are migrated to python3, so remove the support python2 code

Change-Id: Ib85ccd334a94a117e031269cd48706ce3ee3b280

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

On mellanox platform the SFP APIs are migrated to python3, so remove these codes that check if it shoud use python2


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Remove unuseful code, because SFP API has support python3 on mellanox platform

#### How did you do it?
Remove unuseful code

#### How did you verify/test it?
Run platform API tests

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
