### PR TITLE
[Python3] Migrate test_ip_packet.py to py3

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -184,7 +184,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:
@@ -243,7 +243,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:
@@ -302,7 +302,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:
@@ -363,7 +363,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:
@@ -421,7 +421,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:
@@ -472,7 +472,7 @@ class TestIPPacket(object):
 
         testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
         time.sleep(5)
-        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=out_ptf_indices)
+        match_cnt = testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, ports=list(out_ptf_indices))
 
         portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
         if rif_support:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Migrate test_ip_packet.py to py3.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Migrate test_ip_packet.py to py3.

#### How did you do it?

`map()` in Python2 returns list object but in Python3 returns map object(it's actually an iterator), so add explicit convert to `list` to compatible with different versions

#### How did you verify/test it?

Run TC in Py2 and Py3, both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
