### PR TITLE
Support ignoring table entries in DUT health check

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -237,11 +237,11 @@ def _remove_ssh_tunnel_to_syncd_rpc(duthost):
 @pytest.fixture(scope='module')
 def swap_syncd(rand_selected_dut, creds):
     # Swap syncd container
-    docker.swap_syncd(rand_selected_dut, creds)
+    #docker.swap_syncd(rand_selected_dut, creds)
     _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
     yield
     # Restore syncd container
-    docker.restore_default_syncd(rand_selected_dut, creds)
+    #docker.restore_default_syncd(rand_selected_dut, creds)
     _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
 
 

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -237,11 +237,11 @@ def _remove_ssh_tunnel_to_syncd_rpc(duthost):
 @pytest.fixture(scope='module')
 def swap_syncd(rand_selected_dut, creds):
     # Swap syncd container
-    #docker.swap_syncd(rand_selected_dut, creds)
+    docker.swap_syncd(rand_selected_dut, creds)
     _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
     yield
     # Restore syncd container
-    #docker.restore_default_syncd(rand_selected_dut, creds)
+    docker.restore_default_syncd(rand_selected_dut, creds)
     _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to update `core_dump_and_config_check` fixture to support ignoring table entries.
Before this change, we can only ignore a whole table in config_db. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to update `core_dump_and_config_check` fixture to support ignoring table entries.

#### How did you do it?
Add a list EXCLUDE_CONFIG_KEY_NAMES to set the table entries that we don't care.

#### How did you verify/test it?
Verified on a dualtor testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
