### PR TITLE
[202012] Install flask according to different running python version.

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -14,10 +14,12 @@
   - name: Set default Flask version
     set_fact:
       flask_version: "1.1.2"
+      python_command: "python"
 
   - name: Use newer Flask version for pip3
     set_fact:
       flask_version: "2.0.3"
+      python_command: "python3"
     when: pip_executable == "pip3"
 
   - name: Install flask


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [https://github.com/sonic-net/sonic-mgmt/pull/5388], I modify the script `ansible/roles/vm_set/tasks/control_mux_simulator.yml` in order to setup mux_simulator according to different running python version. This pr is aimed at keeping consistent with master branch.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [https://github.com/sonic-net/sonic-mgmt/pull/5388], I modify the script `ansible/roles/vm_set/tasks/control_mux_simulator.yml` in order to setup mux_simulator according to different running python version. This pr is aimed at keeping consistent with master branch.

#### How did you do it?
Install flask according to running python version. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
