### PR TITLE
Reset sshd timeout using ansible's grammar.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -597,10 +597,10 @@
       - name: Reset sshd timeout
         become: True
         lineinfile:
-          name: /etc/ssh/sshd_config
-          regexp: '^ClientAliveInterval [0-9].*'
-          line: 'ClientAliveInterval 900'
-          backrefs: true
+            name: /etc/ssh/sshd_config
+            regexp: '^ClientAliveInterval [0-9].*'
+            line: 'ClientAliveInterval 900'
+            backrefs: true
         shell: systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -596,6 +596,11 @@
       # Increase this time during deploying minigraph
       - name: Reset sshd timeout
         become: True
-        shell: sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
+        lineinfile:
+          name: /etc/ssh/sshd_config
+          regexp: '^ClientAliveInterval [0-9].*'
+          line: 'ClientAliveInterval 900'
+          backrefs: true
+        shell: systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -596,10 +596,10 @@
       # Increase this time during deploying minigraph
       - name: Reset sshd timeout
         lineinfile:
-            dest: /etc/ssh/sshd_config
-            regexp: '^ClientAliveInterval [0-9].*'
-            line: 'ClientAliveInterval 900'
-            backrefs: yes
+          name: /etc/ssh/sshd_config
+          regexp: '^ClientAliveInterval [0-9].*'
+          line: 'ClientAliveInterval 900'
+          backrefs: yes
         become: true
         shell: systemctl restart sshd
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -600,7 +600,7 @@
             regexp: '^ClientAliveInterval [0-9].*'
             line: 'ClientAliveInterval 900'
             backrefs: yes
-        become: True
+        become: true
         shell: systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -595,12 +595,12 @@
       # which may cause timeout when executing `generate_dump -s yesterday`.
       # Increase this time during deploying minigraph
       - name: Reset sshd timeout
-        become: True
         lineinfile:
             name: /etc/ssh/sshd_config
             regexp: '^ClientAliveInterval [0-9].*'
             line: 'ClientAliveInterval 900'
-            backrefs: true
+            backrefs: yes
+        become: True
         shell: systemctl restart sshd
 
     when: deploy is defined and deploy|bool == true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -596,7 +596,7 @@
       # Increase this time during deploying minigraph
       - name: Reset sshd timeout
         lineinfile:
-            name: /etc/ssh/sshd_config
+            dest: /etc/ssh/sshd_config
             regexp: '^ClientAliveInterval [0-9].*'
             line: 'ClientAliveInterval 900'
             backrefs: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [https://github.com/sonic-net/sonic-mgmt/pull/6820], I replaced the value of ClientAliveInterval using `sed`. But there is an warning, so I change it to ansible's own grammar, using `lineinfile` to replace the value. 

Summary:
Fixes # (6820)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [https://github.com/sonic-net/sonic-mgmt/pull/6820], I replaced the value of ClientAliveInterval using `sed`. But there is an warning, so I change it to ansible's own grammar, using `lineinfile` to replace the value. 

#### How did you do it?
Replace `sed` with `lineinfile`. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
