### PR TITLE
Select the last port in the last LAG to run qos remap test

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -206,13 +206,8 @@ def get_t1_active_ptf_ports(dut, tbinfo):
             ptf_portchannel_intfs[k] = []
             for member in v['members']:
                 ptf_portchannel_intfs[k].append(mg_facts['minigraph_ptf_indices'][member])
-    
-    # Sort the output by LAG name
-    sorted_ptf_portchannel_intfs = {}
-    for k in sorted(ptf_portchannel_intfs.keys()):
-        sorted_ptf_portchannel_intfs[k] = ptf_portchannel_intfs[k]
 
-    return sorted_ptf_portchannel_intfs
+    return ptf_portchannel_intfs
 
 def get_t1_bgp_up_ptf_ports(dut, tbinfo):
     """

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -206,8 +206,13 @@ def get_t1_active_ptf_ports(dut, tbinfo):
             ptf_portchannel_intfs[k] = []
             for member in v['members']:
                 ptf_portchannel_intfs[k].append(mg_facts['minigraph_ptf_indices'][member])
+    
+    # Sort the output by LAG name
+    sorted_ptf_portchannel_intfs = {}
+    for k in sorted(ptf_portchannel_intfs.keys()):
+        sorted_ptf_portchannel_intfs[k] = ptf_portchannel_intfs[k]
 
-    return ptf_portchannel_intfs
+    return sorted_ptf_portchannel_intfs
 
 def get_t1_bgp_up_ptf_ports(dut, tbinfo):
     """

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -63,6 +63,14 @@ def _build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac, activ
     return pkt, exp_tunnel_pkt
 
 
+def _last_port_in_last_lag(lags):
+    """
+    A helper function to get the last LAG member in the last portchannel
+    """
+    last_lag = sorted(list(lags.keys()))[-1]
+    return lags[last_lag][-1]
+
+
 def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):
     """
     The test is to verify the dscp rewriting of encapped packets.
@@ -87,7 +95,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
     
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
     # Always select the last port in the last LAG as src_port
-    src_port = list(t1_ports.values())[-1][-1]
+    src_port = _last_port_in_last_lag(t1_ports)
     dst_ports = []
     for ports in t1_ports.values():
         dst_ports.extend(ports)
@@ -143,7 +151,7 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
     active_tor_mac = lower_tor_host.facts['router_mac']
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
     # Always select the last port in the last LAG as src_port
-    src_port = list(t1_ports.values())[-1][-1]
+    src_port = _last_port_in_last_lag(t1_ports)
     mg_facts = upper_tor_host.get_extended_minigraph_facts(tbinfo)
     portchannel_info = mg_facts['minigraph_portchannels']
     tor_pc_intfs = list()

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -86,8 +86,8 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_
     active_tor_mac = lower_tor_host.facts['router_mac']
     
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
-    # Always select the first port in first LAG as src_port
-    src_port = list(t1_ports.values())[0][0]
+    # Always select the last port in the last LAG as src_port
+    src_port = list(t1_ports.values())[-1][-1]
     dst_ports = []
     for ports in t1_ports.values():
         dst_ports.extend(ports)
@@ -142,8 +142,8 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
     dualtor_meta = dualtor_info(ptfhost, upper_tor_host, lower_tor_host, tbinfo)
     active_tor_mac = lower_tor_host.facts['router_mac']
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
-    # Always select the first port in first LAG as src_port
-    src_port = list(t1_ports.values())[0][0]
+    # Always select the last port in the last LAG as src_port
+    src_port = list(t1_ports.values())[-1][-1]
     mg_facts = upper_tor_host.get_extended_minigraph_facts(tbinfo)
     portchannel_info = mg_facts['minigraph_portchannels']
     tor_pc_intfs = list()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to update the src_port in  [test_tunnel_qos_remap.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:qos_remap_last_port?expand=1#diff-0bc1dc320b693a545a1dd0b09c307b3f13faf79f79650fc7a1fe4fb78e3c8480) 

The change is to cover a issue we detected recently. The `DSCP_TO_TC_MAP` applied to a port is not working after the port is added to a LAG. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to update the src_port in  `test_tunnel_qos_remap.py`

#### How did you do it?
Use the last port in the last LAG as source port,

#### How did you verify/test it?
Verified on a dualtor testbed
```
collected 4 items                                                                                                                                                                                     

qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite[active-standby] PASSED                                                                                                                    [ 25%]
qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite[active-active] SKIPPED                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue[active-standby] PASSED                                                                                                [ 75%]
qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue[active-active] SKIPPED                                                                                                [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
