### PR TITLE
Remove autopep8 from pre-commit check

### DIFF
--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -14,11 +14,15 @@ steps:
   displayName: 'checkout sonic-mgmt repo'
 
 - script: |
+    set -ex
+
     sudo pip install pre-commit
     pre-commit install-hooks
   displayName: 'Prepare pre-commit check'
 
 - script: |
+    set -ex
+
     out=`pre-commit run --color never --from-ref HEAD^ --to-ref HEAD 2>&1`
     RC=$?
 
@@ -48,20 +52,23 @@ steps:
       <samp>$(results)</samp>
 
       To run the pre-commit checks locally, you can follow below steps:
-      1. Ensure that the `pre-commit` package is installed:
+      1. Ensure that default python is python3. In sonic-mgmt docker container, default python is python2. You can run
+         the check by activating the python3 virtual environment in sonic-mgmt docker container or outside of sonic-mgmt
+         docker container.
+      2. Ensure that the `pre-commit` package is installed:
       ```
       sudo pip install pre-commit
       ```
-      2. Go to repository root folder
-      3. Install the pre-commit hooks:
+      3. Go to repository root folder
+      4. Install the pre-commit hooks:
       ```
       pre-commit install
       ```
-      4. Use pre-commit to check staged file:
+      5. Use pre-commit to check staged file:
       ```
       pre-commit
       ```
-      5. Alternatively, you can check committed files using:
+      6. Alternatively, you can check committed files using:
       ```
       pre-commit run --from-ref <commit_id> --to-ref <commit_id>
       ```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,6 @@ repos:
     -   id: check-added-large-files
     -   id: check-ast
 
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.6.0
-    hooks:
-    -   id: autopep8
-        args: ["--max-line-length=120", "--in-place"]
-
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The function of autopep8 is duplicated with flake8 and it updates scripts in place by default. The other problem is that autopep8 does not show what it has changed in command output. It simply raises a "failed" flag. We have to run pre-commit check locally to figure out what's the problem.

Considering these drawbacks, we can remove autopep8 from pre-commit check. Just use flake8 check should be enough.

#### How did you do it?
This change removed the autopep8 pre-commit check from the `.pre-commit-config.yaml` config file.

The other thing is that pre-commit only supports python3. This change improved the Github comment template for pre-commit.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
