### PR TITLE
Added python fixture for resetting config changes to fix nightly backend snmp test failures

### DIFF
--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -6,6 +6,11 @@ def setup_check_snmp_ready(duthosts):
     for duthost in duthosts:
         assert wait_until(300, 20, 0, duthost.is_service_fully_started, "snmp"), "SNMP service is not running"
 
+@pytest.fixture(scope="module", autouse=True)
+def enable_queue_counterpoll_type(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost.command('counterpoll queue enable')
+
 def pytest_addoption(parser):
     """
     Adds options to pytest that are used by the snmp tests.

--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -9,9 +9,9 @@ def setup_check_snmp_ready(duthosts):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def enable_queue_counterpoll_type(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    duthost.command('counterpoll queue enable')
+def enable_queue_counterpoll_type(duthosts):
+    for duthost in duthosts:
+        duthost.command('counterpoll queue enable')
 
 
 def pytest_addoption(parser):

--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -1,15 +1,18 @@
 import pytest
 from tests.common.utilities import wait_until
 
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_snmp_ready(duthosts):
     for duthost in duthosts:
         assert wait_until(300, 20, 0, duthost.is_service_fully_started, "snmp"), "SNMP service is not running"
 
+
 @pytest.fixture(scope="module", autouse=True)
 def enable_queue_counterpoll_type(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.command('counterpoll queue enable')
+
 
 def pytest_addoption(parser):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the nightly tests, there were snmp failures on the backend T0 and T1, the cause of which was related to config issues with the DUT, specifically the queue counterpoll being disabled by another test beforehand. To solve this issue, before any of the snmp tests are executed, the queue counterpoll is enabled in a python fixture in the associated conftest.py file. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix snmp test failures occuring in nightly tests on backend T0 and T1

#### How did you do it?
Adding a python fixture that enables the queue counterpoll before the snmp tests are run

#### How did you verify/test it?
Ran the snmp test suite on a DUT in the lab, with the config disabled initially to see that the tests pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
