### PR TITLE
Add KVMDUMP stage, refine check logic

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -51,7 +51,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 43200 --expected-state "PREPARE_TESTBED"
+      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 43200 --expected-states PREPARE_TESTBED EXECUTING KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Lock testbed
@@ -64,7 +64,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 2400 --expected-state "EXECUTING"
+      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 2400 --expected-states EXECUTING KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Prepare testbed
@@ -74,12 +74,23 @@ steps:
       echo "Run test"
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
-      # When "EXECUTING" finish, it changes into "FAILED", "CANCELLED" or "FINISHED"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 18000 --expected-state "FINISHED"
+      # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
+      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 18000 --expected-states KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Run test
     timeoutInMinutes: 300
+
+  - script: |
+      echo "KVM dump"
+      echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
+      echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
+      # When "KVMDUMP" finish, it changes into "FAILED", "CANCELLED" or "FINISHED"
+      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 43200 --expected-states FINISHED CANCELLED FAILED
+    env:
+      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+    displayName: KVM dump
+    timeoutInMinutes: 20
 
   - script: |
       set -ex

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -55,7 +55,7 @@ steps:
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Lock testbed
-    timeoutInMinutes: 720
+    timeoutInMinutes: 240
 
   - script: |
       echo "Prepare testbed"

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -140,7 +140,7 @@ class TestPlanManager(object):
         print("Result of cancelling test plan at {}:".format(tp_url))
         print(str(resp["data"]))
 
-    def poll(self, test_plan_id, interval=60, timeout=36000, expected_state=""):
+    def poll(self, test_plan_id, interval=60, timeout=36000, expected_states=""):
         '''
         The states of testplan can be described as below:
                                                                 |-- FAILED
@@ -190,7 +190,7 @@ class TestPlanManager(object):
                 else:
                     raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds" \
                                     .format(test_plan_id, status, result, time.time() - start_time))
-            elif status == expected_state:
+            elif status in expected_states:
                 return
             else:
                 print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds" \
@@ -287,12 +287,12 @@ if __name__ == "__main__":
         )
 
     parser_poll.add_argument(
-        "-e", "--expected-state",
+        "-e", "--expected-states",
         type=str,
-        dest="expected_state",
+        dest="expected_states",
         required=False,
+        nargs='*',
         help="Expected state.",
-        choices = ["PREPARE_TESTBED", "EXECUTING", "FINISHED"],
         default="FINISHED"
     )
     parser_poll.add_argument(
@@ -373,7 +373,7 @@ if __name__ == "__main__":
                 output=args.output
             )
         elif args.action == "poll":
-            tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_state)
+            tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_states)
         elif args.action == "cancel":
             tp.cancel(args.test_plan_id)
         sys.exit(0)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -48,8 +48,8 @@ class TestPlanManager(object):
         except Exception as e:
             raise Exception("Get token failed with exception: {}".format(repr(e)))
 
-    def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="", min_worker=1, max_worker=2, pr_id="unknown", scripts=[],
-               output=None):
+    def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
+               min_worker=1, max_worker=2, pr_id="unknown", scripts=[], output=None):
         tp_url = "{}/test_plan".format(self.url)
         print("Creating test plan, topology: {}, name: {}, build info:{} {} {}".format(topology, test_plan_name, repo_name, pr_id, build_id))
         print("Test scripts to be covered in this test plan:")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,7 @@ stages:
 
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
-    timeoutInMinutes: 1080
+    timeoutInMinutes: 600
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
     steps:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Add a new stage: KVMDUMP
2. Refine assert logic, support to assert several different statuses,  for example,  A test plan in PREPARE_TESTBED status can be directly jump to CANCELLED due to the operation on Testbedtool management page.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
1. Add a new stage: KVMDUMP
2. Refine assert logic, support to assert several different statuses,  for example,  A test plan in PREPARE_TESTBED status can be directly jump to CANCELLED due to the operation on Testbedtool management page.
#### How did you do it?
1. Add a new stage: KVMDUMP
2. Refine assert logic, support to assert several different statuses,  for example,  A test plan in PREPARE_TESTBED status can be directly jump to CANCELLED due to the operation on Testbedtool management page.
#### How did you verify/test it?
Azure pipeline will test it.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
