### PR TITLE
Enabling sub_port_interface module test cases to run on Marvell(Innovium)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -846,7 +846,7 @@ sub_port_interfaces:
   skip:
     reason: "Unsupported platform or asic"
     conditions:
-      - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3'] and asic_type not in ['barefoot']"
+      - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3'] and asic_type not in ['barefoot','innovium']"
 
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
   skip:


### PR DESCRIPTION

### Description of PR
<!--
Enabling sub_port_interface module test to run for Marvell(Innovium)
-->

Summary:
Enabling sub_port_interface module test to run for Marvell(Innovium)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)


### Back port request
- [*] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enabling sub_port_interface module test to run for Marvell(Innovium)

#### How did you do it?
Added Innovium in supported list check

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
