### PR TITLE
Add Wistron 6512-32R platform skipped item and sku sensor data

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -7208,3 +7208,76 @@ sensors_checks:
 
     sensor_skip_per_version: {}
 
+  x86_64-wistron_6512_32r-r0:
+    alarms:
+      fan: []
+      power: []
+      temp: []
+
+    compares:
+      fan: []
+      power: []
+
+      temp:
+      - - wistron_thermal-i2c-0-48/temp1/temp1_input
+        - wistron_thermal-i2c-0-48/temp1/temp1_max
+      - - wistron_thermal-i2c-0-49/temp1/temp1_input
+        - wistron_thermal-i2c-0-49/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4a/temp1/temp1_input
+        - wistron_thermal-i2c-0-4a/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4b/temp1/temp1_input
+        - wistron_thermal-i2c-0-4b/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4c/temp1/temp1_input
+        - wistron_thermal-i2c-0-4c/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4d/temp1/temp1_input
+        - wistron_thermal-i2c-0-4d/temp1/temp1_max
+      - - wistron_thermal-i2c-0-4f/temp1/temp1_input
+        - wistron_thermal-i2c-0-4f/temp1/temp1_max
+      - - wistron_thermal-i2c-0-68/temp1/temp1_input
+        - wistron_thermal-i2c-0-68/temp1/temp1_max
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+    non_zero:
+      fan:
+      - wistron_fan-i2c-0-44/fan1/fan1_input
+      - wistron_fan-i2c-0-44/fan2/fan2_input
+      - wistron_fan-i2c-0-44/fan3/fan3_input
+      - wistron_fan-i2c-0-44/fan4/fan4_input
+      - wistron_fan-i2c-0-44/fan5/fan5_input
+      - wistron_fan-i2c-0-44/fan6/fan6_input
+      - wistron_fan-i2c-0-44/fan7/fan7_input
+      - wistron_fan-i2c-0-44/fan8/fan8_input
+      - wistron_fan-i2c-0-44/fan9/fan9_input
+      - wistron_fan-i2c-0-44/fan10/fan10_input
+      - wistron_fan-i2c-0-44/fan11/fan11_input
+      - wistron_fan-i2c-0-44/fan12/fan12_input
+      - wistron_fan-i2c-0-44/fan13/fan13_input
+      - wistron_fan-i2c-0-44/fan14/fan14_input
+      power:
+      - wistron_psu2-i2c-0-59/in1/in1_input
+      - wistron_psu2-i2c-0-59/in2/in2_input
+      - wistron_psu2-i2c-0-59/power1/power1_input
+      - wistron_psu2-i2c-0-59/power2/power2_input
+      - wistron_psu2-i2c-0-59/curr1/curr1_input
+      - wistron_psu2-i2c-0-59/curr2/curr2_input
+      - wistron_psu1-i2c-0-5a/in1/in1_input
+      - wistron_psu1-i2c-0-5a/in2/in2_input
+      - wistron_psu1-i2c-0-5a/power1/power1_input
+      - wistron_psu1-i2c-0-5a/power2/power2_input
+      - wistron_psu1-i2c-0-5a/curr1/curr1_input
+      - wistron_psu1-i2c-0-5a/curr2/curr2_input
+
+      temp:
+      - wistron_psu2-i2c-0-59/temp1/temp1_input
+      - wistron_psu1-i2c-0-5a/temp1/temp1_input
+
+    psu_skips: {}
+
+    sensor_skip_per_version: {}
+

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -63,13 +63,13 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_thermal_manager:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "'sw_to3200k' in hwsku"
+      - "('wistron_6512_32r' in hwsku) or ('Wistron_sw_to3200k' in hwsku)"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "'sw_to3200k' in hwsku"
+      - "('wistron_6512_32r' in hwsku) or ('Wistron_sw_to3200k' in hwsku)"
 
 #######################################
 #####   api/test_chassis_fans.py  #####
@@ -107,7 +107,7 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
     reason: "On Cisco 8000 platform the leds belong to the fan_tray and are set through the fan_tray API"
     conditions:
       - "asic_type in ['cisco-8000']"
-      
+
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
   #test_set_fans_speed requires get_speed_tolerance to be implemented
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
@@ -184,7 +184,7 @@ platform_tests/api/test_component.py::TestComponentApi::test_install_firmware:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox'] or ('sw_to3200k' in hwsku)"
+      - "asic_type in ['mellanox'] or ('wistron_6512_32r' in hwsku) or ('Wistron_sw_to3200k' in hwsku)"
 
 platform_tests/api/test_component.py::TestComponentApi::test_is_replaceable:
   skip:
@@ -266,8 +266,8 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
        - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
-   #test_set_fans_speed requires get_speed_tolerance to be implemented 
-   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+   #test_set_fans_speed requires get_speed_tolerance to be implemented
+   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks
    #using RPM rather than thermalctld checking tolerance on percentages
    skip:
      reason: "Unsupported platform API"
@@ -570,7 +570,7 @@ platform_tests/api/test_watchdog.py:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku)"
+      - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 #######################################
 #####           broadcom          #####
@@ -652,7 +652,7 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_j
     # s6100 has not supported get_thermal_manager yet
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json:
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,
@@ -663,7 +663,7 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
     # s6100 has not supported get_thermal_manager yet
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
 
 #######################################
 #####        test_reboot.py       #####
@@ -684,7 +684,7 @@ platform_tests/test_reboot.py::test_power_off_reboot:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"
     conditions:
-      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
+      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku) or (platform in ['armhf-nokia_ixs7215_52x-r0']) or (is_multi_asic==True and release in ['201911'])"
 
 platform_tests/test_reboot.py::test_soft_reboot:
   skip:
@@ -702,7 +702,7 @@ platform_tests/test_reboot.py::test_watchdog_reboot:
   skip:
     reason: "Skip watchdog reboot test for Wistron"
     conditions:
-      - "hwsku in ['Celestica-E1031-T48S4'] or 'sw_to3200k' in hwsku"
+      - "(hwsku in ['Celestica-E1031-T48S4']) or ('sw_to3200k' in hwsku) or ('wistron_6512_32r' in hwsku)"
   skip:
     reason: "Skip watchdog reboot test for m0"
     conditions:


### PR DESCRIPTION
Signed-off-by: RogerX87 <RogerX87@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add the Wistron 6512-32R platform skipped itmes and the sku sensor data for testing

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add the Wistron 6512-32R platform skipped itmes and the sku sensor data for testing

#### How did you do it?
Add the definition for 6512-32R in tests_mark_conditions_platform_tests.yaml and sku-sensors-data.yml
#### How did you verify/test it?
Run the testbed with Wistron 6512-32R

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
