### PR TITLE
Add the missing conditions for test_set_fans_led

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -504,7 +504,8 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000']"
   xfail:
-    reason:
+    reason: "Testcase consistently fails on Celestica, raised issue to track"
+    conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR #6519 , missed the conditions for test_set_fans_led. It will xfail on all platforms.
If no conditions defined, the default add_mark value is True for this case, here for reference: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/plugins/conditional_mark/__init__.py#:~:text=%23%20Unconditionally%20add%20mark,add_mark%20%3D%20True

#### How did you do it?
Add conditions back.

#### How did you verify/test it?
run `platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led
`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
