### PR TITLE
Check `failed` field in result of ansible wait_for module to align sonic-mgmt docker change

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -1,5 +1,4 @@
 import os
-import time
 import pytest
 import httplib
 
@@ -10,6 +9,7 @@ SERVER_PORT = 8000
 
 IPTABLES_PREPEND_RULE_CMD = 'iptables -I INPUT 1 -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
+
 
 @pytest.fixture(scope='function')
 def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, localhost, request):
@@ -22,14 +22,15 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, local
                              delay=1,
                              timeout=5,
                              module_ignore_errors=True)
-    if 'exception' in res:
+    if res['failed'] is True:
 
         res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
         py3_platform_api_available = not res['failed']
 
         supervisor_conf = [
             '[program:platform_api_server]',
-            'command=/usr/bin/python{} /opt/platform_api_server.py --port {}'.format('3' if py3_platform_api_available else '2', SERVER_PORT),
+            'command=/usr/bin/python{} /opt/platform_api_server.py --port {}'.format('3' if py3_platform_api_available
+                                                                                     else '2', SERVER_PORT),
             'autostart=True',
             'autorestart=True',
             'stdout_logfile=syslog',
@@ -54,7 +55,7 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, local
         duthost.command('docker exec -i pmon supervisorctl update')
 
         res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=5)
-        assert 'exception' not in res
+        assert res['failed'] is False
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -94,12 +95,12 @@ def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform
     finally:
         conn.close()
 
+
 @pytest.fixture(autouse=True)
 def check_not_implemented_warnings(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    loganalyzer = LogAnalyzer(ansible_host=duthost,
-                                  marker_prefix="platformapi_test")
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="platformapi_test")
     marker = loganalyzer.init()
     yield
     loganalyzer.match_regex.extend(['WARNING pmon#platform_api_server.py: API.+not implemented'])


### PR DESCRIPTION
The return value of anasible module  (wait_for)  is changed when there is failure in the new sonic-mgmt docker, align the test case

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In the prev sonic-mgmt docker version, the return value is include "exception", and now it dose not include exception, but the 'failed' is always there

Prev return value when is is failed:
{**u'failed': True,** **u'exception**': u'WARNING: The below traceback may *not* be related to the actual failure.\n  File "/tmp/ansible_wait_for_payload_en05hG/__main__.py", line 599, in main\n    s = _create_connection(host, port, min(connect_timeout, alt_connect_timeout))\n  File "/tmp/ansible_wait_for_payload_en05hG/__main__.py", line 456, in _create_connection\n    connect_socket = socket.create_connection((host, port), connect_timeout)\n  File "/usr/lib/python2.7/socket.py", line 575, in create_connection\n    raise err\n', '_ansible_no_log': False, u'msg': u'Timeout when waiting for r-boxer-sw01:8000', u'invocation': {u'module_args': {u'active_connection_states': [u'ESTABLISHED', u'FIN_WAIT1', u'FIN_WAIT2', u'SYN_RECV', u'SYN_SENT', u'TIME_WAIT'], u'state': u'started', u'connect_timeout': 5, u'delay': 1, u'msg': None, u'host': u'r-boxer-sw01', u'sleep': 1, u'timeout': 5, u'exclude_hosts': None, u'search_regex': None, u'path': None, u'port': 8000}},
'changed': False, u'elapsed': 5}

Current return value when it is failed:
{'_ansible_no_log': False,'changed': False,u'elapsed': 5,**'failed': True**,u'invocation': {u'module_args': {u'active_connection_states': [u'ESTABLISHED',u'FIN_WAIT1',u'FIN_WAIT2',u'SYN_RECV', u'SYN_SENT',u'TIME_WAIT'],u'connect_timeout': 5,u'delay': 1,u'exclude_hosts': None,u'host': u'r-tigris-22', u'msg': None, u'path': None, u'port': 8000,u'search_regex': None, u'sleep': 1,u'state': u'started', u'timeout': 5}}, u'msg': u'Timeout when waiting for r-tigris-22:8000'}

The value when it get success:
{u'match_groups': [], '_ansible_no_log': False, 'changed': False, u'elapsed': 1, **'failed': False,** u'state': u'started', u'match_groupdict': {}, u'invocation': {u'module_args': {u'active_connection_states': [u'ESTABLISHED', u'FIN_WAIT1', u'FIN_WAIT2', u'SYN_RECV', u'SYN_SENT', u'TIME_WAIT'], u'host': u'r-boxer-sw01', u'port': 8000, u'delay': 1, u'msg': None, u'state': u'started', u'sleep': 1, u'timeout': 5, u'exclude_hosts': None, u'search_regex': None, u'path': None, u'connect_timeout': 5}}, u'path': None, u'search_regex': None, u'port': 8000}

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The platform api related test case failed with "error: [Errno 111] Connection refused " since the server is not started on the dut
#### How did you do it?

#### How did you verify/test it?
Run the platform api test cases, and it pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
