### PR TITLE
Reset sshd timeout in stage deploy minigraph.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -591,7 +591,7 @@
         delegate_to: localhost
         ignore_errors: true
 
-      -name: Reset sshd timeout
+      - name: Reset sshd timeout
        become: True
        shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -591,8 +591,11 @@
         delegate_to: localhost
         ignore_errors: true
 
+      # In pr https://github.com/sonic-net/sonic-buildimage/pull/12109, it decrease the sshd timeout
+      # which may cause timeout when executing `generate_dump -s yesterday`.
+      # Increase this time during deploying minigraph
       - name: Reset sshd timeout
         become: True
-        shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
+        shell: sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -593,6 +593,6 @@
 
       -name: Reset sshd timeout
        become: True
-       shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config
+       shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -591,4 +591,8 @@
         delegate_to: localhost
         ignore_errors: true
 
+      -name: Reset sshd timeout
+       become: True
+       shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config
+
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -592,7 +592,7 @@
         ignore_errors: true
 
       - name: Reset sshd timeout
-       become: True
-       shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
+        become: True
+        shell: sed -i "s/ClientAliveInterval 300/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [https://github.com/sonic-net/sonic-buildimage/pull/12109], it decrease the sshd timout from 15mins to 5mins. It may cause timeout when executing `generate_dump -s yesterday` in posttest. So in this pr, during deploying minigraph, we reset this time. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [https://github.com/sonic-net/sonic-buildimage/pull/12109], it decrease the sshd timout from 15mins to 5mins. It may cause timeout when executing `generate_dump -s yesterday` in posttest. So in this pr, during deploying minigraph, we reset this time. 

#### How did you do it?
Modify the value `/etc/ssh/sshd_config/ClientAliveInterval` in deploy minigraph. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
