### PR TITLE
Fix unexpected trailing symbol

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -38,7 +38,7 @@ steps:
 
       echo "Created test plan $TEST_PLAN_ID"
       echo "Check https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID for test plan status"
-      echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID'"
+      echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
       TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -38,7 +38,7 @@ steps:
 
       echo "Created test plan $TEST_PLAN_ID"
       echo "Check https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID for test plan status"
-      echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
+      echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID'"
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
       TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)
@@ -51,7 +51,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 43200 --expected-states PREPARE_TESTBED EXECUTING KVMDUMP FINISHED CANCELLED FAILED
+      python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --timeout 43200 --expected-states PREPARE_TESTBED EXECUTING KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Lock testbed
@@ -64,7 +64,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 2400 --expected-states EXECUTING KVMDUMP FINISHED CANCELLED FAILED
+      python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --timeout 2400 --expected-states EXECUTING KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Prepare testbed
@@ -75,7 +75,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 18000 --expected-states KVMDUMP FINISHED CANCELLED FAILED
+      python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --timeout 18000 --expected-states KVMDUMP FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: Run test
@@ -86,7 +86,7 @@ steps:
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
       # When "KVMDUMP" finish, it changes into "FAILED", "CANCELLED" or "FINISHED"
-      python ./.azure-pipelines/test_plan.py poll -i $(TEST_PLAN_ID) --timeout 43200 --expected-states FINISHED CANCELLED FAILED
+      python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --timeout 43200 --expected-states FINISHED CANCELLED FAILED
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
     displayName: KVM dump
@@ -95,7 +95,7 @@ steps:
   - script: |
       set -ex
       echo "Try to cancel test plan $TEST_PLAN_ID, cancelling finished test plan has no effect."
-      python ./.azure-pipelines/test_plan.py cancel -i $(TEST_PLAN_ID)
+      python ./.azure-pipelines/test_plan.py cancel -i "$(TEST_PLAN_ID)"
     condition: always()
     env:
       TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)

--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -47,6 +47,7 @@ steps:
     displayName: Trigger test
 
   - script: |
+      set -ex
       echo "Lock testbed"
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
@@ -58,6 +59,7 @@ steps:
     timeoutInMinutes: 240
 
   - script: |
+      set -ex
       echo "Prepare testbed"
       echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient(We will improve the indication in a short time)"
       echo "If the progress keeps as 0 for more than 1 hour, please cancel and retry this pipeline"
@@ -71,6 +73,7 @@ steps:
     timeoutInMinutes: 40
 
   - script: |
+      set -ex
       echo "Run test"
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"
@@ -82,6 +85,7 @@ steps:
     timeoutInMinutes: 300
 
   - script: |
+      set -ex
       echo "KVM dump"
       echo "TestbedV2 is just online and might not be stable enough, for any issue, please send email to sonictestbedtools@microsoft.com"
       echo "Runtime detailed progress at https://www.testbed-tools.org/scheduler/testplan/$TEST_PLAN_ID"

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -51,7 +51,8 @@ class TestPlanManager(object):
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
                min_worker=1, max_worker=2, pr_id="unknown", scripts=[], output=None):
         tp_url = "{}/test_plan".format(self.url)
-        print("Creating test plan, topology: {}, name: {}, build info:{} {} {}".format(topology, test_plan_name, repo_name, pr_id, build_id))
+        print("Creating test plan, topology: {}, name: {}, build info:{} {} {}".format(topology, test_plan_name,
+                                                                                       repo_name, pr_id, build_id))
         print("Test scripts to be covered in this test plan:")
         print(json.dumps(scripts, indent=4))
 
@@ -200,6 +201,7 @@ class TestPlanManager(object):
         else:
             raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled" \
                             .format(poll_url))
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -149,7 +149,7 @@ class TestPlanManager(object):
                                                                 |-- FINISHED
         '''
 
-        print("Polling progress and status of test plan at https://www.testbed-tools.org/scheduler/testplan/{}" \
+        print("Polling progress and status of test plan at https://www.testbed-tools.org/scheduler/testplan/{}"
               .format(test_plan_id))
         print("Polling interval: {} seconds".format(interval))
         print("Max polling time: {} seconds".format(timeout))
@@ -185,21 +185,21 @@ class TestPlanManager(object):
 
             if status in ["FINISHED", "CANCELLED", "FAILED"]:
                 if result == "SUCCESS":
-                    print("Test plan is successfully {}. Elapsed {:.0f} seconds" \
+                    print("Test plan is successfully {}. Elapsed {:.0f} seconds"
                           .format(status, time.time() - start_time))
                     return
                 else:
-                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds" \
+                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds"
                                     .format(test_plan_id, status, result, time.time() - start_time))
             elif status in expected_states:
                 return
             else:
-                print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds" \
+                print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds"
                       .format(test_plan_id, status, resp_data.get("progress", 0) * 100, time.time() - start_time))
                 time.sleep(interval)
 
         else:
-            raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled" \
+            raise Exception("Max polling time reached, test plan at {} is not successfully finished or cancelled"
                             .format(poll_url))
 
 
@@ -360,12 +360,12 @@ if __name__ == "__main__":
 
             test_plan_name = "{repo}_{reason}_PR_{pr_id}_BUILD_{build_id}_JOB_{job_name}" \
                 .format(
-                repo=repo,
-                reason=reason,
-                pr_id=pr_id,
-                build_id=build_id,
-                job_name=job_name
-            ).replace(' ', '_')
+                    repo=repo,
+                    reason=reason,
+                    pr_id=pr_id,
+                    build_id=build_id,
+                    job_name=job_name
+                ).replace(' ', '_')
             if args.test_set is None or args.test_set == "":
                 # Use topology as default test set if not passed
                 args.test_set = args.topology

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -280,7 +280,7 @@ if __name__ == "__main__":
     for p in [parser_cancel, parser_poll]:
         p.add_argument(
             "-i", "--test-plan-id",
-            type=int,
+            type=str,
             dest="test_plan_id",
             required=True,
             help="Test plan id."
@@ -317,6 +317,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     args = parser.parse_args()
+
+    if "test_plan_id" in args:
+        # vso may add unexpected "'" as trailing symbol
+        # https://github.com/microsoft/azure-pipelines-tasks/issues/10331
+        args.test_plan_id = args.test_plan_id.replace("'", "")
+
     print("Test plan utils parameters: {}".format(args))
     auth_env = ["TENANT_ID", "CLIENT_ID", "CLIENT_SECRET"]
     required_env = ["TESTBED_TOOLS_URL"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
With set -x,  "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID" get a chance to add a unexpected "'" as trailing symbol.
https://github.com/microsoft/azure-pipelines-tasks/issues/10331
I want to keep the set -ex setting, so the sub-steps that relies on TEST_PLAN_ID need to remove possible trailing symbol.
A sample failure:
https://dev.azure.com/mssonic/build/_build/results?buildId=160852&view=logs&j=37033ee9-5136-564d-6562-3f85a337b244&t=c7eb37a5-16b3-5b0b-a481-f1579bc7de47

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
With set -x,  "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID" get a chance to add a unexpected "'" as trailing symbol.
https://github.com/microsoft/azure-pipelines-tasks/issues/10331
I want to keep the set -ex setting, so the sub-steps that relies on TEST_PLAN_ID need to remove possible trailing symbol.
A sample failure:
https://dev.azure.com/mssonic/build/_build/results?buildId=160852&view=logs&j=37033ee9-5136-564d-6562-3f85a337b244&t=c7eb37a5-16b3-5b0b-a481-f1579bc7de47
#### How did you do it?
Remove possible trailing symbol.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
