### PR TITLE
Modify test_container_autorestart config reload source to golden config

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -32,7 +32,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     yield
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -68,7 +68,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
     """
     reload SONiC configuration
     :param duthost: DUT host object
-    :param config_source: configuration source either 'config_db' or 'minigraph'
+    :param config_source: configuration source is 'config_db', 'minigraph' or 'running_golden_config'
     :param wait: wait timeout for DUT to initialize after configuration reload
     :param override_config: override current config with '/etc/sonic/golden_config_db.json'
     :return:

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -12,9 +12,10 @@ logger = logging.getLogger(__name__)
 
 config_sources = ['config_db', 'minigraph', 'running_golden_config']
 
+
 def config_system_checks_passed(duthost):
     logging.info("Checking if system is running")
-    out= duthost.shell("systemctl is-system-running", module_ignore_errors=True)
+    out = duthost.shell("systemctl is-system-running", module_ignore_errors=True)
     if "running" not in out['stdout_lines']:
         logging.info("Checking failure reason")
         fail_reason = duthost.shell("systemctl list-units --state=failed", module_ignore_errors=True)
@@ -29,7 +30,8 @@ def config_system_checks_passed(duthost):
                 return False
 
             out = duthost.shell(
-                "ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value) | sed '1d'".format(asic.asic_index))
+                "ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value) | sed '1d'".format(
+                    asic.asic_index))
             if int(out['stdout'].strip()) < 120:
                 return False
     else:
@@ -63,7 +65,8 @@ def config_force_option_supported(duthost):
 
 
 @ignore_loganalyzer
-def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False,
+def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
+                  safe_reload=False,
                   check_intf_up_ports=False, traffic_shift_away=False, override_config=False):
     """
     reload SONiC configuration
@@ -84,7 +87,8 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
 
     if config_source == 'minigraph':
         if start_dynamic_buffer and duthost.facts['asic_type'] == 'mellanox':
-            output = duthost.shell('redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model', module_ignore_errors=True)
+            output = duthost.shell('redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model',
+                                   module_ignore_errors=True)
             is_buffer_model_dynamic = (output and output.get('stdout') == 'dynamic')
         else:
             is_buffer_model_dynamic = False
@@ -122,11 +126,11 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         # minutes to the maximum wait time. If it's ready sooner, then the
         # function will return sooner.
         pytest_assert(wait_until(wait + 300, 20, 0, duthost.critical_services_fully_started),
-                "All critical services should be fully started!")
+                      "All critical services should be fully started!")
         wait_critical_processes(duthost)
         if config_source == 'minigraph':
             pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, duthost),
-                    "PFC_WD is missing in CONFIG-DB")
+                          "PFC_WD is missing in CONFIG-DB")
 
         if check_intf_up_ports:
             pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Since PR(#6731), we Support config reload from running_golden_config. And before all test cases started, running_golden_config would be dumped. So after all test cases finished, reload from the same golden config.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Since PR(#6731), we Support config reload from running_golden_config. And before all test cases started, running_golden_config would be dumped. So after all test cases finished, reload from the same golden config.

#### How did you do it?

Add parameter config_source='running_golden_config' to method config_reload().

#### How did you verify/test it?

Run TC and TC passed, core dump and config check also passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
