### PR TITLE
[m0] Add support in test_vlan_ping for M0 topo

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -111,9 +111,10 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
     )
 
     # getting port index, mac, ipv4 and ipv6 of ptf ports into a dict
-    for index in range(len(rand_vlan_member_list)):
-        member = rand_vlan_member_list[index]
-        ip_in_vlan = [x for x in vlan_ip_network_v4 if x not in exclude_ip][index]
+    ips_in_vlan = [x for x in vlan_ip_network_v4 if x not in exclude_ip]
+    for member in rand_vlan_member_list:
+        # Get first and last ip in vlan for two vlan members
+        ip_in_vlan = ips_in_vlan[0 if len(ptfhost_info.keys()) == 0 else -1]
         ptfhost_info[member] = {}
         ptfhost_info[member]["Vlanid"] = vlanid
         ptfhost_info[member]["port_index"] = mg_facts['minigraph_ptf_indices'][member]

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 import logging
 import ptf.testutils as testutils
+from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.plugins import ptfadapter
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,16 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
     Teardown:   deletes ipv4 and ipv6 address on ptf hosts and removes routes to VM. Also removes residual static arp entries from tests
     """
     vm_host_info = {}
-    vm_name, vm_info = random.choice(nbrhosts.items())
+
+    vm_name, vm_info = None, None
+    topo_name = tbinfo["topo"]["name"]
+    for nbr_name, nbr_info in nbrhosts.items():
+        if topo_name != "m0" or (topo_name == "m0" and "M1" in nbr_name):
+            vm_name = nbr_name
+            vm_info = nbr_info
+            break
+
+    py_assert(vm_name is not None, "Can't get neighbor vm")
     vm_ip_with_prefix = (vm_info['conf']['interfaces']['Port-Channel1']['ipv4']).decode('utf-8')
     output = vm_info['host'].command("ip addr show dev po1")
     vm_host_info["mac"] = output['stdout_lines'][1].split()[1]
@@ -101,15 +111,16 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
     )
 
     # getting port index, mac, ipv4 and ipv6 of ptf ports into a dict
-    for member in rand_vlan_member_list:
-        random_ip_in_vlan = random.choice([x for x in vlan_ip_network_v4 if x not in exclude_ip])
+    for index in range(len(rand_vlan_member_list)):
+        member = rand_vlan_member_list[index]
+        ip_in_vlan = [x for x in vlan_ip_network_v4 if x not in exclude_ip][index]
         ptfhost_info[member] = {}
         ptfhost_info[member]["Vlanid"] = vlanid
         ptfhost_info[member]["port_index"] = mg_facts['minigraph_ptf_indices'][member]
         ptfhost_info[member]["mac"] = (ptfhost.shell(
             "ifconfig eth%d | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'" % ptfhost_info[member][
                 "port_index"]))['stdout']
-        ptfhost_info[member]["ipv4"] = str(random_ip_in_vlan)
+        ptfhost_info[member]["ipv4"] = str(ip_in_vlan)
         ptfhost_info[member]["ipv6"] = str(
             ipaddress.IPv6Interface(ip6).network[ptfhost_info[member]["port_index"]])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Sometimes test_vlan_ping failed on M0 topo.

#### How did you do it?
Remove randomly select neighbor and vlan ip in test_vlan_ping, which may cause random failed.

#### How did you verify/test it?
Run test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
