### PR TITLE
[backend] [vlan] Update acl template based on test ports

### DIFF
--- a/tests/common/helpers/backend_acl.py
+++ b/tests/common/helpers/backend_acl.py
@@ -1,0 +1,35 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+DUT_TMP_DIR = "/tmp"
+TEMPLATE_DIR = os.path.join(BASE_DIR, '../templates')
+ACL_TEMPLATE = 'backend_acl_update_config.j2'
+
+def apply_acl_rules(duthost, tbinfo, intf_list=None):
+    if "t0-backend" not in tbinfo["topo"]["name"]:
+        return
+
+    dst_acl_template = os.path.join(DUT_TMP_DIR, ACL_TEMPLATE)
+    dst_acl_file = os.path.join(DUT_TMP_DIR, 'backend_new_acl.json')
+    add_var = ''
+
+    if intf_list:
+        duthost.copy(src=os.path.join(TEMPLATE_DIR, ACL_TEMPLATE), dest=dst_acl_template)
+        intfs = ",".join(intf_list)
+        confvar = '{{"intf_list" : "{}"}}'.format(intfs)
+        add_var = "-a '{}' ".format(confvar)
+    else:
+        dst_acl_template = "/usr/share/sonic/templates/backend_acl.j2"
+
+    duthost.shell("sonic-cfggen {}-d -t {} > {}".format(add_var, dst_acl_template, dst_acl_file))
+    tmp = duthost.stat(path=dst_acl_file)
+    if tmp['stat']['exists']:
+        duthost.command("acl-loader update incremental {}".format(dst_acl_file))
+
+
+def bind_acl_table(duthost, tbinfo):
+    if "t0-backend" not in tbinfo["topo"]["name"]:
+        return
+
+    vlan_intfs = duthost.get_vlan_intfs()
+    duthost.command("config acl add table DATAACL L3 -p {}".format(",".join(vlan_intfs)))

--- a/tests/common/templates/backend_acl_update_config.j2
+++ b/tests/common/templates/backend_acl_update_config.j2
@@ -1,0 +1,69 @@
+{%- set vlan2ports = {} %}
+{%- for vlan in VLAN %}
+    {% set portlist = [] %}
+    {%- for vlan_name, port in VLAN_MEMBER %}
+        {%- if vlan_name == vlan %}
+            {%- if portlist.append(port) %}{%- endif %}
+        {%- endif %}
+    {%- endfor %}
+    {%- set _ = vlan2ports.update({vlan: portlist| sort | join(',')}) %}
+{%- endfor %}
+
+
+{
+        "acl": {
+                "acl-sets": {
+                        "acl-set": {
+                                "DATAACL": {
+                                        "acl-entries": {
+                                                "acl-entry": {
+                                                 {% for vlan, vlan_entries in VLAN.items() %}
+    "{{ loop.index }}": {
+                                                             "config": {
+                                                                     "sequence-id": {{ loop.index }}
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "{{ vlan_entries['vlanid'] }}"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "{{ vlan2ports[vlan] }}"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     },
+                                                 {% endfor -%}
+   "999": {
+                                                             "config": {
+                                                                     "sequence-id": 999
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "{{ intf_list }}"
+                                                                             }
+                                                                      }
+                                                             }
+              }
+
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }
+}

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -16,6 +16,7 @@ from tests.common.fixtures.duthost_utils import ports_list, utils_vlan_ports_lis
 from tests.common.fixtures.duthost_utils import utils_create_test_vlans
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add
+from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,26 @@ def work_vlan_ports_list(rand_selected_dut, tbinfo, cfg_facts, ports_list, utils
 
     return work_vlan_ports_list
 
+@pytest.fixture(scope="module")
+def acl_rule_cleanup(duthost, tbinfo):
+    """Cleanup all the existing DATAACL rules"""
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.shell('acl-loader delete')
+
+    yield
+
+@pytest.fixture(scope="module")
+def modify_acl_table(duthost, tbinfo, acl_rule_cleanup):
+   """ Remove the DATAACL table prior to the test and recreate it at the end"""
+   if "t0-backend" in tbinfo["topo"]["name"]:
+       duthost.command('config acl remove table DATAACL')
+
+   yield
+
+   if "t0-backend" in tbinfo["topo"]["name"]:
+       duthost.command('config acl remove table DATAACL')
+       # rebind with new set of ports
+       bind_acl_table(duthost, tbinfo)
 
 def shutdown_portchannels(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TEST_NUM):
     cmds = []
@@ -152,7 +173,7 @@ def startup_portchannels(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TE
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_ports_list, vlan_intfs_dict, cfg_facts):
+def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_ports_list, vlan_intfs_dict, cfg_facts, modify_acl_table):
     duthost = duthosts[rand_one_dut_hostname]
     # --------------------- Setup -----------------------
     try:
@@ -175,6 +196,8 @@ def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_po
             logger.info('"show int portchannel" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
 
             populate_fdb(ptfadapter, work_vlan_ports_list, vlan_intfs_dict)
+            bind_acl_table(duthost, tbinfo)
+            apply_acl_rules(duthost, tbinfo)
     # --------------------- Testing -----------------------
         yield
     # --------------------- Teardown -----------------------

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -100,13 +100,14 @@ def work_vlan_ports_list(rand_selected_dut, tbinfo, cfg_facts, ports_list, utils
 @pytest.fixture(scope="module")
 def acl_rule_cleanup(duthost, tbinfo):
     """Cleanup all the existing DATAACL rules"""
+    # remove all rules under the ACL_RULE table
     if "t0-backend" in tbinfo["topo"]["name"]:
         duthost.shell('acl-loader delete')
 
     yield
 
 @pytest.fixture(scope="module")
-def modify_acl_table(duthost, tbinfo, acl_rule_cleanup):
+def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
    """ Remove the DATAACL table prior to the test and recreate it at the end"""
    if "t0-backend" in tbinfo["topo"]["name"]:
        duthost.command('config acl remove table DATAACL')
@@ -173,7 +174,7 @@ def startup_portchannels(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TE
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_ports_list, vlan_intfs_dict, cfg_facts, modify_acl_table):
+def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_ports_list, vlan_intfs_dict, cfg_facts, setup_acl_table):
     duthost = duthosts[rand_one_dut_hostname]
     # --------------------- Setup -----------------------
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

#### What is the motivation for this PR?
For storage backend, new backend acl was added (https://github.com/sonic-net/sonic-utilities/pull/2236). This caused regression for vlan testcases running on 't0-backend' topology. Modified the testcase to update the acl template based on the selected test ports

#### How did you do it?
Created common helpers to update the acl template and used them in 'test_vlan.py' for 't0-backend' topology

#### How did you verify/test it?
Ran 'test_vlan.py' with the changes and all cases passed
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/nejo_n/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 7 items                                                              

vlan/test_vlan.py::test_vlan_tc1_send_untagged PASSED                    [ 14%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged PASSED                      [ 28%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid PASSED                 [ 42%]
vlan/test_vlan.py::test_vlan_tc4_tagged_unicast PASSED                   [ 57%]
vlan/test_vlan.py::test_vlan_tc5_untagged_unicast PASSED                 [ 71%]
vlan/test_vlan.py::test_vlan_tc6_tagged_untagged_unicast PASSED          [ 85%]
vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag SKIPPED [100%]
```