### PR TITLE
[202012] Support ignoring table entries in DUT health check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1657,23 +1657,47 @@ def core_dump_and_config_check(duthosts, request):
             duts_data[duthost.hostname]["cur_running_config"] = \
                 json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
 
+            # The tables that we don't care
+            EXCLUDE_CONFIG_TABLE_NAMES = set([])
+            # The keys that we don't care
+            # Current skipped keys:
+            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder` fixture to account for the lower performance of the ICMP responder/mux simulator
+            #    compared to real servers and mux cables. It's appropriate to persist this change since the testbed will always be using the ICMP responder
+            #    and mux simulator. Linkmgrd is the only service to consume this table so it should not affect other test cases.
+            EXCLUDE_CONFIG_KEY_NAMES = [
+                'MUX_LINKMGR|LINK_PROBER'
+            ]
+            
+            def _remove_entry(table_name, key_name, config):
+                if table_name in config and key_name in config[table_name]:
+                    config[table_name].pop(key_name)
+                    if len(config[table_name]) == 0:
+                        config.pop(table_name)
+
+            # Remove ignored keys from base config
+            for exclude_key in EXCLUDE_CONFIG_KEY_NAMES:
+                fields = exclude_key.split('|')
+                if len(fields) != 2:
+                    continue
+                _remove_entry(fields[0], fields[1], duts_data[duthost.hostname]["pre_running_config"])
+                _remove_entry(fields[0], fields[1], duts_data[duthost.hostname]["cur_running_config"])
+
+            # Get common keys in pre running config and cur running config
+
             pre_running_config_keys = set(duts_data[duthost.hostname]["pre_running_config"].keys())
             cur_running_config_keys = set(duts_data[duthost.hostname]["cur_running_config"].keys())
 
             # Check if there are extra keys in pre running config
-            pre_config_extra_keys = list(pre_running_config_keys - cur_running_config_keys)
+            pre_config_extra_keys = list(pre_running_config_keys - cur_running_config_keys - EXCLUDE_CONFIG_TABLE_NAMES)
             for key in pre_config_extra_keys:
                 pre_only_config[duthost.hostname].update({key: duts_data[duthost.hostname]["pre_running_config"][key]})
 
             # Check if there are extra keys in cur running config
-            cur_config_extra_keys = list(cur_running_config_keys - pre_running_config_keys)
+            cur_config_extra_keys = list(cur_running_config_keys - pre_running_config_keys - EXCLUDE_CONFIG_TABLE_NAMES)
             for key in cur_config_extra_keys:
                 cur_only_config[duthost.hostname].update({key: duts_data[duthost.hostname]["cur_running_config"][key]})
-
-            # Get common keys in pre running config and cur running config
-            EXCLUDE_CONFIG_KEYS = set([])
-            common_config_keys = list(pre_running_config_keys & cur_running_config_keys - EXCLUDE_CONFIG_KEYS)
-
+            
+            common_config_keys = list(pre_running_config_keys & cur_running_config_keys - EXCLUDE_CONFIG_TABLE_NAMES)
             # Check if the running config is modified after module running
             for key in common_config_keys:
                 #TODO: remove these code when solve the problem of "FLEX_COUNTER_DELAY_STATUS"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to backport #6841 into `202012` branch.
This PR is to update `core_dump_and_config_check` fixture to support ignoring table entries.
Before this change, we can only ignore a whole table in config_db. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to update `core_dump_and_config_check` fixture to support ignoring table entries.

#### How did you do it?
Add a list EXCLUDE_CONFIG_KEY_NAMES to set the table entries that we don't care.

#### How did you verify/test it?
Verified on a dualtor testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
