### PR TITLE
Add timeout for request.post in mux_simulator_control.py

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -167,7 +167,7 @@ def _post(server_url, data):
         server_url = '{}?reqId={}'.format(server_url, uuid.uuid4())  # Add query string param reqId for debugging
         logger.debug('POST {} with {}'.format(server_url, data))     # lgtm [py/clear-text-logging-sensitive-data]
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
-        resp = requests.post(server_url, json=data, headers=headers, timeout=600)
+        resp = requests.post(server_url, json=data, headers=headers, timeout=10)
         logger.debug('Received response {}/{} with content {}'.format(resp.status_code, resp.reason, resp.text))
         return resp.status_code == 200
     except Exception as e:

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -167,7 +167,7 @@ def _post(server_url, data):
         server_url = '{}?reqId={}'.format(server_url, uuid.uuid4())  # Add query string param reqId for debugging
         logger.debug('POST {} with {}'.format(server_url, data))     # lgtm [py/clear-text-logging-sensitive-data]
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
-        resp = requests.post(server_url, json=data, headers=headers)
+        resp = requests.post(server_url, json=data, headers=headers, timeout=600)
         logger.debug('Received response {}/{} with content {}'.format(resp.status_code, resp.reason, resp.text))
         return resp.status_code == 200
     except Exception as e:


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In nightly test, we found test got stuck at toggle mux ports, the server or mux simulator may have some problems, but it shouldn't block test:

```
31/10/2022 10:01:35 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture send_server_to_t1_with_action setup ends --------------------
31/10/2022 10:01:35 mux_simulator_control._toggle_all_simula L0338 INFO   | Toggle all ports to "upper_tor"
31/10/2022 10:01:35 mux_simulator_control._post              L0168 DEBUG  | POST http://10.64.246.225:8082/mux/vms28-6?reqId=789b2f5b-226c-49fa-a543-04a26d103026 with {'active_side': 'upper_tor'}
31/10/2022 10:01:35 connectionpool._new_conn                 L0232 DEBUG  | Starting new HTTP connection (1): 10.64.246.225:8082
```
This is console log, got stuck at `dualtor_io/test_tor_failure.py::test_standby_tor_reboot_upstream[active-standby]` for more than 24 hours.
```
2022-10-31T10:01:28.0286872Z dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream_standby[active-active] SKIPPED [ 40%]
2022-11-01T10:31:12.8362298Z ##[error]The task has timed out.
```

#### How did you do it?
If don't have timeout parameter, it may get stuck forever at some scenarios.
Add default timeout to 10 mins, avoid getting stuck forever.
_timeout is not a time limit on the entire response download; rather, an exception is raised if the server has not issued a response for timeout seconds (more precisely, if no bytes have been received on the underlying socket for timeout seconds). If no timeout is specified explicitly, requests do not time out._
#### How did you verify/test it?
Ran `dualtor_io/test_tor_failure.py`
#### Any platform specific information?
dualtor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
