### PR TITLE
Removing ip-proto from hash_keys for Cisco-8000 Distributed Chassis

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -173,6 +173,10 @@ def hash_keys(duthost):
     if duthost.facts['asic_type'] in ["innovium"]:
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')
+    # removing ip-proto from hash_keys for Cisco-8000 Distributed Chassis
+    if duthost.facts['platform'] in ['x86_64-8800_rp_o-r0', 'x86_64-88_lc0_36fh_mo-r0', 'x86_64-8800_lc_48h_o-r0']:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic


### PR DESCRIPTION
### Description of PR
In case of ip-proto hashing key in test_fib.py::test_hash, we have observed that the protocol by itself doesn’t contain enough entropy for proper distribution using the hashing logic. So for Cisco-8000 Distributed Chassis with T2 profile, we are skipping ip-proto hashing key.

Summary:
Fixes # (issue)

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In case of ip-proto hashing key in test_fib.py::test_hash, we have observed that the protocol by itself doesn’t contain enough entropy for proper distribution using the hashing logic. 

#### How did you do it?
For Cisco-8000 Distributed Chassis with T2 profile, we are skipping ip-proto hashing key.

#### How did you verify/test it?

#### Any platform specific information?
Cisco-8000 Distribute Chassis

#### Supported testbed topology if it's a new test case?
T2

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
