### PR TITLE
Use ptf_runner in qos sai test and fdb mac expire test

### DIFF
--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -3,7 +3,8 @@ import pytest
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401  # lgtm [py/unused-import]
+from tests.ptf_runner import ptf_runner
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx')
@@ -13,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 DISABLE_REFRESH = "disable_refresh"
 REFRESH_DEST_MAC = "refresh_with_dest_mac"
+
+
 class TestFdbMacExpire:
     """
         TestFdbMacExpire Verifies FDb aging timer is respected
@@ -90,24 +93,14 @@ class TestFdbMacExpire:
                 RunAnsibleModuleFail if ptf test fails
         """
         logger.info("Running PTF test case '{0}' on '{1}'".format(testCase, ptfhost.hostname))
-        ptfhost.shell(argv=[
-            "/root/env-python3/bin/ptf",
-            "--test-dir",
-            "ptftests/py3",
-            testCase,
-            "--platform-dir",
+        ptf_runner(
+            ptfhost,
             "ptftests",
-            "--platform",
-            "remote",
-            "-t",
-            ";".join(["{0}={1}".format(k, repr(v)) for k, v in testParams.items()]),
-            "--relax",
-            "--debug",
-            "info",
-            "--log-file",
-            "/tmp/{0}".format(testCase)
-            ],
-            chdir = "/root",
+            testCase,
+            platform_dir="ptftests",
+            params=testParams,
+            log_file="/tmp/{0}".format(testCase),
+            is_python3=True
         )
 
     @pytest.fixture(scope="class", autouse=True)

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -25,9 +25,10 @@ def ptf_collect(host, log_file):
         host.fetch(src=pcap_file, dest=filename_pcap, flat=True, fail_on_missing=False)
         allure.attach.file(filename_pcap, 'ptf_pcap: ' + filename_pcap, allure.attachment_type.PCAP)
 
+
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
-               socket_recv_size=None, log_file=None, device_sockets=[], timeout=0,
+               socket_recv_size=None, log_file=None, device_sockets=[], timeout=0, custom_options="",
                module_ignore_errors=False, is_python3=False):
     # Call virtual env ptf for migrated py3 scripts.
     # ptf will load all scripts under ptftests, it will throw error for py2 scripts.
@@ -37,9 +38,9 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
         if path_exists["stat"]["exists"]:
             cmd = "/root/env-python3/bin/ptf --test-dir {} {}".format(testdir+'/py3', testname)
         else:
-            error_msg = "Virtual environment for Python3 /root/env-python3/bin/ptf doesn't exist.\nPlease check and update docker-ptf image, make sure to use the correct one."
-            logger.error("Exception caught while executing case: {}. Error message: {}"\
-            .format(testname, error_msg))
+            error_msg = "Virtual environment for Python3 /root/env-python3/bin/ptf doesn't exist.\n" \
+                        "Please check and update docker-ptf image, make sure to use the correct one."
+            logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, error_msg))
             raise Exception(error_msg)
     else:
         cmd = "ptf --test-dir {} {}".format(testdir, testname)
@@ -75,6 +76,9 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     if timeout:
         cmd += " --test-case-timeout {}".format(int(timeout))
 
+    if custom_options:
+        cmd += " " + custom_options
+
     if hasattr(host, "macsec_enabled") and host.macsec_enabled:
         if not is_python3:
             logger.error("MACsec is only available in Python3")
@@ -95,7 +99,6 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
             ptf_collect(host, log_file)
         traceback_msg = traceback.format_exc()
         allure.attach(traceback_msg, 'ptf_runner_exception_traceback', allure.attachment_type.TEXT)
-        logger.error("Exception caught while executing case: {}. Error message: {}"\
-            .format(testname, traceback_msg))
+        logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, traceback_msg))
         raise Exception
     return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update the qos sai test and fdb mac expire test to use ptf_runner to run the ptf test, so that the ptf logs can be collected to sonic-mgmt docker and attached to allure report by the ptf_runner.
Also update the changed files to pass the pre-commit check.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to improve the debuggability.
Use ptf_runner to run the ptf test, so that the ptf logs can be collected to sonic-mgmt docker and attached to allure report by the ptf_runner.
#### How did you do it?
Replaced the ptfhost.shell() with ptf runner() in test_fdb_mac_expire.py and qos_sai_base.py, added a "custom_option" parameter in ptf_runner to accept the extra options like " --disable-ipv6" in qos sai test.
Made some minor changes to pass the pre-commit check. 

#### How did you verify/test it?
Run regression on all Nvidia platforms, all test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
