### PR TITLE
Fix `test_active_tor_reboot_downstream`

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -162,7 +162,7 @@ def mux_status_from_nic_simulator(duthost, nic_simulator_client, mux_config, tbi
             nic_addresses=nic_addresses,
             admin_requests=admin_requests[:len(nic_addresses)]
         )
-        call_grpc(client_stub.QueryAdminForwardingPortState, [request])
+        reply = call_grpc(client_stub.QueryAdminForwardingPortState, [request])
 
         mux_status = {}
         for port, port_status in zip(ports, reply.admin_replies):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the error in `test_active_tor_reboot_downstream`:
```
  File "/azp/agent/_work/2/s/tests/common/dualtor/nic_simulator_control.py", line 169, in _get_mux_status
    for port, port_status in zip(ports, reply.admin_replies):
NameError: global name 'reply' is not defined
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
```
dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream[active-active] PASSED                                                                                                                                                                                [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
