### PR TITLE
[kvm test] skip PR testcase test_load_minigraph_with_traffic_shift_away

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -57,6 +57,13 @@ bgp/test_bgp_speaker.py:
     conditions:
       - "topo_name in ['m0']"
 
+bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
+  skip:
+    reason: "Test is flaky and causing PR test to fail unnecessarily"
+    conditions:
+      - "asic_type in ['vs']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6471
+
 bgp/test_bgpmon.py:
   skip:
     reason: "Not supported topology backend."


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_load_minigraph_with_traffic_shift_away is flaky and causing PR test to fail unnecessarily.

#### How did you do it?
Skip test_load_minigraph_with_traffic_shift_away

#### How did you verify/test it?
This PR test

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
