### PR TITLE
get_route_key and count_routes require a space for multi-asic.

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -654,7 +654,7 @@ class SonicAsic(object):
     def count_routes(self, ROUTE_TABLE_NAME):
         ns_prefix = ""
         if self.sonichost.is_multi_asic:
-            ns_prefix = '-n' + str(self.namespace)
+            ns_prefix = '-n ' + str(self.namespace)
         return int(self.shell(
             'sonic-db-cli {} ASIC_DB eval "return #redis.call(\'keys\', \'{}*\')" 0'.format(ns_prefix, ROUTE_TABLE_NAME),
             module_ignore_errors=True, verbose=True)['stdout'])
@@ -662,6 +662,6 @@ class SonicAsic(object):
     def get_route_key(self, ROUTE_TABLE_NAME):
         ns_prefix = ""
         if self.sonichost.is_multi_asic:
-            ns_prefix = '-n' + str(self.namespace)
+            ns_prefix = '-n ' + str(self.namespace)
         return self.shell('sonic-db-cli {} ASIC_DB eval "return redis.call(\'keys\', \'{}*\')" 0'.format(ns_prefix, ROUTE_TABLE_NAME),
             verbose=False)['stdout_lines']


### PR DESCRIPTION
Functions were failing for multi-asic

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR addresses the following:
-sonic-db-cli() command needed a space after '-n'. Updated the  ns_prefix string format with space

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The test case was failing with - ValueError: invalid literal for sonic-db-cli

#### How did you do it?
Add space after '-n' in the string formatted (ns_prefix) which is supplied to sonic-db-cli() command 

#### How did you verify/test it?
Re-run the route testcases and verify the output of count_routes function is as expected

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
