### PR TITLE
fix xfail and skip conflict cases in tests_mark_conditions_platform_tests.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -928,8 +928,6 @@ platform_tests/test_reboot.py::test_warm_reboot:
     reason: "Skip test_warm_reboot for m0/mx"
     conditions:
       - "topo_name in ['m0', 'mx']"
-
-platform_tests/test_reboot.py::test_warm_reboot:
   xfail:
     reason: "case failed and waiting for fix"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -50,7 +50,7 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_supervisor_slot:
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
-    conditions_logical_operator: or
+    conditions_logical_operator: 'OR'
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "'sw_to3200k' in hwsku"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -50,8 +50,10 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_supervisor_slot:
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
+      - "'sw_to3200k' in hwsku"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
   skip:
@@ -60,12 +62,6 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
       - "asic_type in ['mellanox']"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_thermal_manager:
-  skip:
-    reason: "Unsupported platform API"
-    conditions:
-      - "'sw_to3200k' in hwsku"
-
-platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
   skip:
     reason: "Unsupported platform API"
     conditions:
@@ -303,19 +299,17 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+  xfail:
+    reason: "Testcase consistently fails, raised issue to track"
+    conditions:
+      - "hwsku in ['Celestica-DX010-C32']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led:
   skip:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
-
-platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_status:
-  xfail:
-    reason: "Testcase consistently fails, raised issue to track"
-    conditions:
-      - "hwsku in ['Celestica-DX010-C32']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_presence:
   xfail:
@@ -459,8 +453,6 @@ platform_tests/api/test_psu.py::TestPsuApi::test_led:
     reason: "On Cisco 8000, mellanox and Nokia 7215 platform, PSU led are unable to be controlled by software"
     conditions:
       - "asic_type in ['mellanox', 'cisco-8000'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
-
-platform_tests/api/test_psu.py::TestPsuApi::test_led:
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -896,8 +888,6 @@ platform_tests/test_reboot.py::test_fast_reboot:
     reason: "Skip test_fast_reboot for m0/mx"
     conditions:
       - "topo_name in ['m0', 'mx']"
-
-platform_tests/test_reboot.py::test_fast_reboot:
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -915,8 +905,6 @@ platform_tests/test_reboot.py::test_soft_reboot:
     reason: "Skip test_soft_reboot for m0/mx"
     conditions:
       - "topo_name in ['m0', 'mx']"
-
-platform_tests/test_reboot.py::test_soft_reboot:
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
platform_tests/test_reboot.py::test_warm_reboot case has both skip rule and xfail rule.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
platform_tests/test_reboot.py::test_warm_reboot case has both skip rule and xfail rule.
Skip rule invalid due to conflict with xfail rule

#### How did you do it?
combine the xfail rule and skip rule for the case

#### How did you verify/test it?
run the case

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
