### PR TITLE
Ignore ERR kernal log Device is up, set it down before adding it as team port

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -159,3 +159,6 @@ r, ".* ERR syncd#syncd.*SAI_API_LAG:_brcm_sai_lag_acl_bind_update.*"
 # https://github.com/sonic-net/sonic-buildimage/issues/12303
 r, ".* ERR .*echo_receive: failing to read echo rc.*"
 r, ".* ERR .*echo_receive: last:errno=.*"
+
+# https://msazure.visualstudio.com/One/_workitems/edit/16110065
+r, ".* ERR kernel:.* Set it down before adding it as a team port.*"


### PR DESCRIPTION

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
dhcp_relay.test_dhcp_relay::test_dhcp_relay_unicast_mac failed at teardown, it found the following ERR log which should be ignored.
`ERR kernel: [10374.080989] PortChannel103: Device Ethernet120 is up. Set it down before adding it as a team port`

#### How did you do it?
Add the pattern to match this ERR log in common ignore file.
#### How did you verify/test it?
Run `dhcp_relay.test_dhcp_relay::test_dhcp_relay_unicast_ma`c on 202205.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
