### PR TITLE
Fix platform_tests/daemon TCs

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -15,6 +15,7 @@ import threading
 import time
 import traceback
 from io import BytesIO
+from ast import literal_eval
 
 import pytest
 from ansible.parsing.dataloader import DataLoader
@@ -495,13 +496,16 @@ def dump_scapy_packet_show_output(packet):
         sys.stdout = _stdout
 
 
-def compose_dict_from_cli(fields_list):
-    """Convert the output of hgetall command to a dict object containing the field, key pairs of the database table content
+def compose_dict_from_cli(str_output):
+    """Convert the output of sonic-db-cli <DB> HGETALL command from string to
+       dict object containing the field, key pairs of the database table content
 
     Args:
-        fields_list: A list of lines, the output of redis-cli hgetall command
+        str_output: String with output of cli sonic-db-cli <DB> HGETALL <key>
+    Returns:
+        dict: dict object containing the field, key pairs of the database table content
     """
-    return dict(zip(fields_list[0::2], fields_list[1::2]))
+    return literal_eval(str_output)
 
 
 def get_intf_by_sub_intf(sub_intf, vlan_id=None):

--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -7,10 +7,7 @@ This script is to cover the test case in the SONiC platform daemon and service t
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/PMON-Services-Daemons-test-plan.md
 """
 import logging
-import re
 import time
-
-from datetime import datetime
 
 import pytest
 
@@ -75,7 +72,7 @@ def collect_data(duthost):
 
     dev_data = {}
     for k in keys:
-        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout_lines']
+        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
     return {'keys': keys, 'data': dev_data}

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -8,10 +8,7 @@ This script is to cover the test case in the SONiC platform daemon and service t
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/PMON-Services-Daemons-test-plan.md
 """
 import logging
-import re
 import time
-
-from datetime import datetime
 
 import pytest
 
@@ -72,7 +69,7 @@ def check_daemon_status(duthosts, rand_one_dut_hostname):
         time.sleep(10)
 
 def check_pcie_devices_table_ready(duthost):
-    if duthost.shell("redis-cli -n 6 keys '*' | grep PCIE_DEVICES"):
+    if duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES"):
         return True
     return False
 
@@ -81,17 +78,17 @@ def get_pcie_devices_tbl_key(duthosts,rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911"])
     pytest_assert(wait_until(30, 10, 0, check_pcie_devices_table_ready, duthost), "PCIE_DEVICES table is empty")
-    command_output = duthost.shell("redis-cli -n 6 keys '*' | grep PCIE_DEVICES")
+    command_output = duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES")
 
     global pcie_devices_status_tbl_key
     pcie_devices_status_tbl_key = command_output["stdout"]
 
 def collect_data(duthost):
-    keys = duthost.shell('redis-cli -n 6 keys "PCIE_DEVICE|*"')['stdout_lines']
+    keys = duthost.shell('sonic-db-cli STATE_DB KEYS "PCIE_DEVICE|*"')['stdout_lines']
 
     dev_data = {}
     for k in keys:
-        data = duthost.shell('redis-cli -n 6 hgetall "{}"'.format(k))['stdout_lines']
+        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
 

--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -8,10 +8,7 @@ This script is to cover the test case in the SONiC platform daemon and service t
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/PMON-Services-Daemons-test-plan.md
 """
 import logging
-import re
 import time
-
-from datetime import datetime
 
 import pytest
 
@@ -79,7 +76,7 @@ def collect_data(duthost):
 
     dev_data = {}
     for k in keys:
-        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout_lines']
+        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
 
@@ -102,6 +99,23 @@ def data_before_restart(duthosts, enum_supervisor_dut_hostname):
     data = collect_data(duthost)
     return data
 
+def verify_data(data_before, data_after):
+    """
+    Compare PSU_INFO taken from state_db before_restart and after_restart,
+    avoid comparing fields that are not persistent
+    Args:
+        data_before: Dict with PSU_INFO before daemon restart
+        data_after: Dict with PSU_INFO after daemon restart
+    """
+    ignore_fields = ["power", "temp", "current", "voltage", "input_current", "input_voltage"]
+    msg = 'Data_before_restart {} dont match data_after_restart {} for field {}'
+    for psu_key in data_before['data']:
+        for field in data_before['data'][psu_key]:
+            if field not in ignore_fields:
+                value_before = data_before['data'][psu_key][field]
+                value_after = data_after['data'][psu_key][field]
+                pytest_assert(value_before == value_after,
+                              msg.format(value_before, value_after, field))
 
 def test_pmon_psud_running_status(duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
@@ -153,7 +167,7 @@ def test_pmon_psud_stop_and_start_status(check_daemon_status, duthosts, enum_sup
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
+    verify_data(data_before_restart, data_after_restart)
 
 
 def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, enum_supervisor_dut_hostname, data_before_restart):
@@ -179,7 +193,7 @@ def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, enum_sup
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
+    verify_data(data_before_restart, data_after_restart)
 
 
 def test_pmon_psud_kill_and_start_status(check_daemon_status, duthosts, enum_supervisor_dut_hostname, data_before_restart):
@@ -205,4 +219,4 @@ def test_pmon_psud_kill_and_start_status(check_daemon_status, duthosts, enum_sup
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
+    verify_data(data_before_restart, data_after_restart)

--- a/tests/platform_tests/daemon/test_syseepromd.py
+++ b/tests/platform_tests/daemon/test_syseepromd.py
@@ -8,10 +8,7 @@ This script is to cover the test case in the SONiC platform daemon and service t
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/PMON-Services-Daemons-test-plan.md
 """
 import logging
-import re
 import time
-
-from datetime import datetime
 
 import pytest
 
@@ -79,7 +76,7 @@ def collect_data(duthost):
 
     dev_data = {}
     for k in keys:
-        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout_lines']
+        data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Some of `platform_tests/daemon` TC's compare dict with info from database that is taken before and after restart of a daemon, it looks like these dictionary that is compared consist only from keys from database:
```
(Pdb) data_after_restart
{'keys': [u'PSU_INFO|PSU 1', u'PSU_INFO|PSU 2'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}
(Pdb) data_before_restart
{'keys': [u'PSU_INFO|PSU 1', u'PSU_INFO|PSU 2'], 'data': {u'PSU_INFO|PSU 1': {}, u'PSU_INFO|PSU 2': {}}}

$ sonic-db-cli STATE_DB HGETALL "PSU_INFO|PSU 1"
{'presence': 'true', 'status': 'true', 'model': 'PWR-745AC-F', 'serial': 'DDUT92L07R2', 'revision': 'S2', 'temp': '31.0', 'temp_threshold': '95.0', 'voltage': '12.007', 'voltage_min_threshold': '11.4', 'voltage_max_threshold': '12.599', 'current': '14.781', 'power': '177.25', 'is_replaceable': 'True', 'input_current': '0.937', 'input_voltage': '208.75', 'max_power': '750.0', 'led_status': 'green'}
$ sonic-db-cli STATE_DB HGETALL "PSU_INFO|PSU 2"
{'presence': 'true', 'status': 'false', 'model': 'PWR-745AC-F', 'serial': 'DDUT92L07PM', 'revision': 'S2', 'temp': '0.0', 'temp_threshold': '95.0', 'voltage': '0.0', 'voltage_min_threshold': '11.4', 'voltage_max_threshold': '12.599', 'current': '0.0', 'power': '0.0', 'is_replaceable': 'True', 'input_current': '0.0', 'input_voltage': '0.0', 'max_power': '750.0', 'led_status': 'red'}
```
This happens due to usage of `compose_dict_from_cli` with `sonic-db-cli <DB> HGETALL <key> commands`, which returns:
```
[u"{'presence': 'true', 'status': 'false', 'model': 'PWR-745AC-F', 'serial': 'DDUT92L07PM', 'revision': 'S2', 'temp': '0.0', 'temp_threshold': '95.0', 'voltage': '0.0', 'voltage_min_threshold': '11.4', 'voltage_max_threshold': '12.599', 'current': '0.0', 'power': '0.0', 'is_replaceable': 'True', 'input_current': '0.0', 'input_voltage': '0.0', 'max_power': '750.0', 'led_status': 'red'}"]
```
**This PR should fix this issue in next TC's:**
- platform_tests/daemon/test_chassisd.py
- platform_tests/daemon/test_psud.py
- platform_tests/daemon/test_syseepromd.py

Also updated `test_psud.py` to skip certain fields during verification that don't have persistent value `(example: power, voltage)`
Fixes #6581

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix daemon test cases
#### How did you do it?

#### How did you verify/test it?
Check that dictionary consist from key:value info:
```
(Pdb) data_before_restart
{'keys': [u'PSU_INFO|PSU 2', u'PSU_INFO|PSU 1'], 'data': {u'PSU_INFO|PSU 1': {'status': 'true', 'max_power': '750.0', 'power': '184.75', 'temp': '31.0', 'presence': 'true', 'voltage_max_threshold': '12.599', 'led_status': 'green', 'is_replaceable': 'True', 'voltage_min_threshold': '11.4', 'current': '15.39', 'voltage': '12.007', 'input_current': '0.97', 'model': 'PWR-745AC-F', 'temp_threshold': '95.0', 'serial': 'DDUT92L07R2', 'input_voltage': '208.25', 'revision': 'S2'}, u'PSU_INFO|PSU 2': {'status': 'false', 'max_power': '750.0', 'power': '0.0', 'temp': '0.0', 'presence': 'true', 'voltage_max_threshold': '12.599', 'led_status': 'red', 'is_replaceable': 'True', 'voltage_min_threshold': '11.4', 'current': '0.0', 'voltage': '0.0', 'input_current': '0.0', 'model': 'PWR-745AC-F', 'temp_threshold': '95.0', 'serial': 'DDUT92L07PM', 'input_voltage': '0.0', 'revision': 'S2'}}}
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.162195-dirty-20221018.110356
Distribution: Debian 11.5
Kernel: 5.10.0-12-2-amd64
Build commit: 05b1e0601
Build date: Tue Oct 18 15:46:10 UTC 2022
Built by: AzDevOps@sonic-build-workers-00294T
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
