### PR TITLE
[bgp]Fix the test case test_TSA failure when check the routes on the eos host

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -128,7 +128,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
             routes[entry] = community
         results[hostname] = routes
 
-    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=120, concurrent_tasks=8)
+    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
     return all_routes
 
 


### PR DESCRIPTION
when parse_routes_process on the ceos host, on some VM it may failed due to the timeout, increase the timeout from 120s to 180s, and the test case can pass

Change-Id: Id60740d4fd948a087f564e76e8db506047cc67a9

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: when parse_routes_process on the ceos host, on some VM it may failed due to the timeout, increase the timeout from 120s to 180s, and the test case can pass
Fixes # (issue) Fix the test case test_TSA failure when check the routes on the eos host

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Stablize the test_TSA
#### How did you do it?
when parse_routes_process on the ceos host, on some VM it may failed due to the timeout, increase the timeout from 120s to 180s
#### How did you verify/test it?
Run the test_TSA from serveral times, and it can pass
#### Any platform specific information?
NO
#### Supported testbed topology if it's a new test case?
NO
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
