### PR TITLE
Fix get service container status and critical process bug in sonic.py and improve script

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -659,13 +659,16 @@ class SonicHost(AnsibleHostBase):
             service_critical_process['status'] = False
         for line in service_result['stdout_lines']:
             pname, status, _ = re.split('\\s+', line, 2)
+            # 1. Check status is valid
             # Sometimes, stdout_lines may be error messages but not emtpy
             # In this situation, service container status should be false
             # We can check status is valid or not
             # You can just add valid status str in this tuple if meet later
             if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL'):
                 service_critical_process['status'] = False
+            # 2. Check status is not running
             elif status != 'RUNNING':
+                # 3. Check process is critical
                 if pname in critical_group_list or pname in critical_process_list:
                     service_critical_process['exited_critical_process'].append(pname)
                     service_critical_process['status'] = False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -572,11 +572,11 @@ class SonicHost(AnsibleHostBase):
 
         @param service: Name of the SONiC service
         """
-        result = {'status': True}
-        result['exited_critical_process'] = []
-        result['running_critical_process'] = []
-        critical_group_list = []
-        critical_process_list = []
+        result = {
+            'status': True,
+            'exited_critical_process': [],
+            'running_critical_process': []
+        }
 
         # return false if the service is not started
         service_status = self.is_service_fully_started(service)
@@ -594,17 +594,12 @@ class SonicHost(AnsibleHostBase):
         output = self.command("docker exec {} supervisorctl status".format(service), module_ignore_errors=True)
         logging.info("====== supervisor process status for service {} ======".format(service))
 
-        for l in output['stdout_lines']:
-            (pname, status, info) = re.split("\s+", l, 2)
-            if status != "RUNNING":
-                if pname in critical_group_list or pname in critical_process_list:
-                    result['exited_critical_process'].append(pname)
-                    result['status'] = False
-            else:
-                if pname in critical_group_list or pname in critical_process_list:
-                    result['running_critical_process'].append(pname)
-
-        return result
+        return self.get_service_status_and_critical_process(
+            service_result=output,
+            service_critical_process=result,
+            critical_group_list=critical_group_list,
+            critical_process_list=critical_process_list
+        )
 
     def all_critical_process_status(self):
         """
@@ -642,31 +637,44 @@ class SonicHost(AnsibleHostBase):
             service_group_process = group_process_results[service]
 
             service_result = service_results[service]
-            # If container is not running, stdout_lines is empty
-            # In this situation, service container status should be false
-            if not service_result['stdout_lines']:
-                service_critical_process['status'] = False
-            for line in service_result['stdout_lines']:
-                pname, status, _ = re.split('\s+', line, 2)
-                # Sometimes, stdout_lines may be error messages but not emtpy
-                # In this situation, service container status should be false
-                # We can check status is valid or not
-                if status not in ('RUNNING','EXITED','STOPPED'):
-                    if pname in service_group_process['groups'] or pname in service_group_process['processes']:
-                        service_critical_process['exited_critical_process'].append(pname)
-                        service_critical_process['status'] = False
-                elif status != 'RUNNING':
-                    if pname in service_group_process['groups'] or pname in service_group_process['processes']:
-                        service_critical_process['exited_critical_process'].append(pname)
-                        service_critical_process['status'] = False
-                else:
-                    if pname in service_group_process['groups'] or pname in service_group_process['processes']:
-                        service_critical_process['running_critical_process'].append(pname)
-            all_critical_process[service] = service_critical_process
+
+            all_critical_process[service] = self.get_service_status_and_critical_process(
+                service_result=service_result,
+                service_critical_process=service_critical_process,
+                critical_group_list=service_group_process['groups'],
+                critical_process_list=service_group_process['processes']
+            )
 
         return all_critical_process
 
-    
+    def get_service_status_and_critical_process(self, service_result, service_critical_process, critical_group_list,
+                                     critical_process_list):
+        """
+        Parse the result of command "docker exec <container_name> supervisorctl status"
+        and get service container status and critical processes
+        """
+        # If container is not running, stdout_lines is empty
+        # In this situation, service container status should be false
+        if not service_result['stdout_lines']:
+            service_critical_process['status'] = False
+        for line in service_result['stdout_lines']:
+            pname, status, _ = re.split('\\s+', line, 2)
+            # Sometimes, stdout_lines may be error messages but not emtpy
+            # In this situation, service container status should be false
+            # We can check status is valid or not
+            # You can just add valid status str in this tuple if meet later
+            if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL'):
+                service_critical_process['status'] = False
+            elif status != 'RUNNING':
+                if pname in critical_group_list or pname in critical_process_list:
+                    service_critical_process['exited_critical_process'].append(pname)
+                    service_critical_process['status'] = False
+            else:
+                if pname in critical_group_list or pname in critical_process_list:
+                    service_critical_process['running_critical_process'].append(pname)
+
+        return service_critical_process
+
     def get_crm_resources_for_masic(self, namespace = DEFAULT_NAMESPACE):
         """
         @summary: Run the "crm show resources all" command on multi-asic dut and parse its output


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

When running "docker exec <container_name> supervisorctl status" command and parsing its result, sometimes the "stdout_lines" is empty sometimes is error message, they both indicate that the container is not running or running abnormally. In these situations, the service container status should be false.

By the way, the method `all_critical_process_status` and `critical_process_status` in `sonic.py` have some same logic to get service status and critical processes, we can extract the common part to improve the code.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Fix get service container status and critical process bug in `sonic.py` and improve script.

#### How did you do it?

When parsing the result of "docker exec <container_name> supervisorctl status" command , if the "stdout_lines" is empty or error message, the service container status should be false.

At the same time, extract common logic of `all_critical_process_status` and `critical_process_status` to improve the script.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
