### PR TITLE
Revert [LogAnalyzer] Fixed sfp tests - to use common loganalyzer #5301

### DIFF
--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import os
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 ans_host = None
 
@@ -12,17 +13,16 @@ def teardown_module():
 
 
 @pytest.fixture(autouse=True)
-def update_la_ignore_errors_list_for_mlnx(duthost, loganalyzer):
+def update_la_ignore_errors_list_for_mlnx(duthost):
     if duthost.facts["asic_type"] in ["mellanox"]:
-        for host in loganalyzer:
-            loganalyzer[host].ignore_regex.append("kernel.*Eeprom query failed*")
-            # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
-            loganalyzer[host].ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
+        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
+        loganalyzer.load_common_config()
+        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
+        # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
+        loganalyzer.ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
+        marker = loganalyzer.init()
 
     yield
 
     if duthost.facts["asic_type"] in ["mellanox"]:
-        for host in loganalyzer:
-            loganalyzer[host].ignore_regex.remove("kernel.*Eeprom query failed*")
-            # Remove Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
-            loganalyzer[host].ignore_regex.remove(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
+        loganalyzer.analyze(marker)


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
#5301 introduced the issue https://github.com/sonic-net/sonic-mgmt/issues/6491,
`platform_tests.sfp.test_sfputil` keeps failing on Mellanox platforms, since loganalyzer parameter is None.

#### How did you do it?
Revert #5301


#### How did you verify/test it?
Run `platform_tests/sfp/test_sfputil.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
