### PR TITLE
[PCBB] Add testcase to verify PFC for tunnel traffic (Queue 2 and 6)

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -161,8 +161,8 @@ def copy_arp_responder_py(ptfhost):
     ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")
 
 
-@pytest.fixture(scope='class')
-def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
+
+def _ptf_portmap_file(duthost, ptfhost, tbinfo):
     """
         Prepare and copys port map file to PTF host
 
@@ -174,22 +174,39 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
         Returns:
             filename (str): returns the filename copied to PTF host
     """
-    duthost = duthosts[rand_one_dut_hostname]
     intfInfo = duthost.show_interface(command = "status")['ansible_facts']['int_status']
-    portList = natsorted([port for port in intfInfo if port.startswith('Ethernet')])
+    portList = [port for port in intfInfo if port.startswith('Ethernet') and intfInfo[port]['oper_state'] == 'up']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     portMapFile = "/tmp/default_interface_to_front_map.ini"
     with open(portMapFile, 'w') as file:
         file.write("# ptf host interface @ switch front port name\n")
-        file.writelines(
-            map(
-                    lambda (index, port): "{0}@{1}\n".format(index, port),
-                    enumerate(portList)
-                )
-            )
+        ptf_port_map = []
+        for port in portList:
+            if "Ethernet-Rec" not in port or "Ethernet-IB" not in port:
+                index = mg_facts['minigraph_ptf_indices'][port]
+                ptf_port_map.append("{}@{}\n".format(index, port))
+        file.writelines(ptf_port_map)
 
     ptfhost.copy(src=portMapFile, dest="/root/")
 
-    yield "/root/{}".format(portMapFile.split('/')[-1])
+    return "/root/{}".format(portMapFile.split('/')[-1])
+
+
+@pytest.fixture(scope='class')
+def ptf_portmap_file(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, tbinfo):
+    """
+    A class level fixture that calls _ptf_portmap_file
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    yield _ptf_portmap_file(duthost, ptfhost, tbinfo)
+
+
+@pytest.fixture(scope='module')
+def ptf_portmap_file_module(rand_selected_dut, ptfhost, tbinfo):
+    """
+    A module level fixture that calls _ptf_portmap_file
+    """
+    yield _ptf_portmap_file(rand_selected_dut, ptfhost, tbinfo)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -925,15 +925,31 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 59784
-                    pkts_num_trig_ingr_drp: 60410
+                    pkts_num_trig_pfc: 58620
+                    pkts_num_trig_ingr_drp: 59245
                     pkts_num_margin: 4
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 59784
-                    pkts_num_trig_ingr_drp: 60410
+                    pkts_num_trig_pfc: 58620
+                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_margin: 4
+                xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 58620
+                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_margin: 4
+                xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 58620
+                    pkts_num_trig_ingr_drp: 59245
                     pkts_num_margin: 4
                 hdrm_pool_size:
                     dscps: [3, 4]

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -1,14 +1,19 @@
 import logging
 import pytest
 import time
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_garp_service          # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_lower_tor # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, dualtor_info, get_t1_active_ptf_ports, is_tunnel_qos_remap_enabled
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_icmp_responder, run_garp_service # lgtm[py/unused-import]
-import ptf.packet as scapy
-from ptf.mask import Mask
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, dualtor_info, get_t1_active_ptf_ports, mux_cable_server_ip, is_tunnel_qos_remap_enabled
+from tunnel_qos_remap_base import build_testing_packet, check_queue_counter, dut_config, qos_config, run_ptf_test, toggle_mux_to_host, setup_module, update_docker_services, swap_syncd
 from ptf import testutils
-from ptf.testutils import simple_tcp_packet, simple_ipv4ip_packet
+
 
 pytestmark = [
     pytest.mark.topology('t0')
@@ -30,37 +35,6 @@ def check_running_condition(tbinfo, duthost):
     
     # Check tunnel_qos_remap is enabled
     pytest_require(is_tunnel_qos_remap_enabled(duthost), "Only run when tunnel_qos_remap is enabled", True)
-
-
-def _build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp, outer_dscp, ecn=1):
-    pkt = simple_tcp_packet(
-                eth_dst=standby_tor_mac,
-                ip_src=src_ip,
-                ip_dst=dst_ip,
-                ip_dscp=inner_dscp,
-                ip_ecn=ecn,
-                ip_ttl=64
-            )
-    # The ttl of inner_frame is decreased by 1
-    pkt.ttl -= 1
-    ipinip_packet = simple_ipv4ip_packet(
-                eth_dst=active_tor_mac,
-                eth_src=standby_tor_mac,
-                ip_src=standby_tor_ip,
-                ip_dst=active_tor_ip,
-                ip_dscp=outer_dscp,
-                ip_ecn=ecn,
-                inner_frame=pkt[IP]
-            )
-    pkt.ttl += 1
-    exp_tunnel_pkt = Mask(ipinip_packet)
-    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "id") # since src and dst changed, ID would change too
-    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "ttl") # ttl in outer packet is set to 255
-    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "chksum") # checksum would differ as the IP header is not the same
-
-    return pkt, exp_tunnel_pkt
 
 
 def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):
@@ -93,7 +67,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
         dst_ports.extend(ports)
 
     for dscp_combination in DSCP_COMBINATIONS:
-        pkt, expected_pkt = _build_testing_packet(src_ip=DUMMY_IP,
+        pkt, expected_pkt = build_testing_packet(src_ip=DUMMY_IP,
                                                   dst_ip=SERVER_IP,
                                                   active_tor_mac=active_tor_mac,
                                                   standby_tor_mac=dualtor_meta['standby_tor_mac'],
@@ -108,17 +82,6 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
         # Verify encaped packet
         testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports)
 
-def _check_queue_counter(duthost, intfs, queue, counter):
-    output = duthost.shell('show queue counters')['stdout_lines']
-
-    for intf in intfs:
-        for line in output:
-            fields = line.split()
-            if len(fields) == 6 and fields[0] == intf and fields[1] == 'UC{}'.format(queue):
-                if int(fields[2]) >= counter:
-                    return True
-    
-    return False
 
 def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):
     """
@@ -153,7 +116,7 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
     PKT_NUM = 100
 
     for dscp, queue in TEST_DATA:
-        pkt, _ = _build_testing_packet(src_ip=DUMMY_IP,
+        pkt, _ = build_testing_packet(src_ip=DUMMY_IP,
                                         dst_ip=SERVER_IP,
                                         active_tor_mac=active_tor_mac,
                                         standby_tor_mac=dualtor_meta['standby_tor_mac'],
@@ -169,6 +132,41 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
         # Verify queue counters in all possible interfaces
         time.sleep(15)
 
-        pytest_assert(_check_queue_counter(upper_tor_host, tor_pc_intfs, queue, PKT_NUM),
+        pytest_assert(check_queue_counter(upper_tor_host, tor_pc_intfs, queue, PKT_NUM),
                          "The queue counter for DSCP {} Queue {} is not as expected".format(dscp, queue))
 
+
+@pytest.mark.parametrize("xoff_profile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
+def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_profile, setup_module):
+    """
+    The test is to verify xoff threshold for PCBB (Priority Control for Bounced Back traffic)
+    Test steps
+    1. Toggle all ports to active on randomly selected ports
+    2. Populate ARP table by GARP service
+    3. Disable Tx on egress port
+    4. Verify bounced back traffic (tunnel traffic, IPinIP) can trigger PFC at expected queue
+    5. Verify regular traffic can trigger PFC at expected queue
+    """
+    toggle_mux_to_host(rand_selected_dut)
+
+    test_params = dict()
+    test_params.update({
+            "src_port_id": dut_config["lag_port_ptf_id"],
+            "dst_port_id": dut_config["server_port_ptf_id"],
+            "dst_port_ip": dut_config["server_ip"],
+            "active_tor_mac": dut_config["selected_tor_mac"],
+            "active_tor_ip": dut_config["selected_tor_loopback"],
+            "standby_tor_mac": dut_config["unselected_tor_mac"],
+            "standby_tor_ip": dut_config["unselected_tor_loopback"],
+            "server": dut_config["selected_tor_mgmt"],
+            "port_map_file": dut_config["port_map_file"],
+            "sonic_asic_type": dut_config["asic_type"],
+        })
+    # Update qos config into test_params
+    test_params.update(qos_config[xoff_profile])
+    # Run test on ptfhost
+    run_ptf_test(
+        ptfhost,
+        test_case="sai_qos_tests.PCBBPFCTest",
+        test_params=test_params
+    )

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -1,0 +1,330 @@
+
+import ipaddress
+import pytest
+import logging
+import json
+import yaml
+import time
+import ptf.packet as scapy
+from ptf.mask import Mask
+from ptf.testutils import simple_tcp_packet, simple_ipv4ip_packet
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.system_utils import docker
+from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module    # lgtm[py/unused-import]
+
+logger = logging.getLogger(__name__)
+
+def build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp, outer_dscp, ecn=1):
+    pkt = simple_tcp_packet(
+                eth_dst=standby_tor_mac,
+                ip_src=src_ip,
+                ip_dst=dst_ip,
+                ip_dscp=inner_dscp,
+                ip_ecn=ecn,
+                ip_ttl=64
+            )
+    # The ttl of inner_frame is decreased by 1
+    pkt.ttl -= 1
+    ipinip_packet = simple_ipv4ip_packet(
+                eth_dst=active_tor_mac,
+                eth_src=standby_tor_mac,
+                ip_src=standby_tor_ip,
+                ip_dst=active_tor_ip,
+                ip_dscp=outer_dscp,
+                ip_ecn=ecn,
+                inner_frame=pkt[IP]
+            )
+    pkt.ttl += 1
+    exp_tunnel_pkt = Mask(ipinip_packet)
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "id") # since src and dst changed, ID would change too
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "ttl") # ttl in outer packet is set to 255
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "chksum") # checksum would differ as the IP header is not the same
+
+    return pkt, exp_tunnel_pkt
+
+def check_queue_counter(duthost, intfs, queue, counter):
+    output = duthost.shell('show queue counters')['stdout_lines']
+
+    for intf in intfs:
+        for line in output:
+            fields = line.split()
+            if len(fields) == 6 and fields[0] == intf and fields[1] == 'UC{}'.format(queue):
+                if int(fields[2]) >= counter:
+                    return True
+    
+    return False
+
+
+def load_tunnel_qos_map():
+    """
+    Read DSCP_TO_TC_MAP and TC_TO_PRIORITY_GROUP_MAP from file
+    return a dict
+    """
+    TUNNEL_QOS_MAP_FILENAME = r"qos/files/tunnel_qos_map.json"
+    MAP_NAME = "AZURE_TUNNEL"
+    ret = {}
+    with open(TUNNEL_QOS_MAP_FILENAME, "r") as f:
+        maps = json.load(f)
+        
+    ret['dscp_to_tc_map'] = {}
+    for k, v in maps['DSCP_TO_TC_MAP'][MAP_NAME].items():
+        ret['dscp_to_tc_map'][int(k)] = int(v)
+        
+    ret['tc_to_priority_group_map'] = {}
+    for k, v in maps['TC_TO_PRIORITY_GROUP_MAP'][MAP_NAME].items():
+        ret["tc_to_priority_group_map"][int(k)] = int(v)
+        
+    return ret
+
+
+def get_iface_ip(mg_facts, ifacename):
+    for loopback in mg_facts['minigraph_lo_interfaces']:
+        if loopback['name'] == ifacename and ipaddress.ip_address(loopback['addr']).version == 4:
+            return loopback['addr']
+    return None
+
+
+@pytest.fixture(scope='module')
+def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_module):
+    '''
+    Generate a dict including test required params
+    '''
+    duthost = rand_selected_dut
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    asic_type = duthost.facts["asic_type"]
+    # Always use the first portchannel member
+    lag_port_name = list(mg_facts['minigraph_portchannels'].values())[0]['members'][0]
+    lag_port_ptf_id = mg_facts['minigraph_ptf_indices'][lag_port_name]
+
+    muxcable_info = mux_cable_server_ip(duthost)
+    server_port_name = list(muxcable_info.keys())[0]
+    server_ip = muxcable_info[server_port_name]['server_ipv4'].split('/')[0]
+    server_port_ptf_id = mg_facts['minigraph_ptf_indices'][server_port_name]
+    server_port_slice = mg_facts['minigraph_port_indices'][server_port_name]
+    
+    selected_tor_mgmt = mg_facts['minigraph_mgmt_interface']['addr']
+    selected_tor_mac = rand_selected_dut.facts['router_mac']
+    selected_tor_loopback = get_iface_ip(mg_facts, 'Loopback0')
+
+    unselected_dut_mg_facts = rand_unselected_dut.get_extended_minigraph_facts(tbinfo)
+    unselected_tor_mgmt = unselected_dut_mg_facts['minigraph_mgmt_interface']['addr']
+    unselected_tor_mac = rand_unselected_dut.facts['router_mac']
+    unselected_tor_loopback = get_iface_ip(unselected_dut_mg_facts, 'Loopback0')
+
+    return {
+        "asic_type": asic_type,
+        "lag_port_name": lag_port_name,
+        "lag_port_ptf_id": lag_port_ptf_id,
+        "server_port_name": server_port_name,
+        "server_ip": server_ip,
+        "server_port_ptf_id": server_port_ptf_id,
+        "server_port_slice": server_port_slice,
+        "selected_tor_mgmt": selected_tor_mgmt,
+        "selected_tor_mac": selected_tor_mac,
+        "selected_tor_loopback": selected_tor_loopback,
+        "unselected_tor_mgmt": unselected_tor_mgmt,
+        "unselected_tor_mac": unselected_tor_mac,
+        "unselected_tor_loopback": unselected_tor_loopback,
+        "tunnel_qos_map": load_tunnel_qos_map(),
+        "port_map_file": ptf_portmap_file_module
+    }
+
+
+def _lossless_profile_name(dut, port_name, pgs='2-4'):
+    """
+    Read lossless PG name for given port
+    """
+    cmd = "sonic-db-cli APPL_DB hget \'BUFFER_PG_TABLE:{}:{}\' \'profile\'".format(port_name, pgs)
+    profile_name = dut.shell(cmd)['stdout']
+    pytest_assert(profile_name != "")
+    # The output can be pg_lossless_100000_300m_profile or [BUFFER_PROFILE_TABLE:pg_lossless_100000_300m_profile]
+    profile_name = profile_name.split(':')[-1].rstrip(']')
+    return profile_name
+
+
+
+@pytest.fixture(scope='module')
+def qos_config(rand_selected_dut, tbinfo, dut_config):
+    duthost = rand_selected_dut
+    SUPPORTED_ASIC_LIST = ["gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3", "j2c+", "jr2"]
+
+    qos_configs = {}
+    with open(r"qos/files/qos.yml") as file:
+        qos_configs = yaml.load(file, Loader=yaml.FullLoader)
+    
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    vendor = duthost.facts["asic_type"]
+    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    dut_asic = None
+    for asic in SUPPORTED_ASIC_LIST:
+        vendor_asic = "{0}_{1}_hwskus".format(vendor, asic)
+        if vendor_asic in hostvars.keys() and mg_facts["minigraph_hwsku"] in hostvars[vendor_asic]:
+            dut_asic = asic
+            break
+
+    pytest_assert(dut_asic, "Cannot identify DUT ASIC type")
+
+    dut_topo = "topo-"
+    topo = tbinfo["topo"]["name"]
+    if dut_topo + topo in qos_configs['qos_params'].get(dut_asic, {}):
+        dut_topo = dut_topo + topo
+    else:
+        # Default topo is any
+        dut_topo = dut_topo + "any"
+    
+    # Get profile name for src port
+    lag_port_name = dut_config["lag_port_name"]
+    profile_name = _lossless_profile_name(duthost, lag_port_name, '2-4')
+    profile_name = profile_name.lstrip('pg_lossless_').rstrip('_profile')
+
+    return qos_configs['qos_params'][dut_asic][dut_topo][profile_name]
+
+
+def _create_ssh_tunnel_to_syncd_rpc(duthost):
+    dut_asic = duthost.asic_instance()
+    dut_asic.create_ssh_tunnel_sai_rpc()
+
+
+def _remove_ssh_tunnel_to_syncd_rpc(duthost):
+    dut_asic = duthost.asic_instance()
+    dut_asic.remove_ssh_tunnel_sai_rpc()
+
+
+@pytest.fixture(scope='module')
+def swap_syncd(rand_selected_dut, creds):
+    # Swap syncd container
+    docker.swap_syncd(rand_selected_dut, creds)
+    _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
+    yield
+    # Restore syncd container
+    docker.restore_default_syncd(rand_selected_dut, creds)
+    _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
+
+
+def _update_docker_service(duthost, docker="", action="", service=""):
+    """
+    A helper function to start/stop service      
+    """
+    cmd = "docker exec {docker} supervisorctl {action} {service}".format(docker=docker, action=action, service=service)
+    duthost.shell(cmd)
+    logger.info("{}ed {}".format(action, service))
+
+
+@pytest.fixture(scope='module')
+def update_docker_services(rand_selected_dut, swap_syncd, disable_container_autorestart, enable_container_autorestart):
+    """
+    Disable/enable lldp and bgp
+    """
+    feature_list = ['lldp', 'bgp', 'syncd', 'swss']
+    disable_container_autorestart(rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
+
+    SERVICES = [
+            {"docker": "lldp", "service": "lldp-syncd"},
+            {"docker": "lldp", "service": "lldpd"},
+            {"docker": "bgp",  "service": "bgpd"},
+            {"docker": "bgp",  "service": "bgpmon"}
+            ] 
+    for service in SERVICES:
+        _update_docker_service(rand_selected_dut, action="stop", **service)
+    
+    yield
+
+    enable_container_autorestart(rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
+    for service in SERVICES:
+        _update_docker_service(rand_selected_dut, action="start", **service)
+
+
+def _update_mux_feature(duthost, state):
+    cmd = "sudo config feature state mux {}".format(state)
+    duthost.shell(cmd)
+
+
+def _update_muxcable_mode(duthost, mode):
+    cmd = "sudo config muxcable mode {} all".format(mode)
+    duthost.shell(cmd)
+
+
+def _update_counterpoll_state(duthost, counter_name, state):
+    cmd = "sudo counterpoll {} {}".format(counter_name, state)
+    duthost.shell(cmd)
+
+
+@pytest.fixture(scope='module')
+def setup_module(rand_selected_dut, rand_unselected_dut, update_docker_services):
+    '''
+    Module level setup/teardown
+    '''
+    # Set the muxcable mode to manual so that the mux cable won't be toggled by heartbeat
+    _update_muxcable_mode(rand_selected_dut, "manual")
+    _update_muxcable_mode(rand_unselected_dut, "manual")
+    # Disable the counter for watermark so that the cached counter in SAI is not cleared periodically
+    _update_counterpoll_state(rand_selected_dut, 'watermark', 'disable')
+    _update_counterpoll_state(rand_unselected_dut, 'watermark', 'disable')
+    
+    yield
+
+    # Set the muxcable mode to auto
+    _update_muxcable_mode(rand_selected_dut, "auto")
+    _update_muxcable_mode(rand_unselected_dut, "auto")
+    # Enable the counter for watermark
+    _update_counterpoll_state(rand_selected_dut, 'watermark', 'enable')
+    _update_counterpoll_state(rand_unselected_dut, 'watermark', 'enable')
+
+
+def toggle_mux_to_host(duthost):
+    '''
+    Toggle the muxcable status with write_standby.py script
+    '''
+    WRITE_STANDBY = "/usr/local/bin/write_standby.py"
+    cmd = "{} -s active".format(WRITE_STANDBY)
+    duthost.shell(cmd)
+    TIMEOUT = 90
+    while TIMEOUT > 0:
+        muxcables = json.loads(duthost.shell("show muxcable status --json")['stdout'])
+        inactive_muxcables = [intf for intf, muxcable in muxcables['MUX_CABLE'].items() if muxcable['STATUS'] != 'active']
+        if len(inactive_muxcables) > 0:
+            logger.info('Found muxcables not active on {}: {}'.format(duthost.hostname, json.dumps(inactive_muxcables)))
+            time.sleep(10)
+            TIMEOUT -= 10
+        else:
+            logger.info("Mux cable toggled to {}".format(duthost.hostname))
+            break
+    
+    pytest_assert(TIMEOUT > 0, "Failed to toggle muxcable to {}".format(duthost.hostname))
+
+
+def run_ptf_test(ptfhost, test_case='', test_params={}):
+    """
+    A helper function to run test script on ptf host
+    """
+    logger.info("Start running {} on ptf host".format(test_case))
+    pytest_assert(ptfhost.shell(
+                      argv = [
+                          "ptf",
+                          "--test-dir",
+                          "saitests",
+                          test_case,
+                          "--platform-dir",
+                          "ptftests",
+                          "--platform",
+                          "remote",
+                          "-t",
+                          ";".join(["{}={}".format(k, repr(v)) for k, v in test_params.items()]),
+                          "--disable-ipv6",
+                          "--disable-vxlan",
+                          "--disable-geneve",
+                          "--disable-erspan",
+                          "--disable-mpls",
+                          "--disable-nvgre",
+                          "--log-file",
+                          "/tmp/{0}.log".format(test_case),
+                          "--test-case-timeout",
+                          "600"
+                      ],
+                      chdir = "/root",
+                      )["rc"] == 0, "Failed when running test '{0}'".format(test_case))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add a test case to verify PFC for tunnel traffic.

Test steps:
1. Toggle all ports to active on randomly selected ports
2. Populate ARP table by GARP service
3. Disable Tx on egress port
4. Verify bounced back traffic (tunnel traffic, IPinIP) can trigger PFC at expected queue
5. Verify regular traffic can trigger PFC at expected queue

To verify PFC for tunnel traffic, the testing packets are ingressed from T1 (LAG). But all LAG members are removed in current `test_qos_sai.py`. To avoid making the current `testQosSaiPfcXoffLimit` too complicated, the new test case is implemented in a new module.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to add a test case to verify PFC for tunnel traffic.

#### How did you do it?

#### How did you verify/test it?
Verified on `TD3` dualtor testbed. Verification on `TH2` is in progress.  

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Dualtor specific test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
