### PR TITLE
Use conditional mark to skip testcase instead of required_mocked_dualtor

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -12,7 +12,6 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 
 __all__ = [
-    'require_mocked_dualtor',
     'apply_active_state_to_orchagent',
     'apply_dual_tor_neigh_entries',
     'apply_dual_tor_peer_switch_route',
@@ -137,12 +136,6 @@ def _apply_dual_tor_state_to_orchagent(dut, state, tor_mux_intfs):
 
 def is_mocked_dualtor(tbinfo):
     return 'dualtor' not in tbinfo['topo']['name']
-
-
-@pytest.fixture
-def require_mocked_dualtor(tbinfo):
-    pytest_require(is_t0_mocked_dualtor(tbinfo), "This testcase is designed for "
-        "single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed")
 
 
 def set_mux_state(dut, tbinfo, state, itfs, toggle_all_simulator_ports):

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -8,7 +8,7 @@ from ipaddress import ip_interface, IPv4Interface, IPv6Interface, \
                       ip_address, IPv4Address
 from tests.common import config_reload
 from tests.common.dualtor.dual_tor_utils import tor_mux_intfs
-from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 
 __all__ = [

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -245,6 +245,12 @@ dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bg
     conditions:
       - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
 
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0'])"
+
 dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby:
   skip:
     reason: "This testcase is designed for single tor testbed with mock dualtor config."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -209,11 +209,63 @@ drop_packets:
 #######################################
 #####           dualtor           #####
 #######################################
+dualtor/test_orch_stress.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_active_tor_downstream.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_mac_move.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
+
 dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
   xfail:
     reason: "Image issue on Boradcom platforms, but not consistently failing"
     conditions:
       - "asic_type in ['broadcom']"
+
+dualtor/test_standby_tor_upstream_mux_toggle.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    conditions:
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
 
 #######################################
 #####         dut_console         #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -247,7 +247,7 @@ dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bg
 
 dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded:
   skip:
-    reason: "This testcase is designed for single tor testbed with mock dualtor config."
+    reason: "This testcase is designed for single tor testbed with mock dualtor config and dualtor."
     conditions:
       - "(topo_type not in ['t0'])"
 

--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -147,7 +147,6 @@ def config_crm_polling_interval(rand_selected_dut):
 
 
 def test_change_mux_state(
-        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,
@@ -215,7 +214,6 @@ def add_neighbors(dut, neighbors, interface):
 
 
 def test_flap_neighbor_entry_active(
-        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,
@@ -249,7 +247,6 @@ def test_flap_neighbor_entry_active(
 
 
 def test_flap_neighbor_entry_standby(
-        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -65,8 +65,7 @@ def neighbor_reachable(duthost, neighbor_ip):
 
 def test_active_tor_remove_neighbor_downstream_active(
     conn_graph_facts, ptfadapter, ptfhost, testbed_setup,
-    rand_selected_dut, tbinfo,
-    require_mocked_dualtor, set_crm_polling_interval,
+    rand_selected_dut, tbinfo, set_crm_polling_interval,
     tunnel_traffic_monitor, vmhost
 ):
     """
@@ -139,8 +138,7 @@ def test_active_tor_remove_neighbor_downstream_active(
 
 def test_downstream_ecmp_nexthops(
     ptfadapter, rand_selected_dut, tbinfo,
-    require_mocked_dualtor, toggle_all_simulator_ports,
-    tor_mux_intfs, ip_version
+    toggle_all_simulator_ports, tor_mux_intfs, ip_version
     ):
     nexthops_count = 4
     set_mux_state(rand_selected_dut, tbinfo, 'active', tor_mux_intfs, toggle_all_simulator_ports)

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -81,7 +81,6 @@ def enable_garp(duthost):
 
 
 def test_mac_move(
-    require_mocked_dualtor,
     announce_new_neighbor, apply_active_state_to_orchagent,
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, set_crm_polling_interval,

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -128,7 +128,7 @@ def shutdown_one_bgp_session(rand_selected_dut):
     startup_bgp_session(rand_selected_dut, bgp_shutdown)
 
 
-def test_standby_tor_downstream(rand_selected_dut, require_mocked_dualtor, get_testbed_params):
+def test_standby_tor_downstream(rand_selected_dut, get_testbed_params):
     """
     Verify tunnel traffic to active ToR is distributed equally across nexthops, and
     no traffic is forwarded to server from standby ToR
@@ -138,8 +138,7 @@ def test_standby_tor_downstream(rand_selected_dut, require_mocked_dualtor, get_t
 
 
 def test_standby_tor_downstream_t1_link_recovered(
-    rand_selected_dut, require_mocked_dualtor,
-    verify_crm_nexthop_counter_not_increased, tbinfo, get_testbed_params
+    rand_selected_dut, verify_crm_nexthop_counter_not_increased, tbinfo, get_testbed_params
 ):
     """
     Verify traffic is distributed evenly after t1 link is recovered;
@@ -167,7 +166,7 @@ def test_standby_tor_downstream_t1_link_recovered(
 
 
 def test_standby_tor_downstream_bgp_recovered(
-    rand_selected_dut, require_mocked_dualtor, verify_crm_nexthop_counter_not_increased,
+    rand_selected_dut, verify_crm_nexthop_counter_not_increased,
     get_testbed_params, tbinfo
 ):
     """
@@ -253,8 +252,8 @@ def test_standby_tor_downstream_loopback_route_readded(
 def test_standby_tor_remove_neighbor_downstream_standby(
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, rand_unselected_dut, tbinfo,
-    require_mocked_dualtor, set_crm_polling_interval,
-    tunnel_traffic_monitor, vmhost, get_testbed_params,  # noqa: F811
+    set_crm_polling_interval, tunnel_traffic_monitor,  # noqa: F811
+    vmhost, get_testbed_params,
     ip_version
 ):
     """
@@ -310,8 +309,8 @@ def test_standby_tor_remove_neighbor_downstream_standby(
 def test_downstream_standby_mux_toggle_active(
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, rand_unselected_dut, tbinfo,
-    require_mocked_dualtor, tunnel_traffic_monitor,  # noqa: F811
-    vmhost, toggle_all_simulator_ports, tor_mux_intfs,  # noqa: F811
+    tunnel_traffic_monitor, vmhost,  # noqa: F811
+    toggle_all_simulator_ports, tor_mux_intfs,  # noqa: F811
     ip_version, get_testbed_params
 ):
     # set rand_selected_dut as standby and rand_unselected_dut to active tor

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -19,7 +19,6 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa:
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder  # noqa: F401 # lgtm[py/unused-import]
-from tests.common.helpers.assertions import pytest_require as pt_require
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor  # noqa: F401
 from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
@@ -174,8 +173,6 @@ def test_standby_tor_downstream_bgp_recovered(
     Verify traffic is distributed evenly after BGP session is recovered;
     Verify CRM that no new nexthop created
     """
-    # require real dualtor, because for mocked testbed, the route to standby is mocked.
-    pt_require('dualtor' in tbinfo['topo']['name'], "Only run on dualtor testbed")
     PAUSE_TIME = 30
 
     down_bgp = shutdown_random_one_bgp_session(rand_selected_dut)
@@ -224,7 +221,6 @@ def test_standby_tor_downstream_loopback_route_readded(
     """
     Verify traffic is equally distributed via loopback route
     """
-    pt_require('dualtor' in tbinfo['topo']['name'], "Only run on dualtor testbed")
     params = get_testbed_params()
     active_tor_loopback0 = params['active_tor_ip']
 

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -31,7 +31,7 @@ def test_cleanup(rand_selected_dut):
 
 def test_standby_tor_upstream_mux_toggle(
     rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,
-    require_mocked_dualtor, toggle_all_simulator_ports, set_crm_polling_interval):
+    toggle_all_simulator_ports, set_crm_polling_interval):
     itfs, ip = rand_selected_interface
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented
@@ -77,5 +77,3 @@ def test_standby_tor_upstream_mux_toggle(
     crm_facts1 = rand_selected_dut.get_crm_facts()
     unmatched_crm_facts = compare_crm_facts(crm_facts0, crm_facts1)
     pt_assert(len(unmatched_crm_facts)==0, 'Unmatched CRM facts: {}'.format(json.dumps(unmatched_crm_facts, indent=4)))
-
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, we use required_mocked_dualtor to skip testcases in real dualtor under `tests/dualtor/`, but it's not efficient enough, and will cause show mux status error after toggle.
#### How did you do it?
Use conditional mark to skip testcase instead of required mocked dualtor
#### How did you verify/test it?
Run tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
