### PR TITLE
Reset sshd timeout in upgrade_sonic.yml.

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -90,6 +90,13 @@
         disk_used_pcent: 50
       when: disk_used_pcent is not defined
 
+    # In pr https://github.com/sonic-net/sonic-buildimage/pull/12109, it decrease the sshd timeout
+    # which may cause timeout when executing `generate_dump -s yesterday`.
+    # Increase this time during deploying minigraph
+    - name: Reset sshd timeout
+      become: True
+      shell: sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config && systemctl restart sshd
+
     - block:
         - fail: msg="image_url is not defined"
           when: image_url is not defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [https://github.com/https://github.com/https://github.com/sonic-net/sonic-buildimage/pull/12109], it decrease the sshd timout from 15mins to 5mins. It may cause timeout when executing reduce_and_add_sonic_images in upgrade_sonic.yml. So in this pr, we reset this time before executing reduce_and_add_sonic_images.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [https://github.com/https://github.com/https://github.com/sonic-net/sonic-buildimage/pull/12109], it decrease the sshd timout from 15mins to 5mins. It may cause timeout when executing reduce_and_add_sonic_images in upgrade_sonic.yml. So in this pr, we reset this time before executing reduce_and_add_sonic_images.

#### How did you do it?
Modify the value /etc/ssh/sshd_config/ClientAliveInterval in upgrade_sonic.yml.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
