### PR TITLE
[double commit] Correct frame DMAC addr of traffic to using vlan interface addr for dual T0's PFC xoff test

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -84,7 +84,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
         self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLosslessProfile
+        ingressLosslessProfile, egressLosslessProfile, tbinfo
     ):
         """
             Test QoS SAI XOFF limits
@@ -141,6 +141,19 @@ class TestQosSai(QosSaiBase):
 
         if "packet_size" in qosConfig[xoffProfile].keys():
             testParams["packet_size"] = qosConfig[xoffProfile]["packet_size"]
+
+        if "dualtor" in tbinfo["topo"]["name"]:
+            testParams["is_dualtor"] = True
+            if tbinfo["topo"]["type"] == 't0':
+                testParams["is_t0"] = True
+            vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+            if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
+                default_vlan_name = vlan_cfgs['default_vlan_config']
+                if default_vlan_name:
+                    for vlan in vlan_cfgs[default_vlan_name].values():
+                        if 'mac' in vlan and vlan['mac']:
+                            testParams["def_vlan_mac"] = vlan['mac']
+                            break
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -144,8 +144,6 @@ class TestQosSai(QosSaiBase):
 
         if "dualtor" in tbinfo["topo"]["name"]:
             testParams["is_dualtor"] = True
-            if tbinfo["topo"]["type"] == 't0':
-                testParams["is_t0"] = True
             vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
             if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
                 default_vlan_name = vlan_cfgs['default_vlan_config']

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -732,10 +732,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             packet_length = 64
 
-        is_dualtor = bool(self.test_params.get('is_dualtor', False))
-        is_t0 = bool(self.test_params.get('is_t0', False))
+        is_dualtor = self.test_params.get('is_dualtor', False)
         def_vlan_mac = self.test_params.get('def_vlan_mac', None)
-        if is_dualtor and is_t0 and bool(def_vlan_mac):
+        if is_dualtor and def_vlan_mac != None:
             pkt_dst_mac = def_vlan_mac
 
         pkt = construct_ip_pkt(packet_length,

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -731,6 +731,13 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             packet_length = int(self.test_params['packet_size'])
         else:
             packet_length = 64
+
+        is_dualtor = bool(self.test_params.get('is_dualtor', False))
+        is_t0 = bool(self.test_params.get('is_t0', False))
+        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
+        if is_dualtor and is_t0 and bool(def_vlan_mac):
+            pkt_dst_mac = def_vlan_mac
+
         pkt = construct_ip_pkt(packet_length,
                                pkt_dst_mac,
                                src_port_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Correct frame DMAC addr of traffic to using vlan interface addr for dual T0's PFC xoff test


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

failed to forward test traffic on dut.
it caused QoS relevant test case failure.
RCA: for dual-T0's PFC xoff test, traffic from ptf use DUT's vlan interface address as destination mac address, instead of dut's physical interface addrss

#### How did you do it?
pass is_dualtor, is_to, default vlan mac to sai_qos_test, to correct dmac of frame for dual-t0 test scenario.

#### How did you verify/test it?
passed local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
