### PR TITLE
[202012] Set up mix simulator according to different running python version.

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -14,10 +14,12 @@
   - name: Set default Flask version
     set_fact:
       flask_version: "1.1.2"
+      python_command: "python"
 
   - name: Use newer Flask version for pip3
     set_fact:
       flask_version: "2.0.3"
+      python_command: "python3"
     when: pip_executable == "pip3"
 
   - name: Install flask

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env python {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }} {{ vm_set_name }} -v
+ExecStart=/usr/bin/env {{python_command}} {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }} {{ vm_set_name }} -v


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [https://github.com//pull/6833], I modify the script ansible/roles/vm_set/tasks/control_mux_simulator.yml in order to install flask according to different running python version. This pr is aimed at setting up simulator according to different running python version.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [https://github.com//pull/6833], I modify the script ansible/roles/vm_set/tasks/control_mux_simulator.yml in order to install flask according to different running python version. This pr is aimed at setting up simulator according to different running python version.

#### How did you do it?
Set up mix simulator according to running python version.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
