### PR TITLE
Ping neighbors to refresh ARP table in case routers are directly conn…

### DIFF
--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -104,6 +104,8 @@ def arptable_on_switch(dut, asic_host, mg_facts):
             if dut.is_backend_portchannel(intf['attachto'], mg_facts):
 	        continue 
             peer_addr = intf['peer_addr']
+            #In case of directly connected neighbors, ping will populate neighbor's IP to arp table.
+            dut.shell("ping -c 1 {}".format(peer_addr), module_ignore_errors=True)
             if ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
                 all_rebuilt = False
                 break

--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -104,7 +104,6 @@ def arptable_on_switch(dut, asic_host, mg_facts):
             if dut.is_backend_portchannel(intf['attachto'], mg_facts):
 	        continue 
             peer_addr = intf['peer_addr']
-            #In case of directly connected neighbors, ping will populate neighbor's IP to arp table.
             dut.shell("ping -c 1 {}".format(peer_addr), module_ignore_errors=True)
             if ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
                 all_rebuilt = False

--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -102,8 +102,9 @@ def arptable_on_switch(dut, asic_host, mg_facts):
         switch_arptable = asic_host.switch_arptable()['ansible_facts']
         for intf in mg_facts['minigraph_portchannel_interfaces']:
             if dut.is_backend_portchannel(intf['attachto'], mg_facts):
-	        continue 
+                continue
             peer_addr = intf['peer_addr']
+            # ping neighbor to refresh ARP in case of dirctly connected routers.
             dut.shell("ping -c 1 {}".format(peer_addr), module_ignore_errors=True)
             if ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
                 all_rebuilt = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
IP forwarding tests assume neighbors IPs are always available in ARP table. It is not true in case of directly connected neighbors.
### Type of change
Perform ping operation to neighbors to refresh ARP table regardless they are BGP neighbors or directly connected ones.
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Run IP forwarding test cases in routers are directly connected topo.
#### How did you do it?
Ping neighbor to refresh arp table. 
#### How did you verify/test it?
Merge validation run and ipfwd test cases.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
