### PR TITLE
Skip config db diff comparison for advanced-reboot/upgrade tests

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -10,7 +10,8 @@ from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.skip_check_dut_health
 ]
 
 def pytest_generate_tests(metafunc):

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -22,7 +22,8 @@ from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.sanity_check(skip_sanity=True),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip config db diff checks for advanced-reboot and upgrade path cases.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Config DB differences in the upgrade path are expected. The present check compares db diff before and after reboot, and if differences are found the teardown logic performs config reload.

This breaks the testcase flow. Since DB differences are expected in reboot cases, skip the diff check in these cases specifically.

#### How did you do it?

Added a skip marker.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
