### PR TITLE
sonic-mgmt: Fix test_show_platform_syseeprom on Arista devices

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -125,7 +125,31 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             "0x2B": "Mellanox"
             "0xFE": "0xFBA1E964"
     """
-    if 'syseeprom_info' in dut_vars:
+    if 'arista' in duthost.facts.get( 'platform', '' ).lower():
+       """
+       'show platform syseeprom' output is vendor specific and on Arista duts the
+       output is what is contained in our prefdl. Validate that the output contains
+       non empty data.
+       """
+       pytest_assert( len( syseeprom_output_lines ) > 0, "Cmd returns no output" )
+
+       # Validate each output line has a "Key Value" format
+       parsed_syseeprom = {}
+       for line in syseeprom_output_lines:
+          fields = line.split( ': ', 1 )
+          pytest_assert( len( fields ) == 2, "Expected format: 'Key: Value'" )
+
+          key = fields[ 0 ]
+          value = fields[ 1 ]
+          parsed_syseeprom[ key ] = value
+
+       # Validate that we have a min set of expected fields
+       exp_fields = [ "SID", "SKU", "SerialNumber"  ]
+       for exp_field in exp_fields:
+          pytest_assert( parsed_syseeprom.get( exp_field, None ) is not None,
+                         "Expected field {} not present.".format( exp_field ) )
+
+    elif 'syseeprom_info' in dut_vars:
         expected_syseeprom_info_dict = dut_vars['syseeprom_info']
 
         parsed_syseeprom = {}


### PR DESCRIPTION
'show platform syseeprom' is vendor specific and on Arista devices this information is the contents of the prefdl.

Change to minimally validate that the output of the show command is non empty on an Arista device as the output does not conform to the 'syseeprom_info' format.
Use chassis get_system_eeprom_info api to have
'syseeprom_info' formatted data on an Arista device.

Signed-off-by: Aaron Payment <aaronp@arista.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, the test test_show_platform.py::test_show_platform_syseeprom fails on PikeZ due to the test assuming that the output of the cli 'show platform syseeprom' matches syseeprom_info, which is not the case on Arista devices.

#### How did you do it?
Change the test case to validate a minimal format of 'show platform syseeprom' on Arista devices.

#### How did you verify/test it?
Ran the modified test against a PikeZ dut running a 202205  swi and validated that the test is now passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
