### PR TITLE
[SAI-PTF] Add SAI Header Definition Table

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -101,6 +101,7 @@ class KustoConnector(ReportDBConnector):
     EXPECTED_TEST_RUNS_TABLE = "ExpectedTestRuns"
     PIPELINE_TABLE = "TestReportPipeline"
     CASE_INVOC_TABLE = "CaseInvocationReport"
+    SAI_HEADER_INVOC_TABLE = "SAIHeaderDefinition"
 
     TABLE_FORMAT_LOOKUP = {
         METADATA_TABLE: DataFormat.JSON,
@@ -116,6 +117,7 @@ class KustoConnector(ReportDBConnector):
         EXPECTED_TEST_RUNS_TABLE: DataFormat.JSON,
         PIPELINE_TABLE: DataFormat.JSON,
         CASE_INVOC_TABLE: DataFormat.MULTIJSON,
+        SAI_HEADER_INVOC_TABLE: DataFormat.MULTIJSON,
     }
 
     TABLE_MAPPING_LOOKUP = {
@@ -132,6 +134,7 @@ class KustoConnector(ReportDBConnector):
         EXPECTED_TEST_RUNS_TABLE: "ExpectedTestRunsV1",
         PIPELINE_TABLE: "FlatPipelineMappingV1",
         CASE_INVOC_TABLE: "CaseInvocationReportMapping",
+        SAI_HEADER_INVOC_TABLE: "SAIHeaderDefinitionMapping",
     }
 
     def __init__(self, db_name: str):
@@ -224,6 +227,13 @@ class KustoConnector(ReportDBConnector):
         """
         self._upload_case_invoc_report_file(file)
 
+    def upload_sai_header_def_report_file(self, file) -> None:
+        """Upload a report to the back-end data store.
+        Args:
+            file: json
+        """
+        self._upload_sai_header_def_report_file(file)
+
     def upload_pdu_status_data(self, pdu_status_output: List) -> None:
         time = str(datetime.utcnow())
         pdu_output = []
@@ -263,6 +273,9 @@ class KustoConnector(ReportDBConnector):
 
     def _upload_case_invoc_report_file(self, case_invoc_file):
         self._ingest_data_file(self.CASE_INVOC_TABLE, case_invoc_file)
+
+    def _upload_sai_header_def_report_file(self, sai_header_def_file):
+        self._ingest_data_file(self.SAI_HEADER_INVOC_TABLE, sai_header_def_file)
 
     def _upload_pipeline_results(self, external_tracking_id, report_guid, testbed, os_version):
         pipeline_data = {

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -119,6 +119,9 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 kusto_db._upload_case_invoc_report_file(fn)
                 count += 1
                 print("Ingested file {}, {}/{}".format(fn, count, len(fns)))
+    elif args.category == "sai_header_def":
+        for path_name in args.path_list:
+            kusto_db.upload_sai_header_def_report_file(path_name)
 
     else:
         print('Unknown category "{}"'.format(args.category))

--- a/test_reporting/sai_coverage/data_model/sai_interface_header.py
+++ b/test_reporting/sai_coverage/data_model/sai_interface_header.py
@@ -3,8 +3,12 @@ class SAIInterfaceHeader(object):
     Structure of SAI interface header
     """
     def __init__(self, intf_groupname, intf_groupalias, intf_name, intf_alias, file_name):
-        self.intf_groupname = intf_groupname
-        self.intf_groupalias = intf_groupalias
-        self.intf_name = intf_name
-        self.intf_alias = intf_alias
-        self.file_name = file_name
+        sai_method_table_split = intf_groupalias.split('_')
+        sai_feature = sai_method_table_split[1: len(sai_method_table_split)-2]
+
+        self.sai_header = file_name
+        self.sai_id = intf_groupname
+        self.sai_method_table = intf_groupalias
+        self.sai_feature = ''.join(sai_feature)
+        self.sai_api = intf_alias[:-10] if 'attribute' in intf_alias else intf_alias
+        self.sai_alias = intf_alias

--- a/test_reporting/sai_coverage/sai_header_scanner.py
+++ b/test_reporting/sai_coverage/sai_header_scanner.py
@@ -21,7 +21,7 @@ def parse(dir_path):
     Args:
         dir_path: path of SAI headers
     """
-    sai_apis = dict()
+    sai_apis = list()
     for (root, _, filenames) in os.walk(dir_path):
         for filename in filenames:
             if filename.endswith(".h") and filename not in IGNORE_HEADER_FILE_LIST:
@@ -32,8 +32,7 @@ def parse(dir_path):
                         intf_groupname = "SAI_API_" + \
                             filename.split(".")[0].split("sai")[1].upper()
                         intf_groupalias = key[1:]
-                        filename = filename.split(".")[0]
-                        sai_apis = generate_sai_header_json(
+                        generate_sai_header_json(
                             intf_groupname, intf_groupalias, sai_api_list, filename, sai_apis)
     os.makedirs(PRIORI_RESULT_SAVE_DIR, exist_ok=True)
     store_result(sai_apis, os.path.join(
@@ -51,9 +50,7 @@ def generate_sai_header_json(intf_groupname, intf_groupalias, intf_list, filenam
         for (intf_alias, intf_name) in element.items():
             sai_intf = SAIInterfaceHeader(
                 intf_groupname, intf_groupalias, intf_name, intf_alias, filename)
-            sai_apis[intf_name] = sai_intf.__dict__
-
-    return sai_apis
+            sai_apis.append(sai_intf.__dict__)
 
 
 def _parse_api_list_struct(parser, key):

--- a/test_reporting/sai_coverage_scan_and_upload.sh
+++ b/test_reporting/sai_coverage_scan_and_upload.sh
@@ -10,3 +10,4 @@ python3 test_reporting/sai_coverage/case_scanner.py -p ptf
 
 # 4. upload the results (json files) to Kusto
 python3 test_reporting/report_uploader.py result/scan SaiTestData -c case_invoc
+python3 test_reporting/report_uploader.py result/sai_header_scan_result_test.json SaiTestData -c sai_header_def

--- a/test_reporting/sai_coverage_scanner.md
+++ b/test_reporting/sai_coverage_scanner.md
@@ -33,6 +33,8 @@ python3 test_reporting/sai_coverage/case_scanner.py -p ptf
 
 ## 2. Upload results to Kusto
 
+### a) Upload CaseInvocationReport
+
 Firstly, the corresponding table and mapping should be created in Kusto by the following Kusto commands.
 ```kql
 .create table CaseInvocationReport
@@ -78,8 +80,40 @@ upload_time: string
 '{"column":"upload_time","Properties":{"path":"$.upload_time"}}]'
 ```
 
-Then, connect to the `CaseInvocationReportV2` table and ingest data into it.
+Then, connect to the `CaseInvocationReport` table and ingest data into it.
 ```bash
 # 4. upload the results (json files) to Kusto
 python3 test_reporting/report_uploader.py result/scan SaiTestData -c case_invoc
+```
+
+### b) Upload SAIHeaderDefinition
+
+Firstly, the corresponding table and mapping should be created in Kusto by the following Kusto commands.
+
+```kql
+.create table SAIHeaderDefinition
+(
+sai_header: string,
+sai_id: string,
+sai_method_table: string,
+sai_feature: string,
+sai_api: string,
+sai_alias: string,
+branchName: string
+)
+
+.create table SAIHeaderDefinition ingestion json mapping
+'SAIHeaderDefinitionMapping' '['
+'{"column":"sai_header","Properties":{"path":"$.sai_header"}},'
+'{"column":"sai_id","Properties":{"path":"$.sai_id"}},'
+'{"column":"sai_method_table","Properties":{"path":"$.sai_method_table"}},'
+'{"column":"sai_feature","Properties":{"path":"$.sai_feature"}},'
+'{"column":"sai_api","Properties":{"path":"$.sai_api"}},'
+'{"column":"sai_alias","Properties":{"path":"$.sai_alias"}}]'
+```
+
+Then, connect to the `SAIHeaderDefinition` table and ingest data into it.
+```bash
+# 4. upload the results (json files) to Kusto
+python3 test_reporting/report_uploader.py result/sai_header_scan_result_test.json SaiTestData -c sai_header_def
 ```


### PR DESCRIPTION
Signed-off-by: zhiyuanliang-ms <t-zhliang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In summary, this PR is for calculating the usage of CaseInvocation on SAI header definitions.

- Divide SAI header definitions from case invocation
- Ingest SAI header definitions into Kusto

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix a logical bug of CaseInvocation

#### How did you do it?
- I split SAI header definitions and case invocation information (in the `test_reporting` folder), then the usage of CaseInvocation on SAI header definitions can be calculated.
- Modify the corresponding Kusto commands.

#### How did you verify/test it?
I tested the results and update the running script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
