### PR TITLE
Use the newest KVM image after the interface disappear issue is resolved

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -10,7 +10,7 @@ t0:
   - container_checker/test_container_checker.py
   - cacl/test_cacl_application.py
   - cacl/test_cacl_function.py
-#  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcp_relay.py
   - dhcp_relay/test_dhcpv6_relay.py
   - generic_config_updater/test_aaa.py
   - generic_config_updater/test_bgpl.py
@@ -62,7 +62,7 @@ t0:
   - test_procdockerstatsd.py
 
 t0-2vlans:
-#  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcp_relay.py
   - dhcp_relay/test_dhcpv6_relay.py
 
 t0-sonic:

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -36,8 +36,7 @@ steps:
     project: build
     pipeline: 1
     artifact: sonic-buildimage.vs
-    runVersion: specific
-    runId: $(KVM_BUILD_ID)
+    runVersion: 'latestFromBranch'
     runBranch: 'refs/heads/master'
     allowPartiallySucceededBuilds: true
   displayName: "Download sonic kvm image"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use the newest KVM image after the interface disappear issue is resolved

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Use the newest KVM image after the interface disappear issue is resolved
#### How did you do it?
Use the newest KVM image
#### How did you verify/test it?
The azure pipeline will test it.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
