### PR TITLE
Fix the issue of incorrect format for timeout sanity check results after recovery

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -141,10 +141,12 @@ def parallel_run(
             kwargs['node'] = node
             # If sanity check is timeout and killed, we still have some information in results.
             # Sanity check function name looks like _check_bgp_on_dut.
-            check_item_name = target.__name__.split('_')[2]
-            if check_item_name in ['interfaces', 'bgp', 'processes', 'monit', 'dbmemory']:
-                check_result = {"failed": False, "check_item": check_item_name, "host": node.hostname}
-                results[node.hostname] = check_result
+            items = target.__name__.split('_')
+            if len(items) > 2:
+                check_item_name = items[2]
+                if check_item_name in ['interfaces', 'bgp', 'processes', 'monit', 'dbmemory']:
+                    check_result = {"failed": False, "check_item": check_item_name, "host": node.hostname}
+                    results[node.hostname] = check_result
             kwargs['results'] = results
             process_name = "{}--{}".format(target.__name__, node)
             worker = SonicProcess(

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -196,7 +196,14 @@ def check_bgp(duthosts):
         check_result = {"failed": False, "check_item": "bgp", "host": dut.hostname}
 
         networking_uptime = dut.get_networking_uptime().seconds
-        timeout = max(SYSTEM_STABILIZE_MAX_TIME - networking_uptime, 1)
+        if SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480 > 500:
+            # If max_timeout is higher than 600, it will exceed parallel_run's timeout
+            # the check will be killed by parallel_run, we can't get expected results.
+            # 500 seconds is about 8 mins, bgp has enough to get up
+            max_timeout = 500
+        else:
+            max_timeout = SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480
+        timeout = max(max_timeout, 1)
         interval = 20
         wait_until(timeout, interval, 0, _check_bgp_status_helper)
         if (check_result['failed']):


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
sanity_check throw this error:
```
                    logger.info("Run sanity check again after recovery")
                    new_check_results = do_checks(request, pre_check_items, stage=STAGE_PRE_TEST, after_recovery=True)
                    logger.debug("Pre-test sanity check after recovery results:\n%s" % json.dumps(new_check_results, indent=4, default=fallback_serializer))
    
>                   new_failed_results = [result for result in new_check_results if result['failed']]
E                   TypeError: list indices must be integers, not str
```
That's because new_check_results looks like below, it has list in return list.
```
[..
 {
        "check_item": "interfaces", 
        "failed": false, 
        "host": "str2-dx010-acs-6", 
        "down_ports": []
    }, 
    [
        {
            "failed": true
        }
    ], 
    {
        "check_item": "dbmemory", 
        "failed": false, 
        "host": "str2-dx010-acs-6", 
        "total_omem": 41008
    }, 
..]
```

If testbed has unhealthy problem, sanity check will fail and do recovery by config reload.
This recovery is enhanced by https://github.com/sonic-net/sonic-mgmt/pull/6413.
In `_check_bgp_on_dut`, it will check if networking is reloaded, if so, the wait_util timeout is pretty much long, in my failed case it's 637 seconds, which is higher than `parallel_run` timeout(600), so `parallel_run` will timeout and kill this process, set return results as below, which triggers this issue.
`results[p.name] = [{'failed': True}]`


#### How did you do it?
1. Set max timeout to 500 seconds(8.33 mins), bgp has enough time to get up. `parallel_run` will not kill the check process and we can get expected results.
2. Return a dict instead of list if process is timeout and killed.

For the below change, will raise a new separated PR to cover:
Even check process is killed, we still have some useful information to return for sanity check.
After process is killed, we will return results as below. check_item_name and hostname will be parsed from process name.
`check_result = {"failed": True, "check_item": check_item_name, "host": hostname}`
If it's not sanity check process, but something else, we just return a dict with value {'failed': True} and key is hostname which is parsed from name of worker.

The results of normal return:
```
{
    "check_item": "bgp", 
    "failed": true, 
    "host": "sonic", 
    "bgp": {
        "down_neighbors": [
            "fc00::3a", 
            "10.0.0.29"
        ]
    }
}

```
The results of killed process return:
```
    {
        "check_item": "bgp", 
        "failed": true, 
        "host": "sonic"
    }
```

#### How did you verify/test it?
Run any test case on bgp unhealthy testbed, don't skip sanity check and allow recover
`--allow_recover`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
