### PR TITLE
Changed approach of interfaces' flapping on the AOS devices

### DIFF
--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -69,26 +69,12 @@ class AosHost(AnsibleHostBase):
         return self.__str__()
 
     def shutdown(self, interface_name):
-        task_name = 'Shutdown interface {}'.format(interface_name)
-        template = 'configure\n' + \
-                   '    interface {}\n'.format(interface_name) + \
-                   '    shutdown\n' + \
-                   '    exit\n' + \
-                   'exit\n' + \
-                   'exit\n'
-        out = self._exec_jinja_template(task_name, template)
+        out = self.aos_config(lines=['shutdown'], parents=['interface {}'.format(interface_name)])
         logging.info('Shut interface {}'.format(interface_name))
         return {self.hostname : out }
 
     def no_shutdown(self, interface_name):
-        task_name = 'No shutdown interface {}'.format(interface_name)
-        template = 'configure\n' + \
-                   '    interface {}\n'.format(interface_name) + \
-                   '    no shutdown\n' + \
-                   '    exit\n' + \
-                   'exit\n' + \
-                   'exit\n'
-        out = self._exec_jinja_template(task_name, template)
+        out = self.aos_config(lines=['no shutdown'], parents=['interface {}'.format(interface_name)])
         logging.info('No shut interface {}'.format(interface_name))
         return {self.hostname : out }
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Changed approach of interfaces' flapping on the AOS devices

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Using a common approach for interfaces' flapping on the AOS devices.
#### How did you do it?
Used the aos_config module for interfaces' flapping on the AOS devices.
#### How did you verify/test it?
```
PASSED platform_tests/link_flap/test_link_flap.py::test_link_flap
```
#### Any platform specific information?
SONiC Software Version: SONiC.master.140328-dirty-20220827.104720
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 8ccae96bf
Build date: Sat Aug 27 15:29:20 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
