### PR TITLE
Fix port mapping between PTF docker and DUT for chassis

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -16,7 +16,7 @@ class TrafficPorts(object):
         """
         self.mg_facts = mg_facts
         self.bgp_info = self.mg_facts['minigraph_bgp']
-        self.port_idx_info = self.mg_facts['minigraph_port_indices']
+        self.port_idx_info = self.mg_facts['minigraph_ptf_indices']
         self.pc_info = self.mg_facts['minigraph_portchannels']
         self.vlan_info = self.mg_facts['minigraph_vlans']
         self.neighbors = neighbors


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Port mapping between PTF docker and DUT is incorrect for chassis.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To fix port mapping between PTF docker and DUT

#### How did you do it?
port index will be picked from minigraph_ptf_indices instead of minigraph_port_indices as this one will have chassis view.

#### How did you verify/test it?
Verified on SONIC based chassis system.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
