### PR TITLE
Support config reload from running golden config.

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -10,7 +10,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 
 logger = logging.getLogger(__name__)
 
-config_sources = ['config_db', 'minigraph']
+config_sources = ['config_db', 'minigraph', 'running_golden_config']
 
 def config_system_checks_passed(duthost):
     logging.info("Checking if system is running")
@@ -80,10 +80,6 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
             ' or '.join(['"{}"'.format(src) for src in config_sources])
         ))
 
-    cmd = 'config reload -y &>/dev/null'
-    if config_force_option_supported(duthost):
-        cmd = 'config reload -y -f &>/dev/null'
-
     logger.info('reloading {}'.format(config_source))
 
     if config_source == 'minigraph':
@@ -106,6 +102,15 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         duthost.shell('config save -y')
 
     elif config_source == 'config_db':
+        cmd = 'config reload -y &>/dev/null'
+        if config_force_option_supported(duthost):
+            cmd = 'config reload -y -f &>/dev/null'
+        duthost.shell(cmd, executable="/bin/bash")
+
+    elif config_source == 'running_golden_config':
+        cmd = 'config reload -y -l /etc/sonic/running_golden_config.json &>/dev/null'
+        if config_force_option_supported(duthost):
+            cmd = 'config reload -y -f -l /etc/sonic/running_golden_config.json &>/dev/null'
         duthost.shell(cmd, executable="/bin/bash")
 
     modular_chassis = duthost.get_facts().get("modular_chassis")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Perviously, the function `config_reload` only supports reload from config_db.json and minigraph.xml. In pr #6599 , we generate the `running_golden_config.json`. So, I improve this function to support reloading from different configuration file.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Perviously, the function `config_reload` only supports reload from config_db.json and minigraph.xml. In pr #6599 , we generate the `running_golden_config.json`. So, I improve this function to support reloading from different configuration file.

#### How did you do it?
Add `running_golden_config` into `config_sources`, and use `config reload -l` to assign the configuration file.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
