### PR TITLE
Python3 migration: Fix Python3 syntax error

### DIFF
--- a/ansible/dualtor/nic_simulator/__init__.py
+++ b/ansible/dualtor/nic_simulator/__init__.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.version_info.major > 2:
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).parent))
+
 from nic_simulator_grpc_service_pb2 import AdminReply
 from nic_simulator_grpc_service_pb2 import AdminRequest
 from nic_simulator_grpc_service_pb2 import OperationRequest

--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -7,6 +7,10 @@ import re
 import sys
 import time
 
+if sys.version_info.major > 2:
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).parent))
+
 from helpers import *
 
 CONFIG_DB_FILE = "etc/sonic/config_db.json"

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -4,7 +4,12 @@ import natsort
 import json
 import collections
 import logging
+import sys
 from ipaddress import ip_address, IPv4Address
+
+if sys.version_info.major > 2:
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).parent))
 
 from macsec_config_helper import enable_macsec_feature
 from macsec_config_helper import disable_macsec_feature


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes Python3 syntax error when running test case in Python3 ven.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Python3 migration.

#### How did you do it?
Fix Python3 runtime syntax error.

#### How did you verify/test it?
Python3 can run testcase(bgp/test_bgp_fact.py::test_bgp_facts) but we do not care if the result is expected now.
Python2 can run testcase(bgp/test_bgp_fact.py::test_bgp_facts) with expected result.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A