### PR TITLE
[everflow] address testbed setup type checking issue

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -453,12 +453,12 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
 
     """
     topo = tbinfo['topo']['name']
-    if 't1' in topo or 't0' in topo:
-        setup_information = gen_t1t0_setup_information(duthosts, rand_one_dut_hostname, tbinfo)
-        duthost = duthosts[rand_one_dut_hostname]
 
     if 't2' in topo:
         setup_information = gen_t2_setup_information(duthosts, tbinfo)
+    else:
+        setup_information = gen_t1t0_setup_information(duthosts, rand_one_dut_hostname, tbinfo)
+        duthost = duthosts[rand_one_dut_hostname]
 
     # Disable BGP so that we don't keep on bouncing back mirror packets
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
everflow test is failing after PR #6225.

#### How did you do it?
Topology type are more than t2/t0/t1. !(t2) doesn't mean either T0 or T1. This PR fixes the branch error.

#### How did you verify/test it?
Run everflow test on test that is not T0/T1/T2.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
