### PR TITLE
[dualtor][active-active] Fix `nic_simulator` control utilities

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -93,10 +93,6 @@ def nic_simulator_channel(nic_simulator_info):
         # temporarily disable HTTP proxies
         with utilities.update_environ("http_proxy", "https_proxy"):
             _channel = grpc.insecure_channel(server_url)
-            try:
-                grpc.channel_ready_future(_channel).result(timeout=2)
-            except grpc.FutureTimeoutError as e:
-                raise RuntimeError("Failed to establish connection to nic_simulator %s, error(%r)" % (server_url, e))
             channel.append(_channel)
             return _channel
 
@@ -139,7 +135,7 @@ def mux_status_from_nic_simulator(duthost, nic_simulator_client, mux_config, tbi
     def _get_mux_status(ports=None):
         if ports is None:
             ports = active_active_ports.keys()
-        elif isinstance(ports, collections.Iterable):
+        elif isinstance(ports, list) or isinstance(ports, tuple):
             ports = list(ports)
         else:
             ports = [str(ports)]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Two issues:
1. `grpc.channel_ready_future(_channel).result(timeout=2)` is redundant because the channel might not be in `ready` state immediately after channel setup because there is no active rpc request.
2. if `ports` is a string, it could pass the check `isinstance(ports, collections.Iterable)`, let's make the check more strict.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As above.

#### How did you verify/test it?
run `active-active` dualtor testcases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
