### PR TITLE
Skip everflow/test_everflow_interfaces for multi-asic due to sonic-buildimage issue#11776

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -341,8 +341,12 @@ ecmp/test_fgnhg.py:
 #######################################
 everflow/test_everflow_per_interface.py:
   skip:
-    reason: "Skip running on unsupported platforms."
+    reason: "Skip running on dualtor testbed/unsupported platforms or 
+                  multi-asic due to https://github.com/sonic-net/sonic-buildimage/issues/11776"
+    conditions_logical_operator: or
     conditions:
+      - "'dualtor' in topo_name"
+      - "is_multi_asic==True"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -346,8 +346,8 @@ everflow/test_everflow_per_interface.py:
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
-      - "is_multi_asic==True"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
+      - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

'test_everflow_per_interface' test case fails on multi-asic line cards due to the sonic-buildimage issue #11776. This PR adds the test case to the skipped list for multi-asic line cards.

Summary:
Fixes # (issue)
This PR addresses the following:
- Skip 'everflow/test_everflow_per_interface.py' test case for multi-asic line cards, due to the sonic-buildimage issue #11776

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently for multi-asic line cards, 'everflow/test_everflow_per_interface.py' fails due to the sonic-buildimage issue #11776.
Hence, 'everflow/test_everflow_per_interface.py' test case needs to be skipped with this known issue.

#### How did you do it?
- Added 'everflow/test_everflow_per_interface.py' test case in SKIPPED list for multi-asic line cards.

#### How did you verify/test it?
Ran the tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
