### PR TITLE
Move skip check from test script to tests_mark_conditions.yaml for some dualtor cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -209,11 +209,59 @@ drop_packets:
 #######################################
 #####           dualtor           #####
 #######################################
+dualtor/test_orch_stress.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_orchagent_active_tor_downstream.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_orchagent_mac_move.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
 dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active:
   xfail:
     reason: "Image issue on Boradcom platforms, but not consistently failing"
     conditions:
       - "asic_type in ['broadcom']"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
+
+dualtor/test_standby_tor_upstream_mux_toggle.py:
+  skip:
+    reason: "This testcase is designed for single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed"
+    conditions:
+      - "topo_type == 't0' and 'dualtor' in topo_name"
 
 #######################################
 #####         dut_console         #####


### PR DESCRIPTION


Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some test cases under dualtor are skipped on real dualtor testbed, but it still cost more than 10 mins to run fixtures and skip them.
Move these cases from script to tests_mark_conditions.yaml for saving time.
```
2022-10-27T11:03:36.5388747Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv4] SKIPPED [  8%]
2022-10-27T11:03:54.5874265Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv6] SKIPPED [ 16%]
2022-10-27T11:04:13.7323174Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv4] SKIPPED [ 25%]
2022-10-27T11:04:32.4420177Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv6] SKIPPED [ 33%]
2022-10-27T11:04:50.8079190Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv4] SKIPPED [ 41%]
2022-10-27T11:05:08.9424230Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv6] SKIPPED [ 50%]
2022-10-27T11:17:07.0091078Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv4] PASSED [ 58%]
2022-10-27T11:29:54.7414890Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv6] PASSED [ 66%]
2022-10-27T11:30:21.0160615Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv4] SKIPPED [ 75%]
2022-10-27T11:30:36.7692504Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv6] SKIPPED [ 83%]
2022-10-27T11:30:52.1305547Z dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv4] SKIPPED [ 91%]
2022-10-27T11:31:18.5181611Z dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv6] SKIPPED [100%]
```

#### How did you do it?
Move these skipped cases:
```
dualtor.test_orch_stress.test_change_mux_state
dualtor.test_orch_stress.test_flap_neighbor_entry_active
dualtor.test_orch_stress.test_flap_neighbor_entry_standby
dualtor.test_orchagent_active_tor_downstream.test_active_tor_remove_neighbor_downstream_active[ipv4]
dualtor.test_orchagent_active_tor_downstream.test_active_tor_remove_neighbor_downstream_active[ipv6]
dualtor.test_orchagent_active_tor_downstream.test_downstream_ecmp_nexthops[ipv4]
dualtor.test_orchagent_active_tor_downstream.test_downstream_ecmp_nexthops[ipv6]
dualtor.test_orchagent_mac_move.test_mac_move
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream[ipv4]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream[ipv6]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream_bgp_recovered[ipv4]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream_bgp_recovered[ipv6]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream_t1_link_recovered[ipv4]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_downstream_t1_link_recovered[ipv6]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_remove_neighbor_downstream_standby[ipv4]
dualtor.test_orchagent_standby_tor_downstream.test_standby_tor_remove_neighbor_downstream_standby[ipv6]
dualtor.test_standby_tor_upstream_mux_toggle.test_standby_tor_upstream_mux_toggle
```


#### How did you verify/test it?
Run related dualtor cases

```
dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby SKIPPED                                                                                                      [ 33%]
dualtor/test_orch_stress.py::test_flap_neighbor_entry_active SKIPPED                                                                                            [ 66%]
dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby SKIPPED                                                                                           [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
