### PR TITLE
Added back disable loganalyzer in config reload or minigraph reload.

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -361,6 +361,7 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
                       "Not all ipv6 routes are announced to neighbors")
 
 
+@pytest.mark.disable_loganalyzer
 def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA after config save and config reload
@@ -408,6 +409,7 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
                                 "Not all ipv6 routes are announced to neighbors")
 
 
+@pytest.mark.disable_loganalyzer
 def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown,
                                                 traffic_shift_community, tbinfo):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add back disable loganalyzer in config reload or minigraph reload. 
This was already done in PR#6533, but as part of the latest PR#6206, the pytest markers to disable loganalyzer were removed

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add back disable loganalyzer in config reload or minigraph reload
They were removed accidentally when creating PR #6206.

#### How did you do it?
Added @pytest.mark.disable_loganalyzer for test_TSA_TSB_with_config_reload
Added @pytest.mark.disable_loganalyzer for test_load_minigraph_with_traffic_shift_away

#### How did you verify/test it?
Tested test_TSA_TSB_with_config_reload and test_load_minigraph_with_traffic_shift_away on a multi asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
