### PR TITLE
[dualtor] increase MUX toggling wait time to 2 minutes

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -565,7 +565,7 @@ def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, 
     mg_facts = upper_tor_host.get_extended_minigraph_facts(tbinfo)
     port_indices = mg_facts['minigraph_port_indices']
     pytest_assert(
-        utilities.wait_until(30, 5, 0, _check_mux_status_consistency),
+        utilities.wait_until(120, 5, 0, _check_mux_status_consistency),
         "Mux status is inconsistent between the DUTs and mux simulator after toggle"
     )
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Noticed that the mux toggle time is often just exceed the original 30 seconds wait time.

#### How did you do it?
 In order to reduce false positives, increase the wait time to 2 minutes.

#### How did you verify/test it?
Manually run tests that failed often with this issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
