### PR TITLE
Skip watchdog reboot for Supervisor in Cisco 8000 distributed chassis

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -265,6 +265,8 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip watchdog reboot for Supervisor card in Cisco 8000 distributed chassis")
     watchdogutil_status_result = duthost.command("watchdogutil status", module_ignore_errors=True)
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")


### PR DESCRIPTION
### Description of PR
Temporarily skipping watchdog reboot for Supervisor card in Cisco 8000 distributed chassis. Plan is to add support for it soon.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Temporarily skipping watchdog reboot for Supervisor card in Cisco 8000 distributed chassis. Plan is to add support for it soon.

#### How did you do it?
Check if dut is a supervisor node and platform is cisco-8000 sup.

#### How did you verify/test it?
On T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
