### PR TITLE
[m0][mx] Add supoort for M0/MX in test_route_perf

### DIFF
--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
 
     route_group = parser.getgroup("Route test suite options")
 
-    route_group.addoption("--num_routes", action="store", default=10000, type=int,
+    route_group.addoption("--num_routes", action="store", default=None, type=int,
                      help="Number of routes for add/delete")
 
 @pytest.fixture(scope='module')

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -18,6 +18,9 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 ROUTE_TABLE_NAME = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
+DEFAULT_NUM_ROUTES = 10000
+DEAFULT_M0_MX_NUM_ROUTES = 500
+
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
@@ -214,11 +217,17 @@ def exec_routes(duthost, enum_rand_one_frontend_asic_index, prefixes, str_intf_n
     # Retuen time used for set/del routes
     return (end_time - start_time).total_seconds()
 
-def test_perf_add_remove_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname, request, ip_versions, enum_rand_one_frontend_asic_index):
+def test_perf_add_remove_routes(tbinfo, duthosts, enum_rand_one_per_hwsku_frontend_hostname, request, ip_versions, enum_rand_one_frontend_asic_index):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
     # Number of routes for test
     set_num_routes = request.config.getoption("--num_routes")
+    if set_num_routes is None:
+        topo_name = tbinfo["topo"]["name"]
+        if topo_name in ["m0", "mx"]:
+            set_num_routes = DEAFULT_M0_MX_NUM_ROUTES
+        else:
+            set_num_routes = DEFAULT_NUM_ROUTES
 
     # Generate interfaces and neighbors
     NUM_NEIGHS = 50 # Update max num neighbors for multi-asic


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add supoort for M0/MX in test_route_perf

#### How did you do it?

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
