### PR TITLE
[dhcpv6_relay] Change interface binding check regex

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -131,7 +131,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
-        assert "*:*" in output, "dhcp6relay socket is not properly binded"
+        assert ("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']) or "*:*" in output, "{} is not found in {}".format("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']), output)) or ("*:*" in output, "dhcp6relay socket is not properly binded")
 
 def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     """ Test DHCPv6 Counter """

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -131,7 +131,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
-        assert "*:*" in output, "ERR: dhcp6relay socket is not properly binded"
+        assert "*:*" in output, "dhcp6relay socket is not properly binded"
 
 def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     """ Test DHCPv6 Counter """

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -131,7 +131,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
-        assert "*:{}".format(dhcp_relay['downlink_vlan_iface']['name']) in output, "{} is not found in {}".format("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']), output)
+        assert "*:*" in output, "ERR: dhcp6relay socket is not properly binded"
 
 def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     """ Test DHCPv6 Counter """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
dhcp6relay socket binds to any interface instead of specified interface. 

admin@vlab-06:~$ docker exec -it dhcp_relay ss -nlp | grep dhcp6relay
p_raw UNCONN 0      0                                                                                       *:*                          *        users:(("dhcp6relay",pid=66,fd=14))
u_dgr UNCONN 0      0                                                                                       * 1341334                   * 1217572 users:(("dhcp6relay",pid=66,fd=7)) 
udp   UNCONN 0      0                                                     [fe80::2aa:bbff:fecc:ddee]%Vlan1000:547                    [::]:*       users:(("dhcp6relay",pid=66,fd=16))
udp   UNCONN 0      0                                                                          [fc02:1000::1]:547                    [::]:*       users:(("dhcp6relay",pid=66,fd=15))

#### How did you do it?
Remove vlan interface check

#### How did you verify/test it?
Run interface binding test with new dhcp6relay changes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
