### PR TITLE
Skip "FLEX_COUNTER_DELAY_STATUS" when checking running config. 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1757,6 +1757,7 @@ def core_dump_and_config_check(duthosts, request):
 
             # Check if the running config is modified after module running
             for key in common_config_keys:
+                #TODO: remove these code when solve the problem of "FLEX_COUNTER_DELAY_STATUS"
                 if key == "FLEX_COUNTER_TABLE":
                     for sub_key,sub_value in duts_data[duthost.hostname]["pre_running_config"][key].items():
                         if duts_data[duthost.hostname]["pre_running_config"][key][sub_key]["FLEX_COUNTER_STATUS"] != \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1757,7 +1757,19 @@ def core_dump_and_config_check(duthosts, request):
 
             # Check if the running config is modified after module running
             for key in common_config_keys:
-                if duts_data[duthost.hostname]["pre_running_config"][key] != \
+                if key == "FLEX_COUNTER_TABLE":
+                    for sub_key,sub_value in duts_data[duthost.hostname]["pre_running_config"][key].items():
+                        if duts_data[duthost.hostname]["pre_running_config"][key][sub_key]["FLEX_COUNTER_STATUS"] != \
+                                duts_data[duthost.hostname]["cur_running_config"][key][sub_key]["FLEX_COUNTER_STATUS"]:
+                            inconsistent_config[duthost.hostname].update(
+                                {
+                                    key: {
+                                        "pre_value": duts_data[duthost.hostname]["pre_running_config"][key],
+                                        "cur_value": duts_data[duthost.hostname]["cur_running_config"][key]
+                                    }
+                                }
+                            )
+                elif duts_data[duthost.hostname]["pre_running_config"][key] != \
                     duts_data[duthost.hostname]["cur_running_config"][key]:
                     inconsistent_config[duthost.hostname].update(
                         {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr #6541 , it changed the logic of generating golden config.It will cause more reload during test running, and add test running time. Most reload is caused by the "FLEX_COUNTER_DELAY_STATUS" in "FLEX_COUNTER_TABLE". In this pr, we temporarily skip this key, and we fix the issue, we will add this check back. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr #6541 , it changed the logic of generating golden config.It will cause more reload during test running, and add test running time. Most reload is caused by the "FLEX_COUNTER_DELAY_STATUS" in "FLEX_COUNTER_TABLE". In this pr, we temporarily skip this key, and we fix the issue, we will add this check back. 

#### How did you do it?
Skip check the key "FLEX_COUNTER_DELAY_STATUS" when checking the running config. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
