### PR TITLE
Add support to include routed interfaces from the same asic only

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -330,14 +330,23 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
             is_backend_topo = "backend" in tbinfo["topo"]["name"]
             ipv4_interfaces = []
             used_subnets = set()
+            asic_idx = 0
             if mg_facts["minigraph_interfaces"]:
                 for intf in mg_facts["minigraph_interfaces"]:
                     if _is_ipv4_address(intf["addr"]):
-                        ipv4_interfaces.append(intf["attachto"])
+                        intf_asic_idx = duthost.get_port_asic_instance(intf["attachto"]).asic_index
+                        if not ipv4_interfaces:
+                            ipv4_interfaces.append(intf["attachto"])
+                            asic_idx = intf_asic_idx
+                            used_subnets.add(ipaddress.ip_network(intf["subnet"]))
+                        else:
+                            if intf_asic_idx != asic_idx:
+                                continue
+                            else:
+                                ipv4_interfaces.append(intf["attachto"])
                         used_subnets.add(ipaddress.ip_network(intf["subnet"]))
 
             ipv4_lag_interfaces = []
-            asic_idx = 0
             if mg_facts["minigraph_portchannel_interfaces"]:
                 for pt in mg_facts["minigraph_portchannel_interfaces"]:
                     if _is_ipv4_address(pt["addr"]):
@@ -377,6 +386,10 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                     break
             if not loopback_ip:
                 pytest.fail("ipv4 lo interface not found")
+
+            num_intfs = len(ipv4_interfaces + ipv4_lag_interfaces + vlan_sub_interfaces)
+            if num_intfs < peer_count:
+                pytest.skip("Found {} IPv4 interfaces or lags with 1 port member, but require {} interfaces".format(num_intfs, peer_count))
 
             for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces + vlan_sub_interfaces, peer_count), subnets):
                 conn = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When testing test_bgp_update_timer, bgp conftest pick interfaces from different asics. 
Test fails for conn0 on asic0 and conn1 on asic1 since interfaces are on different asics.
Add support to include interfaces from the same asic only. 
Skip testcase if IPv4 interfaces on the same asic are less than required interfaces.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add support to include interfaces from the same asic only.  test_bgp_update_timer fails if interfaces are not on the same asic.

#### How did you do it?
Find the asic.
Include only interfaces belonging to that asic.

#### How did you verify/test it?
Tested test_bgp_update_timer on a multi asics chassis for a board with only one interface on each asic.  This skipped the test case.
Tested test_bgp_update_timer on a multi asics chassis for a board with many interfaces on the same asic. This passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
