### PR TITLE
[auto techsupport] | "show auto-techsupport" CLI output was changed in new 202205 image. 

### DIFF
--- a/tests/common/multibranch/cli/auto_techsupport.py
+++ b/tests/common/multibranch/cli/auto_techsupport.py
@@ -42,7 +42,7 @@ class AutoTechSupportCliDefault:
         'max_techsupport_limit': '10', 'max_core_size': '5', 'since': '2 days ago'}
         """
         with allure.step('Parsing "show auto-techsupport global" output'):
-            regexp = r'(enabled|disabled)\s+(\d+)\s+(\d+.\d+|\d+)\s+(\d+.\d+|\d+)\s+(\d+)\s+(\d+)\s+(.*)'
+            regexp = r'(enabled|disabled)\s+(\d+)\s+(\d+.\d+|\d+)\s+(\d+.\d+|\d+)\s+(\d+|N\/A)\s+(\d+|N\/A)\s+(.*)'
             cmd_output = self.show_auto_techsupport_global()
             state, rate_limit_interval, max_techsupport_limit, max_core_size, avail_mem, min_avail_mem, since = \
                 re.search(regexp, cmd_output).groups()
@@ -85,7 +85,7 @@ class AutoTechSupportCliDefault:
         """
         with allure.step('Parsing "show auto-techsupport-feature" output'):
             result_dict = {}
-            regexp = r'(.*)\s+(enabled|disabled)\s+(\d+)\s+(\d+\.\d|N/A)'
+            regexp = r'(.*)\s+(enabled|disabled)\s+(\d+)\s+(\d+\.\d|N\/A)'
             cmd_output = self.show_auto_techsupport_feature()
 
             name_index = 0

--- a/tests/common/multibranch/cli/auto_techsupport.py
+++ b/tests/common/multibranch/cli/auto_techsupport.py
@@ -11,8 +11,7 @@ class AutoTechSupportCli(object):
         release = kwargs.get('release')
         duthost = kwargs.get('duthost')
         supported_cli_classes = {'default': AutoTechSupportCliDefault(duthost),
-                                 '202111': AutoTechSupportCli202111(duthost),
-                                 '202205': AutoTechSupportCli202205(duthost)}
+                                 '202111': AutoTechSupportCli202111(duthost)}
 
         cli_class = supported_cli_classes.get(release, supported_cli_classes['default'])
         cli_class_name = cli_class.__class__.__name__
@@ -214,8 +213,3 @@ class AutoTechSupportCli202111(AutoTechSupportCliDefault):
                 result_dict[dump[dump_name_index].strip()] = {'triggered_by': dump[triggered_by_index],
                                                               'core_dump': dump[core_dump_index]}
         return result_dict
-
-
-class AutoTechSupportCli202205(AutoTechSupportCli202111):
-    def __int__(self, *args, **kwargs):
-        pass


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Since the CLI output of the command "show auto-techsupport" has been changed for 202205, need to move to the default class (AutoTechSupportCliDefault) instead of inheritance from the AutoTechSupportCli202111
Summary: Fixes the test failure in test_auto_techsupport.py
Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixing the test failure

#### How did you do it?

#### How did you verify/test it?
By running the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
