### PR TITLE
Adding support for generating cvs file for report

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -36,6 +36,8 @@ import defusedxml.ElementTree as ET
 
 
 TEST_REPORT_CLIENT_VERSION = (1, 1, 0)
+REPORT_LIST = list()
+REPORT_LIST.append("Script Name, Total, Pass, Fail, Skip, Error, XFail, Time")
 
 MAXIMUM_XML_SIZE = 20e7  # 20MB
 MAXIMUM_SUMMARY_SIZE = 1024  # 1MB
@@ -282,6 +284,7 @@ def _validate_test_metadata(root):
     if set(seen_properties) < set(REQUIRED_METADATA_PROPERTIES):
         raise JUnitXMLValidationError("missing metadata element(s)")
 
+
 def _validate_test_case_properties(root):
     testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
 
@@ -315,6 +318,7 @@ def _validate_test_case_properties(root):
     missing_testcase_property = set(seen_testcase_properties) < set(REQUIRED_TESTCASE_PROPERTIES)
     if missing_testcase_property:
         print("missing testcase property: {}".format(list(missing_testcase_property)))
+
 
 def _validate_test_cases(root):
     def _validate_test_case(test_case):
@@ -369,7 +373,7 @@ def _extract_test_summary(test_cases):
     test_result_summary = defaultdict(int)
     for _, cases in test_cases.items():
         for case in cases:
-            # Error may occur along with other test results, to count error separately. 
+            # Error may occur along with other test results, to count error separately.
             # The result field is unique per test case, either error or failure.
             # xfails is the counter for all kinds of xfail results (include success/failure/error/skipped)
             test_result_summary["tests"] += 1
@@ -383,6 +387,18 @@ def _extract_test_summary(test_cases):
                                              case["result"] == "xfail_success"
 
     test_result_summary = {k: str(v) for k, v in test_result_summary.items()}
+    total = int(test_result_summary["failures"]) + int(test_result_summary["skipped"]) \
+          + int(test_result_summary["errors"]) + int(test_result_summary["xfails"])
+    passed = int(test_result_summary["tests"]) - int(total)
+    passed = max(0, passed)
+    if case is None:
+        return test_result_summary
+    name = case['file']
+    REPORT_LIST.append("{}, {}, {}, {}, {}, {}, {}, {}".
+                         format(name, test_result_summary["tests"],
+                         passed, test_result_summary["failures"],
+                         test_result_summary["skipped"], test_result_summary["errors"],
+                         test_result_summary["xfails"], test_result_summary["time"]))
     return test_result_summary
 
 
@@ -399,6 +415,7 @@ def _parse_test_metadata(root):
 
     return test_result_metadata
 
+
 def _parse_testcase_properties(root):
     testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
 
@@ -411,6 +428,7 @@ def _parse_testcase_properties(root):
             testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
 
     return testcase_properties
+
 
 def _parse_test_cases(root):
     test_case_results = defaultdict(list)
@@ -690,6 +708,17 @@ python3 junit_xml_parser.py tests/files/sample_tr.xml
             output_file.write(output)
     else:
         print(output)
+
+    tstamp = datetime.now().strftime("%d-%b-%Y-%H:%M:%S.%f")
+
+    if args.output_file:
+        csv_file = open('report_{}_{}.csv'.format(args.output_file.split('.')[0], tstamp), "w+")
+    else:
+        csv_file = open('report_{}.csv'.format(tstamp), "w+")
+
+    for test in REPORT_LIST:
+        csv_file.write(test+'\n')
+    csv_file.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of PR
Adding support to generate csv based report file. The report generate will calculate Total, Pass, Fail, Skip, Error, XFail, Time and provide an easy way to see per script details

E.g.:
Script Name, Total, Pass, Fail, Skip, Error, XFail, Time
syslog/test_syslog_source_ip.py, 28, 0, 0, 28, 0, 0, 59.868999999999986
console/test_console_reversessh.py, 4, 0, 0, 4, 0, 0, 57.82900000000001
ixia/test_tgen.py, 1, 0, 0, 1, 0, 0, 0.001
arp/test_arp_extended.py, 6, 0, 0, 6, 0, 0, 0.002
snappi/pfc/test_pfc_pause_lossy_with_snappi.py, 8, 0, 0, 8, 0, 0, 0.001
generic_config_updater/test_cacl.py, 2, 0, 0, 2, 0, 0, 0.001
platform_tests/test_sensors.py, 1, 0, 0, 1, 0, 0, 56.24
platform_tests/test_thermal_state_db.py, 3, 2, 1, 0, 0, 0, 72.663
generic_config_updater/test_vlan_interface.py, 2, 0, 0, 2, 0, 0, 0.0

Generate both the json file and csv file:
-rw-rw-r--  1 rraghav rraghav   16929 Nov  7 09:20 report_2448_result_07-Nov-2022-09:20:07.767159.csv
-rw-rw-r--  1 rraghav rraghav 2005118 Nov  7 09:20 2448_result.json

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [X] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Adding support to generate csv based report file. The report generate will calculate Total, Pass, Fail, Skip, Error, XFail, Time and provide an easy way to see per script details

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
