### PR TITLE
[BGP] Stablize `test_bgp_update_timer` on dualtor testbeds

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -267,6 +267,9 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
             for conn in connections:
                 ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"],
                                                   conn["neighbor_addr"]))
+                # NOTE: this enables the standby ToR to passively learn
+                # all the neighbors configured on the ptf interfaces
+                ptfhost.shell("arping %s -S %s -C 5" % (vlan_intf_addr, conn["neighbor_addr"].split("/")[0]), module_ignore_errors=True)
             ptfhost.shell("ip route add %s via %s" % (loopback_intf_addr, vlan_intf_addr))
             yield connections
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -9,6 +9,7 @@ import time
 from scapy.all import sniff, IP
 from scapy.contrib import bgp
 from tests.common.helpers.bgp import BGPNeighbor
+from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.mux_simulator_control import mux_server_url
@@ -199,6 +200,16 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
         else:
             return False
 
+    def is_neighbor_sessions_established(duthost, neighbors):
+        is_established = True
+
+        # handle both multi-sic and single-asic
+        bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]
+        for neighbor in neighbors:
+            is_established &= neighbor.ip in bgp_facts["bgp_neighbors"] and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
+
+        return is_established
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     n0, n1 = common_setup_teardown
@@ -206,16 +217,9 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
         n0.start_session()
         n1.start_session()
 
-        # sleep till new sessions are steady
-        time.sleep(60)
-
         # ensure new sessions are ready
-        # handle both multi-sic and single-asic
-        bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]
-        assert n0.ip in bgp_facts["bgp_neighbors"]
-        assert n1.ip in bgp_facts["bgp_neighbors"]
-        assert bgp_facts["bgp_neighbors"][n0.ip]["state"] == "established"
-        assert bgp_facts["bgp_neighbors"][n1.ip]["state"] == "established"
+        if not wait_until(90, 5, 20, lambda: is_neighbor_sessions_established(duthost, (n0, n1))):
+            pytest.fail("Could not establish bgp sessions")
 
         announce_intervals = []
         withdraw_intervals = []
@@ -229,6 +233,7 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
 
             with tempfile.NamedTemporaryFile() as tmp_pcap:
                 duthost.fetch(src=bgp_pcap, dest=tmp_pcap.name, flat=True)
+                duthost.file(path=bgp_pcap, state="absent")
                 bgp_updates = bgp_update_packets(tmp_pcap.name)
 
             announce_from_n0_to_dut = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Stablize `test_bgp_update_timer` on dualtor testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. use `wait_until` to wait for BGP session establishment
2. let the ptfhost arping the vlan address to let the standby ToR learn all the addresses configured on the ptf. This is to facilitate the standby to establish bgp connections to those ptf addresses.
3. remove the saved pcap files

#### How did you verify/test it?
Run on dualtor testbed with image `202205.10`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
