### PR TITLE
update pfc xoff_1 and xoff_2 threshold for td3/topo-t1-lag/100000_300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -682,14 +682,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 59605
-                    pkts_num_trig_ingr_drp: 59967
+                    pkts_num_trig_ingr_drp: 60228
                     pkts_num_margin: 4
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 59605
-                    pkts_num_trig_ingr_drp: 59967
+                    pkts_num_trig_ingr_drp: 60228
                     pkts_num_margin: 4
                 hdrm_pool_size:
                     dscps: [3, 4]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update PFC drop threshold for "td3/topo-t1-lag/100000_300m".

Summary:
Update PFC drop threshold for "td3/topo-t1-lag/100000_300m".

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
below QoS testcase failed for qos parameter "td3\topo-t1-64-lag\100000_300m", because of incorrect drop threshold vlaue.
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_1]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_2]

#### How did you do it?
find correct threshold by manually testing, update qos parameters, make testcase pass.

#### How did you verify/test it?
pass xoff_1 and xoff_2 cases on local run

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
