### PR TITLE
Ignore expected swss, syncd error messages for J2C+ duts during autorestart feature testing

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -98,8 +98,6 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR syncd[0-9]*#syncd.*process_on_fdb_event: FDB notification was not sent since it contain invalid "
             "OIDs.*",
             ".*ERR syncd[0-9]*#syncd.*saiGetMacAddress: failed to get mac address: SAI_STATUS_ITEM_NOT_FOUND.*",
-            ".*ERR syncd[0-9]*#syncd.*logEventData.*",
-            ".*ERR syncd[0-9]*#syncd.*setEndTime.*",
             ".*ERR syncd[0-9]*#syncd.*getSupportedBufferPoolCounters.*",
             ".*ERR syncd[0-9]*#SDK.*mlnx_bridge_1d_oid_to_data: Unexpected bridge type 0 is not 1D.*",
             ".*ERR syncd[0-9]*#SDK.*mlnx_bridge_port_lag_or_port_get: Invalid port type - 2.*",
@@ -121,8 +119,6 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR teamd[0-9]*#teamsyncd.*readData.*Unable to initialize team socket.*",
             ".*ERR swss[0-9]*#orchagent.*set status: SAI_STATUS_ATTR_NOT_IMPLEMENTED_0.*",
             ".*ERR swss[0-9]*#orchagent.*setIntfVlanFloodType.*",
-            ".*ERR swss[0-9]*#orchagent.*handlePortStatusChangeNotification.*",
-            ".*ERR swss[0-9]*#orchagent.*Failed to get port by bridge port ID.*",
             ".*ERR swss[0-9]*#orchagent.*applyDscpToTcMapToSwitch.*",
             ".*ERR swss[0-9]*#buffermgrd.*Failed to process invalid entry.*",
             ".*ERR snmp#snmpd.*",
@@ -179,11 +175,20 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
 
     feature = enum_dut_feature
 
+    impacted_duts = []
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_supervisor_node():
+        impacted_duts = duthosts
+    else:
+        impacted_duts = [duthost]
+
+    logger.info("Impacted DUTs: '{}'".format(impacted_duts))
+
     if loganalyzer:
-        for duthost in duthosts:
-            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict['common'])
+        for a_dut in impacted_duts:
+            loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex_dict['common'])
             if feature in ignore_regex_dict:
-                loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict[feature])
+                loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex_dict[feature])
 
 
 def get_group_program_info(duthost, container_name, group_name):

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -91,12 +91,16 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR syncd[0-9]*#syncd.*SAI_API_UNSPECIFIED:sai_api_query.*",
             ".*ERR syncd[0-9]*#syncd.*SAI_API_SWITCH:sai_query_attribute_enum_values_capability.*",
             ".*ERR syncd[0-9]*#syncd.*SAI_API_SWITCH:sai_object_type_get_availability.*",
+            ".*ERR syncd[0-9]*#syncd.*SAI_API_SWITCH:sai_query_attribute_capability.*",
             ".*ERR syncd[0-9]*#syncd.*sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode.*",
             ".*ERR syncd[0-9]*#syncd.*processQuadEvent.*",
             ".*ERR syncd[0-9]*#syncd.*process_on_fdb_event: invalid OIDs in fdb notifications.*",
             ".*ERR syncd[0-9]*#syncd.*process_on_fdb_event: FDB notification was not sent since it contain invalid "
             "OIDs.*",
             ".*ERR syncd[0-9]*#syncd.*saiGetMacAddress: failed to get mac address: SAI_STATUS_ITEM_NOT_FOUND.*",
+            ".*ERR syncd[0-9]*#syncd.*logEventData.*",
+            ".*ERR syncd[0-9]*#syncd.*setEndTime.*",
+            ".*ERR syncd[0-9]*#syncd.*getSupportedBufferPoolCounters.*",
             ".*ERR syncd[0-9]*#SDK.*mlnx_bridge_1d_oid_to_data: Unexpected bridge type 0 is not 1D.*",
             ".*ERR syncd[0-9]*#SDK.*mlnx_bridge_port_lag_or_port_get: Invalid port type - 2.*",
             ".*ERR syncd[0-9]*#SDK.*mlnx_bridge_port_isolation_group_get: Isolation group is only supported for "
@@ -117,6 +121,9 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR teamd[0-9]*#teamsyncd.*readData.*Unable to initialize team socket.*",
             ".*ERR swss[0-9]*#orchagent.*set status: SAI_STATUS_ATTR_NOT_IMPLEMENTED_0.*",
             ".*ERR swss[0-9]*#orchagent.*setIntfVlanFloodType.*",
+            ".*ERR swss[0-9]*#orchagent.*handlePortStatusChangeNotification.*",
+            ".*ERR swss[0-9]*#orchagent.*Failed to get port by bridge port ID.*",
+            ".*ERR swss[0-9]*#orchagent.*applyDscpToTcMapToSwitch.*",
             ".*ERR swss[0-9]*#buffermgrd.*Failed to process invalid entry.*",
             ".*ERR snmp#snmpd.*",
             ".*ERR dhcp_relay#dhcp6?relay.*bind: Failed to bind socket to link local ipv6 address on interface .* "
@@ -171,12 +178,12 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
     }
 
     feature = enum_dut_feature
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     if loganalyzer:
-        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict['common'])
-        if feature in ignore_regex_dict:
-            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict[feature])
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict['common'])
+            if feature in ignore_regex_dict:
+                loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict[feature])
 
 
 def get_group_program_info(duthost, container_name, group_name):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
'test_container_autorestart' test case fails for swss, syncd, teamd features with certain error messages for J2C+ cards. These errors are documented in sonic-buildimage issue #[12727](https://github.com/sonic-net/sonic-buildimage/issues/12727). This PR helps to ignore these error messages as part of autorestart container testing.

Summary:
Fixes # (issue)
This PR addresses the following:
 - Ignore expected error messages for auto-restart test case for multi-asic chassis, which is documented as part of sonic-buildimage issue #[12727](https://github.com/sonic-net/sonic-buildimage/issues/12727)
 - The added error messages will be reverted once the messages identified in the issue are fixed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently for multi-asic chassis, 'test_autorestart_container' test case fails with error messages documented in the sonic-buildimage issue #[12727](https://github.com/sonic-net/sonic-buildimage/issues/12727).
Hence, ignoring these error messages as part of 'test_autorestart_container' test case with this known issue.

#### How did you do it?
- Added expected ERROR messages to the regex list for all types of duthosts.

#### How did you verify/test it?
Ran the tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
