### PR TITLE
[wr_arp] avoid timeout of connection during wr

### DIFF
--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -65,7 +65,7 @@ class ArpTest(BaseTest):
 
     def dut_exec_cmd(self, cmd):
         self.log("Executing cmd='{}'".format(cmd))
-        stdout, stderr, return_code = self.dut_connection.execCommand(cmd, timeout=30)
+        stdout, stderr, return_code = self.dut_connection.execCommand(cmd, timeout=120)
         self.log("return_code={}, stdout={}, stderr={}".format(return_code, stdout, stderr))
 
         if return_code == 0:


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->



Summary:
ptf docker invokes warm-reboot on the dut using paramiko (not ansible) but the timeout is set just to 30 sec and so 30 sec after the invocation, paramiko terminates the session on DUT thereby killing the process which invokes the warm-reboot.
As a result, the test wr_arp failed with error: "_AssertionError: The DUT wasn't rebooted._"
And the swss docker flaps until the reboot of the system.

It happens from time to time on slow systems.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
stabilize the test

#### How did you do it?
increased the timeout of paramiko connection in wr_arp.py script

#### How did you verify/test it?
tested locally each night during 1 week

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
