### PR TITLE
refactor def reboot in reboot.py

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -104,7 +104,7 @@ def check_warmboot_finalizer_inactive(duthost):
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
 
-def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh):
+def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res):
     hostname = duthost.hostname
     dut_ip = duthost.mgmt_ip
     logger.info('waiting for ssh to drop on {}'.format(hostname))
@@ -121,8 +121,6 @@ def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_s
             logger.error('reboot result: {} on {}'.format(reboot_res.get(), hostname))
         raise Exception('DUT {} did not shutdown'.format(hostname))
 
-    if not wait_for_ssh:
-        return
 
 def wait_for_startup(duthost, localhost, delay, timeout):
     # TODO: add serial output during reboot for better debuggability
@@ -200,6 +198,9 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
     
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
+    # if wait_for_ssh flag is False, do not wait for dut to boot up
+    if not wait_for_ssh:
+        return
     wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -2,6 +2,7 @@ import threading
 import time
 import re
 import logging
+import sys
 from multiprocessing.pool import ThreadPool
 from collections import deque
 from .utilities import wait_until

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -204,14 +204,14 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     logger.info('waiting for switch {} to initialize'.format(hostname))
 
     time.sleep(wait)
-    
+
     # Wait warmboot-finalizer service
     if reboot_type == REBOOT_TYPE_WARM and wait_warmboot_finalizer:
         logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:
             raise Exception('warmboot-finalizer service timeout on DUT {}'.format(hostname))
-    
+
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     pool.terminate()

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -197,7 +197,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
 
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
     
-    wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
+    wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
     # if wait_for_ssh flag is False, do not wait for dut to boot up
     if not wait_for_ssh:
         return

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -167,9 +167,9 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     return [reboot_res, dut_datetime]
 
 
-def reboot(duthost, localhost, reboot_type='cold', delay=10, \
-    timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,\
-    reboot_helper=None, reboot_kwargs=None):
+def reboot(duthost, localhost, reboot_type='cold', delay=10,
+           timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
+           reboot_helper=None, reboot_kwargs=None):
     """
     reboots DUT
     :param duthost: DUT host object

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -104,8 +104,6 @@ def check_warmboot_finalizer_inactive(duthost):
     return 'inactive' == stdout.strip()
 
 def do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool):
-    # pool for executing tasks asynchronously
-    import pdb; pdb.set_trace()
     hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
@@ -155,6 +153,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     :param reboot_kwargs: arguments to pass to the reboot_helper
     :return:
     """
+    # pool for executing tasks asynchronously
     pool = ThreadPool()
     reboot_res, dut_datetime = do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool)
 
@@ -192,8 +191,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         raise Exception('DUT {} did not startup'.format(hostname))
 
     logger.info('ssh has started up on {}'.format(hostname))
-    #wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
-    #wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -4,7 +4,7 @@ import re
 import logging
 from multiprocessing.pool import ThreadPool, TimeoutError
 from collections import deque
-from utilities import wait_until
+from .utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ SONIC_SSH_PORT  = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 REBOOT_TYPE_WARM = "warm"
+REBOOT_TYPE_SAI_WARM = "sai-warm"
 REBOOT_TYPE_COLD = "cold"
 REBOOT_TYPE_SOFT = "soft"
 REBOOT_TYPE_FAST = "fast"
@@ -76,7 +77,15 @@ reboot_ctrl_dict = {
         "wait": 120,
         "cause": "Watchdog",
         "test_reboot_cause_only": True
-    }
+    },
+    REBOOT_TYPE_SAI_WARM: {
+        "command": "/usr/bin/sai_warmboot.sh",
+        "timeout": 300,
+        "wait": 90,
+        "warmboot_finalizer_timeout": 30,
+        "cause": "warm-reboot",
+        "test_reboot_cause_only": False
+    },
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
@@ -94,9 +103,27 @@ def check_warmboot_finalizer_inactive(duthost):
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
 
-def do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool):
+def reboot(duthost, localhost, reboot_type='cold', delay=10, \
+    timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,\
+    reboot_helper=None, reboot_kwargs=None):
+    """
+    reboots DUT
+    :param duthost: DUT host object
+    :param localhost:  local host object
+    :param reboot_type: reboot type (cold, fast, warm)
+    :param delay: delay between ssh availability checks
+    :param timeout: timeout for waiting ssh port state change
+    :param wait: time to wait for DUT to initialize
+    :param wait_for_ssh: Wait for SSH startup
+    :param wait_warmboot_finalizer=True: Wait for WARMBOOT_FINALIZER done
+    :param reboot_helper: helper function to execute the power toggling
+    :param reboot_kwargs: arguments to pass to the reboot_helper
+    :return:
+    """
+
     # pool for executing tasks asynchronously
-    import pdb; pdb.set_trace()
+    pool = ThreadPool()
+    dut_ip = duthost.mgmt_ip
     hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
@@ -126,31 +153,7 @@ def do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, r
     else:
         assert reboot_helper is not None, "A reboot function must be provided for power off reboot"
         reboot_res = pool.apply_async(execute_reboot_helper)
-    return [reboot_res, dut_datetime]
 
-
-def reboot(duthost, localhost, reboot_type='cold', delay=10, \
-    timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,\
-    reboot_helper=None, reboot_kwargs=None):
-    """
-    reboots DUT
-    :param duthost: DUT host object
-    :param localhost:  local host object
-    :param reboot_type: reboot type (cold, fast, warm)
-    :param delay: delay between ssh availability checks
-    :param timeout: timeout for waiting ssh port state change
-    :param wait: time to wait for DUT to initialize
-    :param wait_for_ssh: Wait for SSH startup
-    :param wait_warmboot_finalizer=True: Wait for WARMBOOT_FINALIZER done
-    :param reboot_helper: helper function to execute the power toggling
-    :param reboot_kwargs: arguments to pass to the reboot_helper
-    :return:
-    """
-    pool = ThreadPool()
-    reboot_res, dut_datetime = do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool)
-
-    hostname = duthost.hostname
-    dut_ip = duthost.mgmt_ip
     logger.info('waiting for ssh to drop on {}'.format(hostname))
     res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
@@ -171,6 +174,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     # TODO: add serial output during reboot for better debuggability
     #       This feature requires serial information to be present in
     #       testbed information
+
     logger.info('waiting for ssh to startup on {}'.format(hostname))
     res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
@@ -183,20 +187,18 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         raise Exception('DUT {} did not startup'.format(hostname))
 
     logger.info('ssh has started up on {}'.format(hostname))
-    #wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
-    #wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
 
     time.sleep(wait)
-    
+
     # Wait warmboot-finalizer service
     if reboot_type == REBOOT_TYPE_WARM and wait_warmboot_finalizer:
         logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:
             raise Exception('warmboot-finalizer service timeout on DUT {}'.format(hostname))
-    
+
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     pool.terminate()

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -2,7 +2,7 @@ import threading
 import time
 import re
 import logging
-from multiprocessing.pool import ThreadPool, TimeoutError
+from multiprocessing.pool import ThreadPool
 from collections import deque
 from .utilities import wait_until
 
@@ -183,7 +183,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     :return:
     """
     pool = ThreadPool()
-    
+    hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
         reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
@@ -197,9 +197,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
 
     reboot_res, dut_datetime = do_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
-
-    hostname = duthost.hostname
-    dut_ip = duthost.mgmt_ip
     
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
     wait_for_startup(duthost, localhost, delay, timeout)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -10,7 +10,7 @@ from .utilities import wait_until
 logger = logging.getLogger(__name__)
 
 # SSH defines
-SONIC_SSH_PORT  = 22
+SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 REBOOT_TYPE_WARM = "warm"
@@ -20,7 +20,7 @@ REBOOT_TYPE_SOFT = "soft"
 REBOOT_TYPE_FAST = "fast"
 REBOOT_TYPE_POWEROFF = "power off"
 REBOOT_TYPE_WATCHDOG = "watchdog"
-REBOOT_TYPE_UNKNOWN  = "Unknown"
+REBOOT_TYPE_UNKNOWN = "Unknown"
 REBOOT_TYPE_THERMAL_OVERLOAD = "Thermal Overload"
 
 # Event to signal DUT activeness
@@ -97,12 +97,14 @@ REBOOT_CAUSE_HISTORY_TITLE = ["name", "cause", "time", "user", "comment"]
 MAX_RETRIES = 3
 RETRY_BACKOFF_TIME = 15
 
+
 def check_warmboot_finalizer_inactive(duthost):
     """
     Check if warmboot finalizer service is exited
     """
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
+
 
 def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res):
     hostname = duthost.hostname
@@ -140,6 +142,7 @@ def wait_for_startup(duthost, localhost, delay, timeout):
         raise Exception('DUT {} did not startup'.format(hostname))
 
     logger.info('ssh has started up on {}'.format(hostname))
+
 
 def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold'):
     # pool for executing tasks asynchronously

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -143,7 +143,7 @@ def wait_for_startup(duthost, localhost, delay, timeout):
 
     logger.info('ssh has started up on {}'.format(hostname))
 
-def do_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold'):
+def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold'):
     # pool for executing tasks asynchronously
     hostname = duthost.hostname
 
@@ -197,7 +197,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
 
-    reboot_res, dut_datetime = do_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
+    reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
     
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
     wait_for_startup(duthost, localhost, delay, timeout)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -103,7 +103,7 @@ def check_warmboot_finalizer_inactive(duthost):
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
 
-def do_reboot(duthost, reboot_type, reboot_helper, reboot_kwargs, pool):
+def do_reboot(duthost, reboot_type, reboot_command, reboot_helper, reboot_kwargs, pool):
     hostname = duthost.hostname
 
     def execute_reboot_command():
@@ -157,7 +157,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
         
-    reboot_res, dut_datetime = do_reboot(duthost, reboot_type, reboot_helper, reboot_kwargs, pool)
+    reboot_res, dut_datetime = do_reboot(duthost, reboot_type, reboot_command, reboot_helper, reboot_kwargs, pool)
 
     hostname = duthost.hostname
     dut_ip = duthost.mgmt_ip

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -103,7 +103,47 @@ def check_warmboot_finalizer_inactive(duthost):
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
 
-def do_reboot(duthost, reboot_type, reboot_command, reboot_helper, reboot_kwargs, pool):
+def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh):
+    hostname = duthost.hostname
+    dut_ip = duthost.mgmt_ip
+    logger.info('waiting for ssh to drop on {}'.format(hostname))
+    res = localhost.wait_for(host=dut_ip,
+                             port=SONIC_SSH_PORT,
+                             state='absent',
+                             search_regex=SONIC_SSH_REGEX,
+                             delay=delay,
+                             timeout=timeout,
+                             module_ignore_errors=True)
+
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
+        if reboot_res.ready():
+            logger.error('reboot result: {} on {}'.format(reboot_res.get(), hostname))
+        raise Exception('DUT {} did not shutdown'.format(hostname))
+
+    if not wait_for_ssh:
+        return
+
+def wait_for_startup(duthost, localhost, delay, timeout):
+    # TODO: add serial output during reboot for better debuggability
+    #       This feature requires serial information to be present in
+    #       testbed information
+    hostname = duthost.hostname
+    dut_ip = duthost.mgmt_ip
+    logger.info('waiting for ssh to startup on {}'.format(hostname))
+    res = localhost.wait_for(host=dut_ip,
+                             port=SONIC_SSH_PORT,
+                             state='started',
+                             search_regex=SONIC_SSH_REGEX,
+                             delay=delay,
+                             timeout=timeout,
+                             module_ignore_errors=True)
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
+        raise Exception('DUT {} did not startup'.format(hostname))
+
+    logger.info('ssh has started up on {}'.format(hostname))
+
+def do_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold'):
+    # pool for executing tasks asynchronously
     hostname = duthost.hostname
 
     def execute_reboot_command():
@@ -142,7 +182,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     :param reboot_kwargs: arguments to pass to the reboot_helper
     :return:
     """
-    # pool for executing tasks asynchronously
     pool = ThreadPool()
     
     try:
@@ -156,43 +195,14 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
-        
-    reboot_res, dut_datetime = do_reboot(duthost, reboot_type, reboot_command, reboot_helper, reboot_kwargs, pool)
+
+    reboot_res, dut_datetime = do_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
     hostname = duthost.hostname
     dut_ip = duthost.mgmt_ip
-    logger.info('waiting for ssh to drop on {}'.format(hostname))
-    res = localhost.wait_for(host=dut_ip,
-                             port=SONIC_SSH_PORT,
-                             state='absent',
-                             search_regex=SONIC_SSH_REGEX,
-                             delay=delay,
-                             timeout=timeout,
-                             module_ignore_errors=True)
-
-    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-        if reboot_res.ready():
-            logger.error('reboot result: {} on {}'.format(reboot_res.get(), hostname))
-        raise Exception('DUT {} did not shutdown'.format(hostname))
-
-    if not wait_for_ssh:
-        return
-
-    # TODO: add serial output during reboot for better debuggability
-    #       This feature requires serial information to be present in
-    #       testbed information
-    logger.info('waiting for ssh to startup on {}'.format(hostname))
-    res = localhost.wait_for(host=dut_ip,
-                             port=SONIC_SSH_PORT,
-                             state='started',
-                             search_regex=SONIC_SSH_REGEX,
-                             delay=delay,
-                             timeout=timeout,
-                             module_ignore_errors=True)
-    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-        raise Exception('DUT {} did not startup'.format(hostname))
-
-    logger.info('ssh has started up on {}'.format(hostname))
+    
+    wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
+    wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -4,7 +4,7 @@ import re
 import logging
 from multiprocessing.pool import ThreadPool, TimeoutError
 from collections import deque
-from .utilities import wait_until
+from utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,6 @@ SONIC_SSH_PORT  = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 REBOOT_TYPE_WARM = "warm"
-REBOOT_TYPE_SAI_WARM = "sai-warm"
 REBOOT_TYPE_COLD = "cold"
 REBOOT_TYPE_SOFT = "soft"
 REBOOT_TYPE_FAST = "fast"
@@ -77,15 +76,7 @@ reboot_ctrl_dict = {
         "wait": 120,
         "cause": "Watchdog",
         "test_reboot_cause_only": True
-    },
-    REBOOT_TYPE_SAI_WARM: {
-        "command": "/usr/bin/sai_warmboot.sh",
-        "timeout": 300,
-        "wait": 90,
-        "warmboot_finalizer_timeout": 30,
-        "cause": "warm-reboot",
-        "test_reboot_cause_only": False
-    },
+    }
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
@@ -103,27 +94,9 @@ def check_warmboot_finalizer_inactive(duthost):
     stdout = duthost.command('systemctl is-active warmboot-finalizer.service', module_ignore_errors=True)['stdout']
     return 'inactive' == stdout.strip()
 
-def reboot(duthost, localhost, reboot_type='cold', delay=10, \
-    timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,\
-    reboot_helper=None, reboot_kwargs=None):
-    """
-    reboots DUT
-    :param duthost: DUT host object
-    :param localhost:  local host object
-    :param reboot_type: reboot type (cold, fast, warm)
-    :param delay: delay between ssh availability checks
-    :param timeout: timeout for waiting ssh port state change
-    :param wait: time to wait for DUT to initialize
-    :param wait_for_ssh: Wait for SSH startup
-    :param wait_warmboot_finalizer=True: Wait for WARMBOOT_FINALIZER done
-    :param reboot_helper: helper function to execute the power toggling
-    :param reboot_kwargs: arguments to pass to the reboot_helper
-    :return:
-    """
-
+def do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool):
     # pool for executing tasks asynchronously
-    pool = ThreadPool()
-    dut_ip = duthost.mgmt_ip
+    import pdb; pdb.set_trace()
     hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
@@ -153,7 +126,31 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     else:
         assert reboot_helper is not None, "A reboot function must be provided for power off reboot"
         reboot_res = pool.apply_async(execute_reboot_helper)
+    return [reboot_res, dut_datetime]
 
+
+def reboot(duthost, localhost, reboot_type='cold', delay=10, \
+    timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,\
+    reboot_helper=None, reboot_kwargs=None):
+    """
+    reboots DUT
+    :param duthost: DUT host object
+    :param localhost:  local host object
+    :param reboot_type: reboot type (cold, fast, warm)
+    :param delay: delay between ssh availability checks
+    :param timeout: timeout for waiting ssh port state change
+    :param wait: time to wait for DUT to initialize
+    :param wait_for_ssh: Wait for SSH startup
+    :param wait_warmboot_finalizer=True: Wait for WARMBOOT_FINALIZER done
+    :param reboot_helper: helper function to execute the power toggling
+    :param reboot_kwargs: arguments to pass to the reboot_helper
+    :return:
+    """
+    pool = ThreadPool()
+    reboot_res, dut_datetime = do_reboot(duthost, wait, timeout, warmboot_finalizer_timeout, reboot_type, reboot_helper, reboot_kwargs, pool)
+
+    hostname = duthost.hostname
+    dut_ip = duthost.mgmt_ip
     logger.info('waiting for ssh to drop on {}'.format(hostname))
     res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
@@ -174,7 +171,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     # TODO: add serial output during reboot for better debuggability
     #       This feature requires serial information to be present in
     #       testbed information
-
     logger.info('waiting for ssh to startup on {}'.format(hostname))
     res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
@@ -187,18 +183,20 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         raise Exception('DUT {} did not startup'.format(hostname))
 
     logger.info('ssh has started up on {}'.format(hostname))
+    #wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res, wait_for_ssh)
+    #wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
 
     time.sleep(wait)
-
+    
     # Wait warmboot-finalizer service
     if reboot_type == REBOOT_TYPE_WARM and wait_warmboot_finalizer:
         logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:
             raise Exception('warmboot-finalizer service timeout on DUT {}'.format(hostname))
-
+    
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     pool.terminate()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
refactor `def reboot` function into 3 parts:
```
do_reboot
wait_for_startup
wait_for_shutdown
```
for better reusability, e.g. any reboot testcase can reuse the do_reboot part to perform reboot with any reboot type, also notice that all the 3 parts are thread-protected, meaning a threadPool need to be created to lock the 3 processes, if a reboot is performed. A single check of wait_for_shutdown/startup may or may not need a thread lock.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
break `def reboot()` into 3 parts for better reusability

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
