### PR TITLE
[Python3] Migrate container-autorestart script to python3 and fix bug

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -663,7 +663,7 @@ class SonicHost(AnsibleHostBase):
             # In this situation, service container status should be false
             # We can check status is valid or not
             # You can just add valid status str in this tuple if meet later
-            if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL'):
+            if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL', 'BACKOFF'):
                 service_critical_process['status'] = False
             # 2. Check status is not running
             elif status != 'RUNNING':

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -177,7 +177,7 @@ def get_disabled_container_list(duthost):
     pytest_assert(succeeded, "Failed to get status ('enabled'|'disabled') of containers. Exiting...")
 
     for container_name, status in container_status.items():
-        if "disabled" in status:
+        if "disabled".encode('UTF-8') in status:
             disabled_containers.append(container_name)
 
     return disabled_containers

--- a/tests/common/plugins/log_section_start/__init__.py
+++ b/tests/common/plugins/log_section_start/__init__.py
@@ -94,7 +94,7 @@ def _pytest_import_callback(module):
         try:
             next(it)
         except StopIteration:
-            raise
+            return
         except Exception as detail:
             logging.exception("\n%r", detail)
             raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Migrate test_container_autorestart.py to python3 and add valid service process status.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Migrate test_container_autorestart.py to python3 and add valid service process status.

#### How did you do it?

1. In Python 3, by default, the strings are treated as Unicode. But in Python 2, the strings are by default treated as bytes, and in Python 2 there is the facility of automatic type coercion between Unicode strings and bytes. So I added `.enchode('UTF-8')` to 'disabled' because 'status' was also encoded with UTF-8.
```
if "disabled".encode('UTF-8') in status:
```
2. A generator indeed raises StopIteration when the function is done, it's the normal, expected signal to tell whoever is iterating that there is nothing more to be produced. So changed as follow:
```
        try:
            next(it)
        except StopIteration:
            return
```

3. Add valid service process status 'BACKOFF' when parsing service status:
```
if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL', 'BACKOFF'):
    service_critical_process['status'] = False
```

#### How did you verify/test it?

Run TC in py3 and py2, both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
