### PR TITLE
Change config reload file to running_golden_config in test_container_autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -31,7 +31,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     yield
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index,

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -48,7 +48,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
     """
     reload SONiC configuration
     :param duthost: DUT host object
-    :param config_source: configuration source either 'config_db' or 'minigraph'
+    :param config_source: configuration source is 'config_db', 'minigraph' or 'running_golden_config'
     :param wait: wait timeout for DUT to initialize after configuration reload
     :return:
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Since PR(https://github.com/sonic-net/sonic-mgmt/pull/6731), we support config reload from running_golden_config. And before all test cases started, running_golden_config would be dumped. So after all test cases finished, reload from the same golden config.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Since PR(https://github.com/sonic-net/sonic-mgmt/pull/6731), we Support config reload from running_golden_config. And before all test cases started, running_golden_config would be dumped. So after all test cases finished, reload from the same golden config.

#### How did you do it?

Add parameter config_source='running_golden_config' to method config_reload().

#### How did you verify/test it?

Run TC and TC passed, core dump and config check also passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
