### PR TITLE
[VM]: wait cisco VM ztp finished when kickstart VM

### DIFF
--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -120,11 +120,11 @@
               mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
               mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
     register: kickstart_output
-    until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code == 0'
+    until: '"kickstart_code" in kickstart_output and (kickstart_output.kickstart_code == 0 or kickstart_output.kickstart_code != -1)'
     retries: 5
     delay: 10
     when: vm_name not in vm_list_running.list_vms
-  
+
   # for cisco vm, after destroy/start vm, vm will have existing configuration (which is conflict with cisco_kickstart procedure), need to respin vm
   - name: Respin vm {{ vm_name }}
     include_tasks: respin_cisco_vm.yml
@@ -163,7 +163,7 @@
       vars:
         src_disk_image: "{{ root_path }}/images/{{ cisco_image_filename }}"
         disk_image: "{{ root_path }}/disks/{{ vm_name }}.img"
-    
+
     - name: Check failed cisco {{ vm_name }} reachablity
       iosxr_command:
         commands: show version

--- a/ansible/roles/vm_set/tasks/respin_cisco_vm.yml
+++ b/ansible/roles/vm_set/tasks/respin_cisco_vm.yml
@@ -43,6 +43,6 @@
             mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
             mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
   register: kickstart_output
-  until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code == 0'
+  until: '"kickstart_code" in kickstart_output and (kickstart_output.kickstart_code == 0 or kickstart_output.kickstart_code != -1)'
   retries: 5
   delay: 10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Cisco VM started with ZTP (Zero-touch provisioning) enabled. If ZTP is enabled, management will be reverted(shutdown) after ZTP is finished. The solution is to wait ZTP finished and then start to configure cisco VM.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Solving side effect of ZTP function during CISCO VM kickstart. 

#### How did you do it?
Wait ZTP finished and then start to configure CISCO VM.

#### How did you verify/test it?

1. Using command`./testbed-cli.sh -m veos_vtb -k vcisco -t vtestbed.yaml start-topo-vms vms-kvm-wan-pub password.txt` to start VM.
2. Check logs under host /tmp/serial_utils_*, configuration start when ZTP is finished.
3. Check Cisco VM mgmt interface would be accessed after VM started.

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
`wan-pub`
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
