### PR TITLE
Fix verify_no_packet_any call in fib_test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -365,9 +365,8 @@ class FibTest(BaseTest):
                                 format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
-            rcvd_port_index, rcvd_pkt = verify_no_packet_any(self, masked_exp_pkt, dst_ports)
-            rcvd_port = dst_ports[rcvd_port_index]
-            return (rcvd_port, rcvd_pkt)
+            verify_no_packet_any(self, masked_exp_pkt, dst_ports)
+            return None
     #---------------------------------------------------------------------
 
     def check_ipv6_route(self, src_port, dst_ip_addr, dst_port_lists):
@@ -455,9 +454,8 @@ class FibTest(BaseTest):
                                 format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
-            rcvd_port_index, rcvd_pkt = verify_no_packet_any(self, masked_exp_pkt, dst_ports)
-            rcvd_port = dst_ports[rcvd_port_index]
-            return (rcvd_port, rcvd_pkt)
+            verify_no_packet_any(self, masked_exp_pkt, dst_ports)
+            return None
 
     def check_within_expected_range(self, actual, expected):
         '''

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -366,7 +366,7 @@ class FibTest(BaseTest):
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             verify_no_packet_any(self, masked_exp_pkt, dst_ports)
-            return None
+            return (None, None)
     #---------------------------------------------------------------------
 
     def check_ipv6_route(self, src_port, dst_ip_addr, dst_port_lists):
@@ -455,7 +455,7 @@ class FibTest(BaseTest):
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             verify_no_packet_any(self, masked_exp_pkt, dst_ports)
-            return None
+            return (None, None)
 
     def check_within_expected_range(self, actual, expected):
         '''


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The verify_no_packet_any() returns nothing. This PR fixes verify_no_packet_any() call in fib_test.py to avoid the failure in case of no packets expected (drop action) in FIB TC:
```
    "stderr_lines": [
        "WARNING: No route found for IPv6 destination :: (no default route?)", 
        "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.", 
        "  from cryptography.hazmat.backends import default_backend", 
        "vrf_test.FwdTest ... ERROR", 
        "", 
        "======================================================================", 
        "ERROR: vrf_test.FwdTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"ptftests/vrf_test.py\", line 98, in runTest", 
        "    self.check_fwd_entries()", 
        "  File \"ptftests/vrf_test.py\", line 87, in check_fwd_entries", 
        "    self.check_ip_range(ip_range, next_hop, ipv4)", 
        "  File \"ptftests/fib_test.py\", line 222, in check_ip_range", 
        "    self.check_ip_route(src_port, dst_ip, exp_port_lists, ipv4)", 
        "  File \"ptftests/fib_test.py\", line 265, in check_ip_route", 
        "    res = self.check_ipv4_route(src_port, dst_ip_addr, dst_port_lists)", 
        "  File \"ptftests/fib_test.py\", line 368, in check_ipv4_route", 
        "    rcvd_port_index, rcvd_pkt = verify_no_packet_any(self, masked_exp_pkt, dst_ports)", 
        "TypeError: 'NoneType' object is not iterable", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 0.122s", 
        "", 
        "FAILED (errors=1)"
    ], 
```

Fixes #6460

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix Vrf test cases
#### How did you do it?

#### How did you verify/test it?
Run `vrf/test_vrf.py::TestVrfIsolation`

#### Any platform specific information?
```
SONiC Software Version: SONiC.master.154150-dirty-20220928.095407
Distribution: Debian 11.5
Kernel: 5.10.0-12-2-amd64
Build commit: f890606d8
Build date: Wed Sep 28 16:09:31 UTC 2022
Built by: AzDevOps@sonic-build-workers-0025UB
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
