### PR TITLE
Set vlan_mac and loopback ip for dual tor

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -755,7 +755,7 @@ class ReloadTest(BaseTest):
         for src_port in self.vlan_host_ping_map:
             src_addr = random.choice(self.vlan_host_ping_map[src_port].keys())
             src_mac = self.hex_to_mac(self.vlan_host_ping_map[src_port][src_addr])
-            packet = simple_icmp_packet(eth_src=self.from_server_src_mac,
+            packet = simple_icmp_packet(eth_src=src_mac,,
                                         eth_dst=self.vlan_mac,
                                         ip_src=src_addr,
                                         ip_dst=dut_lo_ipv4)
@@ -770,7 +770,6 @@ class ReloadTest(BaseTest):
                                     ip_dst=dut_lo_ipv4)
 
         self.ping_dut_exp_packet  = Mask(exp_packet)
-        self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.IP, "dst")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.IP, "id")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -139,9 +139,10 @@ class ReloadTest(BaseTest):
         self.check_param('vlan_ports_file', '', required=True)
         self.check_param('ports_file', '', required=True)
         self.check_param('dut_mac', '', required=True)
+        self.check_param('vlan_mac', '', required=True)
         self.check_param('default_ip_range', '', required=True)
         self.check_param('vlan_ip_range', '', required=True)
-        self.check_param('lo_prefix', '10.1.0.32/32', required=False)
+        self.check_param('lo_prefix', '', required=False)
         self.check_param('lo_v6_prefix', 'fc00:1::/64', required=False)
         self.check_param('arista_vms', [], required=True)
         self.check_param('min_bgp_gr_timeout', 15, required=False)
@@ -567,6 +568,8 @@ class ReloadTest(BaseTest):
         if self.reboot_type in ['soft-reboot', 'reboot']:
             raise ValueError('Not supported reboot_type %s' % self.reboot_type)
         self.dut_mac = self.test_params['dut_mac']
+        self.vlan_mac = self.test_params['vlan_mac']
+        self.lo_prefix = self.test_params['lo_prefix']
 
         if self.kvm_test:
             self.log("This test is for KVM platform")
@@ -601,6 +604,7 @@ class ReloadTest(BaseTest):
         self.log("DUT ssh: %s@%s" % (self.test_params['dut_username'], self.test_params['dut_hostname']))
         self.log("DUT reboot limit in seconds: %s" % self.limit)
         self.log("DUT mac address: %s" % self.dut_mac)
+        self.log("DUT vlan mac address: %s" % self.vlan_mac)
 
         self.log("From server src addr: %s" % self.from_server_src_addr)
         self.log("From server src port: %s" % self.from_server_src_port)
@@ -726,8 +730,8 @@ class ReloadTest(BaseTest):
 
     def generate_from_vlan(self):
         packet = simple_tcp_packet(
-                      eth_dst=self.dut_mac,
                       eth_src=self.from_server_src_mac,
+                      eth_dst=self.vlan_mac,
                       ip_src=self.from_server_src_addr,
                       ip_dst=self.from_server_dst_addr,
                       tcp_dport=5000
@@ -747,17 +751,17 @@ class ReloadTest(BaseTest):
 
     def generate_ping_dut_lo(self):
         self.ping_dut_packets = []
-        dut_lo_ipv4 = self.test_params['lo_prefix'].split('/')[0]
+        dut_lo_ipv4 = self.lo_prefix.split('/')[0]
         for src_port in self.vlan_host_ping_map:
             src_addr = random.choice(self.vlan_host_ping_map[src_port].keys())
             src_mac = self.hex_to_mac(self.vlan_host_ping_map[src_port][src_addr])
-            packet = simple_icmp_packet(eth_src=src_mac,
-                                        eth_dst=self.dut_mac,
+            packet = simple_icmp_packet(eth_src=self.from_server_src_mac,
+                                        eth_dst=self.vlan_mac,
                                         ip_src=src_addr,
                                         ip_dst=dut_lo_ipv4)
             self.ping_dut_packets.append((src_port, str(packet)))
 
-        exp_packet = simple_icmp_packet(eth_src=self.dut_mac,
+        exp_packet = simple_icmp_packet(eth_src=self.vlan_mac,
                                         ip_src=dut_lo_ipv4,
                                         icmp_type='echo-reply')
 
@@ -766,6 +770,7 @@ class ReloadTest(BaseTest):
                                     ip_dst=dut_lo_ipv4)
 
         self.ping_dut_exp_packet  = Mask(exp_packet)
+        self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.IP, "dst")
         self.ping_dut_exp_packet.set_do_not_care_scapy(scapy.IP, "id")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -755,7 +755,7 @@ class ReloadTest(BaseTest):
         for src_port in self.vlan_host_ping_map:
             src_addr = random.choice(self.vlan_host_ping_map[src_port].keys())
             src_mac = self.hex_to_mac(self.vlan_host_ping_map[src_port][src_addr])
-            packet = simple_icmp_packet(eth_src=src_mac,,
+            packet = simple_icmp_packet(eth_src=src_mac,
                                         eth_dst=self.vlan_mac,
                                         ip_src=src_addr,
                                         ip_dst=dut_lo_ipv4)

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -174,10 +174,7 @@ class AdvancedReboot:
         vlan_mac = vlan_table[vlan_name]['mac']
         self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
-        if 'dualtor' in tbinfo['topo']['name']:
-            self.rebootData['lo_prefix'] = "10.1.0.33/32"
-        else:
-            self.rebootData['lo_prefix'] = "10.1.0.32/32"
+        self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'], self.mgFacts['minigraph_lo_interfaces][0]['prefixlen'])
 
         vlan_ip_range = dict()
         for vlan in self.mgFacts['minigraph_vlan_interfaces']:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -168,12 +168,16 @@ class AdvancedReboot:
         self.vlanMaxCnt = len(self.mgFacts['minigraph_vlans'].values()[0]['members']) - 1
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
-        config_facts = self.duthost.get_running_config_facts()
-        vlan_table = config_facts['VLAN']
-        vlan_name = list(vlan_table.keys())[0]
-        vlan_mac = vlan_table[vlan_name]['mac']
-        self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
+        if "dualtor" in tbinfo['topo']['name']:
+            config_facts = self.duthost.get_running_config_facts()
+            vlan_table = config_facts['VLAN']
+            vlan_name = list(vlan_table.keys())[0]
+            vlan_mac = self.duthost.get_dut_face_mac(vlan_name)
+            vlan_mac = vlan_table[vlan_name]['mac']
+            self.rebootData['vlan_mac'] = vlan_mac
+        else:
+            self.rebootData['vlan_mac'] = self.rebootData['dut_mac']
         self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'], self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
 
         vlan_ip_range = dict()

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -174,7 +174,7 @@ class AdvancedReboot:
         vlan_mac = vlan_table[vlan_name]['mac']
         self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
-        self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'], self.mgFacts['minigraph_lo_interfaces][0]['prefixlen'])
+        self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'], self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
 
         vlan_ip_range = dict()
         for vlan in self.mgFacts['minigraph_vlan_interfaces']:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -173,7 +173,6 @@ class AdvancedReboot:
             config_facts = self.duthost.get_running_config_facts()
             vlan_table = config_facts['VLAN']
             vlan_name = list(vlan_table.keys())[0]
-            vlan_mac = self.duthost.get_dut_face_mac(vlan_name)
             vlan_mac = vlan_table[vlan_name]['mac']
             self.rebootData['vlan_mac'] = vlan_mac
         else:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -169,14 +169,13 @@ class AdvancedReboot:
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
-        if "dualtor" in tbinfo['topo']['name']:
-            config_facts = self.duthost.get_running_config_facts()
-            vlan_table = config_facts['VLAN']
+        vlan_mac = self.rebootData['dut_mac']
+        config_facts = self.duthost.get_running_config_facts()
+        vlan_table = config_facts.get('VLAN', None)
+        if vlan_table:
             vlan_name = list(vlan_table.keys())[0]
-            vlan_mac = vlan_table[vlan_name]['mac']
-            self.rebootData['vlan_mac'] = vlan_mac
-        else:
-            self.rebootData['vlan_mac'] = self.rebootData['dut_mac']
+            vlan_mac = vlan_table[vlan_name].get('mac', self.rebootData['dut_mac'])
+        self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'], self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
 
         vlan_ip_range = dict()

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -168,7 +168,17 @@ class AdvancedReboot:
         self.vlanMaxCnt = len(self.mgFacts['minigraph_vlans'].values()[0]['members']) - 1
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
+        config_facts = self.duthost.get_running_config_facts()
+        vlan_table = config_facts['VLAN']
+        vlan_name = list(vlan_table.keys())[0]
+        vlan_mac = vlan_table[vlan_name]['mac']
+        self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
+        if 'dualtor' in tbinfo['topo']['name']:
+            self.rebootData['lo_prefix'] = "10.1.0.33/32"
+        else:
+            self.rebootData['lo_prefix'] = "10.1.0.32/32"
+
         vlan_ip_range = dict()
         for vlan in self.mgFacts['minigraph_vlan_interfaces']:
             if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
@@ -609,6 +619,8 @@ class AdvancedReboot:
             "vlan_ports_file" : self.rebootData['vlan_interfaces_file'],
             "ports_file" : self.rebootData['ports_file'],
             "dut_mac" : self.rebootData['dut_mac'],
+            "vlan_mac" : self.rebootData['vlan_mac'],
+            "lo_prefix" : self.rebootData['lo_prefix'],
             "default_ip_range" : self.rebootData['default_ip_range'],
             "vlan_ip_range" : self.rebootData['vlan_ip_range'],
             "lo_v6_prefix" : self.rebootData['lo_v6_prefix'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Dual tor has different mac addresses for router mac and vlan mac. Need to specify the correct mac address for server->t1 packets to be received successfully at the DUT
Dual tor device also has different loopback address. Updated test to use the correct one.

#### How did you do it?
Update vlan mac and lo prefix for dual tor test

#### How did you verify/test it?
Ran test manually on dual tor device, verify server->t1 packets are received

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
