### PR TITLE
Fix regular matching feature 'p4rt' failed in test_container_autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -22,7 +22,7 @@ pytestmark = [
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 60
 CONTAINER_RESTART_THRESHOLD_SECS = 300
-CONTAINER_NAME_REGEX = (r"([a-zA-Z_-]+)(\d*)$")
+CONTAINER_NAME_REGEX = r"([a-zA-Z_-]+)(\d*)([a-zA-Z_-]+)(\d*)$"
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
 
@@ -379,8 +379,8 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
 
-    # bgp0 -> bgp, bgp -> bgp
-    feature_name = re.match(CONTAINER_NAME_REGEX, container_name).group(1)
+    # bgp0 -> bgp, bgp -> bgp, p4rt -> p4rt
+    feature_name = ''.join(re.match(CONTAINER_NAME_REGEX, container_name).groups()[:-1])
 
     # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
     pytest_require(feature_name not in skip_condition,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

To support multi-ASIC platform, the script used regular match to get feature name, like bgp0 -> bgp, but did not work for p4rt. In this PR, modify the regular expression to support service name that has digit in middle like p4rt.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

To support multi-ASIC platform, the script used regular match to get feature name, like bgp0 -> bgp, but did not work for p4rt. In this PR, modify the regular expression to support service name that has digit in middle like p4rt.

#### How did you do it?

1. Modify CONTAINER_NAME_REGEX from `r"([a-zA-Z_-]+)(\d*)$"` to `r"([a-zA-Z_-]+)(\d*)([a-zA-Z_-]+)(\d*)$"`
2. Then feature name can get from `''.join(re_match_result.groups()[:-1])`

#### How did you verify/test it?

Write a test case and get expected result.

```
--------------------
('input_container_name: ', 'syncd')
('output_feature_name: ', 'syncd')
--------------------
('input_container_name: ', 'syncd13')
('output_feature_name: ', 'syncd')
--------------------
('input_container_name: ', 'p4rt')
('output_feature_name: ', 'p4rt')
--------------------
('input_container_name: ', 'p4rt0')
('output_feature_name: ', 'p4rt')
--------------------
('input_container_name: ', 'bgp0')
('output_feature_name: ', 'bgp')
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
