### PR TITLE
Individual tx channel disable for test_tx_disable_channel test

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -543,18 +543,18 @@ class TestSfpApi(PlatformApiTestBase):
                 continue
 
             if info_dict["type_abbrv_name"] == "QSFP-DD" or info_dict["type_abbrv_name"] == "OSFP-8X":
-                # Test all lanes for a eight-channel transceiver
-                all_lane_mask = 0xFF
+                # Test all channels for a eight-channel transceiver
+                all_channel_mask = 0xFF
                 expected_mask = 0x80
             else:
-                # Test all lanes for a four-channel transceiver
-                all_lane_mask = 0XF
+                # Test all channels for a four-channel transceiver
+                all_channel_mask = 0XF
                 expected_mask = 0x8
 
             # We iterate in reverse here so that we end with 0x0 (no channels disabled)
             while expected_mask >= 0:
                 # Enable TX on all channels
-                ret = sfp.tx_disable_channel(platform_api_conn, i, all_lane_mask, False)
+                ret = sfp.tx_disable_channel(platform_api_conn, i, all_channel_mask, False)
                 self.expect(ret is True, "Failed to enable TX on all channels for transceiver {}".format(i))
 
                 ret = sfp.tx_disable_channel(platform_api_conn, i, expected_mask, True)

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -542,11 +542,19 @@ class TestSfpApi(PlatformApiTestBase):
                 logger.warning("test_tx_disable_channel: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
-            # Test all TX disable combinations for a four-channel transceiver (i.e., 0x0 through 0xF)
+            if info_dict["type_abbrv_name"] == "QSFP-DD" or info_dict["type_abbrv_name"] == "OSFP-8X":
+                # Test all lanes for a eight-channel transceiver
+                all_lane_mask = 0xFF
+                expected_mask = 0x80
+            else:
+                # Test all lanes for a four-channel transceiver
+                all_lane_mask = 0XF
+                expected_mask = 0x8
+
             # We iterate in reverse here so that we end with 0x0 (no channels disabled)
-            for expected_mask in range(0xF, -1, -1):
+            while expected_mask >= 0:
                 # Enable TX on all channels
-                ret = sfp.tx_disable_channel(platform_api_conn, i, 0xF, False)
+                ret = sfp.tx_disable_channel(platform_api_conn, i, all_lane_mask, False)
                 self.expect(ret is True, "Failed to enable TX on all channels for transceiver {}".format(i))
 
                 ret = sfp.tx_disable_channel(platform_api_conn, i, expected_mask, True)
@@ -555,6 +563,11 @@ class TestSfpApi(PlatformApiTestBase):
                 tx_disable_chan_mask = sfp.get_tx_disable_channel(platform_api_conn, i)
                 if self.expect(tx_disable_chan_mask is not None, "Unable to retrieve transceiver {} TX disabled channel data".format(i)):
                     self.expect(tx_disable_chan_mask == expected_mask, "Transceiver {} TX disabled channel data is incorrect".format(i))
+
+                if expected_mask == 0:
+                    break
+                else:
+                    expected_mask = expected_mask >> 1
         self.assert_expectations()
 
     def _check_lpmode_status(self, sfp,platform_api_conn, i, state):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enabling individual tx channel disable for test_tx_disable_channel test and adding support for 8 channel transceiver

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, tx channel disable as part of test_tx_disable_channel test is done in combinations of multiple channels rather than just disabling individual channel at a time. The current change will disable the tx for one channel at a time and then will enable tx for all channels after the test is completed.
Also, the test will now be capable of handling 8 channel transceivers

#### How did you do it?
Based on the transceiver type, the expected mask is set for 4 or 8 channel and then tx is disabled for each channel in a while loop. Once tx disable for all channels have been verified, all lanes are brought of reset

#### How did you verify/test it?
```
With 4-channel transceiver (QSFP28 or later) on str2-7260cx3-acs-9
Without changes, link goes down after running the test_tx_disable_channel test
admin@str2-7260cx3-acs-9:~$ show int status | grep "down       up"                                                                                        
   Ethernet240          165,166      50G   9100    N/A  Ethernet61/1           trunk    down       up  QSFP28 or later         off
   Ethernet244          169,170      50G   9100    N/A  Ethernet62/1           trunk    down       up  QSFP28 or later         off
   Ethernet248          189,190      50G   9100    N/A  Ethernet63/1           trunk    down       up  QSFP28 or later         off
   Ethernet252          177,178      50G   9100    N/A  Ethernet64/1           trunk    down       up  QSFP28 or later         off
admin@str2-7260cx3-acs-9:~$

With private changes, link remains up after running the test_tx_disable_channel test
admin@str2-7260cx3-acs-9:~$ show int status | grep "down       up"
admin@str2-7260cx3-acs-9:~$

   Ethernet240          165,166      50G   9100    N/A  Ethernet61/1           trunk      up       up  QSFP28 or later         off
   Ethernet242          167,168      50G   9100    N/A  Ethernet61/3           trunk      up       up  QSFP28 or later         off
   Ethernet244          169,170      50G   9100    N/A  Ethernet62/1           trunk      up       up  QSFP28 or later         off
   Ethernet246          171,172      50G   9100    N/A  Ethernet62/3           trunk      up       up  QSFP28 or later         off
   Ethernet248          189,190      50G   9100    N/A  Ethernet63/1           trunk      up       up  QSFP28 or later         off
   Ethernet250          191,192      50G   9100    N/A  Ethernet63/3           trunk      up       up  QSFP28 or later         off
   Ethernet252          177,178      50G   9100    N/A  Ethernet64/1           trunk      up       up  QSFP28 or later         off
   Ethernet254          179,180      50G   9100    N/A  Ethernet64/3           trunk      up       up  QSFP28 or later         off

---------- generated xml file: /var/src/workspace_tx_channel/tests/logs/platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel.xml ----------
=============================================================== 1 passed in 225.28 seconds ===============================================================
INFO:root:Can not get Allure report URL. Please check logs
patelmi@e54429a272fa:/var/src/workspace_tx_channel/tests$
[tests_doc0:docker*                                                                
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
