### PR TITLE
[arp]: Extend proxy_arp to cover dualtor scenario (#6465)

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -1,5 +1,5 @@
 t0:
-  - arp/test_arp_dualtor.py
+  - arp/test_arp_extended.py
   - arp/test_neighbor_mac.py
   - arp/test_neighbor_mac_noptf.py
   - bgp/test_bgp_fact.py

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -1,4 +1,7 @@
 import logging
+import ptf.testutils as testutils
+import ptf.mask as mask
+import ptf.packet as packet
 import pytest
 import time
 
@@ -10,6 +13,9 @@ from ipaddress import ip_network, IPv6Network, IPv4Network
 from tests.arp.arp_utils import increment_ipv6_addr, increment_ipv4_addr
 from tests.common.helpers.assertions import pytest_require as pt_require
 from tests.common.utilities import wait
+from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6ND_NA, \
+                      ICMPv6NDOptSrcLLAddr, in6_getnsmac, \
+                      in6_getnsma, inet_pton, inet_ntop, socket
 
 
 CRM_POLLING_INTERVAL = 1
@@ -139,7 +145,7 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
+def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     try:
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -230,17 +236,16 @@ def ip_and_intf_info(config_facts, intfs_for_test, ptfhost, ptfadapter):
         except ValueError:
             continue
 
-    # The VLAN interface on the DUT has an x.x.x.1 address assigned (or x::1 in the case of IPv6)
-    # But the network_address property returns an x.x.x.0 address (or x::0 for IPv6) so we increment by two to avoid conflict
+    # Increment address by 3 to offset it from the intf on which the address may be learned
     if intf_ipv4_addr is not None:
-        ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=2)
+        ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=3)
         ptf_intf_ipv4_hosts = intf_ipv4_addr.hosts()
     else:
         ptf_intf_ipv4_addr = None
         ptf_intf_ipv4_hosts = None
 
     if intf_ipv6_addr is not None:
-        ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=2)
+        ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=3)
     else:
         ptf_intf_ipv6_addr = None
 
@@ -284,6 +289,72 @@ def proxy_arp_enabled(rand_selected_dut, config_facts):
 
     yield all('enabled' in val for val in new_proxy_arp_vals)
 
+    proxy_arp_del_cmd = 'sonic-db-cli CONFIG_DB HDEL "VLAN_INTERFACE|Vlan{}" proxy_arp'
     for vid, proxy_arp_val in old_proxy_arp_vals.items():
         if 'enabled' not in proxy_arp_val:
-            duthost.shell(proxy_arp_config_cmd.format(vid, 'disabled'))
+            # Delete the DB entry instead of using the config command to satisfy check_dut_health_status
+            duthost.shell(proxy_arp_del_cmd.format(vid))
+
+def generate_link_local_addr(mac):
+    parts = mac.split(":")
+    parts.insert(3, "ff")
+    parts.insert(4, "fe")
+    parts[0] = "{:x}".format(int(parts[0], 16) ^ 2)
+
+    ipv6Parts = []
+    for i in range(0, len(parts), 2):
+        ipv6Parts.append("".join(parts[i:i+2]))
+    ipv6 = "fe80::{}".format(":".join(ipv6Parts))
+    return ipv6
+
+@pytest.fixture(params=['v4', 'v6'])
+def packets_for_test(request, ptfadapter, duthost, config_facts, tbinfo, ip_and_intf_info):
+    ip_version = request.param
+    src_addr_v4, _, src_addr_v6, _, ptf_intf_index = ip_and_intf_info
+    ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
+    vlans = config_facts['VLAN']
+    topology = tbinfo['topo']['name']
+    dut_mac = ''
+    for vlan_details in vlans.values():
+        if 'dualtor' in topology:
+            dut_mac = vlan_details['mac'].lower()
+        else:
+            dut_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+        break
+
+    if ip_version == 'v4':
+        tgt_addr = increment_ipv4_addr(src_addr_v4)
+        out_pkt = testutils.simple_arp_packet(
+                                eth_dst='ff:ff:ff:ff:ff:ff',
+                                eth_src=ptf_intf_mac,
+                                ip_snd=src_addr_v4,
+                                ip_tgt=tgt_addr,
+                                arp_op=1,
+                                hw_snd=ptf_intf_mac
+                            )
+        exp_pkt = testutils.simple_arp_packet(
+                                eth_dst=ptf_intf_mac,
+                                eth_src=dut_mac,
+                                ip_snd=tgt_addr,
+                                ip_tgt=src_addr_v4,
+                                arp_op=2,
+                                hw_snd=dut_mac,
+                                hw_tgt=ptf_intf_mac
+        )
+    elif ip_version == 'v6':
+        tgt_addr = increment_ipv6_addr(src_addr_v6)
+        ll_src_addr = generate_link_local_addr(ptf_intf_mac)
+        multicast_tgt_addr = in6_getnsma(inet_pton(socket.AF_INET6, tgt_addr))
+        multicast_tgt_mac = in6_getnsmac(multicast_tgt_addr)
+        out_pkt = Ether(src=ptf_intf_mac, dst=multicast_tgt_mac) 
+        out_pkt /= IPv6(dst=inet_ntop(socket.AF_INET6, multicast_tgt_addr), src=ll_src_addr)
+        out_pkt /= ICMPv6ND_NS(tgt=tgt_addr) 
+        out_pkt /= ICMPv6NDOptSrcLLAddr(lladdr=ptf_intf_mac)
+
+        exp_pkt = Ether(src=dut_mac, dst=ptf_intf_mac) 
+        exp_pkt /= IPv6(dst=ll_src_addr, src=generate_link_local_addr(dut_mac))
+        exp_pkt /= ICMPv6ND_NA(tgt=tgt_addr, S=1, R=1, O=0)
+        exp_pkt /= ICMPv6NDOptSrcLLAddr(type=2, lladdr=dut_mac)
+        exp_pkt = mask.Mask(exp_pkt)
+        exp_pkt.set_do_not_care_scapy(packet.IPv6, 'fl')
+    return ip_version, out_pkt, exp_pkt

--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -1,140 +1,66 @@
-import logging
+"""
+This module tests ARP scenarios specific to dual ToR testbeds
+"""
 import ptf.testutils as testutils
 import pytest
-import ptf.mask as mask
-import ptf.packet as packet
 
-from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6ND_NA, \
-                      ICMPv6NDOptSrcLLAddr, in6_getnsmac, \
-                      in6_getnsma, inet_pton, inet_ntop, socket
-from tests.arp.arp_utils import clear_dut_arp_cache, increment_ipv6_addr, increment_ipv4_addr
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, show_muxcable_status  # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_garp_service, change_mac_addresses, run_icmp_responder
+from tests.common.utilities import wait_until
 
-pytestmark = [
-    pytest.mark.topology('t0', 'dualtor')
+pytestmark= [
+    pytest.mark.topology('dualtor')
 ]
 
-logger = logging.getLogger(__name__)
-
-def test_arp_garp_enabled(rand_selected_dut, garp_enabled, ip_and_intf_info, intfs_for_test, config_facts, ptfadapter):
+@pytest.fixture
+def restore_mux_auto_config(duthosts):
     """
-    Send a gratuitous ARP (GARP) packet from the PTF to the DUT
-
-    The DUT should learn the (previously unseen) ARP info from the packet
+    Fixture to ensure ToRs have all mux interfaces set to auto after testing
     """
-    pytest_require(garp_enabled, 'Gratuitous ARP not enabled for this device')
-    duthost = rand_selected_dut
-    ptf_intf_ipv4_addr = ip_and_intf_info[0]
 
-    arp_request_ip = increment_ipv4_addr(ptf_intf_ipv4_addr)
-    arp_src_mac = '00:00:07:08:09:0a'
-    _, _, intf1_index, _, = intfs_for_test
+    yield
 
-    pkt = testutils.simple_arp_packet(pktlen=60,
-                                eth_dst='ff:ff:ff:ff:ff:ff',
-                                eth_src=arp_src_mac,
-                                vlan_pcp=0,
-                                arp_op=2,
-                                ip_snd=arp_request_ip,
-                                ip_tgt=arp_request_ip,
-                                hw_snd=arp_src_mac,
-                                hw_tgt='ff:ff:ff:ff:ff:ff'
-                            )
+    for duthost in duthosts:
+        duthost.shell("sudo config mux mode auto all")
 
-    clear_dut_arp_cache(duthost)
-
-    logger.info("Sending GARP for target {} from PTF interface {}".format(arp_request_ip, intf1_index))
-    testutils.send_packet(ptfadapter, intf1_index, pkt)
-
-    vlan_intfs = config_facts['VLAN_INTERFACE'].keys()
-
-    switch_arptable = duthost.switch_arptable()['ansible_facts']
-    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower())
-    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
-
-def generate_link_local_addr(mac):
-    parts = mac.split(":")
-    parts.insert(3, "ff")
-    parts.insert(4, "fe")
-    parts[0] = "{:x}".format(int(parts[0], 16) ^ 2)
-
-    ipv6Parts = []
-    for i in range(0, len(parts), 2):
-        ipv6Parts.append("".join(parts[i:i+2]))
-    ipv6 = "fe80::{}".format(":".join(ipv6Parts))
-    return ipv6
-
-@pytest.fixture(params=['v4', 'v6'])
-def packets_for_test(request, ptfadapter, duthost, config_facts, tbinfo, ip_and_intf_info):
-    ip_version = request.param
-    src_addr_v4, _, src_addr_v6, _, ptf_intf_index = ip_and_intf_info
-    ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
-    vlans = config_facts['VLAN']
-    topology = tbinfo['topo']['name']
-    dut_mac = ''
-    for vlan_details in vlans.values():
-        if 'dualtor' in topology:
-            dut_mac = vlan_details['mac'].lower()
-        else:
-            dut_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
-        break
-
-    if ip_version == 'v4':
-        tgt_addr = increment_ipv4_addr(src_addr_v4)
-        out_pkt = testutils.simple_arp_packet(
-                                eth_dst='ff:ff:ff:ff:ff:ff',
-                                eth_src=ptf_intf_mac,
-                                ip_snd=src_addr_v4,
-                                ip_tgt=tgt_addr,
-                                arp_op=1,
-                                hw_snd=ptf_intf_mac
-                            )
-        exp_pkt = testutils.simple_arp_packet(
-                                eth_dst=ptf_intf_mac,
-                                eth_src=dut_mac,
-                                ip_snd=tgt_addr,
-                                ip_tgt=src_addr_v4,
-                                arp_op=2,
-                                hw_snd=dut_mac,
-                                hw_tgt=ptf_intf_mac
-        )
-    elif ip_version == 'v6':
-        tgt_addr = increment_ipv6_addr(src_addr_v6)
-        ll_src_addr = generate_link_local_addr(ptf_intf_mac)
-        multicast_tgt_addr = in6_getnsma(inet_pton(socket.AF_INET6, tgt_addr))
-        multicast_tgt_mac = in6_getnsmac(multicast_tgt_addr)
-        out_pkt = Ether(src=ptf_intf_mac, dst=multicast_tgt_mac) 
-        out_pkt /= IPv6(dst=inet_ntop(socket.AF_INET6, multicast_tgt_addr), src=ll_src_addr)
-        out_pkt /= ICMPv6ND_NS(tgt=tgt_addr) 
-        out_pkt /= ICMPv6NDOptSrcLLAddr(lladdr=ptf_intf_mac)
-
-        exp_pkt = Ether(src=dut_mac, dst=ptf_intf_mac) 
-        exp_pkt /= IPv6(dst=ll_src_addr, src=generate_link_local_addr(dut_mac))
-        exp_pkt /= ICMPv6ND_NA(tgt=tgt_addr, S=1, R=1, O=0)
-        exp_pkt /= ICMPv6NDOptSrcLLAddr(type=2, lladdr=dut_mac)
-        exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_scapy(packet.IPv6, 'fl')
-
-    return ip_version, out_pkt, exp_pkt
-
-def test_proxy_arp(proxy_arp_enabled, ip_and_intf_info, ptfadapter, packets_for_test):
+def test_proxy_arp_for_standby_neighbor(proxy_arp_enabled, ip_and_intf_info, restore_mux_auto_config,
+    ptfadapter, packets_for_test, upper_tor_host, toggle_all_simulator_ports_to_upper_tor):
     """
-    Send an ARP request or neighbor solicitation (NS) to the DUT for an IP address within the subnet of the DUT's VLAN.
+    Send an ARP request or neighbor solicitation (NS) to the DUT for an IP address within the subnet of the DUT's VLAN that is
+    routed via the IPinIP tunnel (i.e. that IP points to a standby neighbor)
 
     DUT should reply with an ARP reply or neighbor advertisement (NA) containing the DUT's own MAC
+
+    Test steps:
+    1. During setup, learn neighbor IPs on ToR interfaces using `run_garp_service` fixture
+    2. Pick a learned IP address as the target IP and generate an ARP request/neighbor solicitation for it
+    3. Set the interface this IP is learned on to standby. This will ensure the route for the IP points to the
+       IPinIP tunnel
+    4. Send the ARP request/NS packet to the ToR on some other active interface
+    5. Expect the ToR to still proxy ARP for the IP and send an ARP reply/neighbor advertisement back, even though
+       the route for the requested IP is pointing to the tunnel
     """
-    pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')
+    # This should never fail since we are only running on dual ToR platforms
+    pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs, check dual ToR configuration')
 
     ptf_intf_ipv4_addr, _, ptf_intf_ipv6_addr, _, ptf_intf_index  = ip_and_intf_info
-
     ip_version, outgoing_packet, expected_packet = packets_for_test
 
     if ip_version == 'v4':
         pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
+        intf_name_cmd = "show arp | grep '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv4_addr)
     elif ip_version == 'v6':
         pytest_require(ptf_intf_ipv6_addr is not None, 'No IPv6 VLAN address configured on device')
+        intf_name_cmd= "show ndp | grep '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv6_addr)
 
+    # Find the interface on which the target IP is learned and set it to standby to force it to point to a tunnel route
+    intf_name = upper_tor_host.shell(intf_name_cmd)['stdout']
+    mux_mode_cmd = "sudo config mux mode standby {}".format(intf_name)
+    upper_tor_host.shell(mux_mode_cmd)
+    pytest_assert(wait_until(5, 1, 0, lambda: show_muxcable_status(upper_tor_host)[intf_name]['status'] == "standby"),
+                  "Interface {} not standby on {}".format(intf_name, upper_tor_host))
     ptfadapter.dataplane.flush()
     testutils.send_packet(ptfadapter, ptf_intf_index, outgoing_packet)
     testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -1,0 +1,78 @@
+"""
+This module tests extended ARP features including gratuitous ARP and proxy ARP
+"""
+import logging
+import ptf.testutils as testutils
+import pytest
+import ptf.mask as mask
+import ptf.packet as packet
+
+from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6ND_NA, \
+                      ICMPv6NDOptSrcLLAddr, in6_getnsmac, \
+                      in6_getnsma, inet_pton, inet_ntop, socket
+from tests.arp.arp_utils import clear_dut_arp_cache, increment_ipv6_addr, increment_ipv4_addr
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+
+pytestmark = [
+    pytest.mark.topology('t0', 'dualtor')
+]
+
+logger = logging.getLogger(__name__)
+
+def test_arp_garp_enabled(rand_selected_dut, garp_enabled, ip_and_intf_info, intfs_for_test, config_facts, ptfadapter):
+    """
+    Send a gratuitous ARP (GARP) packet from the PTF to the DUT
+
+    The DUT should learn the (previously unseen) ARP info from the packet
+    """
+    pytest_require(garp_enabled, 'Gratuitous ARP not enabled for this device')
+    duthost = rand_selected_dut
+    ptf_intf_ipv4_addr = ip_and_intf_info[0]
+
+    arp_request_ip = increment_ipv4_addr(ptf_intf_ipv4_addr)
+    arp_src_mac = '00:00:07:08:09:0a'
+    _, _, intf1_index, _, = intfs_for_test
+
+    pkt = testutils.simple_arp_packet(pktlen=60,
+                                eth_dst='ff:ff:ff:ff:ff:ff',
+                                eth_src=arp_src_mac,
+                                vlan_pcp=0,
+                                arp_op=2,
+                                ip_snd=arp_request_ip,
+                                ip_tgt=arp_request_ip,
+                                hw_snd=arp_src_mac,
+                                hw_tgt='ff:ff:ff:ff:ff:ff'
+                            )
+
+    clear_dut_arp_cache(duthost)
+
+    logger.info("Sending GARP for target {} from PTF interface {}".format(arp_request_ip, intf1_index))
+    testutils.send_packet(ptfadapter, intf1_index, pkt)
+
+    vlan_intfs = config_facts['VLAN_INTERFACE'].keys()
+
+    switch_arptable = duthost.switch_arptable()['ansible_facts']
+    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower())
+    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
+
+def test_proxy_arp(proxy_arp_enabled, ip_and_intf_info, ptfadapter, packets_for_test):
+    """
+    Send an ARP request or neighbor solicitation (NS) to the DUT for an IP address within the subnet of the DUT's VLAN.
+
+    DUT should reply with an ARP reply or neighbor advertisement (NA) containing the DUT's own MAC
+    """
+    pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')
+
+    ptf_intf_ipv4_addr, _, ptf_intf_ipv6_addr, _, ptf_intf_index  = ip_and_intf_info
+
+    ip_version, outgoing_packet, expected_packet = packets_for_test
+
+    if ip_version == 'v4':
+        pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
+    elif ip_version == 'v6':
+        pytest_require(ptf_intf_ipv6_addr is not None, 'No IPv6 VLAN address configured on device')
+
+    ptfadapter.dataplane.flush()
+    testutils.send_packet(ptfadapter, ptf_intf_index, outgoing_packet)
+    testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -231,18 +231,42 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
 @pytest.fixture(scope='module', autouse=True)
 def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if tbinfo['topo']['type'] == 't0':
         garp_config = {}
+        vlans = config_facts['VLAN']
+        vlan_intfs = config_facts['VLAN_INTERFACE']
+        dut_mac = ''
+        for vlan_details in vlans.values():
+            if 'dualtor' in tbinfo['topo']['name']:
+                dut_mac = vlan_details['mac'].lower()
+            else:
+                dut_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+            break
+
+        dst_ipv6 = ''
+        for intf_details in vlan_intfs.values():
+            for key in intf_details.keys():
+                try:
+                    intf_ip = ip_interface(key)
+                    if intf_ip.version == 6:
+                        dst_ipv6 = intf_ip.ip
+                        break
+                except ValueError:
+                    continue
+            break
 
         ptf_indices = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_ptf_indices"]
         if 'dualtor' not in tbinfo['topo']['name']:
             # For mocked dualtor testbed
             mux_cable_table = {}
-            server_ipv4_base_addr, _ = request.getfixturevalue('mock_server_base_ip_addr')
+            server_ipv4_base_addr, server_ipv6_base_addr = request.getfixturevalue('mock_server_base_ip_addr')
             for i, intf in enumerate(request.getfixturevalue('tor_mux_intfs')):
                 server_ipv4 = str(server_ipv4_base_addr + i)
+                server_ipv6 = str(server_ipv6_base_addr + i)
                 mux_cable_table[intf] = {}
                 mux_cable_table[intf]['server_ipv4'] = unicode(server_ipv4)
+                mux_cable_table[intf]['server_ipv6'] = unicode(server_ipv6)
         else:
             # For physical dualtor testbed
             mux_cable_table = duthost.get_running_config_facts()['MUX_CABLE']
@@ -252,9 +276,13 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
         for vlan_intf, config in mux_cable_table.items():
             ptf_port_index = ptf_indices[vlan_intf]
             server_ip = ip_interface(config['server_ipv4']).ip
+            server_ipv6 = ip_interface(config['server_ipv6']).ip
 
             garp_config[ptf_port_index] = {
-                                            'target_ip': '{}'.format(server_ip)
+                                            'dut_mac': '{}'.format(dut_mac),
+                                            'dst_ipv6': '{}'.format(dst_ipv6),
+                                            'target_ip': '{}'.format(server_ip),
+                                            'target_ipv6': '{}'.format(server_ipv6)
                                         }
 
         ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, GARP_SERVICE_PY), dest=OPT_DIR)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -10,6 +10,15 @@ acl/test_acl_outer_vlan.py:
       - asic_type=="cisco-8000"
 
 #######################################
+#####            arp              #####
+#######################################
+arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
+  skip:
+    reason: "`accept_untracked_na` currently only available in 202012"
+    conditions:
+      - "release not in ['202012']"
+
+#######################################
 #####            bgp              #####
 #######################################
 bgp/test_bgp_speaker.py:

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -101,7 +101,7 @@ test_t0() {
     tgname=1vlan
     if [ x$section == x"part-1" ]; then
       tests="\
-      arp/test_arp_dualtor.py \
+      arp/test_arp_extended.py \
       arp/test_neighbor_mac.py \
       arp/test_neighbor_mac_noptf.py\
       bgp/test_bgp_fact.py \


### PR DESCRIPTION
- Rename `test_arp_dualtor.py` to `test_arp_extended.py`
- Create new file `test_arp_dualtor.py` specifically for dual ToR scenarios - Add test to verify proxy ARP behavior for target IPs learned on standby links - Skip this test on non 202012 devices since it depends on `accept_untracked_na` which is currently only available in 202012
- Extend GARP service to send NA messages
- Edit PR tests/kvm tests to use the new `test_arp_extended.py` name

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
