### PR TITLE
[sub_port] [backend] Update acl template based on the test ports

### DIFF
--- a/tests/sub_port_interfaces/templates/backend_acl_update_config.j2
+++ b/tests/sub_port_interfaces/templates/backend_acl_update_config.j2
@@ -1,0 +1,69 @@
+{%- set vlan2ports = {} %}
+{%- for vlan in VLAN %}
+    {% set portlist = [] %}
+    {%- for vlan_name, port in VLAN_MEMBER %}
+        {%- if vlan_name == vlan %}
+            {%- if portlist.append(port) %}{%- endif %}
+        {%- endif %}
+    {%- endfor %}
+    {%- set _ = vlan2ports.update({vlan: portlist| sort | join(',')}) %}
+{%- endfor %}
+
+
+{
+        "acl": {
+                "acl-sets": {
+                        "acl-set": {
+                                "DATAACL": {
+                                        "acl-entries": {
+                                                "acl-entry": {
+                                                 {% for vlan, vlan_entries in VLAN.items() %}
+    "{{ loop.index }}": {
+                                                             "config": {
+                                                                     "sequence-id": {{ loop.index }}
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "{{ vlan_entries['vlanid'] }}"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "{{ vlan2ports[vlan] }}"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     },
+                                                 {% endfor -%}
+   "999": {
+                                                             "config": {
+                                                                     "sequence-id": 999
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "{{ intf_list }}"
+                                                                             }
+                                                                      }
+                                                             }
+              }
+
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }
+}


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
For storage backend, new backend acl was added (sonic-net/sonic-utilities#2236). This caused regression for sub port testcases running on 't0-backend' topology.  Modified the testcase to update the acl template based on the selected test ports 

#### How did you verify/test it?
Ran the sub port testcases with the change and they passed