### PR TITLE
changing routes added in test_crm_route from 10 to 16

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -474,9 +474,9 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
 
     # Add IPv[4/6] routes 
-    # Cisco platforms need an upward of 10 routes for crm_stats_ipv4_route_available to decrement
+    # Cisco platforms need an upward of 16 routes for crm_stats_ipv4_route_available to decrement
     if is_cisco_device(duthost) and ip_ver == '4':
-        total_routes = 10
+        total_routes = 16
     else:
         total_routes = 1
     for i in range(total_routes):


### PR DESCRIPTION
Increasing routes added in test_crm_route from 10 to 16.
It was assumed that adding 10 routes would be sufficient to ensure that the HW would decrement the CRM resource count by 1. But this does not happen in some cases; so changing the routes added from 10 to 16
