### PR TITLE
Ignore echo_receive related ERR log for now

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -157,5 +157,5 @@ r, ".* ERR syncd#syncd.*SAI_API_ACL:_brcm_sai_acl_obj_unbind.*"
 r, ".* ERR syncd#syncd.*SAI_API_LAG:_brcm_sai_lag_acl_bind_update.*"
 
 # https://github.com/sonic-net/sonic-buildimage/issues/12303
-r, ".* ERR python3: :- echo_receive: failing to read echo rc.*"
-r, ".* ERR python3: :- echo_receive: last:errno=.*"
+r, ".* ERR .*echo_receive: failing to read echo rc.*"
+r, ".* ERR .*echo_receive: last:errno=.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -155,3 +155,7 @@ r, ".* ERR pmon#ycable.*Error: Could not get port instance for muxcable info for
 r, ".* ERR syncd#syncd.*SAI_API_ACL:_brcm_sai_acl_table_group_bind_point_detach.*"
 r, ".* ERR syncd#syncd.*SAI_API_ACL:_brcm_sai_acl_obj_unbind.*"
 r, ".* ERR syncd#syncd.*SAI_API_LAG:_brcm_sai_lag_acl_bind_update.*"
+
+# https://github.com/sonic-net/sonic-buildimage/issues/12303
+r, ".* ERR python3: :- echo_receive: failing to read echo rc.*"
+r, ".* ERR python3: :- echo_receive: last:errno=.*"


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, there is an issue for echo_receive related ERR log, issue https://github.com/sonic-net/sonic-buildimage/issues/12303.
test_lag_2 failed at teardown loganalyzer because this ERR log, ignore it for now, when the issue is fixed, will remove these two ignore ERRs.

#### How did you do it?
Add below ERR log into `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`
```
r, ".* ERR python3: :- echo_receive: failing to read echo rc.*"
r, ".* ERR python3: :- echo_receive: last:errno=.*"
```
#### How did you verify/test it?
Run `pc.test_lag_2.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
