### PR TITLE
[dualtor]: Wait for neighbor to become reachable

### DIFF
--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import random
 
+from ipaddress import ip_address
 from ptf import testutils
 from tests.common.dualtor.dual_tor_mock import *
 from tests.common.dualtor.dual_tor_utils import dualtor_info
@@ -19,6 +20,8 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
 from tests.common.fixtures.ptfhost_utils import run_garp_service
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 
 pytestmark = [
@@ -51,6 +54,13 @@ def testbed_setup(ip_version, ptfhost, rand_selected_dut, rand_unselected_dut, t
     else:
         raise ValueError("Unknown IP version '%s'" % ip_version)
     return test_port, server_ip, ip_version
+
+
+def neighbor_reachable(duthost, neighbor_ip):
+    neigh_table = duthost.switch_arptable()['ansible_facts']['arptable']
+    ip_version = 'v4' if ip_address(neighbor_ip).version == 4 else 'v6'
+    neigh_status = neigh_table[ip_version][neighbor_ip]['state'].lower()
+    return "reachable" in neigh_status
 
 
 def test_active_tor_remove_neighbor_downstream_active(
@@ -106,6 +116,8 @@ def test_active_tor_remove_neighbor_downstream_active(
         remove_neighbor_ct = remove_neighbor(ptfhost, tor, server_ip, ip_version, removed_neighbor)
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), remove_neighbor_ct, tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
+        # wait up to a minute for the neighbor entry to become reachable due to performance limitation on some testbeds/lab servers
+        pytest_assert(wait_until(60, 5, 0, lambda: neighbor_reachable(tor, server_ip)))
 
         logging.info("send traffic to server %s after neighbor entry is restored", server_ip)
         server_traffic_monitor = ServerTrafficMonitor(


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Due to limited performance on some lab servers, after running `arp_update` in `test_active_tor_remove_neighbor_downstream_active` neighbor entries can take a long time to transition from 'INCOMPLETE' to 'REACHABLE' which causes unexpected packet drops

#### How did you do it?
- Wait for the neighbor entry used by the test to become reachable before sending traffic
- Improve dual ToR mocking by only waiting until ToR is healthy after service restart and removing redundant SWSS restarts

#### How did you verify/test it?
Run the test case, make sure it passes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
