### PR TITLE
Removing ip-proto hash test for Marvell(Innovium) chip type

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -158,6 +158,9 @@ def hash_keys(duthost):
             hash_keys.remove('ip-proto')
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
+    if duthost.facts['asic_type'] in ["innovium"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic


### PR DESCRIPTION
### Description of PR
Removing ip-proto hash test for Marvell(Innovium) chip type.

Summary:
Removing ip-proto hash test for Marvell(Innovium) chip type.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)


### Back port request
- [*] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
IP-Proto hashing not supported for innovium chip and excluding it from test
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
