### PR TITLE
[bugfix] Fix KeyError in FLEX_COUNTER_STATUS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1825,8 +1825,19 @@ def core_dump_and_config_check(duthosts, request):
                 # TODO: remove these code when solve the problem of "FLEX_COUNTER_DELAY_STATUS"
                 if key == "FLEX_COUNTER_TABLE":
                     for sub_key, sub_value in duts_data[duthost.hostname]["pre_running_config"][key].items():
-                        if duts_data[duthost.hostname]["pre_running_config"][key][sub_key]["FLEX_COUNTER_STATUS"] != \
-                                duts_data[duthost.hostname]["cur_running_config"][key][sub_key]["FLEX_COUNTER_STATUS"]:
+                        try:
+                            pre_value = duts_data[duthost.hostname]["pre_running_config"][key][sub_key]
+                            cur_value = duts_data[duthost.hostname]["cur_running_config"][key][sub_key]
+                            if pre_value["FLEX_COUNTER_STATUS"] != cur_value["FLEX_COUNTER_STATUS"]:
+                                inconsistent_config[duthost.hostname].update(
+                                    {
+                                        key: {
+                                            "pre_value": duts_data[duthost.hostname]["pre_running_config"][key],
+                                            "cur_value": duts_data[duthost.hostname]["cur_running_config"][key]
+                                        }
+                                    }
+                                )
+                        except KeyError:
                             inconsistent_config[duthost.hostname].update(
                                 {
                                     key: {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In 7050 dualtor testbed, the current config `FLEX_COUNTER_STATUS` doesn't have the sub key `BUFFER_POOL_WATERMARK`, which will cause a key error. This pr will catch this error. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In 7050 dualtor testbed, the current config `FLEX_COUNTER_STATUS` doesn't have the sub key `BUFFER_POOL_WATERMARK`, which will cause a key error. This pr will catch this error. 

#### How did you do it?
Use try...except to catch the error. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
