### PR TITLE
Only fails critical process check when process name in critical process list

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -652,7 +652,9 @@ class SonicHost(AnsibleHostBase):
                 # In this situation, service container status should be false
                 # We can check status is valid or not
                 if status not in ('RUNNING','EXITED','STOPPED'):
-                    service_critical_process['status'] = False
+                    if pname in service_group_process['groups'] or pname in service_group_process['processes']:
+                        service_critical_process['exited_critical_process'].append(pname)
+                        service_critical_process['status'] = False
                 elif status != 'RUNNING':
                     if pname in service_group_process['groups'] or pname in service_group_process['processes']:
                         service_critical_process['exited_critical_process'].append(pname)


### PR DESCRIPTION


Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, `test_pretest.py::test_features_state` failed because psud process is not running, but it's not critical process for pmon container. BTW, it's an know issue that psud exited on Celestica platform.
```
root@str2-dx010-acs-7:/# supervisorctl status
chassis_db_init                  EXITED    Oct 15 08:00 AM
dependent-startup                EXITED    Oct 15 08:01 AM
lm-sensors                       EXITED    Oct 15 08:00 AM
pcied                            RUNNING   pid 29, uptime 3:08:42
psud                             FATAL     Exited too quickly (process log may have details)
```
The issue was introduced by #6486.
#### How did you do it?
If one process is not running, it should check if it's in critical process list, if yes, then fails the process check and reports it as failure, if not, should skip this process.

#### How did you verify/test it?
Run `test_pretest.py::test_features_state` on Celestica platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
