### PR TITLE
[route] Fix random loss of arp info in test_static_route_ecmp

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -219,6 +219,8 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             #FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)
+            for nexthop_addr in nexthop_addrs:
+                res = duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
             with RouteFlowCounterTestContext(is_route_flow_counter_supported, duthost, [prefix], {prefix: {'packets': '1'}}):
                 generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -220,7 +220,7 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)
             for nexthop_addr in nexthop_addrs:
-                res = duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
+                duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
             with RouteFlowCounterTestContext(is_route_flow_counter_supported, duthost, [prefix], {prefix: {'packets': '1'}}):
                 generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [# 6576](https://github.com/sonic-net/sonic-mgmt/issues/6576)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix test_static_route_ecmp failed due to losing arp info after config reload.

#### How did you do it?
After config reload, run ping cmd.

#### How did you verify/test it?
Run test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
