### PR TITLE
Limit the length of pre-commit check results

### DIFF
--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -28,10 +28,10 @@ steps:
     RC=$?
 
     # Truncate the output if it has more than 20 lines
-    if [[ `echo "$out" | wc -l > 20` ]]; then
+    if [[ `echo "$out" | wc -l` -gt 20 ]]; then
       out=`echo "$out" | head -n 20`
-      out=`echo "$out\n...\n[truncated extra lines, please run pre-commit locally to view full check results]"`
-      out=`printf "$out`
+      out="$out\n...\n[truncated extra lines, please run pre-commit locally to view full check results]"
+      out=`printf "$out"`
     fi
 
     br='<br/>'

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -23,21 +23,19 @@ steps:
 - script: |
     set -x
 
+    # Run pre-commit check and capture the output
     out=`pre-commit run --color never --from-ref HEAD^ --to-ref HEAD 2>&1`
     RC=$?
 
-    echo "Pre-commit check results:"
-    echo "$out"
+    # Truncate the output if it has more than 20 lines
+    if [[ `echo "$out" | wc -l > 20` ]]; then
+      out=`echo "$out" | head -n 20`
+      out=`echo "$out\n...\n[truncated extra lines, please run pre-commit locally to view full check results]"`
+      out=`printf "$out`
+    fi
 
     br='<br/>'
     results=`echo "$out" |  while read line; do echo $line$br; done | tr -d '\n'`
-
-    # Truncate the output if it has more than 20 lines
-    if [[ `echo "$results" | wc -l > 20` ]]; then
-      results=`echo "$results" | head -n 20`
-      results=`echo "$results\n...\n[truncated extra lines, please run pre-commit locally to view full check results]"`
-      results=`printf "$results`
-    fi
 
     echo "##vso[task.setvariable variable=results;]$results"
 

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -21,11 +21,12 @@ steps:
   displayName: 'Prepare pre-commit check'
 
 - script: |
-    set -x
-
     # Run pre-commit check and capture the output
     out=`pre-commit run --color never --from-ref HEAD^ --to-ref HEAD 2>&1`
     RC=$?
+
+    echo "Pre-commit check results:"
+    echo "$out"
 
     # Truncate the output if it has more than 20 lines
     if [[ `echo "$out" | wc -l` -gt 20 ]]; then
@@ -34,9 +35,17 @@ steps:
       out=`printf "$out"`
     fi
 
+    # Append '<br/>' to each line and join them into a single line. Explanation of this trick:
+    #
+    # The check results need to be passed in an AZP variable to the subsequent task for posting Github comment.
+    # However, AZP does not support multiple lines in variable value. We need a way to join multiple lines into a
+    # single line and then expand them into multiple lines in Github comment.
+    # Luckily we can embed the html new line tag '<br/>' in the variable value. Github web page is able to render
+    # that html tag as a new line.
     br='<br/>'
     results=`echo "$out" |  while read line; do echo $line$br; done | tr -d '\n'`
 
+    # Store the check results in an AZP variable, it will be rendered in Github comment
     echo "##vso[task.setvariable variable=results;]$results"
 
     exit $RC

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -14,14 +14,14 @@ steps:
   displayName: 'checkout sonic-mgmt repo'
 
 - script: |
-    set -ex
+    set -x
 
     sudo pip install pre-commit
     pre-commit install-hooks
   displayName: 'Prepare pre-commit check'
 
 - script: |
-    set -ex
+    set -x
 
     out=`pre-commit run --color never --from-ref HEAD^ --to-ref HEAD 2>&1`
     RC=$?
@@ -31,6 +31,14 @@ steps:
 
     br='<br/>'
     results=`echo "$out" |  while read line; do echo $line$br; done | tr -d '\n'`
+
+    # Truncate the output if it has more than 20 lines
+    if [[ `echo "$results" | wc -l > 20` ]]; then
+      results=`echo "$results" | head -n 20`
+      results=`echo "$results\n...\n[truncated extra lines, please run pre-commit locally to view full check results]"`
+      results=`printf "$results`
+    fi
+
     echo "##vso[task.setvariable variable=results;]$results"
 
     exit $RC

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1823,4 +1823,3 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
 # HACK: testutils.verify_packets_any to workaround code bug
 # TODO: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
 testutils.verify_packets_any = verify_packets_any_fixed
-# dummy comment to trigger pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1823,3 +1823,4 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
 # HACK: testutils.verify_packets_any to workaround code bug
 # TODO: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
 testutils.verify_packets_any = verify_packets_any_fixed
+# dummy comment to trigger pre-commit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR 6523 introduced an issue and caused the pre-commit check results cannot be rendered in Github comment.
What's more, the pre-commit check results could be too long to be displayed in a Github comment.

#### How did you do it?
This change fixed the rendering issue and also added code to limit the length of pre-commit check results.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
