### PR TITLE
[grpc] update GRPC configuration with sed

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -543,24 +543,28 @@
 
           - name: parse initial grpc credentials
             set_fact:
-              grpc_secrets: "{{ grpc_credential_content.content | b64decode | from_json }}"
+              grpc_secrets_before: "{{ grpc_credential_content.content | b64decode | from_json }}"
 
           - name: use insecure grpc for testing
+            shell: "sed -E -i 's/\"type\": \"secure\"/\"type\": \"insecure\"/' {{ grpc_credential_file }}"
+            become: true
+
+          - name: collect current grpc credentials
+            slurp:
+              path: "{{ grpc_credential_file }}"
+            register: grpc_credential_content
+
+          - name: parse current grpc credentials
             set_fact:
-              grpc_secrets: "{{ grpc_secrets | combine(new_item, recursive=true) }}"
-            vars:
-              new_item: "{ '{{ item.key }}': { 'config': 'insecure' } }"
-            with_dict: "{{ grpc_secrets }}"
+              grpc_secrets_after: "{{ grpc_credential_content.content | b64decode | from_json }}"
+
+          - name: show original grpc setting
+            debug:
+              var: grpc_secrets_before
 
           - name: show new grpc setting
             debug:
-              var: grpc_secrets
-
-          - name: save new grpc setting
-            copy:
-              content: "{{ grpc_secrets | to_nice_json }}"
-              dest: "{{ grpc_credential_file }}"
-            become: true
+              var: grpc_secrets_after
 
           - name: restart the pmon service
             service:


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The original code updated the grpc configuration and left a file with unexpected format. Causing the ycabled module unable to initialize.

#### How did you do it?
Use more direct way (sed) to update the configuration file.

#### How did you verify/test it?
Deploy minigraph on active-active testbed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
