### PR TITLE
Improve speed of stopping exabgp if PTF container is already down

### DIFF
--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -96,12 +96,20 @@
     delegate_to: localhost
   when: exabgp_action == 'start'
 
+- name: Check if ptf is accessible
+  wait_for:
+    host: "{{ ptf_host_ip }}"
+    port: 22
+    timeout: 3
+  register: ptf_accessible
+  ignore_errors: true
+  delegate_to: localhost
+
 - block:
   - name: Stop exabgp processes for IPv4 on PTF
     exabgp:
       name: "{{ vm_item.key }}"
       state: "stopped"
-    ignore_unreachable: yes
     loop: "{{ topology['VMs']|dict2items }}"
     loop_control:
       loop_var: vm_item
@@ -111,9 +119,8 @@
     exabgp:
       name: "{{ vm_item.key }}-v6"
       state: "stopped"
-    ignore_unreachable: yes
     loop: "{{ topology['VMs']|dict2items }}"
     loop_control:
       loop_var: vm_item
     delegate_to: "{{ ptf_host }}"
-  when: exabgp_action == 'stop'
+  when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PR #6241 added steps to stop exabgp process running in PTF container during remove-topo procedure. However, when the PTF container is already down, stopping exabgp could take a long time. The code need to stop all the exabgp processes one by one. Because PTF container is already down, each stopping operation will timeout eventually. This is even worse on t1 topology which has totally 48 exabgp processes to stop.

#### How did you do it?
This change added step to check PTF accessibility before trying to stop exabgp processes. When the PTF is inaccessible, just skip the steps stopping exabgp.

#### How did you verify/test it?
Tried remove-topo and add-topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
