### PR TITLE
Fix `set_drop_active_active` teardown failure

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -286,5 +286,4 @@ def set_drop_active_active(mux_config, nic_simulator_client):
             "Set drop recover on port %s, mux server %s, portid %s",
             interface_name, nic_address, portid,
         )
-
-    _call_set_drop_nic_simulator(_nic_addresses, _portids, _directions, recover=True)
+        _call_set_drop_nic_simulator(_nic_addresses, _portids, _directions, recover=True)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
fix `set_drop_active_active` teardown failure

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
call `_call_set_drop_nic_simulator` in the loop.

#### How did you verify/test it?
run `test_link_drop` on dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
