### PR TITLE
Fix test_snmp_memory

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -79,6 +79,8 @@ def test_snmp_memory(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
         snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
                                     community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
         facts = collect_memory(duthost)
+        # net-snmp calculate cached memory as cached + sreclaimable
+        facts['Cached'] = int(facts['Cached']) + int(facts['SReclaimable'])
         # Verify correct behaviour of sysTotalMemory
         pytest_assert(not abs(snmp_facts['ansible_sysTotalMemory'] - int(facts['MemTotal'])),
                       "Unexpected res sysTotalMemory {} v.s. {}".format(snmp_facts['ansible_sysTotalMemory'], facts['MemTotal']))


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  `snmp/test_snmp_memory.py::test_snmp_memory` gets failed with message below:
```
> pytest.fail("Snmp memory MIBs: {} differs more than {} %".format(snmp_diff, percent))
E Failed: Snmp memory MIBs: ['ansible_sysCachedMemory'] differs more than 4 %
```
Starting from `SONiC.master.137279-dirty-20220820.094848` snmp value for cached memory differ from value collected from DUT.
It seems that difference is caused by `snmpd` memory calculation approach - [12192](https://github.com/sonic-net/sonic-buildimage/issues/12192#issuecomment-1276413286)
This PR should align test case.

Fixes #6307 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Update test_snmp_memory so that it properly compare cached memory. 
#### How did you do it?

#### How did you verify/test it?
Run `snmp/test_snmp_memory.py::test_snmp_memory`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.154150-dirty-20220928.095407
Distribution: Debian 11.5
Kernel: 5.10.0-12-2-amd64
Build commit: f890606d8
Build date: Wed Sep 28 16:09:31 UTC 2022
Built by: AzDevOps@sonic-build-workers-0025UB
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
