### PR TITLE
[teardown errors] fix tsa test errors by disable loganalyzer

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -282,7 +282,7 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
         pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_6, 6),
                       "Not all ipv6 routes are announced to neighbors")
 
-
+@pytest.mark.disable_loganalyzer
 def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
     Test TSA after config save and config reload
@@ -323,7 +323,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
                       "Not all ipv6 routes are announced to neighbors")
 
-
+@pytest.mark.disable_loganalyzer
 def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown,
                                                 traffic_shift_community):
     """

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -282,6 +282,7 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
         pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_6, 6),
                       "Not all ipv6 routes are announced to neighbors")
 
+
 @pytest.mark.disable_loganalyzer
 def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
@@ -322,6 +323,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_tea
                       "Not all ipv4 routes are announced to neighbors")
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
                       "Not all ipv6 routes are announced to neighbors")
+
 
 @pytest.mark.disable_loganalyzer
 def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There would be many error logs during config reload or minigraph reload, need to disable loganalyzer when involve a reload.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
There would be many error logs during config reload or minigraph reload, need to disable loganalyzer when involve a reload.

#### How did you do it?
disable loganalyzer when involve a reload in testcases.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
