### PR TITLE
Disable PFC watchdog in `test_cpu_memory_usage_counterpoll`

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -100,8 +100,23 @@ def counterpoll_cpu_threshold(duthosts, request):
     return counterpoll_cpu_usage_threshold
 
 
+@pytest.fixture
+def disable_pfcwd(duthosts, enum_rand_one_per_hwsku_hostname):
+    """
+    Disable PFCWD before testing, and start_default after testing
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    pfcwd_status = duthost.shell("sonic-db-cli CONFIG_DB hget \'DEVICE_METADATA|localhost\' \'default_pfcwd_status\'")['stdout']
+    if pfcwd_status != 'enable':
+        yield
+        return
+    duthost.shell('pfcwd stop')
+    yield
+    duthost.shell('pfcwd start_default')
+
+
 def test_cpu_memory_usage_counterpoll(duthosts, enum_rand_one_per_hwsku_hostname,
-                                      setup_thresholds, restore_counter_poll, counterpoll_type, counterpoll_cpu_threshold):
+                                      setup_thresholds, restore_counter_poll, counterpoll_type, counterpoll_cpu_threshold, disable_pfcwd):
     """Check DUT memory usage and process cpu usage are within threshold.
     Disable all counterpoll types except tested one
     Collect memory and CPUs usage for 60 secs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to disable PFC watchdog in test case `test_cpu_memory_usage_counterpoll`.
We found that `test_cpu_memory_usage_counterpoll` is not consistently passing on SN4600 testbed because the CPU usage of `sx_sdk` is above the threshold 10%.
Even though all counter poll is disabled, the CPU usage of `sx_sdk` is still above 20%. I think it's probably because PFC watchdog is consistently counting queue/pg counters.
After disable PFC watchdog, the CPU usage of `sx_sdk` is below 1%.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to disable PFC watchdog in test case `test_cpu_memory_usage_counterpoll`.

#### How did you do it?
Add a function level fixture `disable_pfcwd` to do this.

#### How did you verify/test it?
Verified on MSN4600c testbed. The test is consistently passing now.

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
