### PR TITLE
Test lossy (non-pfc) queue for cisco-8000 platform

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2099,6 +2099,26 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 1350
                     cell_size: 384
+                lossy_queue_voq_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 4
+                    packet_size: 64
+                    cell_size: 384
+                lossy_queue_voq_2:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 8000
+                    pkts_num_margin: 4
+                    packet_size: 64
+                    cell_size: 384
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1
@@ -2204,6 +2224,26 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 1350
                     cell_size: 384
+                lossy_queue_voq_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 4
+                    packet_size: 64
+                    cell_size: 384
+                lossy_queue_voq_2:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 8000
+                    pkts_num_margin: 4
+                    packet_size: 64
+                    cell_size: 384
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1
@@ -2299,6 +2339,26 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 4
                     packet_size: 1350
+                    cell_size: 384
+                lossy_queue_voq_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 4
+                    packet_size: 64
+                    cell_size: 384
+                lossy_queue_voq_2:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    src_port_id: 34
+                    dst_port_id: 36
+                    pkts_num_trig_egr_drp: 8000
+                    pkts_num_margin: 4
+                    packet_size: 64
                     cell_size: 384
                 wm_q_shared_lossless:
                     dscp: 3

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -34,6 +34,7 @@ from tests.common.dualtor.dual_tor_utils import dualtor_ports             # lgtm
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.pfcwd.files.pfcwd_helper import set_pfc_timers, start_wd_on_ports
 from qos_sai_base import QosSaiBase
+from tests.common.cisco_data import get_markings_dut, setup_markings_dut
 
 logger = logging.getLogger(__name__)
 
@@ -729,6 +730,70 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.LossyQueueTest",
             testParams=testParams
         )
+
+    @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
+    def testQosSaiLossyQueueVoq(
+        self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        ingressLossyProfile ,duthost, localhost
+    ):
+        """
+            Test QoS SAI Lossy queue with non_default voq and default voq
+            Args:
+                LossyVoq : qos.yml entry lookup key
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                ingressLossyProfile (Fxiture): Map of ingress lossy buffer profile attributes
+                duthost : DUT host params 
+                localhost : local host params
+            Returns:
+                None
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000":
+            pytest.skip("Lossy Queue Voq test is not supported")
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        testPortIps = dutConfig["testPortIps"]
+
+        if "lossy_queue_voq_2" in LossyVoq :
+            original_voq_markings = get_markings_dut(duthost)
+            setup_markings_dut(duthost, localhost, voq_allocation_mode = "default")
+
+        try:
+            testParams = dict()
+            testParams.update(dutTestParams["basicParams"])
+            testParams.update({
+                "dscp": qosConfig[LossyVoq]["dscp"],
+                "ecn": qosConfig[LossyVoq]["ecn"],
+                "pg": qosConfig[LossyVoq]["pg"],
+                "src_port_id": qosConfig[LossyVoq]["src_port_id"],
+                "src_port_ip": testPortIps[qosConfig[LossyVoq]["src_port_id"]]['peer_addr'],
+                "dst_port_id": qosConfig[LossyVoq]["dst_port_id"],
+                "dst_port_ip": testPortIps[qosConfig[LossyVoq]["dst_port_id"]]['peer_addr'],
+                "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
+                "pkts_num_trig_egr_drp": qosConfig[LossyVoq]["pkts_num_trig_egr_drp"]
+            })
+
+
+            if "packet_size" in qosConfig[LossyVoq].keys():
+                testParams["packet_size"] = qosConfig[LossyVoq]["packet_size"]
+                testParams["cell_size"] = qosConfig[LossyVoq]["cell_size"]
+
+            if "pkts_num_margin" in qosConfig[LossyVoq].keys():
+                testParams["pkts_num_margin"] = qosConfig[LossyVoq]["pkts_num_margin"]
+
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.LossyQueueVoqTest",
+                testParams=testParams
+            )
+
+        finally:
+            if "lossy_queue_voq_2" in LossyVoq :
+                setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
         self, ptfhost, dutTestParams, dutConfig

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -156,8 +156,8 @@ class TestQosSai(QosSaiBase):
         dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile
     ):
         """
-            Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link. 
-            Ingress PG occupancy must cross into shared headroom region when the PFC Storm is seen 
+            Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link.
+            Ingress PG occupancy must cross into shared headroom region when the PFC Storm is seen
             Only for MLNX Platforms
 
             Args:
@@ -734,7 +734,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLossyProfile ,duthost, localhost
+        ingressLossyProfile, duthost, localhost
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -746,7 +746,7 @@ class TestQosSai(QosSaiBase):
                     and test ports
                 dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
                 ingressLossyProfile (Fxiture): Map of ingress lossy buffer profile attributes
-                duthost : DUT host params 
+                duthost : DUT host params
                 localhost : local host params
             Returns:
                 None
@@ -759,9 +759,9 @@ class TestQosSai(QosSaiBase):
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         testPortIps = dutConfig["testPortIps"]
 
-        if "lossy_queue_voq_2" in LossyVoq :
+        if "lossy_queue_voq_2" in LossyVoq:
             original_voq_markings = get_markings_dut(duthost)
-            setup_markings_dut(duthost, localhost, voq_allocation_mode = "default")
+            setup_markings_dut(duthost, localhost, voq_allocation_mode="default")
 
         try:
             testParams = dict()
@@ -778,7 +778,6 @@ class TestQosSai(QosSaiBase):
                 "pkts_num_trig_egr_drp": qosConfig[LossyVoq]["pkts_num_trig_egr_drp"]
             })
 
-
             if "packet_size" in qosConfig[LossyVoq].keys():
                 testParams["packet_size"] = qosConfig[LossyVoq]["packet_size"]
                 testParams["cell_size"] = qosConfig[LossyVoq]["cell_size"]
@@ -792,7 +791,7 @@ class TestQosSai(QosSaiBase):
             )
 
         finally:
-            if "lossy_queue_voq_2" in LossyVoq :
+            if "lossy_queue_voq_2" in LossyVoq:
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -14,6 +14,7 @@ from ptf.testutils import (ptf_ports,
                            simple_arp_packet,
                            send_packet,
                            simple_tcp_packet,
+                           simple_udp_packet,
                            simple_qinq_tcp_packet,
                            simple_ip_packet)
 from ptf.mask import Mask
@@ -2396,6 +2397,129 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.client, port_list[src_port_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
                 self.client, port_list[dst_port_id])
+            # recv port no pfc
+            assert(recv_counters[pg] == recv_counters_base[pg])
+            # recv port no ingress drop
+            for cntr in ingress_counters:
+                assert(recv_counters[cntr] == recv_counters_base[cntr])
+            # xmit port egress drop
+            for cntr in egress_counters:
+                assert(xmit_counters[cntr] > xmit_counters_base[cntr])
+
+        finally:
+            sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+
+class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        switch_init(self.client)
+
+        # Parse input parameters
+        dscp = int(self.test_params['dscp'])
+        ecn = int(self.test_params['ecn'])
+        pg = int(self.test_params['pg']) + 2 # The pfc counter index starts from index 2 in sai_thrift_read_port_counters
+        sonic_version = self.test_params['sonic_version']
+        router_mac = self.test_params['router_mac']
+        dst_port_id = int(self.test_params['dst_port_id'])
+        dst_port_ip = self.test_params['dst_port_ip']
+        dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
+        src_port_id = int(self.test_params['src_port_id'])
+        src_port_ip = self.test_params['src_port_ip']
+        src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        asic_type = self.test_params['sonic_asic_type']
+
+        # get counter names to query
+        ingress_counters, egress_counters = get_counter_names(sonic_version)
+
+        # prepare tcp packet data
+        ttl = 64
+
+        pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
+        pkts_num_trig_egr_drp = int(self.test_params['pkts_num_trig_egr_drp'])
+        if 'packet_size' in self.test_params.keys():
+            packet_length = int(self.test_params['packet_size'])
+            cell_size = int(self.test_params['cell_size'])
+            if packet_length != 64:
+                cell_occupancy = (packet_length + cell_size - 1) / cell_size
+                pkts_num_trig_egr_drp /= cell_occupancy
+        else:
+            packet_length = 64
+
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        # crafting 2 udp packets with different udp_dport in order for traffic to go through different flows
+        pkt = simple_udp_packet(pktlen=packet_length,
+                               eth_dst=pkt_dst_mac,
+                               eth_src=src_port_mac,
+                               ip_src=src_port_ip,
+                               ip_dst=dst_port_ip,
+                               ip_tos=((dscp << 2) | ecn),
+                               udp_sport = 1024,
+                               udp_dport = 2048,
+                               ip_ecn=ecn,
+                               ip_ttl=ttl)
+
+        pkt2 = simple_udp_packet(pktlen=packet_length,
+                               eth_dst=pkt_dst_mac,
+                               eth_src=src_port_mac,
+                               ip_src=src_port_ip,
+                               ip_dst=dst_port_ip,
+                               ip_tos=((dscp << 2) | ecn),
+                               udp_sport = 1024,
+                               udp_dport = 2049,
+                               ip_ecn=ecn,
+                               ip_ttl=ttl)
+        print >> sys.stderr, "dst_port_id: %d, src_port_id: %d " % (dst_port_id, src_port_id)
+        # in case dst_port_id is part of LAG, find out the actual dst port
+        # for given IP parameters
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip
+        )
+        print >> sys.stderr, "actual dst_port_id: %d" % (dst_port_id)
+
+        # get a snapshot of counter values at recv and transmit ports
+        # queue_counters value is not of our interest here
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+        # add slight tolerance in threshold characterization to consider
+        # the case that npu puts packets in the egress queue after we pause the egress
+        # or the leak out is simply less than expected as we have occasionally observed
+        if 'pkts_num_margin' in self.test_params.keys():
+            margin = int(self.test_params['pkts_num_margin'])
+        else:
+            margin = 2
+
+        sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+
+        try:
+            if asic_type == 'cisco-8000':
+                assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, int(self.test_params['pg']), asic_type))
+                # send packets short of triggering egress drop on flow1 and flow2
+                send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
+                send_packet(self, src_port_id, pkt2, pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
+
+            # allow enough time for the dut to sync up the counter values in counters_db
+            time.sleep(8)
+            # get a snapshot of counter values at recv and transmit ports
+            # queue counters value is not of our interest here
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            # recv port no pfc
+            assert(recv_counters[pg] == recv_counters_base[pg])
+            # recv port no ingress drop
+            for cntr in ingress_counters:
+                assert(recv_counters[cntr] == recv_counters_base[cntr])
+            # xmit port no egress drop
+            for cntr in egress_counters:
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr])
+
+            # send 1 packet to trigger egress drop
+            send_packet(self, src_port_id, pkt, 1 + 2 * margin)
+            send_packet(self, src_port_id, pkt2, 1 + 2 * margin)
+            # allow enough time for the dut to sync up the counter values in counters_db
+            time.sleep(8)
+            # get a snapshot of counter values at recv and transmit ports
+            # queue counters value is not of our interest here
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2409,6 +2409,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
 
+
 class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         switch_init(self.client)
@@ -2416,7 +2417,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
         ecn = int(self.test_params['ecn'])
-        pg = int(self.test_params['pg']) + 2 # The pfc counter index starts from index 2 in sai_thrift_read_port_counters
+        # The pfc counter index starts from index 2 in sai_thrift_read_port_counters
+        pg = int(self.test_params['pg']) + 2
         sonic_version = self.test_params['sonic_version']
         router_mac = self.test_params['router_mac']
         dst_port_id = int(self.test_params['dst_port_id'])
@@ -2447,26 +2449,26 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # crafting 2 udp packets with different udp_dport in order for traffic to go through different flows
         pkt = simple_udp_packet(pktlen=packet_length,
-                               eth_dst=pkt_dst_mac,
-                               eth_src=src_port_mac,
-                               ip_src=src_port_ip,
-                               ip_dst=dst_port_ip,
-                               ip_tos=((dscp << 2) | ecn),
-                               udp_sport = 1024,
-                               udp_dport = 2048,
-                               ip_ecn=ecn,
-                               ip_ttl=ttl)
+                                eth_dst=pkt_dst_mac,
+                                eth_src=src_port_mac,
+                                ip_src=src_port_ip,
+                                ip_dst=dst_port_ip,
+                                ip_tos=((dscp << 2) | ecn),
+                                udp_sport=1024,
+                                udp_dport=2048,
+                                ip_ecn=ecn,
+                                ip_ttl=ttl)
 
         pkt2 = simple_udp_packet(pktlen=packet_length,
-                               eth_dst=pkt_dst_mac,
-                               eth_src=src_port_mac,
-                               ip_src=src_port_ip,
-                               ip_dst=dst_port_ip,
-                               ip_tos=((dscp << 2) | ecn),
-                               udp_sport = 1024,
-                               udp_dport = 2049,
-                               ip_ecn=ecn,
-                               ip_ttl=ttl)
+                                 eth_dst=pkt_dst_mac,
+                                 eth_src=src_port_mac,
+                                 ip_src=src_port_ip,
+                                 ip_dst=dst_port_ip,
+                                 ip_tos=((dscp << 2) | ecn),
+                                 udp_sport=1024,
+                                 udp_dport=2049,
+                                 ip_ecn=ecn,
+                                 ip_ttl=ttl)
         print >> sys.stderr, "dst_port_id: %d, src_port_id: %d " % (dst_port_id, src_port_id)
         # in case dst_port_id is part of LAG, find out the actual dst port
         # for given IP parameters
@@ -2491,7 +2493,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             if asic_type == 'cisco-8000':
-                assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, int(self.test_params['pg']), asic_type))
+                assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, int(self.test_params['pg']),
+                       asic_type))
                 # send packets short of triggering egress drop on flow1 and flow2
                 send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
                 send_packet(self, src_port_id, pkt2, pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
@@ -2531,6 +2534,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+
 
 # pg shared pool applied to both lossy and lossless traffic
 


### PR DESCRIPTION
Rebased from https://github.com/sonic-net/sonic-mgmt/pull/6078

### Description of PR
Adding new test for lossy (non-pfc) queue for cisco-8000 platform .

What is the motivation for this PR?
Verify traffic on lossy queues .

How did you verify/test it?
Verified this testcase on local cisco-8000 setup

This PR has dependency on #5982
Once the above PR is merged , then this PR should be merged

