### PR TITLE
[202205][m0] Add support for m0 in dir_bcast_test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
@@ -56,7 +56,7 @@ class BcastTest(BaseTest):
         self.setUpVlan(self.test_params['vlan_info'])
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = list(range(1, 25)) + list(range(28, 32))
-        if self.test_params['testbed_type'] == 't0-52':
+        if self.test_params['testbed_type'] in ['t0-52', 'm0']:
             self.src_ports = list(range(0, 52))
         if self.test_params['testbed_type'] == 't0-56':
             self.src_ports = list(range(0, 2)) + list(range(4, 6)) + list(range(8, 10)) + list(range(12, 18)) + list(range(20, 22)) + \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_dir_bcast failed in m0 topo.

#### How did you do it?
Add support for m0 in dir_bcast_test.py

#### How did you verify/test it?
Run test_dir_bcast.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
