### PR TITLE
[tests/override_config_table] Update override config test with new CLI

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -58,7 +58,7 @@ def get_running_config(duthost):
 
 def reload_minigraph_with_golden_config(duthost, json_data):
     duthost.copy(content=json.dumps(json_data, indent=4), dest=GOLDEN_CONFIG)
-    config_reload(duthost, config_source="minigraph", safe_reload=True)
+    config_reload(duthost, config_source="minigraph", safe_reload=True, override_config=True)
 
 
 @pytest.fixture(scope="module")
@@ -175,7 +175,7 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
     current_config = get_running_config(duthost)
     pytest_assert(
         current_config.get('SYSLOG_SERVER', None) is None,
-        "Empty table removal fail: {}".format(current_config['SYSLOG_SERVER'])
+        "Empty table removal fail: {}".format(current_config)
     )
 
 
@@ -187,3 +187,4 @@ def test_load_minigraph_with_golden_config(duthost, setup_env):
     load_minigraph_with_golden_new_feature(duthost)
     full_config = setup_env
     load_minigraph_with_golden_full_config(duthost, full_config)
+    load_minigraph_with_golden_empty_table_removal(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: load_minigraph CLI with overriding has changed. Update in E2E test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
config load_minigraph no longer consume /etc/sonic/golden_config_db.json as default. Updated CLI will override with option -o. So I updated the override config test with the new CLI.
#### How did you do it?
Update test CLI.
#### How did you verify/test it?
Run local test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
