### PR TITLE
[testbed] Improve ansible playbooks for deploy fanouts

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -462,18 +462,6 @@ def get_port_name_list(hwsku):
     port_name_list_sorted = natsorted(port_name_list)
     return port_name_list_sorted
 
-
-def get_port_alias_list(hwsku):
-    # Create a map of SONiC port alias to physical port index
-    # Start by creating a list of all port alias
-    port_alias_to_name_map, _, _ = get_port_alias_to_name_map(hwsku)
-    port_alias_list = port_alias_to_name_map.keys()
-    # Sort the list in natural order, because SONiC port alias, when
-    # sorted in natural sort order, match the phyical port index order
-    port_alias_list_sorted = natsorted(port_alias_list)
-    return port_alias_list_sorted
-
-
 def build_results(lab_graph, hostnames, ignore_error=False):
     """
     Refactor code for building json results.
@@ -509,7 +497,6 @@ def build_results(lab_graph, hostnames, ignore_error=False):
                 device_vlan_map_list[hostname] = {}
 
                 port_name_list_sorted = get_port_name_list(dev['HwSku'])
-                port_alias_list_sorted = get_port_alias_list(dev['HwSku'])
                 logging.debug("For %s with hwsku %s, port_name_list is %s" % (hostname, dev['HwSku'], port_name_list_sorted))
                 for a_host_vlan in host_vlan["VlanList"]:
                     # Get the corresponding port for this vlan from the port vlan list for this hostname
@@ -518,14 +505,12 @@ def build_results(lab_graph, hostnames, ignore_error=False):
                         if a_host_vlan in port_vlans[a_port]['vlanlist']:
                             if a_port in port_name_list_sorted:
                                 port_index = port_name_list_sorted.index(a_port)
-                            elif a_port in port_alias_list_sorted:
-                                port_index = port_alias_list_sorted.index(a_port)
+                                device_vlan_map_list[hostname][port_index] = a_host_vlan
+                                found_port_for_vlan = True
+                                break
                             elif not ignore_error:
                                 msg = "Did not find port for %s in the ports based on hwsku '%s' for host %s" % (a_port, dev['HwSku'], hostname)
                                 return (False, msg)
-                            device_vlan_map_list[hostname][port_index] = a_host_vlan
-                            found_port_for_vlan = True
-                            break
                     if not found_port_for_vlan and not ignore_error:
                         msg = "Did not find corresponding link for vlan %d in %s for host %s" % (a_host_vlan, port_vlans, hostname)
                         return (False, msg)

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -34,5 +34,5 @@
   - import_tasks: rootfanout_connect.yml
     vars:
       deploy_leaf: true
-  when: sw_type == 'FanoutLeaf'
+  when: sw_type == 'FanoutLeaf' or sw_type == 'FanoutLeafSonic'
   tags: always

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -34,5 +34,5 @@
   - import_tasks: rootfanout_connect.yml
     vars:
       deploy_leaf: true
-  when: sw_type == 'FanoutLeaf' or sw_type == 'FanoutLeafSonic'
+  when: 'FanoutLeaf' in sw_type
   tags: always

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -34,5 +34,5 @@
   - import_tasks: rootfanout_connect.yml
     vars:
       deploy_leaf: true
-  when: 'FanoutLeaf' in sw_type
+  when: '"FanoutLeaf" in sw_type'
   tags: always

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
@@ -10,13 +10,8 @@
     src: "sonic_deploy_202012.j2"
     dest: "/tmp/base_config.json"
 
-- name: copy platform related startup config
-  copy:
-    src: "{{ fanout_platform }}.json"
-    dest: "/tmp/platform_config.json"
-
 - name: generate config_db.json
-  shell: sonic-cfggen -H -j /tmp/base_config.json -j /tmp/platform_config.json --print-data > /etc/sonic/config_db.json
+  shell: sonic-cfggen -H -j /tmp/base_config.json --print-data > /etc/sonic/config_db.json
   become: yes
 
 - name: disable all copp rules

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
@@ -20,26 +20,13 @@
     dest: "/usr/share/sonic/templates/copp_cfg.j2"
   become: yes
 
-- name: Reboot switch to load the config
-  shell: reboot
-  async: 300
-  poll: 0
-  become: yes
+- name: SONiC update config db
+  shell: config reload -y
+  become: true
 
-- name: Wait for switch to come back
-  local_action: wait_for
-  args:
-    host: "{{ ansible_ssh_host }}"
-    port: 22
-    state: started
-    search_regex: "OpenSSH"
-    delay: 180
-    timeout: 600
-  changed_when: false
-
-- name: pause for 60s to wait for fanout switch to initialize
+- name: wait for SONiC update config db finish
   pause:
-    seconds: 60
+    seconds: 180
 
 - name: Setup broadcom based fanouts
   block:

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -10,13 +10,8 @@
     src: "sonic_deploy_202205.j2"
     dest: "/tmp/base_config.json"
 
-- name: copy platform related startup config
-  copy:
-    src: "{{ fanout_platform }}.json"
-    dest: "/tmp/platform_config.json"
-
 - name: generate config_db.json
-  shell: sonic-cfggen -H -j /tmp/base_config.json -j /tmp/platform_config.json --print-data > /etc/sonic/config_db.json
+  shell: sonic-cfggen -H -j /tmp/base_config.json --print-data > /etc/sonic/config_db.json
   become: yes
 
 - name: disable all copp rules
@@ -25,26 +20,13 @@
     dest: "/usr/share/sonic/templates/copp_cfg.j2"
   become: yes
 
-- name: Reboot switch to load the config
-  shell: reboot
-  async: 300
-  poll: 0
-  become: yes
+- name: SONiC update config db
+  shell: config reload -y
+  become: true
 
-- name: Wait for switch to come back
-  local_action: wait_for
-  args:
-    host: "{{ ansible_ssh_host }}"
-    port: 22
-    state: started
-    search_regex: "OpenSSH"
-    delay: 180
-    timeout: 600
-  changed_when: false
-
-- name: pause for 60s to wait for fanout switch to initialize
+- name: wait for SONiC update config db finish
   pause:
-    seconds: 60
+    seconds: 180
 
 - name: Setup broadcom based fanouts
   block:

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -21,7 +21,7 @@ no spanning-tree vlan {{ device_vlan_range[inventory_hostname] | list | join(','
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
 !
-username {{ secret_group_vars["fanout"]["ansible_eos_user"] }} privilege 15 role network-admin secret 0 {{ secret_group_vars["fanout"]["ansible_eos_pass"] }}
+username admin privilege 15 role network-admin secret 0 {{ lab_admin_pass }}
 username eapi privilege 15 secret 0 {{ lab_admin_pass }}
 !
 vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -29,7 +29,7 @@ vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 vrf definition management
    rd 1:1
 !
-{% for i in range(1, device_port_vlans[inventory_hostname]|length + 1) %}
+{% for i in range(1, 33) %}
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 {% if intf not in device_port_vlans[inventory_hostname] %}
 {% set intf =  'Ethernet' + i|string  %}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -29,93 +29,25 @@ vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 vrf definition management
    rd 1:1
 !
-{% for i in range(1, 33) %}
-{% set intf =  'Ethernet' + i|string + '/1'  %}
-{% if intf not in device_port_vlans[inventory_hostname] %}
-{% set intf =  'Ethernet' + i|string  %}
-{% endif %}
+{% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
-{% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 100gfull
-   error-correction encoding reed-solomon
-   no switchport mac address learning
-   no shutdown
-{%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 40gfull
-   no switchport mac address learning
-   no shutdown
-{%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 50gfull
-   no error-correction encoding
-   no switchport mac address learning
-   no shutdown
-{% set intf =  'Ethernet' + i|string + '/3'  %}
-interface {{ intf }}
-{%         if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 50gfull
-   no error-correction encoding
-   no switchport mac address learning
-   no shutdown
-{%         else %}
-   shutdown
-{%         endif %}
-{%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 10gfull
-   no error-correction encoding
-   no switchport mac address learning
-   no shutdown
-{%         for j in range(2,5) %}
-{% set intf =  'Ethernet' + i|string + '/' + j|string %}
-interface {{ intf }}
-{%             if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
-   spanning-tree portfast
-   speed forced 10gfull
-   no error-correction encoding
-   no switchport mac address learning
-   no shutdown
-{%             else %}
-   shutdown
-{%             endif %}
-{%         endfor %}
-{%     else %}
-{#        Not valid speed value #}
-   shutdown
-{%     endif %}
-{% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+   speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
+{%   if device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+{%   else %}
+   switchport mode dot1q-tunnel
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
+   error-correction encoding reed-solomon
+{%     else %}
+   no error-correction encoding
+{%     endif %}
+{%   endif %}
    spanning-tree portfast
-   speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
    no switchport mac address learning
    no shutdown
-{% else %}
-   shutdown
-{% endif %}
 !
 {% endfor %}
 !

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -110,7 +110,7 @@ interface {{ intf }}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    spanning-tree portfast
-   speed force 40gfull
+   speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
    no switchport mac address learning
    no shutdown
 {% else %}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -21,7 +21,7 @@ no spanning-tree vlan {{ device_vlan_range[inventory_hostname] | list | join(','
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
 !
-username admin privilege 15 role network-admin secret 0 {{ lab_admin_pass }}
+username {{ secret_group_vars["fanout"]["ansible_eos_user"] }} privilege 15 role network-admin secret 0 {{ secret_group_vars["fanout"]["ansible_eos_pass"] }}
 username eapi privilege 15 secret 0 {{ lab_admin_pass }}
 !
 vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -29,6 +29,10 @@ vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 vrf definition management
    rd 1:1
 !
+interface defaults
+   ethernet
+      shutdown
+!
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}

--- a/ansible/roles/fanout/templates/sonic_deploy_202012.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202012.j2
@@ -102,31 +102,6 @@
     {% endfor %}
     },
 
-    "BUFFER_QUEUE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0-2": {
-            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|3-4": {
-            "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|5-6": {
-            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-    {% endfor %}
-    },
-
-    "BUFFER_PG": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0": {
-            "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|3-4": {
-            "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
-        }{% if not loop.last %},{% endif %}
-    {% endfor %}
-    },
-
     "CABLE_LENGTH": {
         "AZURE": {
     {% for alias in fanout_port_config %}
@@ -184,51 +159,6 @@
         "scheduler.1": {
             "type": "DWRR",
             "weight": "15"
-        }
-    },
-
-    "BUFFER_POOL": {
-        "egress_lossless_pool": {
-            "type": "egress",
-            "mode": "static",
-            "size": "15982720"
-        },
-        "egress_lossy_pool": {
-            "type": "egress",
-            "mode": "dynamic",
-            "size": "9243812"
-        },
-        "ingress_lossless_pool": {
-            "xoff": "4194112",
-            "type": "ingress",
-            "mode": "dynamic",
-            "size": "10875072"
-        }
-    },
-
-    "BUFFER_PROFILE": {
-        "egress_lossless_profile": {
-            "static_th": "15982720",
-            "pool": "[BUFFER_POOL|egress_lossless_pool]",
-            "size": "1518"
-        },
-        "egress_lossy_profile": {
-            "dynamic_th": "3",
-            "pool": "[BUFFER_POOL|egress_lossy_pool]",
-            "size": "1518"
-        },
-        "ingress_lossy_profile": {
-            "dynamic_th": "3",
-            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-            "size": "0"
-        },
-        "pg_lossless_100000_300m_profile": {
-            "xon_offset": "2288",
-            "dynamic_th": "0",
-            "xon": "2288",
-            "xoff": "268736",
-            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-            "size": "1248"
         }
     },
 

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -102,31 +102,6 @@
     {% endfor %}
     },
 
-    "BUFFER_QUEUE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0-2": {
-            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|3-4": {
-            "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|5-6": {
-            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-    {% endfor %}
-    },
-
-    "BUFFER_PG": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0": {
-            "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "{{ fanout_port_config[alias]['name'] }}|3-4": {
-            "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
-        }{% if not loop.last %},{% endif %}
-    {% endfor %}
-    },
-
     "CABLE_LENGTH": {
         "AZURE": {
     {% for alias in fanout_port_config %}
@@ -184,51 +159,6 @@
         "scheduler.1": {
             "type": "DWRR",
             "weight": "15"
-        }
-    },
-
-    "BUFFER_POOL": {
-        "egress_lossless_pool": {
-            "type": "egress",
-            "mode": "static",
-            "size": "15982720"
-        },
-        "egress_lossy_pool": {
-            "type": "egress",
-            "mode": "dynamic",
-            "size": "9243812"
-        },
-        "ingress_lossless_pool": {
-            "xoff": "4194112",
-            "type": "ingress",
-            "mode": "dynamic",
-            "size": "10875072"
-        }
-    },
-
-    "BUFFER_PROFILE": {
-        "egress_lossless_profile": {
-            "static_th": "15982720",
-            "pool": "[BUFFER_POOL|egress_lossless_pool]",
-            "size": "1518"
-        },
-        "egress_lossy_profile": {
-            "dynamic_th": "3",
-            "pool": "[BUFFER_POOL|egress_lossy_pool]",
-            "size": "1518"
-        },
-        "ingress_lossy_profile": {
-            "dynamic_th": "3",
-            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-            "size": "0"
-        },
-        "pg_lossless_100000_300m_profile": {
-            "xon_offset": "2288",
-            "dynamic_th": "0",
-            "xon": "2288",
-            "xoff": "268736",
-            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
-            "size": "1248"
         }
     },
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Improve the ansible playbooks and jinja templates for deploy SONiC/Arista-7060 leaf fanouts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Improve the ansible playbooks for deploy SONiC/Arista-7060 leaf fanouts.

#### How did you do it?

**For SONiC fanout switch**

1. Use `config reolad` instead of `reboot` while deploying.
1. Update `config_db.json` templates. Removed some useless configuration.
1. Push configuration to root fanout when leaf fanout type is SONiC

**For Arista-7060 fanout switch**

1. Improve startup-config jinja template, make the logic clearer.
1. Use the interface speed from connection graph instead of hard code `40gfull` in startup-config template.
1. Use `interface defaults ethernet shutdown` in startup-config template to config `shutdown` on all the unconnected ports.

#### How did you verify/test it?

Verified in physical lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
