### PR TITLE
Added back correct ixia/pfc import statements that were removed

### DIFF
--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -4,6 +4,12 @@ import pytest
 from files.helper import run_pfc_test
 from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts
+from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
+    ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
+from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+    lossy_prio_list
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot


### PR DESCRIPTION
Signed-off-by: dojha <devojha@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Added back the correct import statements of pytest fixtures that were removed earlier from #5928 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
When running ixia test cases in test_pfc_pause_lossless.py, the tests were failing due to missing imports
#### How did you do it?
Added import statements
#### How did you verify/test it?
Ran ixia tests on DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
