### PR TITLE
Fix `vrf unbind` command in spytest/apis/routing/vrf.py

### DIFF
--- a/spytest/apis/routing/vrf.py
+++ b/spytest/apis/routing/vrf.py
@@ -4,15 +4,16 @@ from utilities.utils import get_interface_number_from_name
 from apis.system.rest import config_rest, delete_rest, get_rest
 from apis.routing.ip import configure_loopback
 
-def verify_vrf(dut,**kwargs):
+
+def verify_vrf(dut, **kwargs):
     """
     verify_vrf(dut1,vrfname="Vrf-103")
     """
 
     cli_type = kwargs.pop('cli_type', st.get_ui_type(dut))
-    #cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
+    # cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
     if 'vrfname' in kwargs:
-        if not isinstance(kwargs['vrfname'],list):
+        if not isinstance(kwargs['vrfname'], list):
             vname_list = [kwargs['vrfname']]
         else:
             vname_list = kwargs['vrfname']
@@ -22,24 +23,24 @@ def verify_vrf(dut,**kwargs):
     if cli_type == 'click':
         st.log("verify show vrf output")
         cmd = "show vrf"
-        output = st.show(dut,cmd)
+        output = st.show(dut, cmd)
         for vname in vname_list:
-            match = {"vrfname":vname}
+            match = {"vrfname": vname}
             entries = filter_and_select(output, ["vrfname"], match)
             if not bool(entries):
                 return bool(entries)
         return True
     elif cli_type == 'klish':
         cmd = 'show ip vrf'
-        output = st.show(dut,cmd,type=cli_type)
+        output = st.show(dut, cmd, type=cli_type)
         for vname in vname_list:
-            match = {"vrfname":vname}
+            match = {"vrfname": vname}
             entries = filter_and_select(output, ["vrfname"], match)
             if not bool(entries):
                 return bool(entries)
         return True
-    elif cli_type in ['rest-patch','rest-put']:
-        rest_urls = st.get_datastore(dut,'rest_urls')
+    elif cli_type in ['rest-patch', 'rest-put']:
+        rest_urls = st.get_datastore(dut, 'rest_urls')
         for vname in vname_list:
             rest_url = rest_urls['vrf_config'].format(vname)
             payload = get_rest(dut, rest_url=rest_url)['output']['openconfig-network-instance:network-instance']
@@ -52,15 +53,16 @@ def verify_vrf(dut,**kwargs):
     else:
         st.log("Unsupported cli")
 
-def verify_vrf_verbose(dut,**kwargs):
+
+def verify_vrf_verbose(dut, **kwargs):
     """
     verify_vrf_verbose(dut1,vrfname="Vrf-103",interface='Ethernet2')
     """
     cli_type = kwargs.pop('cli_type', st.get_ui_type(dut))
-    #cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
+    # cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
     vrfname = kwargs['vrfname']
     interface = kwargs['interface']
-    if not isinstance(vrfname,list):
+    if not isinstance(vrfname, list):
         vrfname = [vrfname]
     if cli_type == 'click':
         cmd = "show vrf --verbose"
@@ -68,25 +70,25 @@ def verify_vrf_verbose(dut,**kwargs):
             st.community_unsupported(cmd, dut)
             cmd = "show vrf"
         st.log("verify {} output".format(cmd))
-        output = st.show(dut,cmd)
-        for vname,intf in zip(vrfname,interface):
-            match = {"vrfname":vname,"interfaces": intf}
-            entries = filter_and_select(output,["vrfname"],match)
+        output = st.show(dut, cmd)
+        for vname, intf in zip(vrfname, interface):
+            match = {"vrfname": vname, "interfaces": intf}
+            entries = filter_and_select(output, ["vrfname"], match)
             if not bool(entries):
                 return bool(entries)
         return True
     elif cli_type == 'klish':
         cmd = "show ip vrf"
-        output = st.show(dut,cmd,type=cli_type)
-        for vname,intf in zip(vrfname,interface):
-            match = {"vrfname":vname,"interfaces": intf}
-            entries = filter_and_select(output,["vrfname"],match)
+        output = st.show(dut, cmd, type=cli_type)
+        for vname, intf in zip(vrfname, interface):
+            match = {"vrfname": vname, "interfaces": intf}
+            entries = filter_and_select(output, ["vrfname"], match)
             if not bool(entries):
                 return bool(entries)
         return True
-    elif cli_type in ['rest-patch','rest-put']:
-        rest_urls = st.get_datastore(dut,'rest_urls')
-        for vname,intf in zip(vrfname,interface):
+    elif cli_type in ['rest-patch', 'rest-put']:
+        rest_urls = st.get_datastore(dut, 'rest_urls')
+        for vname, intf in zip(vrfname, interface):
             rest_url = rest_urls['vrf_config'].format(vname)
             payload = get_rest(dut, rest_url=rest_url)['output']['openconfig-network-instance:network-instance']
             for item in payload:
@@ -101,6 +103,7 @@ def verify_vrf_verbose(dut,**kwargs):
     else:
         st.log("Unsupported cli")
 
+
 def get_vrf_verbose(dut, **kwargs):
     """
     get_vrf_verbose(dut1,vrfname="Vrf-1")
@@ -113,7 +116,7 @@ def get_vrf_verbose(dut, **kwargs):
         return False
 
     cli_type = kwargs.pop('cli_type', st.get_ui_type(dut))
-    #cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
+    # cli_type = "klish" if cli_type in ["rest-put", "rest-patch"] else cli_type
     if cli_type == 'click':
         cmd = "show vrf --verbose"
         if not st.is_feature_supported("show-vrf-verbose-command", dut):
@@ -128,26 +131,27 @@ def get_vrf_verbose(dut, **kwargs):
         return entries[0]
     elif cli_type == 'klish':
         cmd = "show ip vrf"
-        output = st.show(dut,cmd,type=cli_type)
+        output = st.show(dut, cmd, type=cli_type)
         entries = filter_and_select(output, None, match_dict)
         if len(output) == 0:
             st.error("OUTPUT is Empty")
             return []
         return entries[0]
-    elif cli_type in ['rest-patch','rest-put']:
-        rest_urls = st.get_datastore(dut,'rest_urls')
+    elif cli_type in ['rest-patch', 'rest-put']:
+        rest_urls = st.get_datastore(dut, 'rest_urls')
         vname = kwargs['vrfname']
         vrf_info = {}
         interfaces = []
         rest_url = rest_urls['vrf_config'].format(vname)
         payload = get_rest(dut, rest_url=rest_url)['output']['openconfig-network-instance:network-instance']
-        #klish output = {u'interfaces': ['PortChannel10', 'Vlan3'], u'vrfname': 'Vrf-103'}
+        # klish output = {u'interfaces': ['PortChannel10', 'Vlan3'], u'vrfname': 'Vrf-103'}
         for item in payload:
             vrf_info['vrfname'] = item['state']['name']
             for interface in item['interfaces']['interface']:
                 interfaces.append(interface['state']['id'])
         vrf_info['interfaces'] = interfaces
         return vrf_info
+
 
 def config_vrf(dut, **kwargs):
     """
@@ -161,7 +165,7 @@ def config_vrf(dut, **kwargs):
     else:
         config = 'yes'
     if 'vrf_name' in kwargs:
-        if not isinstance(kwargs['vrf_name'],list):
+        if not isinstance(kwargs['vrf_name'], list):
             vrf_name = [kwargs['vrf_name']]
         else:
             vrf_name = kwargs['vrf_name']
@@ -203,13 +207,14 @@ def config_vrf(dut, **kwargs):
             st.error("klish mode not working.")
             return False
         return True
-    elif cli_type in ['rest-patch','rest-put']:
-        http_method = kwargs.pop('http_method',cli_type)
-        rest_urls = st.get_datastore(dut,'rest_urls')
+    elif cli_type in ['rest-patch', 'rest-put']:
+        http_method = kwargs.pop('http_method', cli_type)
+        rest_urls = st.get_datastore(dut, 'rest_urls')
         if config.lower() == 'yes':
             for vrf in vrf_name:
                 rest_url = rest_urls['vrf_config'].format(vrf)
-                ocdata = {"openconfig-network-instance:network-instance":[{"name":vrf,"config":{"name":vrf,"enabled":bool(1)}}]}
+                ocdata = {"openconfig-network-instance:network-instance":
+                          [{"name": vrf, "config": {"name": vrf, "enabled": bool(1)}}]}
                 response = config_rest(dut, http_method=http_method, rest_url=rest_url, json_data=ocdata)
                 if not response:
                     st.log(response)
@@ -225,9 +230,10 @@ def config_vrf(dut, **kwargs):
     else:
         st.log("Unsupported cli")
 
+
 def bind_vrf_interface(dut, **kwargs):
     """
-    #Sonic cmd: 
+    #Sonic cmd:
     # config interface bind <interface-name> <vrf-name>
     # config interface unbind <interface-name>
     eg: bind_vrf_interface(dut = dut1, vrf_name = 'Vrf-test', intf_name ='Ethernet8', config = 'no')
@@ -238,14 +244,14 @@ def bind_vrf_interface(dut, **kwargs):
     else:
         config = 'yes'
     if 'vrf_name' in kwargs:
-        if not isinstance(kwargs['vrf_name'],list):
+        if not isinstance(kwargs['vrf_name'], list):
             vrf_name = [kwargs['vrf_name']]
         else:
             vrf_name = kwargs['vrf_name']
     else:
         st.log("Mandatory parameter vrfname is not found")
     if 'intf_name' in kwargs:
-        if not isinstance(kwargs['intf_name'],list):
+        if not isinstance(kwargs['intf_name'], list):
             intf_name = [kwargs['intf_name']]
         else:
             intf_name = kwargs['intf_name']
@@ -260,7 +266,7 @@ def bind_vrf_interface(dut, **kwargs):
     if cli_type == 'click':
         my_cmd = ''
         if config.lower() == 'yes':
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 if 'Loopback' in intf:
                     if not st.is_feature_supported("config-loopback-add-command", dut):
                         st.log("Community build doesn't need Loopback interface configuration")
@@ -268,7 +274,7 @@ def bind_vrf_interface(dut, **kwargs):
                         my_cmd += 'sudo config loopback add {}\n'.format(intf)
                 my_cmd += 'sudo config interface vrf bind {} {}\n'.format(intf, vrf)
         else:
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 if not st.is_feature_supported("vrf-needed-for-unbind", dut):
                     st.log("Unbind operation is not supported in this build")
                 else:
@@ -287,13 +293,13 @@ def bind_vrf_interface(dut, **kwargs):
     elif cli_type == 'klish':
         command = ''
         if config.lower() == 'yes':
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 intfv = get_interface_number_from_name(intf)
                 command = command + "\n" + "interface {} {}".format(intfv['type'], intfv['number'])
                 command = command + "\n" + "ip vrf forwarding {}".format(vrf)
                 command = command + "\n" + "exit"
         else:
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 intfv = get_interface_number_from_name(intf)
                 command = command + "\n" + "interface {} {}".format(intfv['type'], intfv['number'])
                 command = command + "\n" + "no ip vrf forwarding {}".format(vrf)
@@ -305,22 +311,23 @@ def bind_vrf_interface(dut, **kwargs):
             st.error("klish mode not working.")
             return False
         return True
-    elif cli_type in ['rest-patch','rest-put']:
-        http_method = kwargs.pop('http_method',cli_type)
-        rest_urls = st.get_datastore(dut,'rest_urls')
+    elif cli_type in ['rest-patch', 'rest-put']:
+        http_method = kwargs.pop('http_method', cli_type)
+        rest_urls = st.get_datastore(dut, 'rest_urls')
         if config.lower() == 'yes':
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 intfv = get_interface_number_from_name(intf)
                 if 'Loopback' in intfv['type']:
                     configure_loopback(dut, loopback_name=intf, config='yes')
                 rest_url = rest_urls['vrf_bind_config'].format(vrf, intf)
-                ocdata = {"openconfig-network-instance:interface":[{"id":intf,"config":{"id":intf,"interface":intf}}]}
+                ocdata = {"openconfig-network-instance:interface":
+                          [{"id": intf, "config": {"id": intf, "interface": intf}}]}
                 response = config_rest(dut, http_method=http_method, rest_url=rest_url, json_data=ocdata)
                 if not response:
-                   st.log(response)
-                   return False
+                    st.log(response)
+                    return False
         elif config.lower() == 'no':
-            for vrf,intf in zip(vrf_name,intf_name):
+            for vrf, intf in zip(vrf_name, intf_name):
                 rest_url = rest_urls['vrf_bind_config'].format(vrf, intf)
                 response = delete_rest(dut, rest_url=rest_url)
                 if not response:
@@ -333,13 +340,14 @@ def bind_vrf_interface(dut, **kwargs):
     else:
         st.log("Unsupported cli")
 
+
 def config_vrfs(dut, vrf_data_list={}, config='yes', cli_type=''):
 
     if config == 'yes' or config == 'add':
         config = 'add'
     elif config == 'no' or config == 'del':
         config = 'del'
-    else :
+    else:
         st.error("Invalid config type {}".format(config))
         return False
 
@@ -359,7 +367,7 @@ def config_vrfs(dut, vrf_data_list={}, config='yes', cli_type=''):
             st.error("Spytest API not yet supported for REST type")
             return False
 
-    if cli_type in ['click', 'klish' ] :
+    if cli_type in ['click', 'klish']:
         try:
             st.config(dut, command, type=cli_type)
         except Exception as e:
@@ -380,7 +388,7 @@ def _clear_vrf_config_helper(dut_list, cli_type=''):
         if cli_type == 'click':
             output = st.show(dut, "show vrf")
         elif cli_type == 'klish':
-            output = st.show(dut, "show ip vrf",type=cli_type)
+            output = st.show(dut, "show ip vrf", type=cli_type)
         st.log("##### VRF : {}".format(output))
         if len(output) == 0:
             continue

--- a/spytest/apis/routing/vrf.py
+++ b/spytest/apis/routing/vrf.py
@@ -227,7 +227,9 @@ def config_vrf(dut, **kwargs):
 
 def bind_vrf_interface(dut, **kwargs):
     """
-    #Sonic cmd: Config interface <bind |unbind> <interface-name> <vrf-name>
+    #Sonic cmd: 
+    # config interface bind <interface-name> <vrf-name>
+    # config interface unbind <interface-name>
     eg: bind_vrf_interface(dut = dut1, vrf_name = 'Vrf-test', intf_name ='Ethernet8', config = 'no')
     """
     st.log('API to bind interface to VRF')
@@ -268,9 +270,9 @@ def bind_vrf_interface(dut, **kwargs):
         else:
             for vrf,intf in zip(vrf_name,intf_name):
                 if not st.is_feature_supported("vrf-needed-for-unbind", dut):
-                    my_cmd += 'sudo config interface vrf unbind {}\n'.format(intf)
+                    st.log("Unbind operation is not supported in this build")
                 else:
-                    my_cmd += 'sudo config interface vrf unbind {} {}\n'.format(intf, vrf)
+                    my_cmd += 'sudo config interface vrf unbind {}\n'.format(intf)
                 if 'Loopback' in intf:
                     if not st.is_feature_supported("config-loopback-add-command", dut):
                         st.log("Community build doesn't need Loopback interface un-configuration")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
As per [vrf unbind documentation in Command-Reference.md](https://github.com/sonic-net/sonic-utilities/blob/master/doc/Command-Reference.md#interface-vrf-bind--unbind-config-commands), unbind command does not require `<vrf_name>` argument. Updated the test case to reflect this behavior.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
