### PR TITLE
[dualtor_io] Fix `test_active_tor_shutdown_bgp_sessions_upstream`

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -168,13 +168,20 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
 
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host,
-        expected_standby_health="unhealthy",
-        cable_type=cable_type
-    )
+    if cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type
+        )
 
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            cable_type=cable_type
+        )
 
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix regression introduced by https://github.com/sonic-net/sonic-mgmt/pull/6369. 

For `active-standby` interfaces, shutdown bgp on `active` side, it will turn in to `standby, healthy`. 

Downstream test is currently disabled for `active-standby` so I didn't modify it. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
```
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_upstream.xml -
------------------------ live log sessionfinish ------------------------
20:44:39 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 2 passed in 805.73 seconds =======
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
