### PR TITLE
[dualtor][grpc] Add retries and timeout to gRPC calls

### DIFF
--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -61,7 +61,9 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
         logging.debug("Start set drop for upper ToR at %s", time.time())
         for port in active_active_ports:
             logging.debug("Set drop on port %s, portid %s, direction %s" % (port, portid, direction))
-            set_drop_active_active(port, portid, direction)
+        portids = [portid for _ in active_active_ports]
+        directions = [direction for _ in active_active_ports]
+        set_drop_active_active(active_active_ports, portids, directions)
 
     return _drop_flow_upper_tor_active_active
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add timeout and retries to gRPC calls.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. add gRPC call help function `call_grpc` to enable retries and timeout
2. Make a gRPC `set_drop` call once for all active-active ports instead one `set_drop` call for one port.

#### How did you verify/test it?
Run `test_link_drop.py` test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
