### PR TITLE
[LogAnalyzer] Fixed sfp tests - to use common loganalyzer

### DIFF
--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import os
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 ans_host = None
 
@@ -13,16 +12,17 @@ def teardown_module():
 
 
 @pytest.fixture(autouse=True)
-def update_la_ignore_errors_list_for_mlnx(duthost):
+def update_la_ignore_errors_list_for_mlnx(duthost, loganalyzer):
     if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
-        loganalyzer.load_common_config()
-        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
-        # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
-        loganalyzer.ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
-        marker = loganalyzer.init()
+        for host in loganalyzer:
+            loganalyzer[host].ignore_regex.append("kernel.*Eeprom query failed*")
+            # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
+            loganalyzer[host].ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
 
     yield
 
     if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer.analyze(marker)
+        for host in loganalyzer:
+            loganalyzer[host].ignore_regex.remove("kernel.*Eeprom query failed*")
+            # Remove Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
+            loganalyzer[host].ignore_regex.remove(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -24,7 +24,6 @@ cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
 cmd_sfp_set_lpmode = "sudo sfputil lpmode"
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6491
Loganalyzer parameter is None because test_sfputil.py disable loganalyzer in pytest mark.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix https://github.com/sonic-net/sonic-mgmt/issues/6491
Revert https://github.com/sonic-net/sonic-mgmt/pull/6493 and add #5301 back.

#### How did you do it?
Remove disable-loganalyzer in test_sfputil.py then loganalyzer parameter will not be None.

#### How did you verify/test it?
Run `test_sfputil.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
