### PR TITLE
[voq] [chassis] Bug fixes to get iface_namingmode tests to work on multi-asic linecards of a T2 chassis

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -165,7 +165,7 @@ class SonicPortAliasMap():
                     else:
                         alias = name
                     add_port = False
-                    if role in {"Ext", "Inb", "Rec"} or (role == "Int" and include_internal):
+                    if role in {"Ext"} or (role in ["Int", "Inb", "Rec"] and include_internal):
                         add_port = True
                         aliases.append((alias, -1 if port_index == -1 or len(mapping) <= port_index else mapping[port_index]))
                         portmap[name] = alias


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, the following test isfailing on multi-asic linecards on a T2 VoQ chassis.
- show pfc counters: This fails as the Inband and Recycle ports show in the 'show pfc counters' table while they are not expected.

#### How did you do it?
- show pfc counters:
   - Treat Inband and Recycle ports on a VoQ chassis as internal ports. Since the inband and recycle ports do not show up in 'show' commands unless we specify '-d all' option, they should be treated similar to internal ports.


#### How did you verify/test it?
Ran the test against a multi-asic linecard in a T2 VoQ chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
