### PR TITLE
Updated syncd name for BRCM DNX chipsets

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -116,6 +116,10 @@ def swap_syncd(duthost, creds):
     vendor_id = _get_vendor_id(duthost)
 
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
+
+    if duthost.facts.get("platform_asic") == 'broadcom-dnx':
+        docker_syncd_name = docker_syncd_name + "-dnx"
+
     docker_rpc_image = docker_syncd_name + "-rpc"
 
     # Force image download to go through mgmt network
@@ -169,6 +173,9 @@ def restore_default_syncd(duthost, creds):
     vendor_id = _get_vendor_id(duthost)
 
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
+
+    if duthost.facts.get("platform_asic") == 'broadcom-dnx':
+        docker_syncd_name = docker_syncd_name + "-dnx"
 
     duthost.stop_service("swss")
     duthost.delete_container("syncd")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Updated test infra to fetch syncd-rpc for DNX chipsets with correct name

Summary:
Fixes # (issue)
Updated syncd-rpc name to include dnx for chassis systems

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To allow downloading of syncd-rpc image for chassis system

#### How did you do it?
Added check for chassis based hwsku for fetching dnx image

#### How did you verify/test it?
Tested on real hardware.

#### Any platform specific information?
Chassis based systems

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
