### PR TITLE
make critical test job retriable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ stages:
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -46,7 +46,7 @@ stages:
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -61,7 +61,7 @@ stages:
     displayName: "kvmtest-t0 by TestbedV2"
     timeoutInMinutes: 1080
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -73,7 +73,7 @@ stages:
     displayName: "kvmtest-t0-2vlans by TestbedV2"
     timeoutInMinutes: 1080
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -120,7 +120,7 @@ stages:
     displayName: "kvmtest-t1-lag classic"
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -134,7 +134,7 @@ stages:
     displayName: "kvmtest-t1-lag by TestbedV2"
     timeoutInMinutes: 1080
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
continueOnError tasks return partiallySuccess if failed, hence some critical test jobs can't be retried because AZP considers it as succeeded but it actually does not.
Set continueOnError as false fixes this problem. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
continueOnError tasks return partiallySuccess if failed, hence some critical test jobs can't be retried because AZP considers it as succeeded but it actually does not.
Set continueOnError as false fixes this problem. 
#### How did you do it?
Set continueOnError as false for critical tasks
#### How did you verify/test it?
AZP tests it.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
