### PR TITLE
Fix compatibility issue between python2 and python3 in `null_route` test

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -192,7 +192,7 @@ def generate_packet(src_ip, dst_ip, dst_mac):
     """
     Build ipv4 and ipv6 packets/expected_packets for testing.
     """
-    if ipaddress.ip_network(str(src_ip), False).version == 4:
+    if ipaddress.ip_network(src_ip.encode().decode(), False).version == 4:
         pkt = testutils.simple_ip_packet(eth_dst=dst_mac, ip_src=src_ip, ip_dst=dst_ip)
         exp_pkt = Mask(pkt)
         exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
@@ -244,7 +244,7 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter, apply_pre_defi
         src_ip = test_item[0]
         action = test_item[1]
         expected_result = test_item[2]
-        ip_ver = ipaddress.ip_network(str(src_ip), False).version
+        ip_ver = ipaddress.ip_network(src_ip.encode().decode(), False).version
         logger.info("Testing with src_ip = {} action = {} expected_result = {}"
                     .format(src_ip, action, expected_result))
         pkt, exp_pkt = generate_packet(src_ip, DST_IP[ip_ver], router_mac)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
I fixed style issues in `null_route` test, but imported a compatibility issue.
In python3, str type contains unicode characters, but if we use str in python2 instead of unicode, will cause AddressValueError. Python2 can only recognize unicode IPv4/v6 address
Relate PR: https://github.com/sonic-net/sonic-mgmt/pull/6679
#### How did you do it?
Use string.encode().decode() instead of str() or unicode(), and in python2, we will get unicode IPv4/v6 address, in python3, we will get IPv4/v6 address string
#### How did you verify/test it?
Run `acl/null_route/test_null_route_helper.py` test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
