### PR TITLE
Ping neighbors to refresh ARP table

### DIFF
--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -102,8 +102,10 @@ def arptable_on_switch(dut, asic_host, mg_facts):
         switch_arptable = asic_host.switch_arptable()['ansible_facts']
         for intf in mg_facts['minigraph_portchannel_interfaces']:
             if dut.is_backend_portchannel(intf['attachto'], mg_facts):
-	        continue 
+                continue
             peer_addr = intf['peer_addr']
+            # ping neighbor to refresh ARP in case of dirctly connected routers.
+            dut.shell("ping -c 1 {}".format(peer_addr), module_ignore_errors=True)
             if ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
                 all_rebuilt = False
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
IP forwarding tests assume neighbors IPs are always available in ARP table. It is not true in case of directly connected neighbors.
Summary:
Fixes # (issue)
Perform ping operation to neighbors to refresh ARP table regardless they are BGP neighbors or directly connected ones.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
I need to run IP forwarding test cases in routers are directly connected topo.
#### How did you do it?
Ping neighbor to refresh arp table.
#### How did you verify/test it?
ipfwd test cases.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
Yes
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
