### PR TITLE
[202012] Check the notif type of test_get_firmware_update_notification only when the update is required

### DIFF
--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -172,7 +172,8 @@ class TestComponentApi(PlatformApiTestBase):
             for image in image_list:
                 notif = component.get_firmware_update_notification(platform_api_conn, i, image)
                 # Can return "None" if no update required. 
-                pytest_assert(isinstance(notif, STRING_TYPE), "Component {}: Firmware update notification appears to be incorrect from image {}".format(i, image))
+                if notif is not None:
+                    pytest_assert(isinstance(notif, STRING_TYPE), "Component {}: Firmware update notification appears to be incorrect from image {}".format(i, image))
 
     def test_install_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]


### PR DESCRIPTION
[ Cherry-Pick ]
Check the notif type of test_get_firmware_update_notification only when the update is required the update is required. (#6274)

What is the motivation for this PR?
Test test_get_firmware_update_notification got failed if no update is required.

How did you do it?
Don't check the return type if any update is not available or not required.

How did you verify/test it?
Run test_get_firmware_update_notification and see if no failure

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
