### PR TITLE
Xfail some platform_api cases on Celestica platform due to known psud issue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -74,6 +74,20 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
 #######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
+platform_tests/api/test_chassis::TestChassisApi:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_speed_tolerance:
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
   #using RPM rather than thermalctld checking tolerance on percentages
@@ -226,6 +240,18 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+
+platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led:
   skip:
@@ -237,6 +263,13 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 ##### api/test_fan_drawer_fans.py #####
 #######################################
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_speed_tolerance:
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
   #using RPM rather than thermalctld checking tolerance on percentages
@@ -309,6 +342,18 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_status:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+
+platform_tests/api/test_psu.py::TestPsuApi::test_get_presence:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu.py::TestPsuApi::test_led:
   skip:
@@ -321,6 +366,11 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
   skip:
@@ -348,12 +398,23 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_serial:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_presence:
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
   skip:
     reason: "On Cisco 8000 and mellanox platform, PSU led are unable to be controlled by software"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000']"
+  xfail:
+    reason: "Celestica known issue"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -47,18 +47,6 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_supervisor_slot:
     conditions:
       - "asic_type in ['mellanox']"
 
-platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
-  skip:
-    reason: "Unsupported platform API"
-    conditions:
-      - "asic_type in ['barefoot'] and hwsku in ['newport']"
-
-platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
-  skip:
-    reason: "Unsupported platform API"
-    conditions:
-      - "asic_type in ['mellanox']"
-
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_thermal_manager:
   skip:
     reason: "Unsupported platform API"
@@ -68,8 +56,16 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_thermal_manager:
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
+    conditions_logical_operator: or
     conditions:
       - "'sw_to3200k' in hwsku"
+      - "asic_type in ['barefoot'] and hwsku in ['newport']"
+
+platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['mellanox']"
 
 #######################################
 #####   api/test_chassis_fans.py  #####
@@ -106,22 +102,20 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_serial:
   #Fan tray serial numbers cannot be retrieved through software in cisco platform
   #there is no fan tray idprom
   skip:
-    reason: "Unsupported platform API"
+    reason: "Unsupported platform API or retrieving fan tray serial number is not supported in Cisco 8000"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
-    reason: "Retrieving fan tray serial number is not supported in Cisco 8000"
-    conditions:
       - "asic_type in ['cisco-8000']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
   skip:
-    reason: "Unsupported platform API"
+    reason: "Unsupported platform API or on Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
-    reason: "On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API"
-    conditions:
       - "asic_type in ['cisco-8000']"
-      
+
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
   #test_set_fans_speed requires get_speed_tolerance to be implemented
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
@@ -299,8 +293,8 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
        - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
-   #test_set_fans_speed requires get_speed_tolerance to be implemented 
-   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+   #test_set_fans_speed requires get_speed_tolerance to be implemented
+   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
    #using RPM rather than thermalctld checking tolerance on percentages
    skip:
      reason: "Unsupported platform API"
@@ -761,12 +755,10 @@ platform_tests/test_reboot.py::test_warm_reboot:
 
 platform_tests/test_reboot.py::test_watchdog_reboot:
   skip:
-    reason: "Skip watchdog reboot test for Wistron"
+    reason: "Skip watchdog reboot test for Wistron or m0"
+    conditions_logical_operator: or
     conditions:
       - "hwsku in ['Celestica-E1031-T48S4'] or 'sw_to3200k' in hwsku"
-  skip:
-    reason: "Skip watchdog reboot test for m0"
-    conditions:
       - "topo_name in ['m0']"
 
 #######################################


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some platform_api cases failed on Celestica platform due to know psud issue.
File an issue to track it https://github.com/sonic-net/sonic-mgmt/issues/6512.
These are impacted cases:
```
platform_tests.api.test_chassis.TestChassisApi::test_get_model
platform_tests.api.test_chassis.TestChassisApi::test_get_serial
platform_tests.api.test_chassis.TestChassisApi::test_get_base_mac
platform_tests.api.test_chassis.TestChassisApi::test_get_system_eeprom_info
platform_tests.api.test_chassis_fans.TestChassisFans::test_get_presence
platform_tests.api.test_chassis_fans.TestChassisFans::test_get_status
platform_tests.api.test_chassis_fans.TestChassisFans::test_get_speed
platform_tests.api.test_chassis_fans.TestChassisFans::test_get_direction
platform_tests.api.test_chassis_fans.TestChassisFans::test_get_fans_target_speed
platform_tests.api.test_chassis_fans.TestChassisFans::test_set_fans_speed
platform_tests.api.test_chassis_fans.TestChassisFans::test_set_fans_led
platform_tests.api.test_fan_drawer.TestFanDrawerApi::test_get_presence
platform_tests.api.test_fan_drawer.TestFanDrawerApi::test_get_status
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_get_presence
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_get_status
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_get_speed
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_get_direction
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_get_fans_target_speed
platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans::test_set_fans_speed
platform_tests.api.test_psu.TestPsuApi::test_get_presence
platform_tests.api.test_psu.TestPsuApi::test_get_status
platform_tests.api.test_psu.TestPsuApi::test_power
platform_tests.api.test_psu_fans.TestPsuFans::test_get_presence
platform_tests.api.test_psu_fans.TestPsuFans::test_set_fans_led
```
#### How did you do it?
Xfail those cases for now.

#### How did you verify/test it?
```
=========================== short test summary info ============================
XFAIL platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led[str-dx010-acs-4]
  Celestica known issue
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
