### PR TITLE
Fix for test_nhop_group.py::test_nhop_group_member_order_capability

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -24,6 +24,7 @@ cavium_hwskus: [ "AS7512", "XP-SIM" ]
 barefoot_hwskus: [ "montara", "mavericks", "Arista-7170-64C", "newport", "Arista-7170-32CD-C32" ]
 
 marvell_hwskus: [ "et6448m" ]
+innovium_tl7_hwskus: ["Wistron_sw_to3200k_32x100" , "Wistron_sw_to3200k"]
 
 cisco_hwskus: ["Cisco-8102-C64"]
 cisco-8000_gb_hwskus: ["Cisco-8102-C64"]

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -481,6 +481,7 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
             ips = [arplist.ip_mac_list[x].ip for x in range(arp_count)]
 
             # add IP route
+            nhop.ip_nhops = []
             nhop.add_ip_route(ip_prefix, ips)
 
             nhop.program_routes()
@@ -512,7 +513,7 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
     # as there is always probability even after change of Hash Function same nexthop/neighbor is selected.
 
     # Fill this array after first run of test case which will give neighbor selected
-    SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP = { "th": "172.16.0.16" }
+    SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP = { "th": "172.16.0.16" , "tl7": "172.16.0.13"}
 
     vendor = duthost.facts["asic_type"]
     hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]


### PR DESCRIPTION
Fix for test_nhop_group.py::test_nhop_group_member_order_capability and adding innovium(Marvell) platform details

### Description of PR
Fix for test_nhop_group.py::test_nhop_group_member_order_capability and adding Innovium(Marvell) platform details to pass test_nhop_group_member_order_capability 

Test ipfwd/test_nhop_group.py::test_nhop_group_member_order_capability failing with latest change
With latest scrip change, duplicate routes are getting added and route add is failing.

Summary:
Fixes # 6500

### Type of change

- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fixing the test failure for test_nhop_group_member_order_capability and adding Innovium(Marvell) platform specific details to pass this test.
#### How did you do it?

#### How did you verify/test it?
Ran the test with change and it passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation