### PR TITLE
Fix Python3 RuntimeError - dictionary changed size during iteration

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -123,8 +123,9 @@ def read_asic_name(hwsku):
 
         return "unknown"
 
-    except IOError as e:
+    except IOError:
         return None
+
 
 def load_dut_basic_facts(inv_name, dut_name):
     """Run 'ansible -m dut_basic_facts' command to get some basic DUT facts.
@@ -154,6 +155,7 @@ def load_dut_basic_facts(inv_name, dut_name):
         logger.error('Failed to load dut basic facts, exception: {}'.format(repr(e)))
 
     return results
+
 
 def get_basic_facts(session):
     testbed_name = session.config.option.testbed
@@ -209,6 +211,7 @@ def load_minigraph_facts(inv_name, dut_name):
 
     return results
 
+
 def load_config_facts(inv_name, dut_name):
     """Run 'ansible -m config_facts -a 'host={{hostname}} source='persistent' ' command to get some basic config facts.
 
@@ -225,7 +228,8 @@ def load_config_facts(inv_name, dut_name):
     logger.info('Getting config basic facts')
     try:
         # get config basic faces
-        ansible_cmd = ['ansible', '-m', 'config_facts', '-i', '../ansible/{}'.format(inv_name), '{}'.format(dut_name), '-a', 'host={} source=\'persistent\''.format(dut_name)]
+        ansible_cmd = ['ansible', '-m', 'config_facts', '-i', '../ansible/{}'.format(inv_name),
+                       '{}'.format(dut_name), '-a', 'host={} source=\'persistent\''.format(dut_name)]
         raw_output = subprocess.check_output(ansible_cmd).decode('utf-8')
         logger.debug('raw config basic facts:\n{}'.format(raw_output))
         output_fields = raw_output.split('SUCCESS =>', 1)
@@ -238,6 +242,7 @@ def load_config_facts(inv_name, dut_name):
         logger.error('Failed to load config basic facts, exception: {}'.format(repr(e)))
 
     return results
+
 
 def load_switch_capabilities_facts(inv_name, dut_name):
     """Run 'ansible -m switch_capabilities_facts' command to get some basic config facts.
@@ -267,6 +272,7 @@ def load_switch_capabilities_facts(inv_name, dut_name):
 
     return results
 
+
 def load_console_facts(inv_name, dut_name):
     """Run 'ansible -m console_facts' command to get some basic console facts.
 
@@ -294,6 +300,7 @@ def load_console_facts(inv_name, dut_name):
         logger.error('Failed to load console basic facts, exception: {}'.format(repr(e)))
 
     return results
+
 
 def load_basic_facts(session):
     """Load some basic facts that can be used in condition statement evaluation.
@@ -446,15 +453,15 @@ def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basi
         if condition_result and dynamic_update_skip_reason:
             mark_details['reason'].append(condition)
         return condition_result
-    except Exception as e:
+    except Exception:
         logger.error('Failed to evaluate condition, raw_condition={}, condition_str={}'.format(
             condition,
             condition_str))
         return False
 
 
-def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, basic_facts, \
-    conditions_logical_operator, session):
+def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, basic_facts,
+        conditions_logical_operator, session):
     """Evaluate all the condition strings.
 
     Evaluate a single condition or multiple conditions. If multiple conditions are supplied, apply AND or OR

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -113,7 +113,7 @@ def read_asic_name(hwsku):
         with open(asic_name_file) as f:
             asic_name = yaml.safe_load(f)
 
-        for key, value in asic_name.items():
+        for key, value in asic_name.copy().items():
             if ('td' not in key) and ('th' not in key) and ('spc' not in key):
                 asic_name.pop(key)
 

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -461,7 +461,7 @@ def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basi
 
 
 def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, basic_facts,
-        conditions_logical_operator, session):
+                        conditions_logical_operator, session):
     """Evaluate all the condition strings.
 
     Evaluate a single condition or multiple conditions. If multiple conditions are supplied, apply AND or OR
@@ -485,9 +485,11 @@ def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, ba
     if isinstance(conditions, list):
         # Apply 'AND' or 'OR' operation to list of conditions based on conditions_logical_operator(by default 'AND')
         if conditions_logical_operator == 'OR':
-            return any([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts, session) for c in conditions])
+            return any([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts, session)
+                        for c in conditions])
         else:
-            return all([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts, session) for c in conditions])
+            return all([evaluate_condition(dynamic_update_skip_reason, mark_details, c, basic_facts, session)
+                        for c in conditions])
     else:
         if conditions is None or conditions.strip() == '':
             return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix Python3 RuntimeError - dictionary changed size during iteration

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Python3 migration: In Python3, you cannot add/remove elements in a dictionary while iterating through it.

#### How did you do it?
Use copy(). This way you iterate over the original dictionary fields and on the fly can change the desired dict.

#### How did you verify/test it?
Both Python2 and Python3 can run bgp/test_bgp_facts.py successfully.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A