### PR TITLE
add Ether check in macsec_dp_poll

### DIFF
--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -401,11 +401,15 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
                 or exp_pkt is None:
             return ret
         pkt = scapy.Ether(ret.packet)
-        if pkt[scapy.Ether].type != 0x88e5:
-            if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
-                return ret
-            else:
-                continue
+        if pkt.haslayer(scapy.Ether):
+            if pkt[scapy.Ether].type != 0x88e5:
+                if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+                    return ret
+                else:
+                    continue
+        else:
+            continue
+
         macsec_info = load_macsec_info(test.duthost, find_portname_from_ptf_id(test.mg_facts, ret.port), force_reload[ret.port])
         if macsec_info:
             encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
https://github.com/sonic-net/sonic-mgmt/issues/6459

When run "test_acl.py" based on the master branch of sonic-mgmt in Cisco Lab, we hit the following error:

19:01:00 init.pytest_runtest_call L0040 ERROR | Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
self.ihook.pytest_pyfunc_call(pyfuncitem=self)
File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in call
return self._hookexec(self, self.get_hookimpls(), kwargs)
File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
return self._inner_hookexec(hook, methods, kwargs)
File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in
firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
return outcome.get_result()
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
_reraise(*ex) # noqa
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
res = hook_impl.function(*args)
File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
testfunction(**testargs)
File "/data/tests/acl/test_acl.py", line 710, in test_ingress_unmatched_blocked
self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
File "/data/tests/acl/test_acl.py", line 908, in _verify_acl_traffic
testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
File "/usr/lib/python2.7/dist-packages/ptf/testutils.py", line 2476, in verify_no_packet_any
verify_no_packet(test, pkt, (device, port))
File "/usr/lib/python2.7/dist-packages/ptf/testutils.py", line 2418, in verify_no_packet
test, device_number=device, port_number=port, exp_pkt=pkt, timeout=timeout
File "/data/tests/common/plugins/ptfadapter/init.py", line 48, in _dp_poll
return origin_dp_poll(test, device_number=device_number, port_number=port_number, timeout=timeout, exp_pkt=exp_pkt)
File "/data/tests/macsec/macsec_helper.py", line 378, in macsec_dp_poll
if pkt[scapy.Ether].type != 0x88e5:
File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 1344, in getitem
raise IndexError("Layer [%s] not found" % name)
IndexError: Layer [Ether] not found

### Steps to reproduce the issue:
based on master branch of sonic-mgmt, run "test_acl.py" in local T1 testbed.
Describe the results you received:
The error is due to the "macsec_dp_poll" doesn't skip the non-ether l2 packet.
In our test network, it has STP packet as follows:
19:01:00 macsec_helper.macsec_dp_poll L0374 WARNING| George pkt:###[ 802.3 ]###
dst = 01:00:0c:cc:cc:cd
src = 64:3a:ea:e5:33:d0
len = 50
###[ LLC ]###
dsap = 0xaa
ssap = 0xaa
ctrl = 3
###[ SNAP ]###
OUI = 00:00:0c
code = 0x10b
###[ Spanning Tree Protocol ]###
proto = 0
version = 2
bpdutype = 2
bpduflags = 60
rootid = 34768
rootmac = 64:3a:ea:e5:33:43
pathcost = 0
bridgeid = 34768
bridgemac = 64:3a:ea:e5:33:43
portid = 32909
age = 0.0
maxage = 20.0
hellotime = 2.0
fwddelay = 15.0
###[ Raw ]###
load = '\x00\x00\x00\x00\x02\x07\xd0'

### Solution
The poll function should skip non-ether pkt.
We need add a check func before handle it. 
