### PR TITLE
Return useful information for sanity check if parallel_run timeout

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -96,7 +96,6 @@ def parallel_run(
                 if init_result:
                     init_result['failed'] = True
                     results[results.keys()[0]] = init_result
-                    logger.info("killing results:{}".format(results))
                 else:
                     results[p.name] = {'failed': True}
                 try:

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -51,7 +51,7 @@ class SonicProcess(Process):
 
 
 def parallel_run(
-    target, args, kwargs, nodes_list, timeout=None, concurrent_tasks=24
+    target, args, kwargs, nodes_list, timeout=None, concurrent_tasks=24, init_result=None
 ):
     """Run target function on nodes in parallel
 
@@ -81,7 +81,7 @@ def parallel_run(
             worker.name, worker.returncode)
         )
 
-    def force_terminate(workers):
+    def force_terminate(workers, init_result):
         # Some processes cannot be terminated. Try to kill them and raise flag.
         running_processes = [worker for worker in workers if worker.is_alive()]
         if len(running_processes) > 0:
@@ -91,7 +91,14 @@ def parallel_run(
                 )
             )
             for p in running_processes:
-                results[p.name] = {'failed': True}
+                # If sanity check process is killed, it still has init results.
+                # set its failed to True.
+                if init_result:
+                    init_result['failed'] = True
+                    results[results.keys()[0]] = init_result
+                    logger.info("killing results:{}".format(results))
+                else:
+                    results[p.name] = {'failed': True}
                 try:
                     os.kill(p.pid, signal.SIGKILL)
                 except OSError as err:
@@ -129,6 +136,10 @@ def parallel_run(
 
         while len(nodes) and tasks_running < concurrent_tasks:
             node = nodes.pop(0)
+            # For sanity check process, initial results in case of timeout.
+            if init_result:
+                init_result["host"] = node.hostname
+                results[node.hostname] = init_result
             kwargs['node'] = node
             kwargs['results'] = results
             process_name = "{}--{}".format(target.__name__, node)
@@ -154,7 +165,7 @@ def parallel_run(
             logger.debug("all processes have timedout")
             tasks_running -= len(workers)
             tasks_done += len(workers)
-            force_terminate(workers)
+            force_terminate(workers, init_result)
             del workers[:]
         else:
             tasks_running -= len(gone)
@@ -174,13 +185,19 @@ def parallel_run(
                 worker.name
             ))
             worker.terminate()
-            results[worker.name] = {'failed': True}
+            # If sanity check process is killed, it still has init results.
+            # set its failed to True.
+            if init_result:
+                init_result['failed'] = True
+                results[results.keys()[0]] = init_result
+            else:
+                results[worker.name] = {'failed': True}
 
     end_time = datetime.datetime.now()
     delta_time = end_time - start_time
 
     # force terminate any workers still running
-    force_terminate(workers)
+    force_terminate(workers, init_result)
 
     # if we have failed processes, we should log the exception and exit code
     # of each Process and fail

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -75,8 +75,9 @@ def _find_down_ports(dut, phy_interfaces, ip_interfaces):
 
 @pytest.fixture(scope="module")
 def check_interfaces(duthosts):
+    init_result = {"failed": False, "check_item": "interfaces"}
     def _check(*args, **kwargs):
-        result = parallel_run(_check_interfaces_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
+        result = parallel_run(_check_interfaces_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600, init_result=init_result)
         return result.values()
 
     @reset_ansible_local_tmp
@@ -136,8 +137,9 @@ def check_interfaces(duthosts):
 
 @pytest.fixture(scope="module")
 def check_bgp(duthosts):
+    init_result = {"failed": False, "check_item": "bgp"}
     def _check(*args, **kwargs):
-        result = parallel_run(_check_bgp_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
+        result = parallel_run(_check_bgp_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=10, init_result=init_result)
         return result.values()
 
     @reset_ansible_local_tmp
@@ -243,7 +245,8 @@ def _is_db_omem_over_threshold(command_output):
 @pytest.fixture(scope="module")
 def check_dbmemory(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_dbmemory_on_dut, args, kwargs, duthosts, timeout=600)
+        init_result = {"failed": False, "check_item": "dbmemory"}
+        result = parallel_run(_check_dbmemory_on_dut, args, kwargs, duthosts, timeout=600, init_result=init_result)
         return result.values()
 
     @reset_ansible_local_tmp
@@ -614,7 +617,8 @@ def check_monit(duthosts):
     @return: A dictionary contains the testing result (failed or not failed) and the status of each service.
     """
     def _check(*args, **kwargs):
-        result = parallel_run(_check_monit_on_dut, args, kwargs, duthosts, timeout=600)
+        init_result = {"failed": False, "check_item": "monit"}
+        result = parallel_run(_check_monit_on_dut, args, kwargs, duthosts, timeout=600, init_result=init_result)
         return result.values()
 
     @reset_ansible_local_tmp
@@ -678,13 +682,14 @@ def check_monit(duthosts):
 @pytest.fixture(scope="module")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
+        init_result = {"failed": False, "check_item": "processes"}
         timeout = 600
         # Increase the timeout for multi-asic virtual switch DUT.
         for node in duthosts.nodes:
             if 'kvm' in node.sonichost.facts['platform'] and node.sonichost.is_multi_asic:
                 timeout = 1000
                 break
-        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=timeout)
+        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=timeout, init_result=init_result)
         return result.values()
 
     @reset_ansible_local_tmp


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In #6573, just return results is changed from list to dict `{'failed': True}`, but there is no meaningful information in it.

Even check process is killed, we still want to have some useful information to return for sanity check.
After process is killed, we will return results as below:
check_result = {"failed": True, "check_item": check_item_name, "host": hostname}
If it's not sanity check process, but something else, we just return a dict with value {'failed': True} and key is name of worker.

The results of normal return:

```
{
    "check_item": "bgp", 
    "failed": true, 
    "host": "sonic", 
    "bgp": {
        "down_neighbors": [
            "fc00::3a", 
            "10.0.0.29"
        ]
    }
}
```

The results of killed process return:


```
    {
        "check_item": "processes", 
        "failed": true, 
        "host": "sonic"
    }, 
    {
        "check_item": "bgp", 
        "failed": true, 
        "host": "sonic"
    }
```

#### How did you do it?
Add init_results in the beginning of every sanity check function, such as:
init_result = {"failed": False, "check_item": "bgp"}
At the begining of `parallel_run`, set `"host"` of init_result to `dut.hostname`.
If `parallel_run `timeout and execute force termination, change "`failed`" to True.

#### How did you verify/test it?
Run any test case on bgp unhealthy testbed, don't skip sanity check and allow recover
`--allow_recover`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
