### PR TITLE
[TestbedV2] Consider KVMDUMP as failure

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -193,6 +193,9 @@ class TestPlanManager(object):
                     raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds"
                                     .format(test_plan_id, status, result, time.time() - start_time))
             elif status in expected_states:
+                if status == "KVMDUMP":
+                    raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds"
+                                    .format(test_plan_id, status, result, time.time() - start_time))
                 return
             else:
                 print("Test plan id: {}, status: {}, progress: {}%, elapsed: {:.0f} seconds"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, if the test failed, 'run test' step will continue to 'KVM dump' step with success which is confusing.
So consider KVMDUMP as a failure.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, if the test failed, 'run test' step will continue to 'KVM dump' step with success which is confusing.
Consider KVMDUMP as a failure.
#### How did you do it?
Consider KVMDUMP as a failure.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
