### PR TITLE
Fix apt-get update retry failed when apt-get update failed during add topology

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -54,7 +54,7 @@
   become: yes
   environment: "{{ proxy_env | default({}) }}"
   register: apt_update_res
-  until: apt_update_res.cache_updated
+  until: apt_update_res.cache_updated is defined and apt_update_res.cache_updated
   retries: 5
   delay: 10
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

If apt-get update failed, there was no attribute cache_updated in returned value, so the retry condition would not execute.
Add judgment for cache_updated, if it was defined, then check its value.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
If apt-get update failed, there was no attribute cache_updated in returned value, so the retry condition would not execute.

#### How did you do it?
Add judgment for cache_updated, if it was defined, then check its value.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
