### PR TITLE
Adding and modifying files for VxLAN-CRM testcases.

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -209,19 +209,36 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
-        "--include_crm",
-        action="store",
-        default=False,
-        type=bool,
-        help="Enable CRM tests."
-    )
-
-    vxlan_group.addoption(
         "--include_long_tests",
         action="store",
         default=False,
         type=bool,
         help="Run the long-running testcases."
+    )
+
+    vxlan_group.addoption(
+        "--crm_num_nexthops",
+        action="store",
+        default=4096,
+        type=int,
+        help="CRM:Number of available pool of nexthops."
+    )
+
+    vxlan_group.addoption(
+        "--crm_num_nexthop_groups",
+        action="store",
+        default=512,
+        type=int,
+        help="CRM:Number of Vnet nexthop groups."
+    )
+
+    vxlan_group.addoption(
+        "--crm_num_nexthop_group_members",
+        action="store",
+        default=1024,
+        type=int,
+        help="CRM:Number of Vnet nexthop group members"
+             "(number of repeated addresses to use across all the routes)."
     )
 
 

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -1,0 +1,220 @@
+import logging
+import pytest
+import ipaddress
+from functools import reduce
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.ptfhost_utils \
+    import copy_ptftests_directory     # noqa: F401
+from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401
+    Test_VxLAN,
+    fixture_setUp,
+    fixture_encap_type)
+
+Logger = logging.getLogger(__name__)
+ecmp_utils = Ecmp_Utils()
+
+
+def uniq(lst):
+    last = object()
+    for item in sorted(lst):
+        if item == last:
+            continue
+        yield item
+        last = item
+
+
+def sort_and_deduplicate(list_of_entries):
+    return list(uniq(sorted(list_of_entries, reverse=True)))
+
+
+def unique_in_list(list1):
+    return (reduce(lambda re, x: re+[x] if x not in re else re, list1, []))
+
+
+@pytest.fixture(name="argument_setup", scope="module")
+def _fixture_argument_setup(request):
+
+    request.config.option.total_number_of_endpoints =\
+        request.config.option.crm_num_nexthops
+
+    request.config.option.total_number_of_nexthops =\
+        request.config.option.crm_num_nexthop_group_members
+
+    request.config.option.ecmp_nhs_per_destination =\
+        (request.config.option.crm_num_nexthop_group_members /
+            request.config.option.crm_num_nexthop_groups)
+
+    if request.config.option.ecmp_nhs_per_destination <= 1:
+        raise RuntimeError(
+            "This config will not raise the number of ECMP groups,"
+            " pls change the commandline arguments."
+            "crm_num_nexthop_group_members/crm_num_nexthop_groups "
+            "must be more than 1")
+
+
+@pytest.fixture(name="setup_neighbors", scope="module")
+def fixture_setup_neighbors(setUp, encap_type, minigraph_facts):
+    duthost = setUp['duthost']
+    a_family = Ecmp_Utils.get_outer_layer_version(encap_type)
+    t2_neighbors = Ecmp_Utils.get_all_interfaces_running_bgp(
+        duthost,
+        minigraph_facts,
+        "T2")
+
+    IP_TYPE = {
+        'v4': ipaddress.IPv4Address,
+        'v6': ipaddress.IPv6Address
+    }
+    intf = None
+    for addr in t2_neighbors.keys():
+        if isinstance(ipaddress.ip_address(addr), IP_TYPE[a_family]):
+            intf = t2_neighbors[addr].keys()[0]
+            break
+    if not intf:
+        raise RuntimeError(
+            "Couldn't find an interface to use "
+            "for encap_type:{}".format(encap_type))
+
+    if a_family == "v4":
+        duthost.shell(
+            "sudo config interface ip add {} 200.0.0.1/16".format(intf))
+        for count in range(200):
+            duthost.shell(
+                "sudo arp -s 200.0.{}.2 0a:bb:cc:dd:ee:ff".format(count))
+    else:
+        duthost.shell(
+            "sudo config interface ip add {} DDDD::200:0:0:1/64".format(intf))
+        for count in range(200):
+            duthost.shell(
+                "sudo ip -6 neigh add DDDD::200:0:{}:2 "
+                "lladdr 00:11:22:33:44:55 dev {}".format(count, intf))
+
+    # We have setup 201 neighbors so far.
+    yield 201
+
+    if a_family == "v4":
+        for count in range(200):
+            duthost.shell("sudo arp -d 200.0.{}.2".format(count))
+        duthost.shell(
+            "sudo config interface ip remove {} 200.0.0.1/16".format(intf))
+    else:
+        for count in range(200):
+            duthost.shell(
+                "sudo ip -6 neigh del DDDD::200:0:{}:2 "
+                "lladdr 00:11:22:33:44:55 dev {}".format(count, intf))
+        duthost.shell(
+            "sudo config interface ip remove {} DDDD::200:0:0:1/64".format(
+                intf))
+
+
+class Test_VxLAN_Crm(Test_VxLAN):
+    '''
+        Class for all testcases that verify Critical Resource Monitoring
+        counters.
+    '''
+    # CRM tolerance
+    tolerance = 0.90
+
+    def crm_assert(self, crm_output, resource_name, required_increase):
+        '''
+           Helper function to verify the usage went up as per
+           requirement.
+        '''
+        pytest_assert(
+            crm_output[resource_name]['used'] >=
+            self.setup['crm'][resource_name]['used'] +
+            self.tolerance * required_increase,
+            "CRM:{} usage didn't increase as needed:old:{}, "
+            "new:{}, diff:{}, expected_diff:{}".format(
+                resource_name,
+                self.setup['crm'][resource_name]['used'],
+                crm_output[resource_name]['used'],
+                (self.setup['crm'][resource_name]['used'] -
+                    crm_output[resource_name]['used']),
+                required_increase))
+
+    def test_crm_16k_routes(self, setUp, encap_type, setup_neighbors):
+        '''
+            Verify that the CRM counter values for ipv4_route, ipv4_nexthop,
+            ipv6_route and ipv6_nexthop are updated as per the vxlan route
+            configs.
+        '''
+        self.setup = setUp
+        outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
+
+        number_of_routes_configured = 0
+        set_of_unique_endpoints = set()
+
+        for vnet in self.setup[encap_type]['dest_to_nh_map'].keys():
+            number_of_routes_configured += \
+                len(self.setup[encap_type]['dest_to_nh_map'][vnet].keys())
+
+            dest_to_nh_map = self.setup[encap_type]['dest_to_nh_map'][vnet]
+            for _, nexthops in dest_to_nh_map.items():
+                set_of_unique_endpoints = \
+                    set_of_unique_endpoints | set(nexthops)
+
+        crm_output = \
+            self.setup['duthost'].get_crm_resources()['main_resources']
+
+        self.crm_assert(
+            crm_output,
+            'ip{}_route'.format(outer_layer_version),
+            number_of_routes_configured)
+        self.crm_assert(
+            crm_output,
+            'ip{}_nexthop'.format(outer_layer_version),
+            setup_neighbors)
+
+    def nexthop_group_helper(self, encap_type):
+        # number of nexthop groups configured:
+        #  = number of unique-looking list of nexthops.
+        # if destA:[nhA,nhB], and destB:[nhB,nhA], we have 1 nexthop group.
+        list_of_nexthop_groups = set()
+        for vnet in self.setup[encap_type]['dest_to_nh_map'].keys():
+            dest_to_nh_map = self.setup[encap_type]['dest_to_nh_map'][vnet]
+            list_of_nexthop_groups = list_of_nexthop_groups | \
+                set(tuple(i) for i in unique_in_list(
+                    sort_and_deduplicate(dest_to_nh_map.values())))
+
+        number_of_nh_groups = 0
+        number_of_nh_group_members = 0
+        for nhg in list_of_nexthop_groups:
+            if len(nhg) > 1:
+                number_of_nh_groups += 1
+                number_of_nh_group_members += len(nhg)
+        return (number_of_nh_groups, number_of_nh_group_members)
+
+    def test_crm_512_nexthop_groups(self, setUp, encap_type):
+        '''
+            Verify that the CRM counter values for nexthop_group is updated as
+            per the vxlan route configs.
+        '''
+        self.setup = setUp
+        Logger.info("Verifying encap_type:%s", encap_type)
+        crm_output = \
+            self.setup['duthost'].get_crm_resources()['main_resources']
+        (number_of_nh_groups, number_of_group_members) = \
+            self.nexthop_group_helper(encap_type)
+        self.crm_assert(
+            crm_output,
+            'nexthop_group',
+            number_of_nh_groups)
+
+    def test_crm_128_group_members(self, setUp, encap_type):
+        '''
+            Verify that the CRM counter values for nexthop_group_member
+            is updated as per the vxlan route configs.
+        '''
+        self.setup = setUp
+        Logger.info("Verifying encap_type:%s", encap_type)
+        crm_output = \
+            self.setup['duthost'].get_crm_resources()['main_resources']
+        (number_of_nh_groups, number_of_group_members) = \
+            self.nexthop_group_helper(encap_type)
+        self.crm_assert(
+            crm_output,
+            'nexthop_group_member',
+            number_of_group_members)

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -45,7 +45,6 @@
                                       for the DUT. Default: 4789
         bfd                         : Set it to True if you want to run all
                                       VXLAN cases with BFD Default: False
-        include_crm                 : Include the CRM testcases. Default:False
         include_long_tests          : Include the entropy, random-hash
                                       testcases, that take longer time.
                                       Default: False
@@ -55,6 +54,7 @@ import time
 import logging
 from datetime import datetime
 import json
+import re
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -91,11 +91,11 @@ def fixture_encap_type(request):
         This fixture forces the script to perform one encap_type at a time.
         So this script doesn't support multiple encap types at the same.
     '''
-    yield request.param
+    return request.param
 
 
 @pytest.fixture(autouse=True)
-def ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
+def _ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""
     if loganalyzer:
         loganalyzer[rand_one_dut_hostname].ignore_regex.extend(
@@ -108,6 +108,20 @@ def ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
                 ".*Vnet Route Mismatch reported.*"
             ])
     return
+
+
+def setup_crm_interval(duthost, interval):
+    crm_stdout = duthost.shell("crm show summary")['stdout_lines']
+    match = re.search("Polling Interval: ([0-9]*) second", "".join(crm_stdout))
+
+    if match:
+        current_polling_seconds = match.group(1)
+    else:
+        raise RuntimeError(
+            "Couldn't parse the crm polling "
+            "interval. output:{}".format(crm_stdout))
+    duthost.shell("crm config polling interval {}".format(interval))
+    return current_polling_seconds
 
 
 @pytest.fixture(name="setUp", scope="module")
@@ -154,7 +168,6 @@ def fixture_setUp(duthosts,
     Logger.info("Constants to be used in the script:%s", ecmp_utils.Constants)
 
     data['enable_bfd'] = request.config.option.bfd
-    data['include_crm'] = request.config.option.include_crm
     data['include_long_tests'] = request.config.option.include_long_tests
     data['monitor_file'] = '/tmp/bfd_responder_monitor_file.txt'
     data['ptfhost'] = ptfhost
@@ -164,6 +177,9 @@ def fixture_setUp(duthosts,
         data['duthost'].get_extended_minigraph_facts(tbinfo)
     data['dut_mac'] = data['duthost'].facts['router_mac']
     data['vxlan_port'] = request.config.option.vxlan_port
+    data['original_crm_interval'] = setup_crm_interval(data['duthost'],
+                                                       interval=3)
+    time.sleep(4)
     data['crm'] = data['duthost'].get_crm_resources()['main_resources']
     ecmp_utils.configure_vxlan_switch(
         data['duthost'],
@@ -305,6 +321,8 @@ def fixture_setUp(duthosts,
     time.sleep(1)
     if request.config.option.bfd:
         ecmp_utils.stop_bfd_responder(data['ptfhost'])
+
+    setup_crm_interval(data['duthost'], int(data['original_crm_interval']))
 
 
 class Test_VxLAN():
@@ -1894,81 +1912,3 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_dport=False,
             random_src_ip=True,
             tolerance=0.03)
-
-
-@pytest.mark.skipif(
-    "config.option.include_crm is False",
-    reason="This test will be run only if "
-           "'--include_crm=True' is provided.")
-class Test_VxLAN_Crm(Test_VxLAN):
-    '''
-        Class for all testcases that verify Critical Resource Monitoring
-        counters.
-    '''
-    def test_crm_16k_routes(self, setUp, encap_type):
-        '''
-            Verify that the CRM counter values for ipv4_route, ipv4_nexthop,
-            ipv6_route and ipv6_nexthop are updated as per the vxlan route
-            configs.
-        '''
-        self.setup = setUp
-        vnet = self.setup[encap_type]['dest_to_nh_map'].keys()[0]
-        crm_output = \
-            self.setup['duthost'].get_crm_resources()['main_resources']
-        outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
-        number_of_routes_configured = \
-            len(self.setup[encap_type]['dest_to_nh_map'][vnet].keys())
-
-        # We need the count of unique endpoints.
-        dest_nh_map = self.setup[encap_type]['dest_to_nh_map'][vnet]
-        set_of_unique_endpoints = set()
-        for _, nexthops in dest_nh_map.items():
-            set_of_unique_endpoints = \
-                set_of_unique_endpoints | set(nexthops)
-        number_of_nexthops_configured = len(set_of_unique_endpoints)
-
-        routes_used = \
-            crm_output['ip{}_route'.format(outer_layer_version)]['used']
-        nhs_used = \
-            crm_output['ip{}_nexthop'.format(outer_layer_version)]['used']
-        old_routes = \
-            self.setup['crm']['ip{}_route'.format(outer_layer_version)]['used']
-        old_nhs = self.setup['crm'][
-            'ip{}_nexthop'.format(outer_layer_version)]['used']
-
-        pytest_assert(
-            routes_used >= old_routes + 0.90 * number_of_routes_configured,
-            "CRM:ip{}_route usage didn't increase as needed".format(
-                outer_layer_version))
-        pytest_assert(
-            nhs_used >= old_nhs + 0.90 * number_of_nexthops_configured,
-            "CRM:ip{}_nexthop usage didn't increase as needed".format(
-                outer_layer_version))
-
-    def test_crm_512_nexthop_groups(self, setUp, encap_type):
-        '''
-            Verify that the CRM counter values for nexthop_group is updated as
-            per the vxlan route configs.
-        '''
-        self.setup = setUp
-        Logger.info("Verifying encap_type:%s", encap_type)
-        crm_output = \
-            self.setup['duthost'].get_crm_resources()['main_resources']
-        pytest_assert(
-            crm_output['nexthop_group']['used'] >=
-            self.setup['crm']['nexthop_group']['used'] + 16000,
-            "CRM:nexthop_group usage didn't increase as needed")
-
-    def test_crm_128_group_members(self, setUp, encap_type):
-        '''
-            Verify that the CRM counter values for nexthop_group_member
-            is updated as per the vxlan route configs.
-        '''
-        self.setup = setUp
-        Logger.info("Verifying encap_type:%s", encap_type)
-        crm_output = \
-            self.setup['duthost'].get_crm_resources()['main_resources']
-        pytest_assert(
-            crm_output['nexthop_group_member']['used'] >=
-            self.setup['crm']['nexthop_group_member']['used'] + 16000,
-            "CRM:nexthop_group_member usage didn't increase as needed")


### PR DESCRIPTION
The following tests are covered. The NHs are not counted, so they are done differently.

CRM cases are  pulled out of the main script, and will be kept in a seperate script.
- This is needed because the number of routes for CRM is different from the main script.
- The BFD scale will not work with the CRM, since the ptf can’t handle that many number of monitors.

The first one has 2 parts, one is number of routes and the other is number of nexthops. The nexthops count increments only if nexthop really changes. Since we use default route for all our traffic, this number doesn’t go up during the script execution.  So we use a different method(using arp entries) to check this.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
CRM cases are  pulled out of the main script, and will be kept in a seperate script.
- This is needed because the number of routes for CRM is different from the main script.
- The BFD scale will not work with the CRM, since the ptf can’t handle that many number of monitors.

The first one has 2 parts, one is number of routes and the other is number of nexthops. The nexthops count increments only if nexthop really changes. Since we use default route for all our traffic, this number doesn’t go up during the script execution.  So we use a different method(using arp entries) to check this.

Summary:
VxLAN CRM testcases.
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Automating CRM tests in vxlan HLD.
#### How did you do it?
Implemented and added a new file.
#### How did you verify/test it?
Ran it on my testbed. Total runtime for 3 x4 cases is about 20 minutes.
#### Any platform specific information?
- NIL -
#### Supported testbed topology if it's a new test case?
T1, T1-lag
### Documentation
https://github.com/sonic-net/SONiC/blob/master/doc/vxlan/Overlay%20ECMP%20with%20BFD.md