### PR TITLE
[chassis] skip test_bgp_gr_helper.py for T2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -39,6 +39,12 @@ bgp/test_bgp_bbr.py:
     conditions:
       - "'t1' not in topo_type"
 
+bgp/test_bgp_gr_helper.py:
+  skip:
+    reason: "BGP Graceful restart not enabled on T2"
+    conditions:
+      - "'t2' in topo_name"
+
 bgp/test_bgp_multipath_relax.py:
   skip:
     reason: "Not supported topology backend."
@@ -69,6 +75,7 @@ bgp/test_bgpmon.py:
     reason: "Not supported topology backend."
     conditions:
       - "'backend' in topo_name"
+
 
 #######################################
 #####            cacl             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -755,11 +755,7 @@ snmp/test_snmp_queue.py:
   skip:
     reason: "Interfaces not present on supervisor node"
     conditions:
-      - "is_supervisor"
-  skip:
-    reason: "M0 topo does not support test_snmp_queue"
-    conditions:
-      - "topo_name in ['m0']"
+      - "is_supervisor or topo_name in ['m0']"
 
 #######################################
 #####            span             #####


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skip the test `test_bgp_gr_helper` for T2 topology because the BGP graceful restart is not enabled on T2 devices

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach

#### How did you do it?
Add a condtion in `tests_mark_conditions.yaml` to skip `test_bgp_gr_helper`  if testbed topology is T2
#### How did you verify/test it?
Run the test_bgp_gr_helper on T2 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
