### PR TITLE
Remove ping_all_neighbors since neighbor can be pinged only from the …

### DIFF
--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -681,7 +681,6 @@ def check_arptable_mac(host, asic, neighbor, mac, checkstate=True):
 
 def check_arptable_state_for_nbrs(host, asic, neighbors, state):
     logger.info("Checking arp table state {} of nbr {} on {}".format(state, neighbors, asic))
-    #sonic_ping(asic, neighbor, verbose=True)
     arptable = asic.switch_arptable()['ansible_facts']
 
     for neighbor in neighbors:
@@ -786,10 +785,6 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             logger.info("Verify neighbor after mac change: %s, port %s", neighbor, local_port)
             check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
 
-        logger.info("Ping neighbors: %s from all line cards", nbr_to_test)
-
-        ping_all_neighbors(duthosts, all_cfg_facts, nbr_to_test)
-
     finally:
         logger.info("-" * 60)
         logger.info("Will Restore ethernet mac on port %s, vm %s", nbrinfo['shell_intf'], nbrinfo['vm'])
@@ -807,7 +802,6 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
 
         dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, nbr_to_test, nbrhosts, all_cfg_facts, nbr_macs)
 
-    ping_all_neighbors(duthosts, all_cfg_facts, nbr_to_test)
 
 
 class LinkFlap(object):
@@ -1217,4 +1211,4 @@ class TestGratArp(object):
                               "MAC {} didn't change in ARP table".format(original_mac))
 
             check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
-            ping_all_neighbors(duthosts, all_cfg_facts, [neighbor])
+

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -1194,7 +1194,6 @@ class TestGratArp(object):
                 pytest_assert(wait_until(60, 2, 0, check_arptable_mac, duthost, asic, neighbor, NEW_MAC, checkstate=True),
                               "MAC {} didn't change in ARP table of neighbor {}".format(NEW_MAC, neighbor))
                 check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
-                ping_all_neighbors(duthosts, all_cfg_facts, [neighbor])
             finally:
                 logger.info("Will Restore ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
                             nbrinfo['shell_intf'], nbrinfo['vm'])


### PR DESCRIPTION
…connected ASIC when eBGP is down

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
test_neighbor_hw_mac_change and test_gratarp_macchange testcases try to ping_all_neighbors from all the asics but ping fails because eBGP to the neighbor is down.
A neighbor can be pinged only from the connected ASIC when eBGP is down and this is already done in the same testcases.0
Therefore, Removing ping_all_neighbors from both testcases.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Remove ping_all_neighbors since neighbor can be pinged only from the connected ASIC when eBGP is down.

#### How did you do it?
Removed ping_all_neighbors from test_neighbor_hw_mac_change testcase.
Removed ping_all_neighbors from test_gratarp_macchange testcase.

#### How did you verify/test it?
Tested test_neighbor_hw_mac_change and test_gratarp_macchange in a multi ASIC chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
