### PR TITLE
Skip Broadcom related platform tests for other vendors

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.broadcom,
+    pytest.mark.asic('broadcom'),
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
### Description of PR
Fixed pytest mark for broadcom tests in /platform_tests/broadcom. This was causing broadcom tests to be run for other vendors

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixed pytest mark for broadcom tests in /platform_tests/broadcom. This was causing broadcom tests to be run for other vendors

#### How did you do it?
Check for broadcom asic

#### How did you verify/test it?
Verified it on T2 profile

#### Any platform specific information?
Broadcom asic type

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
