### PR TITLE
Support different RC in case of pre or post sanity check failed

### DIFF
--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -21,15 +21,52 @@ INFRA_CHECK_ITEMS = [
 
 # Recover related definitions
 RECOVER_METHODS = {
-    "config_reload": {"cmd": "bash -c 'config reload -y &>/dev/null'", "reboot": False, "adaptive": False, 'recover_wait': 120},
-    "config_reload_f": {"cmd": "bash -c 'config reload -f -y &>/dev/null'", "reboot": False, "adaptive": False, 'recover_wait': 120},
-    "load_minigraph": {"cmd": "bash -c 'config load_minigraph -y &>/dev/null'", "reboot": False, "adaptive": False, 'recover_wait': 60},
-    "reboot": {"cmd": "reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
-    "warm_reboot": {"cmd": "warm-reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
-    "fast_reboot": {"cmd": "fast_reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
-    "adaptive": {"cmd": None, "reboot": False, "adaptive": True, 'recover_wait': 30},
+    "config_reload": {
+        "cmd": "bash -c 'config reload -y &>/dev/null'",
+        "reboot": False,
+        "adaptive": False,
+        'recover_wait': 120
+    },
+    "config_reload_f": {
+        "cmd": "bash -c 'config reload -f -y &>/dev/null'",
+        "reboot": False,
+        "adaptive": False,
+        'recover_wait': 120
+    },
+    "load_minigraph": {
+        "cmd": "bash -c 'config load_minigraph -y &>/dev/null'",
+        "reboot": False,
+        "adaptive": False,
+        'recover_wait': 60
+    },
+    "reboot": {
+        "cmd": "reboot",
+        "reboot": True,
+        "adaptive": False,
+        'recover_wait': 120
+    },
+    "warm_reboot": {
+        "cmd": "warm-reboot",
+        "reboot": True,
+        "adaptive": False,
+        'recover_wait': 120
+    },
+    "fast_reboot": {
+        "cmd": "fast_reboot",
+        "reboot": True,
+        "adaptive": False,
+        'recover_wait': 120
+    },
+    "adaptive": {
+        "cmd": None,
+        "reboot": False,
+        "adaptive": True,
+        'recover_wait': 30
+    },
 }       # All supported recover methods
 
 STAGE_PRE_TEST = 'stage_pre_test'
 STAGE_POST_TEST = 'stage_post_test'
-SANITY_CHECK_FAILED_RC = 10
+PRE_SANITY_CHECK_FAILED_RC = 10
+POST_SANITY_CHECK_FAILED_RC = 11
+SANITY_CHECK_FAILED_RC = 12

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -329,7 +329,8 @@ function run_individual_tests()
                 rm -f ${LOG_PATH}/${test_dir}/${test_name}.log
             fi
         else
-            if [ ${ret_code} -eq 10 ]; then     # rc 10 means sanity check failed
+            # rc 10 means pre-test sanity check failed, rc 12 means boths pre-test and post-test sanity check failed
+            if [ ${ret_code} -eq 10 ] || [${ret_code} -eq 12 ]; then
                 echo "=== Sanity check failed for $test_script. Skip rest of the scripts if there is any. ==="
                 return ${ret_code}
             fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PR #6166 introduced different pytest return code in case of sanity check failed. However, the return code is the same if pre-test or post-test sanity check failed.

The run_tests.sh script skips running rest of the test scripts if sanity check failed.

Actually, there is a difference between pre-test and post-test sanity check failure. The pre-test sanity check has code to do recovery. Post-test sanity check does not have recovery. If pre-test sanity check still failed after recovery, there is no point to run rest of the scripts. However, if post-test sanity check failed, we should continue to run rest of the scripts because the next script may be able to recover the testbed during pre-test sanity check.

#### How did you do it?
This change introduced different return code for pre-test and post-test sanity check.
* pre-test only sanity check failed -> 10
* post-test only sanity check failed -> 11
* both pre and post test sanity check failed -> 12.

The run_tests.sh script was updated to skip tests only when pytest return code is either 10 or 12.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
