### PR TITLE
Changes to fix flaky TSA test on KVM

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -50,11 +50,11 @@ def verify_traffic_shift(host, outputs, match_result):
 
 def get_traffic_shift_state(host):
     outputs = host.shell('TSC')['stdout_lines']
-    if verify_traffic_shift(host, outputs, TS_NORMAL) is not "ERROR":
+    if verify_traffic_shift(host, outputs, TS_NORMAL) != "ERROR":
         return TS_NORMAL
-    if verify_traffic_shift(host, outputs, TS_MAINTENANCE) is not "ERROR":
+    if verify_traffic_shift(host, outputs, TS_MAINTENANCE) != "ERROR":
         return TS_MAINTENANCE
-    if verify_traffic_shift(host, outputs, TS_INCONSISTENT) is not "ERROR":
+    if verify_traffic_shift(host, outputs, TS_INCONSISTENT) != "ERROR":
         return TS_INCONSISTENT
     pytest.fail("TSC return unexpected state {}".format("ERROR"))
 
@@ -103,8 +103,8 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
                                                                                              BGP_COMMUNITY_HEADING)
             # For compatibility on EOS of old version
             cmd_backup = "show ipv6 bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6,
-                                                                                                        BGP_ENTRY_HEADING,
-                                                                                                        BGP_COMMUNITY_HEADING)
+                                                                                                BGP_ENTRY_HEADING,
+                                                                                                BGP_COMMUNITY_HEADING)
         res = host.eos_command(commands=[cmd], module_ignore_errors=True)
         if res['failed'] and cmd_backup != "":
             res = host.eos_command(commands=[cmd_backup], module_ignore_errors=True)
@@ -295,7 +295,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
         # Issue TSA on DUT
         duthost.shell("TSA")
         duthost.shell('sudo config save -y')
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        config_reload(duthost, check_intf_up_ports=True)
 
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
@@ -313,16 +313,18 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
         # Recover to Normal state
         duthost.shell("TSB")
         duthost.shell('sudo config save -y')
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        config_reload(duthost, check_intf_up_ports=True)
 
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                      "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                      "Not all ipv6 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0, 
+                                verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
+                                "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0, 
+                                verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
+                                "Not all ipv6 routes are announced to neighbors")
 
 
 def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown,
@@ -357,7 +359,9 @@ def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpm
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                      "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                      "Not all ipv6 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0, 
+                                verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
+                                "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0, 
+                                verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
+                                "Not all ipv6 routes are announced to neighbors")

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -318,9 +318,10 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
-        pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
+        # Wait until all routes are announced to neighbors
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
                       "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
                       "Not all ipv6 routes are announced to neighbors")
 
 
@@ -355,7 +356,8 @@ def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpm
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
-        pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
+        # Wait until all routes are announced to neighbors
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 4), 4),
                       "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, parse_rib(duthost, 6), 6),
                       "Not all ipv6 routes are announced to neighbors")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_TSA_TSB_with_config_reload &  test_load_minigraph_with_traffic_shift_away tests fail intermittently and cause PR test failures

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Prevent intermittent PR test failure while executing test_TSA_TSB_with_config_reload.  When route learning after config reload/load_minigraph takes longer, this results in failure while validating if all routes are learnt

#### How did you do it?
Added changes to wait until all routes are learnt

#### How did you verify/test it?
Run test_TSA_TSB_with_config_reload multiple times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
