### PR TITLE
[dualtor]: Fix loopback route removal

### DIFF
--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -194,7 +194,7 @@ def test_standby_tor_downstream_bgp_recovered(
     check_tunnel_balance(**params)
 
 def route_matches_expected_state(duthost, route_ip, expect_route):
-    get_route_cmd = "ip route | grep {}".format(route_ip)
+    get_route_cmd = "ip route | grep -w {}".format(route_ip)
     rc = int(duthost.shell(get_route_cmd, module_ignore_errors=True)['rc'])
     return rc == 0 if expect_route else 1
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Removing the peer switch loopback route with `ip route` commands does not persist since the route is learned over BGP

#### How did you do it?
Shutdown BGP sessions on the peer ToR to make sure the route is no longer advertised

#### How did you verify/test it?
Run the test and make sure that the route checks are passing.
Note that the test case is still expected to fail due to ongoing QOS issues
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
