### PR TITLE
Remove bypass on duplicate lanes' platforms for GCU tests

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -27,21 +27,6 @@ def check_image_version(duthost):
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 
-@pytest.fixture(scope="module", autouse=True)
-def bypass_duplicate_lanes_platform(duthost):
-    """Skips platform that has duplicate lanes in default config
-
-    Args:
-        duthost: DUT host object.
-
-    Returns:
-        None.
-    """
-    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s' or \
-            duthost.facts['platform'] == 'x86_64-dellemc_s5232f_c3538-r0':
-        pytest.skip("Temporary skip platform with duplicate lanes...")
-
-
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -13,14 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 # Module Fixture
-@pytest.fixture(scope="module", autouse=True)
-def bypass_duplicate_lanes_platform(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s' or \
-            duthost.facts['platform'] == 'x86_64-dellemc_s5232f_c3538-r0':
-        pytest.skip("Temporary skip platform with duplicate lanes...")
-
-
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Duplicate lane check was added in sonic-utilities. Remove that in sonic-mgmt.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The GCU-related tests were bypassed in duplicate lanes' platforms. We don't want to skip GCU tests on such platforms. 
So we update the unique lane check and simply bypass the check for such platforms in GCU feature.
Now the GCU tests can be tested on such platforms.
#### How did you do it?
Fix in GCU feature.
https://github.com/sonic-net/sonic-utilities/pull/2343 has been updated to sonic-buildimage.
#### How did you verify/test it?
Run e2e test in specific platform.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
