### PR TITLE
Update syseeprom_info generation in TestbedProcessing

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -653,18 +653,12 @@ def makeLabYAML(data, devices, testbed, outfile):
                         'serial': devices[dut].get("serial"),
                         'os': devices[dut].get("os"),
                         'model': devices[dut].get("model"),
-                        'asic_type': devices[dut].get("asic_type"),
-                        'syseeprom_info': {"0x21": devices[dut].get("syseeprom_info").get("0x21"),
-                                           "0x22": devices[dut].get("syseeprom_info").get("0x22"),
-                                           "0x23": devices[dut].get("syseeprom_info").get("0x23"),
-                                           "0x24": devices[dut].get("syseeprom_info").get("0x24"),
-                                           "0x25": devices[dut].get("syseeprom_info").get("0x25"),
-                                           "0x26": devices[dut].get("syseeprom_info").get("0x26"),
-                                           "0x2A": devices[dut].get("syseeprom_info").get("0x2A"),
-                                           "0x2B": devices[dut].get("syseeprom_info").get("0x2B"),
-                                           "0xFE": devices[dut].get("syseeprom_info").get("0xFE")}
+                        'asic_type': devices[dut].get("asic_type")
                         }
                     })
+                    if devices[dut].get("syseeprom_info"):
+                        dutDict[dut].update({'syseeprom_info': {field: devices[dut]["syseeprom_info"][field] \
+                            for field in devices[dut]["syseeprom_info"]}})
                     sonicDict[group]['hosts'].update(dutDict)
     if "fanout" in deviceGroup['lab']['children']:
         for fanoutType in deviceGroup['fanout']['children']:


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update TestbedProcessing so that syseeprom_info would generate dynamically in lab file. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Generate syseeprom_info in lab file dynamically
#### How did you do it?

#### How did you verify/test it?
Check that lab file have all syseeprom_info 
Run `platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.172539-dirty-20221110.175553
Distribution: Debian 11.5
Kernel: 5.10.0-12-2-amd64
Build commit: 7c746e67d
Build date: Thu Nov 10 18:01:32 UTC 2022
Built by: AzDevOps@sonic-build-workers-002D7H
Platform: x86_64-accton_as9516_32d-r0
HwSKU: newport
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
