### PR TITLE
Fix xfail for dir_bcast in dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -325,15 +325,6 @@ iface_namingmode/test_iface_namingmode.py::TestShowQueue:
       - "topo_name in ['m0']"
 
 #######################################
-#####           mvrf              #####
-#######################################
-mvrf:
-  skip:
-    reason: "M0 topo does not support mvrf"
-    conditions:
-      - "topo_name in ['m0']"
-
-#######################################
 #####            ip               #####
 #######################################
 ip/test_ip_packet.py:
@@ -409,6 +400,15 @@ mpls/test_mpls.py:
     reason: "MPLS TCs are not supported on Barefoot plarforms"
     conditions:
       - "asic_type in ['barefoot']"
+
+#######################################
+#####           mvrf              #####
+#######################################
+mvrf:
+  skip:
+    reason: "M0 topo does not support mvrf"
+    conditions:
+      - "topo_name in ['m0']"
 
 #######################################
 #####           nat               #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -367,11 +367,11 @@ ipfwd/test_dir_bcast.py:
   skip:
     reason: "Unsupported topology."
     conditions:
-      - "topo_type not in ['t0', 'm0', 'dualtor']"
+      - "topo_type not in ['t0', 'm0']"
   xfail:
     reason: "Dualtor do not support now, need to fix in buildimage."
     conditions:
-      - "topo_type in ['dualtor']"
+      - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-buildimage/issues/12167
 
 ipfwd/test_mtu.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
xfail for dir_bcast in dualtor didn't work because 'dualtor' is not 'topo_type'
#### How did you do it?
Use 'topo_name' for dualtor instead of 'topo_type'
#### How did you verify/test it?
Run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
