### PR TITLE
Adding watchdog timeout values for Cisco 8808 Supervisor and Different LCs

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -95,3 +95,21 @@ x86_64-8102_64h_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+x86_64-8800_rp_o-r0:    
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-88_lc0_36fh_mo-r0:    
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-8800_lc_48h_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -113,3 +113,4 @@ x86_64-8800_lc_48h_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+    


### PR DESCRIPTION
### Description of PR
Adding watchdog timeout values for Cisco 8808 Supervisor and Different LCs

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Adding watchdog timeout values for Cisco 8808 Supervisor and Different LCs

#### How did you do it?

#### How did you verify/test it?
Verified on Cisco platform for T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
