### PR TITLE
[backend] Modify sub port testcases to use common acl helpers

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.common.ptf_agent_updater import PtfAgentUpdater
@@ -39,8 +40,6 @@ from sub_ports_helpers import remove_bond_port
 from sub_ports_helpers import add_static_route_to_dut
 from sub_ports_helpers import remove_static_route_from_dut
 from sub_ports_helpers import update_dut_arp_table
-from sub_ports_helpers import apply_acl_rules
-from sub_ports_helpers import bind_acl_table
 
 
 def pytest_addoption(parser):
@@ -77,7 +76,7 @@ def modify_acl_table(duthost, tbinfo, port_type, acl_rule_cleanup):
    yield
 
    if "t0-backend" in tbinfo["topo"]["name"] and 'lag' in port_type:
-       bind_acl_table(duthost)
+       bind_acl_table(duthost, tbinfo)
 
 @pytest.fixture
 def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_type, tbinfo):

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -1005,22 +1005,3 @@ def check_balancing(port_hit_cnt):
         return True
 
     return False
-
-def apply_acl_rules(duthost, tbinfo, intf_list):
-    if "t0-backend" not in tbinfo["topo"]["name"]:
-        return
-
-    dst_acl_template = os.path.join(DUT_TMP_DIR, ACL_TEMPLATE)
-    dst_acl_file = os.path.join(DUT_TMP_DIR, 'backend_new_acl.json')
-    duthost.copy(src=os.path.join(TEMPLATE_DIR, ACL_TEMPLATE), dest=dst_acl_template)
-    intfs = ",".join(intf_list)
-    confvar = '{{"intf_list" : "{}"}}'.format(intfs)
-    duthost.shell("sonic-cfggen -a '{}' -d -t {} > {}".format(confvar, dst_acl_template, dst_acl_file))
-    tmp = duthost.stat(path=dst_acl_file)
-    if tmp['stat']['exists']:
-        duthost.command("acl-loader update incremental {}".format(dst_acl_file))
-
-
-def bind_acl_table(duthost):
-    vlan_intfs = duthost.get_vlan_intfs()
-    duthost.command("config acl add table DATAACL L3 -p {}".format(",".join(vlan_intfs)))


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Modify sub port testcases to use common backend acl helpers added as part of #6686

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

#### How did you verify/test it?
Ran the sub port testcases with this change and all cases passed
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/nejo_n/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 29 items                                                             

sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port] PASSED [  3%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port_in_lag] PASSED [  6%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port] PASSED [ 10%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port_in_lag] PASSED [ 13%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_untagged_packet_not_routed[port] PASSED [ 17%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port] PASSED [ 20%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port_in_lag] PASSED [ 24%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port] PASSED [ 27%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port_in_lag] PASSED [ 31%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port] PASSED [ 34%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port_in_lag] PASSED [ 37%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port] PASSED [ 41%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port_in_lag] PASSED [ 44%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port-TCP-UDP-ICMP] PASSED [ 48%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port_in_lag-TCP-UDP-ICMP] PASSED [ 51%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port-TCP-UDP-ICMP] PASSED [ 55%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port_in_lag-TCP-UDP-ICMP] PASSED [ 58%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[same-TCP-UDP-ICMP-PORT] PASSED [ 62%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[different-TCP-UDP-ICMP-PORT] PASSED [ 65%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port-TCP-UDP-ICMP] PASSED [ 68%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port_in_lag-TCP-UDP-ICMP] PASSED [ 72%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port-TCP-UDP-ICMP] PASSED [ 75%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port_in_lag-TCP-UDP-ICMP] PASSED [ 79%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port] PASSED [ 82%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port_in_lag] PASSED [ 86%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port] PASSED [ 89%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port_in_lag] PASSED [ 93%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] PASSED [ 96%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag] PASSED [100%]
```
