### PR TITLE
Bfd multihop tests [202012]

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -1,0 +1,182 @@
+import binascii
+import socket
+import struct
+import select
+import json
+import argparse
+import os.path
+from fcntl import ioctl
+import logging
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
+import scapy.all as scapy2
+scapy2.conf.use_pcap=True
+from  scapy.contrib.bfd import BFD
+
+def get_if(iff, cmd):
+    s = socket.socket()
+    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    s.close()
+
+    return ifreq
+
+def get_mac(iff):
+    SIOCGIFHWADDR = 0x8927          # Get hardware address
+    return get_if(iff, SIOCGIFHWADDR)[18:24]
+
+
+class Interface(object):
+
+    def __init__(self, iface):
+        self.iface = iface
+        self.socket = None
+        self.mac_address = get_mac(iface)
+
+    def __del__(self):
+        if self.socket:
+            self.socket.close()
+
+    def bind(self):
+        self.socket = scapy2.conf.L2listen(iface=self.iface, filter="udp port 4784")
+
+    def handler(self):
+        return self.socket
+
+    def recv(self):
+        sniffed = self.socket.recv()
+        pkt = sniffed[0]
+        str_pkt = str(pkt).encode("HEX")
+        binpkt = binascii.unhexlify(str_pkt)
+        return binpkt
+
+    def send(self, data):
+        scapy2.sendp(data, iface=self.iface)
+
+    def mac(self):
+        return self.mac_address
+
+    def name(self):
+        return self.iface
+
+
+class Poller(object):
+    def __init__(self, interfaces, responder):
+        self.responder = responder
+        self.mapping = {}
+        for interface in interfaces:
+            self.mapping[interface.handler()] = interface
+
+    def poll(self):
+        handlers = self.mapping.keys()
+        while True:
+            (rdlist, _, _) = select.select(handlers, [], [])
+            for handler in rdlist:
+                self.responder.action(self.mapping[handler])
+
+
+class BFDResponder(object):
+    def __init__(self, sessions):
+        self.sessions = sessions
+        return
+
+    def action(self, interface):
+        data = interface.recv()
+        mac_src, mac_dst, ip_src, ip_dst,  bfd_remote_disc, bfd_state = self.extract_bfd_info(data)
+        if ip_dst not in self.sessions:
+            return
+        session = self.sessions[ip_dst]
+
+        if bfd_state== 3L:
+            interface.send(session["pkt"])
+            return
+
+        if bfd_state == 2L:
+            return
+        session = self.sessions[ip_dst]
+        session["other_disc"] = bfd_remote_disc
+        bfd_pkt_init = self.craft_bfd_packet( session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, 2L )
+        print("sending INIT", bfd_pkt_init)
+        interface.send(bfd_pkt_init)
+        bfd_pkt_init.payload.payload.payload.load.sta =3L
+        session["pkt"] = bfd_pkt_init
+        return
+
+    def extract_bfd_info(self, data):
+        # remote_mac, remote_ip, request_ip, op_type
+        ether = scapy2.Ether(data)
+        mac_src= ether.src
+        mac_dst = ether.dst
+        ip_src = ether.payload.src
+        ip_dst = ether.payload.dst
+        bfdpkt = BFD(ether.payload.payload.payload.load)
+        bfd_remote_disc =bfdpkt.my_discriminator
+        bfd_state = bfdpkt.sta
+        return mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state
+
+    def craft_bfd_packet(self, session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state):
+        ethpart = scapy2.Ether(data)
+        bfdpart = BFD(ethpart.payload.payload.payload.load)
+        bfdpart.my_discriminator = session["my_disc"]
+        bfdpart.your_discriminator = bfd_remote_disc
+        bfdpart.sta = bfd_state
+
+        ethpart.payload.payload.payload.load = bfdpart
+        ethpart.src = mac_dst
+        ethpart.dst = mac_src
+        ethpart.payload.src= ip_dst
+        ethpart.payload.dst= ip_src
+        return ethpart
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='ARP autoresponder')
+    parser.add_argument('--conf', '-c', type=str, dest='conf', default='/tmp/from_t1.json', help='path to json file with configuration')
+    args = parser.parse_args()
+
+    return args
+
+def main():
+    args = parse_args()
+
+    if not os.path.exists(args.conf):
+        print("Can't find file %s" % args.conf)
+        return
+
+    with open(args.conf) as fp:
+        data = json.load(fp)
+
+    # generate ip_sets. every ip address will have it's own uniq mac address
+    sessions = {}
+    local_disc_base = 0xcdba0000
+    local_src_port = 14000
+    ifaces = {}
+    for bfd in data:
+        curr_session = {}
+        curr_session["local"] = bfd["local_addr"]
+        curr_session["remote"] = bfd["neighbor_addr"]
+        curr_session["intf"] = bfd["ptf_intf"]
+        curr_session["multihop"] = bfd["multihop"]
+        curr_session["my_disc"] =  local_disc_base
+        curr_session["other_disc"] = 0x00
+        curr_session["mac"] = get_mac( str( bfd["ptf_intf"]))
+        curr_session["src_port"] = local_src_port
+        curr_session["pkt"] = ""
+        if bfd["ptf_intf"] not in ifaces:
+            ifaces[curr_session["intf"]] = curr_session["mac"]
+
+        local_disc_base +=1
+        local_src_port +=1
+        sessions[curr_session["local"]] = curr_session
+    ifaceobjs =[]
+    for iface_name in ifaces.keys():
+        iface = Interface(str(iface_name))
+        iface.bind()
+        ifaceobjs.append(iface)
+
+    resp = BFDResponder(sessions)
+
+    p = Poller(ifaceobjs, resp)
+    p.poll()
+
+    return
+
+if __name__ == '__main__':
+    main()

--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    parser.addoption("--num_sessions", action="store", default=5)
+    parser.addoption("--num_sessions_scale", action="store", default=128)

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -14,15 +14,11 @@ from pkg_resources import parse_version
 from tests.common import constants
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't1-lag')
+   pytest.mark.topology('t1')
 ]
 
-def skip_201911_and_older(duthost):
-    """ Skip the current test if the DUT version is 201911 or older.
-    """
-    if parse_version(duthost.kernel_version) <= parse_version('4.9.0'):
-        pytest.skip("Test not supported for 201911 images or older. Skipping the test")
-
+BFD_RESPONDER_SCRIPT_SRC_PATH = '../ansible/roles/test/files/helpers/bfd_responder.py'
+BFD_RESPONDER_SCRIPT_DEST_PATH = '/opt/bfd_responder.py'
 
 def is_dualtor(tbinfo):
     """Check if the testbed is dualtor."""
@@ -96,6 +92,47 @@ def get_neighbors(duthost, tbinfo, ipv6=False, count=1):
             return [t1_ipv4_pattern.format(idx * 2) for idx in indices], 31, [t1_ipv4_pattern.format(idx * 2 + 1) for idx in indices], [t0_intfs[_] for _ in indices], [ptf_ports[_] for _ in indices]
 
 
+def get_loopback_intf(mg_facts, ipv6):
+    ipv6idx = 0 if mg_facts['minigraph_lo_interfaces'][0]['prefixlen'] == 128 else 1
+    if ipv6:
+        return mg_facts['minigraph_lo_interfaces'][ipv6idx]['addr']
+    else:
+         return mg_facts['minigraph_lo_interfaces'][(ipv6idx+1) %2]['addr']
+
+def get_neighbors_multihop(duthost, tbinfo, ipv6=False, count=1):
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    t0_ipv4_pattern = '4.{}.{}.1'
+    t0_ipv6_pattern = '3000:3000:{:x}::3000'
+    t0_intfs = get_t0_intfs(mg_facts)
+    ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in t0_intfs]
+    loopback_addr = get_loopback_intf( mg_facts, ipv6 )
+
+    index = random.sample(list(range(len(t0_intfs))), k=1)[0]
+    port_intf = t0_intfs[index]
+    ptf_intf = ptf_ports[index]
+    nexthop_ip = ""
+    neighbour_dev_name = mg_facts['minigraph_neighbors'][port_intf]['name']
+    for bgpinfo in  mg_facts['minigraph_bgp']:
+        if bgpinfo['name'] == neighbour_dev_name:
+            nexthop_ip =  bgpinfo['addr']
+            if  ipv6 and ":" not in nexthop_ip :
+                nexthop_ip = ""
+                continue
+            break
+    if nexthop_ip =="":
+        assert False
+    neighbor_addrs = []
+    idx2 =0
+    for idx in range(1, count):
+        if idx %250 ==0:
+            idx2 +=1
+        if ipv6:
+            neighbor_addrs.append(t0_ipv6_pattern.format(idx))
+        else:
+            neighbor_addrs.append(t0_ipv4_pattern.format((idx%250),idx2))
+    
+    return loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs
+
 def init_ptf_bfd(ptfhost):
     ptfhost.shell("bfdd-beacon")
 
@@ -117,7 +154,13 @@ def del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=Fa
         if ipv6:
             ptfhost.shell("ip -6 addr del {}/{} dev eth{}".format(neighbor_addrs[idx], prefix_len, neighbor_interfaces[idx]), module_ignore_errors=True)
         else:
-            ptfhost.shell("ip addr del {}/{} dev eth{}".format(neighbor_addrs[idx], prefix_len, neighbor_interfaces[idx]), module_ignore_errors=True)
+            cmd_buffer += "ip addr del {}/{} dev eth{} ;".format(neighbor_addrs[idx], prefix_len,
+                                                                 neighbor_interfaces[idx])
+        if idx % 50 == 0:
+            ptfhost.shell(cmd_buffer, module_ignore_errors=True)
+            cmd_buffer = ""
+    if cmd_buffer != "":
+        ptfhost.shell(cmd_buffer, module_ignore_errors=True)
 
 
 def check_ptf_bfd_status(ptfhost, neighbor_addr, local_addr, expected_state):
@@ -157,8 +200,51 @@ def create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs):
     if result['rc'] != 0:
         pytest.fail('Failed to apply BFD session configuration file: {}'.format(result['stderr']))
 
+def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neighbor_addrs):
+    # Create a tempfile for BFD sessions
+    bfd_file_dir = duthost.shell('mktemp')['stdout']
+    ptf_file_dir = ptfhost.shell('mktemp')['stdout']
+    bfd_config = []
+    ptf_config = []
+    for neighbor_addr in neighbor_addrs:
+        bfd_config.append({
+            "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
+                "local_addr": loopback_addr,
+                "multihop" : "true"
+            },
+            "OP": "SET"
+        })
+        ptf_config.append(
+            {
+                "neighbor_addr": loopback_addr,
+                "local_addr" : neighbor_addr,
+                "multihop" : "true",
+                "ptf_intf" : "eth{}".format(ptf_intf)
+            }
+        )
 
-def remove_bfd_sessions(duthost, local_addrs, neighbor_addrs):
+    # Copy json file to DUT
+    duthost.copy(content=json.dumps(bfd_config, indent=4), dest=bfd_file_dir, verbose=False)
+
+    # Apply BFD sessions with swssconfig
+    result = duthost.shell('docker exec -i swss swssconfig /dev/stdin < {}'.format(bfd_file_dir),
+                           module_ignore_errors=True)
+    if result['rc'] != 0:
+        pytest.fail('Failed to apply BFD session configuration file: {}'.format(result['stderr']))
+    # Copy json file to PTF
+    ptfhost.copy(content=json.dumps(ptf_config, indent=4), dest=ptf_file_dir, verbose=False)
+
+    ptfhost.copy(src=BFD_RESPONDER_SCRIPT_SRC_PATH, dest=BFD_RESPONDER_SCRIPT_DEST_PATH)
+
+    extra_vars = {"bfd_responder_args" : "-c {}".format(ptf_file_dir)}
+    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
+
+    ptfhost.template(src='templates/bfd_responder.conf.j2', dest='/etc/supervisor/conf.d/bfd_responder.conf')
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+    ptfhost.command('supervisorctl start bfd_responder')
+
+def remove_bfd_sessions(duthost, neighbor_addrs):
     # Create a tempfile for BFD sessions
     bfd_file_dir = duthost.shell('mktemp')['stdout']
     bfd_config = []
@@ -167,7 +253,6 @@ def remove_bfd_sessions(duthost, local_addrs, neighbor_addrs):
         duthost.shell("sonic-db-cli APPL_DB hmset 'BFD_SESSION_TABLE:default:default:{}' local_addr {}".format(neighbor_addr, local_addrs[idx]))
         bfd_config.append({
             "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
-                "local_addr": local_addrs[idx]
             },
             "OP": "DEL"
         })
@@ -218,10 +303,9 @@ def test_bfd(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_r
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
     finally:
         stop_ptf_bfd(ptfhost)
-        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=False)
-        remove_bfd_sessions(duthost, local_addrs, neighbor_addrs)
-        if 't1' in tbinfo['topo']['name']:
-            remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+        remove_bfd_sessions(duthost, neighbor_addrs)
+        remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
 
 
 @pytest.mark.skip(reason="Test may currently fail due to lack of hardware support")
@@ -238,11 +322,12 @@ def test_bfd_ipv6(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports
         add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=True)
         create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs)
 
-        time.sleep(1)
-
-        for idx, neighbor_addr in enumerate(neighbor_addrs):
-            check_dut_bfd_status(duthost, neighbor_addr, "Up")
-            check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
+       time.sleep(10)
+        bfd_state = ptfhost.shell("bfdd-control status")
+        dut_state = duthost.shell("show bfd summary")
+        for itr in local_addrs:
+            assert itr in bfd_state['stdout']
+            assert itr in dut_state['stdout']
 
         update_idx = random.choice(range(bfd_session_cnt))
         update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[idx], "down")
@@ -256,7 +341,34 @@ def test_bfd_ipv6(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
     finally:
         stop_ptf_bfd(ptfhost)
-        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=True)
-        remove_bfd_sessions(duthost, local_addrs, neighbor_addrs)
-        if 't1' in tbinfo['topo']['name']:
-            remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+        remove_bfd_sessions(duthost, neighbor_addrs)
+        remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+
+
+@pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
+def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):
+    duthost = rand_selected_dut
+
+    bfd_session_cnt = int(request.config.getoption('--num_sessions'))
+    loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs = get_neighbors_multihop(duthost, tbinfo, ipv6, count = bfd_session_cnt)
+    try:
+        cmd_buffer = ""
+        for neighbor in neighbor_addrs:
+            cmd_buffer += 'sudo ip route add {} via {} ;'.format(neighbor, nexthop_ip)
+        duthost.shell(cmd_buffer)
+
+        create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neighbor_addrs)
+
+        time.sleep(1)
+        for neighbor_addr in neighbor_addrs:
+            check_dut_bfd_status(duthost, neighbor_addr, "Up")
+
+    finally:
+        remove_bfd_sessions(duthost, neighbor_addrs)
+        cmd_buffer = ""
+        for neighbor in neighbor_addrs:
+            cmd_buffer += 'sudo ip route delete {} via {} ;'.format(neighbor, nexthop_ip)
+        duthost.shell(cmd_buffer)
+        ptfhost.command('supervisorctl stop bfd_responder')
+        ptfhost.file(path=BFD_RESPONDER_SCRIPT_DEST_PATH, state="absent")

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -1,24 +1,17 @@
 import pytest
-import ipaddress
-import natsort
 import random
 import time
 import json
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_responder_py
-from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
-from tests.common.dualtor.mux_simulator_control import mux_server_url
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
-from pkg_resources import parse_version
-from tests.common import constants
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 
 pytestmark = [
-   pytest.mark.topology('t1')
+    pytest.mark.topology('t1')
 ]
 
 BFD_RESPONDER_SCRIPT_SRC_PATH = '../ansible/roles/test/files/helpers/bfd_responder.py'
 BFD_RESPONDER_SCRIPT_DEST_PATH = '/opt/bfd_responder.py'
+
 
 def is_dualtor(tbinfo):
     """Check if the testbed is dualtor."""
@@ -36,60 +29,97 @@ def get_t0_intfs(mg_facts):
 
 
 def add_dut_ip(duthost, intfs, ips, prefix_len):
+    cmd_buffer = ""
     for idx in range(len(intfs)):
-        duthost.shell('sudo config interface ip add {} {}/{}'.format(intfs[idx], ips[idx], prefix_len))
+        cmd_buffer += 'sudo config interface ip add {} {}/{} ;'.format(intfs[idx], ips[idx], prefix_len)
+        if idx % 50 == 0:
+            duthost.shell(cmd_buffer)
+            cmd_buffer = ""
+    if cmd_buffer != "":
+        duthost.shell(cmd_buffer)
 
 
 def remove_dut_ip(duthost, intfs, ips, prefix_len):
+    cmd_buffer = ""
     for idx in range(len(intfs)):
-        duthost.shell('sudo config interface ip remove {} {}/{}'.format(intfs[idx], ips[idx], prefix_len))
+        cmd_buffer += 'sudo config interface ip remove {} {}/{} ;'.format(intfs[idx], ips[idx], prefix_len)
+        if idx % 50 == 0:
+            duthost.shell(cmd_buffer)
+            cmd_buffer = ""
+    if cmd_buffer != "":
+        duthost.shell(cmd_buffer)
 
 
 def get_neighbors(duthost, tbinfo, ipv6=False, count=1):
-    topo_type = tbinfo['topo']['name']
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    prefix_len = 127 if ipv6 else 31
+    ip_pattern = '2000:2000::{:x}' if ipv6 else '101.0.0.{}'
+    t0_intfs = get_t0_intfs(mg_facts)
+    ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in t0_intfs]
+    count = min(count, len(t0_intfs))
+    indices = random.sample(list(range(len(t0_intfs))), k=count)
+    port_intfs = [t0_intfs[_] for _ in indices]
+    neighbor_devs = []
+    for intf in port_intfs:
+        pc_member = False
+        for pc in mg_facts['minigraph_portchannels']:
+            if intf in mg_facts['minigraph_portchannels'][pc]['members']:
+                neighbor_devs.append(pc)
+                pc_member = True
+                break
+        if not pc_member:
+            neighbor_devs.append(intf)
 
-    if 't0' in topo_type:
-        vlan_intf = mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]
-        prefix_len = vlan_intf['prefixlen']
-        vlan_addr = vlan_intf["addr"]
+    local_addrs = [ip_pattern.format(idx * 2) for idx in indices]
+    neighbor_addrs = [ip_pattern.format(idx * 2 + 1) for idx in indices]
+    neighbor_interfaces = [ptf_ports[_] for _ in indices]
 
-        is_backend_topology = mg_facts.get(constants.IS_BACKEND_TOPOLOGY_KEY, False)
-        if is_dualtor(tbinfo):
-            server_ips = mux_cable_server_ip(duthost)
-            vlan_intfs = natsort.natsorted(server_ips.keys())
-            neighbor_devs = [mg_facts["minigraph_ptf_indices"][_] for _ in vlan_intfs]
-            server_ip_key = "server_ipv6" if ipv6 else "server_ipv4"
-            neighbor_addrs = [server_ips[_][server_ip_key].split("/")[0] for _ in vlan_intfs]
-            neighbor_interfaces = neighbor_devs
-        else:
-            vlan_subnet = ipaddress.ip_network(vlan_intf['subnet'])
-            vlan = mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]['attachto']]
-            vlan_ports = vlan['members']
-            vlan_id = vlan['vlanid']
-            vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports]
-            neighbor_devs = vlan_ptf_ports
-            # backend topology use ethx.x(e.g. eth30.1000) during servers and T0 in ptf
-            # in other topology use ethx(e.g. eth30)
-            if is_backend_topology:
-                neighbor_interfaces = [str(dev) + constants.VLAN_SUB_INTERFACE_SEPARATOR + str(vlan_id) for dev in neighbor_devs]
-            else:
-                neighbor_interfaces = neighbor_devs
-            neighbor_addrs = [str(vlan_subnet[i + 2]) for i in range(len(neighbor_devs))]
-        count = min(count, len(neighbor_devs))
-        indices = random.sample(list(range(len(neighbor_devs))), k=count)
-        return [vlan_addr for _ in indices], prefix_len, [neighbor_addrs[_] for _ in indices], [neighbor_devs[_] for _ in indices], [neighbor_interfaces[_] for _ in indices]
-    elif 't1' in topo_type:
-        t1_ipv4_pattern = '101.0.0.{}'
-        t1_ipv6_pattern = '2000:2000::{:x}'
-        t0_intfs = get_t0_intfs(mg_facts)
-        ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in t0_intfs]
-        count = min(count, len(t0_intfs))
-        indices = random.sample(list(range(len(t0_intfs))), k=count)
+    return local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces
+
+
+def get_neighbors_scale(duthost, tbinfo, ipv6=False, scale_count=1):
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    t1_ipv4_pattern = '104.0.{}.{}'
+    t1_ipv6_pattern = '2002:2000::{:x}'
+    t0_intfs = get_t0_intfs(mg_facts)
+    ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in t0_intfs]
+    count = min(2, len(t0_intfs))
+    indices = random.sample(list(range(len(t0_intfs))), k=count)
+    port_intfs = [t0_intfs[_] for _ in indices]
+    neighbor_intfs = []
+    for intf in port_intfs:
+        pc_member = False
+        for pc in mg_facts['minigraph_portchannels']:
+            if intf in mg_facts['minigraph_portchannels'][pc]['members']:
+                neighbor_intfs.append(pc)
+                pc_member = True
+                break
+        if not pc_member:
+            neighbor_intfs.append(intf)
+    ptf_intfs = [ptf_ports[_] for _ in indices]
+    # local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces
+    local_addrs = []
+    neighbor_addrs = []
+    neighbor_devs = []
+    ptf_devs = []
+    index = 0
+    for idx in range(1, scale_count):
+        if idx != 0 and idx % 127 == 0:
+            index += 1
         if ipv6:
-            return [t1_ipv6_pattern.format(idx * 2) for idx in indices], 127, [t1_ipv6_pattern.format(idx * 2 + 1) for idx in indices], [t0_intfs[_] for _ in indices], [ptf_ports[_] for _ in indices]
+            local_addrs.append(t1_ipv6_pattern.format(idx * 2))
+            neighbor_addrs.append(t1_ipv6_pattern.format(idx * 2 + 1))
+            neighbor_devs.append(neighbor_intfs[index])
+            ptf_devs.append(ptf_intfs[index])
         else:
-            return [t1_ipv4_pattern.format(idx * 2) for idx in indices], 31, [t1_ipv4_pattern.format(idx * 2 + 1) for idx in indices], [t0_intfs[_] for _ in indices], [ptf_ports[_] for _ in indices]
+            rolloveridx = idx % 125
+            idx2 = idx // 125
+            local_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2))
+            neighbor_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2 + 1))
+            neighbor_devs.append(neighbor_intfs[index])
+            ptf_devs.append(ptf_intfs[index])
+    prefix = 127 if ipv6 else 31
+    return local_addrs, prefix, neighbor_addrs, neighbor_devs, ptf_devs
 
 
 def get_loopback_intf(mg_facts, ipv6):
@@ -97,7 +127,8 @@ def get_loopback_intf(mg_facts, ipv6):
     if ipv6:
         return mg_facts['minigraph_lo_interfaces'][ipv6idx]['addr']
     else:
-         return mg_facts['minigraph_lo_interfaces'][(ipv6idx+1) %2]['addr']
+        return mg_facts['minigraph_lo_interfaces'][(ipv6idx + 1) % 2]['addr']
+
 
 def get_neighbors_multihop(duthost, tbinfo, ipv6=False, count=1):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -105,33 +136,34 @@ def get_neighbors_multihop(duthost, tbinfo, ipv6=False, count=1):
     t0_ipv6_pattern = '3000:3000:{:x}::3000'
     t0_intfs = get_t0_intfs(mg_facts)
     ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in t0_intfs]
-    loopback_addr = get_loopback_intf( mg_facts, ipv6 )
+    loopback_addr = get_loopback_intf(mg_facts, ipv6)
 
     index = random.sample(list(range(len(t0_intfs))), k=1)[0]
     port_intf = t0_intfs[index]
     ptf_intf = ptf_ports[index]
     nexthop_ip = ""
     neighbour_dev_name = mg_facts['minigraph_neighbors'][port_intf]['name']
-    for bgpinfo in  mg_facts['minigraph_bgp']:
+    for bgpinfo in mg_facts['minigraph_bgp']:
         if bgpinfo['name'] == neighbour_dev_name:
-            nexthop_ip =  bgpinfo['addr']
-            if  ipv6 and ":" not in nexthop_ip :
+            nexthop_ip = bgpinfo['addr']
+            if ipv6 and ":" not in nexthop_ip:
                 nexthop_ip = ""
                 continue
             break
-    if nexthop_ip =="":
+    if nexthop_ip == "":
         assert False
     neighbor_addrs = []
-    idx2 =0
+    idx2 = 0
     for idx in range(1, count):
-        if idx %250 ==0:
-            idx2 +=1
+        if idx % 250 == 0:
+            idx2 += 1
         if ipv6:
             neighbor_addrs.append(t0_ipv6_pattern.format(idx))
         else:
-            neighbor_addrs.append(t0_ipv4_pattern.format((idx%250),idx2))
-    
+            neighbor_addrs.append(t0_ipv4_pattern.format((idx % 250), idx2))
+
     return loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs
+
 
 def init_ptf_bfd(ptfhost):
     ptfhost.shell("bfdd-beacon")
@@ -142,17 +174,27 @@ def stop_ptf_bfd(ptfhost):
 
 
 def add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=False):
+    cmd_buffer = ""
     for idx in range(len(neighbor_addrs)):
         if ipv6:
-            ptfhost.shell("ip -6 addr add {}/{} dev eth{}".format(neighbor_addrs[idx], prefix_len, neighbor_interfaces[idx]))
+            cmd_buffer += "ip -6 addr add {}/{} dev eth{} ;".format(neighbor_addrs[idx], prefix_len,
+                                                                    neighbor_interfaces[idx])
         else:
-            ptfhost.shell("ip addr add {}/{} dev eth{}".format(neighbor_addrs[idx], prefix_len, neighbor_interfaces[idx]))
+            cmd_buffer += "ip addr add {}/{} dev eth{} ;".format(neighbor_addrs[idx], prefix_len,
+                                                                 neighbor_interfaces[idx])
+        if idx % 50 == 0:
+            ptfhost.shell(cmd_buffer)
+            cmd_buffer = ""
+    if cmd_buffer != "":
+        ptfhost.shell(cmd_buffer)
 
 
 def del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=False):
+    cmd_buffer = ""
     for idx in range(len(neighbor_addrs)):
         if ipv6:
-            ptfhost.shell("ip -6 addr del {}/{} dev eth{}".format(neighbor_addrs[idx], prefix_len, neighbor_interfaces[idx]), module_ignore_errors=True)
+            cmd_buffer += "ip -6 addr del {}/{} dev eth{} ;".format(neighbor_addrs[idx], prefix_len,
+                                                                    neighbor_interfaces[idx])
         else:
             cmd_buffer += "ip addr del {}/{} dev eth{} ;".format(neighbor_addrs[idx], prefix_len,
                                                                  neighbor_interfaces[idx])
@@ -164,33 +206,44 @@ def del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=Fa
 
 
 def check_ptf_bfd_status(ptfhost, neighbor_addr, local_addr, expected_state):
-    bfd_state = ptfhost.shell("bfdd-control status local {} remote {}".format(neighbor_addr, local_addr))["stdout"].split("\n")
+    bfd_state = ptfhost.shell("bfdd-control status local {} remote {}"
+                              .format(neighbor_addr, local_addr))["stdout"].split("\n")
     for line in bfd_state:
         field = line.split('=')[0].strip()
         if field == "state":
-            assert line.split('=')[1].strip() == expected_state
+            assert expected_state in line.split('=')[1].strip()
 
 
 def check_dut_bfd_status(duthost, neighbor_addr, expected_state):
-    bfd_state = duthost.shell("sonic-db-cli STATE_DB HGET 'BFD_SESSION_TABLE|default|default|{}' 'state'".format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
-    assert bfd_state[0] == expected_state
+    bfd_state = duthost.shell("sonic-db-cli STATE_DB HGET 'BFD_SESSION_TABLE|default|default|{}' 'state'"
+                              .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
+    assert expected_state in bfd_state[0]
 
 
-def create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs):
+def create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, dut_init_first, scale_test=False):
     # Create a tempfile for BFD sessions
     bfd_file_dir = duthost.shell('mktemp')['stdout']
     bfd_config = []
+    ptf_buffer = ""
+    if scale_test:
+        # Force the PTF initialization to be first if running a scale test.
+        # Doing so that we can send batches of 50 commands to PTF and keep the code readable.
+        assert (dut_init_first is False)
 
     for idx, neighbor_addr in enumerate(neighbor_addrs):
-        duthost.shell("sonic-db-cli APPL_DB hmset 'BFD_SESSION_TABLE:default:default:{}' local_addr {}".format(neighbor_addr, local_addrs[idx]))
         bfd_config.append({
             "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
                 "local_addr": local_addrs[idx]
             },
             "OP": "SET"
         })
-        ptfhost.shell("bfdd-control connect local {} remote {}".format(neighbor_addr, local_addrs[idx]))
+        ptf_buffer += "bfdd-control connect local {} remote {} ; ".format(neighbor_addr, local_addrs[idx])
+        if scale_test and idx % 50 == 0:
+            ptfhost.shell(ptf_buffer)
+            ptf_buffer = ""
 
+    if not dut_init_first and ptf_buffer != "":
+        ptfhost.shell(ptf_buffer)
     # Copy json file to DUT
     duthost.copy(content=json.dumps(bfd_config, indent=4), dest=bfd_file_dir, verbose=False)
 
@@ -199,6 +252,9 @@ def create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs):
                            module_ignore_errors=True)
     if result['rc'] != 0:
         pytest.fail('Failed to apply BFD session configuration file: {}'.format(result['stderr']))
+    if dut_init_first:
+        ptfhost.shell(ptf_buffer)
+
 
 def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neighbor_addrs):
     # Create a tempfile for BFD sessions
@@ -210,16 +266,16 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
         bfd_config.append({
             "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
                 "local_addr": loopback_addr,
-                "multihop" : "true"
+                "multihop": "true"
             },
             "OP": "SET"
         })
         ptf_config.append(
             {
                 "neighbor_addr": loopback_addr,
-                "local_addr" : neighbor_addr,
-                "multihop" : "true",
-                "ptf_intf" : "eth{}".format(ptf_intf)
+                "local_addr": neighbor_addr,
+                "multihop": "true",
+                "ptf_intf": "eth{}".format(ptf_intf)
             }
         )
 
@@ -236,7 +292,7 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
 
     ptfhost.copy(src=BFD_RESPONDER_SCRIPT_SRC_PATH, dest=BFD_RESPONDER_SCRIPT_DEST_PATH)
 
-    extra_vars = {"bfd_responder_args" : "-c {}".format(ptf_file_dir)}
+    extra_vars = {"bfd_responder_args": "-c {}".format(ptf_file_dir)}
     ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
 
     ptfhost.template(src='templates/bfd_responder.conf.j2', dest='/etc/supervisor/conf.d/bfd_responder.conf')
@@ -244,13 +300,12 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
     ptfhost.command('supervisorctl update')
     ptfhost.command('supervisorctl start bfd_responder')
 
+
 def remove_bfd_sessions(duthost, neighbor_addrs):
     # Create a tempfile for BFD sessions
     bfd_file_dir = duthost.shell('mktemp')['stdout']
     bfd_config = []
-
     for idx, neighbor_addr in enumerate(neighbor_addrs):
-        duthost.shell("sonic-db-cli APPL_DB hmset 'BFD_SESSION_TABLE:default:default:{}' local_addr {}".format(neighbor_addr, local_addrs[idx]))
         bfd_config.append({
             "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
             },
@@ -271,74 +326,58 @@ def update_bfd_session_state(ptfhost, neighbor_addr, local_addr, state):
     ptfhost.shell("bfdd-control session local {} remote {} state {}".format(neighbor_addr, local_addr, state))
 
 
-@pytest.mark.skip(reason="Test may currently fail due to lack of hardware support")
-def test_bfd(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):
-    duthost = rand_selected_dut
-    bfd_session_cnt = 5
-    skip_201911_and_older(duthost)
-    local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces = get_neighbors(duthost, tbinfo, count = bfd_session_cnt)
+def update_bfd_state(ptfhost, neighbor_addr, local_addr, state):
+    ptfhost.shell("bfdd-control session local {} remote {} {}".format(neighbor_addr, local_addr, state))
 
+
+@pytest.mark.parametrize('dut_init_first', [True, False], ids=['dut_init_first', 'ptf_init_first'])
+@pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
+def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_first):
+    duthost = rand_selected_dut
+    bfd_session_cnt = int(request.config.getoption('--num_sessions'))
+    local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces = get_neighbors(duthost, tbinfo, ipv6,
+                                                                                                count=bfd_session_cnt)
     try:
-        if 't1' in tbinfo['topo']['name']:
-            add_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+        add_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
         init_ptf_bfd(ptfhost)
-        add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=False)
-        create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs)
+        add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+        create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, dut_init_first)
 
         time.sleep(1)
-
         for idx, neighbor_addr in enumerate(neighbor_addrs):
             check_dut_bfd_status(duthost, neighbor_addr, "Up")
             check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
 
         update_idx = random.choice(range(bfd_session_cnt))
-        update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[idx], "down")
+        update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "admin")
+        time.sleep(1)
 
-        for idx in range(bfd_session_cnt):
+        for idx, neighbor_addr in enumerate(neighbor_addrs):
             if idx == update_idx:
-                check_dut_bfd_status(duthost, neighbor_addr, "Down")
-                check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Down")
+                check_dut_bfd_status(duthost, neighbor_addr, "Admin_Down")
+                check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "AdminDown")
             else:
                 check_dut_bfd_status(duthost, neighbor_addr, "Up")
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
-    finally:
-        stop_ptf_bfd(ptfhost)
-        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
-        remove_bfd_sessions(duthost, neighbor_addrs)
-        remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
 
+        update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "up")
+        time.sleep(1)
 
-@pytest.mark.skip(reason="Test may currently fail due to lack of hardware support")
-def test_bfd_ipv6(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):
-    duthost = rand_selected_dut
-    bfd_session_cnt = 5
-    skip_201911_and_older(duthost)
-    local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces = get_neighbors(duthost, tbinfo, ipv6=True, count = bfd_session_cnt)
-
-    try:
-        if 't1' in tbinfo['topo']['name']:
-            add_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
-        init_ptf_bfd(ptfhost)
-        add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6=True)
-        create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs)
-
-       time.sleep(10)
-        bfd_state = ptfhost.shell("bfdd-control status")
-        dut_state = duthost.shell("show bfd summary")
-        for itr in local_addrs:
-            assert itr in bfd_state['stdout']
-            assert itr in dut_state['stdout']
+        check_dut_bfd_status(duthost, neighbor_addrs[update_idx], "Up")
+        check_ptf_bfd_status(ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "Up")
 
         update_idx = random.choice(range(bfd_session_cnt))
-        update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[idx], "down")
+        update_bfd_state(ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "suspend")
+        time.sleep(5)
 
-        for idx in range(bfd_session_cnt):
+        for idx, neighbor_addr in enumerate(neighbor_addrs):
             if idx == update_idx:
                 check_dut_bfd_status(duthost, neighbor_addr, "Down")
-                check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Down")
+                check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Init")
             else:
                 check_dut_bfd_status(duthost, neighbor_addr, "Up")
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up")
+
     finally:
         stop_ptf_bfd(ptfhost)
         del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
@@ -347,11 +386,41 @@ def test_bfd_ipv6(rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports
 
 
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
-def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):
+def test_bfd_scale(request, rand_selected_dut, ptfhost, tbinfo, ipv6):
+    duthost = rand_selected_dut
+    bfd_session_cnt = int(request.config.getoption('--num_sessions_scale'))
+    local_addrs, prefix_len, neighbor_addrs, neighbor_devs, neighbor_interfaces = \
+        get_neighbors_scale(duthost, tbinfo, ipv6, scale_count=bfd_session_cnt)
+
+    try:
+        add_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+        init_ptf_bfd(ptfhost)
+        add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+        create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, False, True)
+
+        time.sleep(10)
+        bfd_state = ptfhost.shell("bfdd-control status")
+        dut_state = duthost.shell("show bfd summary")
+        for itr in local_addrs:
+            assert itr in bfd_state['stdout']
+            assert itr in dut_state['stdout']
+
+    finally:
+        time.sleep(10)
+        stop_ptf_bfd(ptfhost)
+        del_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+        remove_bfd_sessions(duthost, neighbor_addrs)
+        remove_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
+
+
+@pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
+def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
+                      toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):    # noqa F811
     duthost = rand_selected_dut
 
     bfd_session_cnt = int(request.config.getoption('--num_sessions'))
-    loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs = get_neighbors_multihop(duthost, tbinfo, ipv6, count = bfd_session_cnt)
+    loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs = get_neighbors_multihop(duthost, tbinfo, ipv6,
+                                                                                 count=bfd_session_cnt)
     try:
         cmd_buffer = ""
         for neighbor in neighbor_addrs:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -17,6 +17,16 @@ arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
     reason: "`accept_untracked_na` currently only available in 202012"
     conditions:
       - "release not in ['202012']"
+
+#######################################
+#####            bfd              #####
+#######################################
+bfd/test_bfd.py:
+  skip:
+    reason: "Test not supported for 201911 images or older, other than mlnx4600c and cosco-8102. Skipping the test"
+    conditions:
+      - "(kernel_version <= '4.9.0') or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
+
 #######################################
 #####            bgp              #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -17,7 +17,6 @@ arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
     reason: "`accept_untracked_na` currently only available in 202012"
     conditions:
       - "release not in ['202012']"
-
 #######################################
 #####            bgp              #####
 #######################################

--- a/tests/templates/bfd_responder.conf.j2
+++ b/tests/templates/bfd_responder.conf.j2
@@ -1,0 +1,10 @@
+[program:bfd_responder]
+command=/usr/bin/python /opt/bfd_responder.py {{ bfd_responder_args }}
+process_name=bfd_responder
+stdout_logfile=/tmp/bfd_responder.out.log
+stderr_logfile=/tmp/bfd_responder.err.log
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1


### PR DESCRIPTION
Cherry-pick of PR #6032 for 202012



Summary:
The openBFDD being used to verify BFD functionality in sonic does not support multi-hop BFD sessions.
This PR adds a script that acts as a responder and initiator of BFD multi-hop sessions. This script is used by a new bfd multi-hop test added in the existing test suite.
