### PR TITLE
Dual TOR QoS testcase fix: force use lower TOR as target DUT

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -839,7 +839,7 @@ def enable_container_autorestart():
     return enable_container_autorestart
 
 @pytest.fixture(scope='module')
-def swapSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, creds):
+def swapSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, creds, tbinfo, lower_tor_host):
     """
         Swap syncd on DUT host
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -869,6 +869,40 @@ def swapSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, cred
         if swapSyncd:
             docker.restore_default_syncd(duthost, new_creds)
 
+@pytest.fixture(scope='module')
+def swapQosSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, creds, tbinfo, lower_tor_host):
+    """
+        Swap syncd on DUT host
+
+        Args:
+            request (Fixture): pytest request object
+            duthost (AnsibleHost): Device Under Test (DUT)
+
+        Returns:
+            None
+    """
+    if 'dualtor' in tbinfo['topo']['name']:
+        duthost = lower_tor_host
+    else:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    swapSyncd = request.config.getoption("--qos_swap_syncd")
+    public_docker_reg = request.config.getoption("--public_docker_registry")
+    try:
+        if swapSyncd:
+            if public_docker_reg:
+                new_creds = copy.deepcopy(creds)
+                new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
+                new_creds['docker_registry_username'] = ''
+                new_creds['docker_registry_password'] = ''
+            else:
+                new_creds = creds
+            docker.swap_syncd(duthost, new_creds)
+
+        yield
+    finally:
+        if swapSyncd:
+            docker.restore_default_syncd(duthost, new_creds)
+
 def get_host_data(request, dut):
     '''
     This function parses multple inventory files and returns the dut information present in the inventory
@@ -1521,7 +1555,7 @@ def duts_running_config_facts(duthosts):
     return cfg_facts
 
 @pytest.fixture(scope='class')
-def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, ptf_portmap_file):
+def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, ptf_portmap_file, lower_tor_host):
     """
         Prepares DUT host test params
 
@@ -1534,7 +1568,10 @@ def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
         Returns:
             dut_test_params (dict): DUT host test params
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if 'dualtor' in tbinfo['topo']['name']:
+        duthost = lower_tor_host
+    else:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["name"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -850,37 +850,6 @@ def swapSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, cred
         Returns:
             None
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    swapSyncd = request.config.getoption("--qos_swap_syncd")
-    public_docker_reg = request.config.getoption("--public_docker_registry")
-    try:
-        if swapSyncd:
-            if public_docker_reg:
-                new_creds = copy.deepcopy(creds)
-                new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
-                new_creds['docker_registry_username'] = ''
-                new_creds['docker_registry_password'] = ''
-            else:
-                new_creds = creds
-            docker.swap_syncd(duthost, new_creds)
-
-        yield
-    finally:
-        if swapSyncd:
-            docker.restore_default_syncd(duthost, new_creds)
-
-@pytest.fixture(scope='module')
-def swapQosSyncd(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, creds, tbinfo, lower_tor_host):
-    """
-        Swap syncd on DUT host
-
-        Args:
-            request (Fixture): pytest request object
-            duthost (AnsibleHost): Device Under Test (DUT)
-
-        Returns:
-            None
-    """
     if 'dualtor' in tbinfo['topo']['name']:
         duthost = lower_tor_host
     else:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -644,7 +644,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def ssh_tunnel_to_syncd_rpc(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-        swapQosSyncd, tbinfo, lower_tor_host
+        swapSyncd, tbinfo, lower_tor_host
     ):
         if 'dualtor' in tbinfo['topo']['name']:
             duthost = lower_tor_host
@@ -659,14 +659,14 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def updateIptables(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapQosSyncd, tbinfo, lower_tor_host
+        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapSyncd, tbinfo, lower_tor_host
     ):
         """
             Update iptables on DUT host with drop rule for BGP SYNC packets
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
-                swapQosSyncd (Fixture): swapQosSyncd fixture is required to run prior to updating iptables
+                swapSyncd (Fixture): swapSyncd fixture is required to run prior to updating iptables
 
             Returns:
                 None
@@ -692,7 +692,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def stopServices(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-        swapQosSyncd, enable_container_autorestart, disable_container_autorestart,
+        swapSyncd, enable_container_autorestart, disable_container_autorestart,
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports
     ):
         """
@@ -700,7 +700,7 @@ class QosSaiBase(QosBase):
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
-                swapQosSyncd (Fxiture): swapQosSyncd fixture is required to run prior to stopping services
+                swapSyncd (Fxiture): swapSyncd fixture is required to run prior to stopping services
 
             Returns:
                 None

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -644,7 +644,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def ssh_tunnel_to_syncd_rpc(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-        swapSyncd, tbinfo, lower_tor_host
+        swapQosSyncd, tbinfo, lower_tor_host
     ):
         if 'dualtor' in tbinfo['topo']['name']:
             duthost = lower_tor_host
@@ -659,14 +659,14 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def updateIptables(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapSyncd, tbinfo, lower_tor_host
+        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapQosSyncd, tbinfo, lower_tor_host
     ):
         """
             Update iptables on DUT host with drop rule for BGP SYNC packets
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
-                swapSyncd (Fixture): swapSyncd fixture is required to run prior to updating iptables
+                swapQosSyncd (Fixture): swapQosSyncd fixture is required to run prior to updating iptables
 
             Returns:
                 None
@@ -692,7 +692,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def stopServices(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-        swapSyncd, enable_container_autorestart, disable_container_autorestart,
+        swapQosSyncd, enable_container_autorestart, disable_container_autorestart,
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports
     ):
         """
@@ -700,7 +700,7 @@ class QosSaiBase(QosBase):
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
-                swapSyncd (Fxiture): swapSyncd fixture is required to run prior to stopping services
+                swapQosSyncd (Fxiture): swapQosSyncd fixture is required to run prior to stopping services
 
             Returns:
                 None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Avoid to unexpected selection of different DUT for Thrift RPC, traffic and PTF test behaviors at dual TOR environment. Force to use lower TOR which is active TOR in QoS test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test behavior of "testQosSaiPfcXoffLimit" is unstable, frequently fail for same SONiC image, QoS parameter and mgmt brach.
The reason is that Thrift RPC and traffic happen on TOR which is unexpected DUT. It's caused by randomly picking DUT.

Force to use lower TOR as target DUT, to avoid Thrift RPC, traffic and PTF test behaviors happen on different TOR.

P.S.
- This change attempt to introduce a quickly fix for active TOR's QoS test scenario. Regarding to QoS test for standby TOR, will fix with similar thought later: force to use upper TOR which is standby TOR in dual TOR 's QoS test.
- In order to keep changes backward compatible, add "swapQosSyncd()" base on "swapSyncd()", and only use it in QoS test.

#### How did you do it?
Force to use lower TOR as target DUT, make sure Thrift RPC, traffic and test behavoirs happen on same DUT.

#### How did you verify/test it?
run local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
