### PR TITLE
Adding innovium(Marvell) specific changes to run PFCWD module tests

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -130,6 +130,8 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     logger.info("Setting up storm params")
     pfc_queue_index = 4
     pfc_frames_count = 300000
+    if is_innovium_device(duthost):
+        pfc_frames_count = 500000
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                            pfc_frames_number=pfc_frames_count, peer_info=peer_params)
     storm_handle.deploy_pfc_gen()


### PR DESCRIPTION
### Description of PR
Incrementing pfc frames count for one of the pfcwd test, only for Innovium(Marvell) ASIC platforms.


Summary:

Incrementing pfc frame count for storm generation, possibly for faster CPUs where current count may not be sufficient.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ x] 201911
- [ x] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
Update the PFCWD time accuracy test setup for innovium(Marvell) ASIC platforms

#### How did you do it?
Added conditional check to modify pfc frames count for Innovium(Marvell) ASIC platforms

#### How did you verify/test it?
Ran pfcwd/test_pfcwd_timer_accuracy.py test with this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

