### PR TITLE
[dualtor_io] enable `--disable_arp_cache` when config reload with active-active interfaces

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -64,7 +64,7 @@ def config_force_option_supported(duthost):
 
 @ignore_loganalyzer
 def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False,
-                  check_intf_up_ports=False, traffic_shift_away=False, override_config=False):
+                  check_intf_up_ports=False, traffic_shift_away=False, override_config=False, disable_arp_cache=False):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -80,9 +80,12 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
             ' or '.join(['"{}"'.format(src) for src in config_sources])
         ))
 
-    cmd = 'config reload -y &>/dev/null'
+    cmd = 'config reload -y'
     if config_force_option_supported(duthost):
-        cmd = 'config reload -y -f &>/dev/null'
+        cmd += ' -f'
+    if disable_arp_cache: 
+        cmd += ' -d'
+    cmd += ' &>/dev/null'
 
     logger.info('reloading {}'.format(config_source))
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -93,7 +93,7 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,
     
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                    action=lambda: config_reload(upper_tor_host, wait=0))
+                                    action=lambda: config_reload(upper_tor_host, wait=0, disable_arp_cache=True))
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)
@@ -134,7 +134,7 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host,
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                    action=lambda: config_reload(lower_tor_host, wait=0))
+                                    action=lambda: config_reload(lower_tor_host, wait=0, disable_arp_cache=True))
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Details in: 
https://github.com/sonic-net/sonic-platform-daemons/issues/291

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To increment passing rate of image 202205. 

#### How did you do it?
Disable arp cache if testing `config reload` with active-active interfaces. 

#### How did you verify/test it?
Tests passed for `test_upper_tor_config_reload_upstream`
```
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor_io/test_normal_op.py::test_upper_tor_config_reload_upstream.xml -
------------------------------------------------- live log sessionfinish --------------------------------------------------
00:22:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 2 passed in 994.78 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
