### PR TITLE
[test gap] Add test case to test SSH connect and IP packet forward when disk is exhausted

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -7,3 +7,8 @@ NAME_KEY = "name"
 IS_BACKEND_TOPOLOGY_KEY = "is_backend_topology"
 # a topology whos name contains the indicator 'backend' will be considered as a backend topology
 BACKEND_TOPOLOGY_IND = "backend"
+# ssh connect default username and password
+DEFAULT_SSH_CONNECT_PARAMS = {
+    "public": {"username": "admin",
+               "password": "YourPaSsWoRd"}
+}

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -661,3 +661,15 @@ def update_environ(*remove, **update):
         env.update(to_restore)
         for k in to_removed:
             env.pop(k)
+
+
+def get_image_type(duthost):
+    """get the SONiC image type
+    It might be public/microsoft/...or any other type.
+    Different vendors can define their different types by checking the specific information from the build image.
+    Args:
+        duthost: AnsibleHost instance for DUT
+    Returns: image type. Str. It should be the right key in DEFAULT_SSH_CONNECT_PARAMS in tests/common/constants.py
+    """
+
+    return "public"

--- a/tests/disk/test_disk_exhaustion.py
+++ b/tests/disk/test_disk_exhaustion.py
@@ -1,0 +1,210 @@
+import ipaddress
+
+import paramiko
+import ptf.testutils as testutils
+import re
+import logging
+import time
+import pytest
+from ptf import mask, packet
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.portstat_utilities import parse_column_positions
+from tests.common.constants import DEFAULT_SSH_CONNECT_PARAMS
+from tests.common.utilities import get_image_type
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
+    pytest.mark.topology('any')
+]
+
+
+def parse_interfaces(output_lines, pc_ports_map):
+    """
+    Parse the interfaces from 'show ip route' into an array
+    """
+    route_targets = []
+    ifaces = []
+    output_lines = output_lines[3:]
+
+    for item in output_lines:
+        match = re.search("(Ethernet\\d+|PortChannel\\d+)", item)
+        if match:
+            route_targets.append(match.group(0))
+
+    for route_target in route_targets:
+        if route_target.startswith("Ethernet"):
+            ifaces.append(route_target)
+        elif route_target.startswith("PortChannel") and route_target in pc_ports_map:
+            ifaces.extend(pc_ports_map[route_target])
+
+    return route_targets, ifaces
+
+
+def parse_rif_counters(output_lines):
+    """
+    Parse the output of "show interfaces counters rif" command
+    """
+
+    header_line = ''
+    separation_line = ''
+    separation_line_number = 0
+    for idx, line in enumerate(output_lines):
+        if line.find('----') >= 0:
+            header_line = output_lines[idx - 1]
+            separation_line = output_lines[idx]
+            separation_line_number = idx
+            break
+
+    try:
+        positions = parse_column_positions(separation_line)
+    except Exception:
+        logger.error('Possibly bad command output')
+        return {}
+
+    headers = []
+    for pos in positions:
+        header = header_line[pos[0]:pos[1]].strip().lower()
+        headers.append(header)
+
+    if not headers:
+        return {}
+
+    results = {}
+    for line in output_lines[separation_line_number + 1:]:
+        portstats = []
+        for pos in positions:
+            portstat = line[pos[0]:pos[1]].strip()
+            portstats.append(portstat)
+
+        intf = portstats[0]
+        results[intf] = {}
+        for idx in range(1, len(portstats)):  # Skip the first column interface name
+            results[intf][headers[idx]] = portstats[idx]
+
+    return results
+
+
+def construct_packet_and_get_params(duthost, ptfadapter, tbinfo):
+    """
+    Construct data packet and get related params
+    """
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    # generate peer_ip and port channel pair, be like:[("10.0.0.57", "PortChannel0001")]
+    peer_ip_pc_pair = [(pc["peer_addr"], pc["attachto"]) for pc in mg_facts["minigraph_portchannel_interfaces"]
+                       if
+                       ipaddress.ip_address(pc['peer_addr']).version == 4]
+
+    pc_ports_map = {pair[1]: mg_facts["minigraph_portchannels"][pair[1]]["members"] for pair in
+                    peer_ip_pc_pair}
+
+    if len(mg_facts["minigraph_interfaces"]) >= 2:
+        # generate peer_ip and interfaces pair,
+        # be like:[("10.0.0.57", ["Ethernet48"])]
+        peer_ip_ifaces_pair = [(intf["peer_addr"], [intf["attachto"]]) for intf in mg_facts["minigraph_interfaces"]
+                               if
+                               ipaddress.ip_address(intf['peer_addr']).version == 4]
+
+    else:
+        # generate peer_ip and interfaces(port channel members) pair,
+        # be like:[("10.0.0.57", ["Ethernet48", "Ethernet52"])]
+        peer_ip_ifaces_pair = [(pair[0], mg_facts["minigraph_portchannels"][pair[1]]["members"]) for pair in
+                               peer_ip_pc_pair]
+
+    # use first port of first peer_ip_ifaces pair as input port
+    # all ports in second peer_ip_ifaces pair will be output/forward port
+    ptf_port_idx = mg_facts["minigraph_ptf_indices"][peer_ip_ifaces_pair[0][1][0]]
+    # Some platforms do not support rif counter
+    try:
+        rif_counter_out = parse_rif_counters(
+            duthost.command("show interfaces counters rif")["stdout_lines"])
+        rif_iface = list(rif_counter_out.keys())[0]
+        rif_support = False if rif_counter_out[rif_iface]['rx_err'] == 'N/A' else True
+    except Exception as e:
+        logger.info("Show rif counters failed with exception: {}".format(repr(e)))
+        rif_support = False
+
+    pkt = testutils.simple_ip_packet(
+        eth_dst=duthost.facts["router_mac"],
+        eth_src=ptfadapter.dataplane.get_mac(0, ptf_port_idx),
+        ip_src=peer_ip_ifaces_pair[0][0],
+        ip_dst=peer_ip_ifaces_pair[1][0])
+
+    exp_pkt = pkt.copy()
+    exp_pkt.payload.ttl = pkt.payload.ttl - 1
+    exp_pkt = mask.Mask(exp_pkt)
+
+    exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+    exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
+
+    out_rif_ifaces, out_ifaces = parse_interfaces(
+        duthost.command("show ip route %s" % peer_ip_ifaces_pair[1][0])["stdout_lines"],
+        pc_ports_map)
+
+    out_ptf_indices = map(lambda iface: mg_facts["minigraph_ptf_indices"][iface], out_ifaces)
+
+    return pkt, ptf_port_idx, exp_pkt, out_ptf_indices, rif_support
+
+
+def test_disk_exhaustion(duthost, ptfadapter, tbinfo):
+    """Test SONiC basic performance(like ssh-connect, packet forward...) when disk is exhausted
+    Args:
+        duthost: DUT host object
+        ptfadapter: PTF adapter object
+        tbinfo: Testbed information
+    """
+
+    PKT_NUM = 1000
+    PKT_NUM_MIN = PKT_NUM * 0.9
+
+    # Construct packet and get params
+    pkt, ptf_port_idx, exp_pkt, out_ptf_indices, rif_support = construct_packet_and_get_params(duthost=duthost,
+                                                                                               ptfadapter=ptfadapter,
+                                                                                               tbinfo=tbinfo)
+
+    # Clear stats
+    duthost.command("portstat -c")
+
+    if rif_support:
+        duthost.command("sonic-clear rifcounters")
+    ptfadapter.dataplane.flush()
+
+    # Check SONiC image type and get default username and password to SSH connect
+    default_username_password = DEFAULT_SSH_CONNECT_PARAMS[get_image_type(duthost=duthost)]
+
+    # Simulate disk exhaustion and release space after 60 seconds
+    # Use command 'fallocate' to create large file, it's effective.
+    # Create a shell script to do the operations like fallocate and remove file,
+    # because when space is full, duthost.command() is not work
+    duthost.shell_cmds(cmds=[
+        "echo 'fallocate -l 50G /tmp/file' > /tmp/test.sh",
+        "echo 'sleep 60' >> /tmp/test.sh",
+        "echo 'sudo rm /tmp/file' >> /tmp/test.sh",
+        "chmod u+x /tmp/test.sh",
+        "nohup /tmp/test.sh >/dev/null 2>&1 &"
+    ], continue_on_fail=False, module_ignore_errors=True)
+
+    # Test ssh connect manually
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        ssh.connect(duthost.mgmt_ip, username=default_username_password["username"],
+                    password=default_username_password["password"], allow_agent=False,
+                    look_for_keys=False)
+    except Exception:
+        logger.info("Current login params:\tusername={}, password={}".format(default_username_password["username"],
+                                                                             default_username_password["password"]))
+        raise
+
+    # Test IP packet forward
+    testutils.send(ptfadapter, ptf_port_idx, pkt, PKT_NUM)
+    time.sleep(5)
+    match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+
+    pytest_assert(match_cnt >= PKT_NUM_MIN, "DUT Forwarded {} packets, not in expected range".format(match_cnt))
+    logger.info("DUT Forwarded {} packets, in expected range".format(match_cnt))
+
+    # Wait for disk space release
+    time.sleep(60)

--- a/tests/ssh/test_ssh_default_password.py
+++ b/tests/ssh/test_ssh_default_password.py
@@ -1,6 +1,8 @@
 import pytest
 import paramiko
 import logging
+from tests.common.constants import DEFAULT_SSH_CONNECT_PARAMS
+from tests.common.utilities import get_image_type
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -9,11 +11,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LOGIN_PARAMS_DICT = {
-    "public": {"username": "admin",
-               "password": "YourPaSsWoRd"}
-}
-
 
 def test_ssh_default_password(duthost):
     """verify the initial SSH password is always expected.
@@ -21,17 +18,13 @@ def test_ssh_default_password(duthost):
     Args:
         duthost: AnsibleHost instance for DUT
     """
-
-    # 1. define the default params in global value `DEFAULT_LOGIN_PARAMS_DICT`
-    # and the specific approach to get the image type in `get_image_type()`
-
-    # 2. check SONiC version and get default username and password
-    default_username_password = DEFAULT_LOGIN_PARAMS_DICT[get_image_type(duthost=duthost)]
+    # Check SONiC image type and get default username and password to SSH connect
+    default_username_password = DEFAULT_SSH_CONNECT_PARAMS[get_image_type(duthost=duthost)]
 
     logger.info("current login params:\tusername={}, password={}".format(default_username_password["username"],
                                                                          default_username_password["password"]))
 
-    # 3. re-connect SONiC via SSH with expected password
+    # Test SSH connect with expected username and password
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     try:
@@ -41,19 +34,3 @@ def test_ssh_default_password(duthost):
     except paramiko.AuthenticationException:
         logger.info("SSH connect failed. Make sure use the expected password according to the SONiC image.")
         raise
-
-
-def get_image_type(duthost):
-    """get the SONiC image type
-
-    It might be public/microsoft/...or any other type.
-    Different vendors can define their different types by checking the specific information from the build image.
-
-    Args:
-        duthost: AnsibleHost instance for DUT
-
-    Returns: image type. Str. It should be the right key in DEFAULT_LOGIN_PARAMS_DICT.
-
-    """
-
-    return "public"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

When disk is exhausted, We hope that some basic functions of the system are normal, especially, SSH connect and data packet forward is normal.
In additon, this case reuses some codes in `test_ssh_default_password.py`, so move it into the common and make it general.

Summary:
Fixes #3618

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Test SSH connect and IP packet forward is normal when disk is exhausted.

#### How did you do it?

Firstly, get SSH connect params and construct IP packet. 
Then use 'fallocate' command to create large file to exhaust the disk. 
Next test SSH connect manually and test IP packet forward with PTF. 
Finally, release the space.

#### How did you verify/test it?

Run TC in different Testbeds with T0/T1 topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
