### PR TITLE
Added xfail markers to certain platform API tests due to known issues

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -72,28 +72,28 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
       - "'sw_to3200k' in hwsku"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_model:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
@@ -146,49 +146,49 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
       - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_presence:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_status:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_target_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
@@ -311,14 +311,14 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
       - "asic_type in ['mellanox'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
@@ -365,42 +365,42 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
        - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_status:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_presence:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_direction:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_target_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
@@ -441,6 +441,9 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_status:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+  xfail:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
@@ -455,6 +458,8 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+  xfail:
+    reason: "Testcase consistently fails, raised issue to track"
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
  
@@ -465,7 +470,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_presence:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
@@ -497,6 +502,8 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
     reason: "On Cisco 8000 and mellanox platform, PSU led are unable to be controlled by software"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000']"
+  xfail:
+    reason:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
@@ -507,7 +514,7 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed:
       - "asic_type in ['mellanox']"
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_presence:
-  skip:
+  xfail:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -460,6 +460,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
       - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
   xfail:
     reason: "Testcase consistently fails, raised issue to track"
+    conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
  

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -71,6 +71,30 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
     conditions:
       - "'sw_to3200k' in hwsku"
 
+platform_tests/api/test_chassis.py::TestChassisApi::test_get_model:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
 #######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
@@ -116,6 +140,48 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000']"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_presence:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_status:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_target_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
 
 #######################################
 #####    api/test_component.py    #####
@@ -233,6 +299,18 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
     conditions:
       - "asic_type in ['mellanox'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
 
+platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
 
 #######################################
 ##### api/test_fan_drawer_fans.py #####
@@ -274,6 +352,42 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
      conditions:
        - "asic_type in ['mellanox', 'cisco-8000']"
 
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_status:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_presence:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_direction:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_target_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+
 #######################################
 ##### api/test_module.py #####
 #######################################
@@ -308,7 +422,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_status:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or 'Celestica-DX010-C32' in hwsku"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_led:
   skip:
@@ -320,13 +434,19 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
-
+      - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0'] or 'Celestica-DX010-C32' in hwsku"
+ 
 platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
   skip:
     reason: "Unsupported platform API"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
+platform_tests/api/test_psu.py::TestPsuApi::test_get_presence:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
 
 #######################################
 #####    api/test_psu_fans.py     #####
@@ -353,13 +473,19 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
   skip:
     reason: "On Cisco 8000 and mellanox platform, PSU led are unable to be controlled by software"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000']"
+      - "asic_type in ['mellanox', 'cisco-8000'] or 'Celestica-DX010-C32' in hwsku"
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed:
   skip:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+
+platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_presence:
+  skip:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/6518 and 'Celestica-DX010-C32' in hwsku"
 
 #######################################
 #####        api/test_sfp.py      #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -75,25 +75,29 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_model:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 #####   api/test_chassis_fans.py  #####
@@ -145,43 +149,50 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_presence:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_status:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_target_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 #####    api/test_component.py    #####
@@ -303,14 +314,15 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
-
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 ##### api/test_fan_drawer_fans.py #####
@@ -356,37 +368,43 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_status:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_presence:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_direction:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_target_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 ##### api/test_module.py #####
@@ -422,7 +440,9 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_status:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox'] or 'Celestica-DX010-C32' in hwsku"
+      - "asic_type in ['mellanox']"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu.py::TestPsuApi::test_led:
   skip:
@@ -434,7 +454,9 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0'] or 'Celestica-DX010-C32' in hwsku"
+      - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
  
 platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
   skip:
@@ -446,7 +468,8 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_presence:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 #####    api/test_psu_fans.py     #####
@@ -473,7 +496,9 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
   skip:
     reason: "On Cisco 8000 and mellanox platform, PSU led are unable to be controlled by software"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000'] or 'Celestica-DX010-C32' in hwsku"
+      - "asic_type in ['mellanox', 'cisco-8000']"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed:
   skip:
@@ -485,7 +510,8 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_presence:
   skip:
     reason: "Testcase consistently fails, raised issue to track"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/6518 and 'Celestica-DX010-C32' in hwsku"
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6518
 
 #######################################
 #####        api/test_sfp.py      #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Several platform API and PSU related tests are failing due to known issues on the Celestica dx010 platform. Github tracker issues #6512 and #6518 raised and tests skipped for the time being.

#### How did you do it?

Add skip section in tests_mark_conditions_platform_tests.yaml file.

#### How did you verify/test it?

'''
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_presence[str2-dx010-acs-7] SKIPPED            [ 15%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_status[str2-dx010-acs-7] SKIPPED              [ 38%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_speed[str2-dx010-acs-7] SKIPPED               [ 61%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction[str2-dx010-acs-7] SKIPPED           [ 69%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_target_speed[str2-dx010-acs-7] SKIPPED   [ 76%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed[str2-dx010-acs-7] SKIPPED          [ 92%]
platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led[str2-dx010-acs-7] SKIPPED            [100%]



11/10/2022 20:35:55 __init__.pytest_collection_modifyitems   L0538 DEBUG  | Found match "[{u'platform_tests/api/test_chassis.py::TestChassisApi::test_get_model': {u'skip': {u'reason': u'Testcase consistently fails, raised issue to track', u'conditions': [u"https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"]}}}, {u'platform_tests/api': {u'skip': {u'reason': u'Unsupported platform API', u'conditions': [u"is_multi_asic==True and release in ['201911']"]}}}]" for test case "platform_tests/api/test_chassis.py::TestChassisApi::test_get_model[str2-dx010-acs-7]"

11/10/2022 20:35:56 __init__.pytest_collection_modifyitems   L0538 DEBUG  | Found match "[{u'platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial': {u'skip': {u'reason': u'Testcase consistently fails, raised issue to track', u'conditions': [u"https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"]}}}, {u'platform_tests/api': {u'skip': {u'reason': u'Unsupported platform API', u'conditions': [u"is_multi_asic==True and release in ['201911']"]}}}]" for test case "platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial[str2-dx010-acs-7]"

11/10/2022 20:35:56 __init__.pytest_collection_modifyitems   L0538 DEBUG  | Found match "[{u'platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac': {u'skip': {u'reason': u'Testcase consistently fails, raised issue to track', u'conditions': [u"https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"]}}}, {u'platform_tests/api': {u'skip': {u'reason': u'Unsupported platform API', u'conditions': [u"is_multi_asic==True and release in ['201911']"]}}}]" for test case "platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac[str2-dx010-acs-7]"

11/10/2022 20:35:56 __init__.pytest_collection_modifyitems   L0538 DEBUG  | Found match "[{u'platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info': {u'skip': {u'reason': u'Testcase consistently fails, raised issue to track', u'conditions': [u"https://github.com/sonic-net/sonic-mgmt/issues/6512 and 'Celestica-DX010-C32' in hwsku"]}}}, {u'platform_tests/api': {u'skip': {u'reason': u'Unsupported platform API', u'conditions': [u"is_multi_asic==True and release in ['201911']"]}}}]" for test case "platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info[str2-dx010-acs-7]"



platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_presence[str2-dx010-acs-7] SKIPPED       [ 15%]
platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_status[str2-dx010-acs-7] SKIPPED         [ 38%]
platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_speed[str2-dx010-acs-7] SKIPPED          [ 61%]
platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_direction[str2-dx010-acs-7] SKIPPED      [ 69%]
platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_target_speed[str2-dx010-acs-7] SKIPPED [ 76%]
platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed[str2-dx010-acs-7] SKIPPED     [ 92%]



- generated xml file: /var/src/sonic-mgmt-int/tests/logs/platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status.xml SKIPPED [1] platform_tests/api/test_fan_drawer.py: Testcase consistently fails, raised issue to track
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence.xml SKIPPED [1] platform_tests/api/test_fan_drawer.py: Testcase consistently fails, raised issue to track



platform_tests/api/test_psu.py::TestPsuApi::test_get_presence[str2-dx010-acs-7] SKIPPED                          [ 14%]
platform_tests/api/test_psu.py::TestPsuApi::test_get_status[str2-dx010-acs-7] SKIPPED                            [ 42%]
platform_tests/api/test_psu.py::TestPsuApi::test_power[str2-dx010-acs-7] SKIPPED                                 [ 71%]



platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_presence[str2-dx010-acs-7] SKIPPED                    [ 15%]
platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led[str2-dx010-acs-7] SKIPPED                    [100%]

'''

#### Any platform specific information?

This is on the Celestica dx010 platform only

#### Supported testbed topology if it's a new test case?
N/A