### PR TITLE
Enhance test_orchagent_standby_tor_downstream_enhance

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -22,6 +22,12 @@ from ptf.testutils import *
 PACKET_NUM = 10000
 # packet count for verifying traffic is not forwarded from standby tor to server directly
 PACKET_NUM_FOR_NEGATIVE_CHECK = 100
+# max times we can try for verifying balanced traffic
+MAX_TIMES_CHECK = 100
+# basic packet count for verifying traffic is forwarded via IPinIP tunnel
+BASIC_PACKET_NUM = 10
+# basic packet count for verifying traffic is not forwarded from standby tor to server directly
+BASIC_PACKET_NUM_FOR_NEGATIVE_CHECK = 10
 
 DIFF = 0.25 # The valid range for balance check
 SRC_IP_RANGE = ['8.0.0.0', '8.255.255.255']
@@ -58,6 +64,7 @@ class IpinIPTunnelTest(BaseTest):
         self.hash_key_list = self.test_params['hash_key_list']
         self.dataplane = ptf.dataplane_instance
         self.is_ipv4 = isinstance(ip_address(self.server_ip), IPv4Address)
+        self.completeness_level = self.test_params['completeness_level']
 
     def runTest(self):
         """
@@ -178,12 +185,14 @@ class IpinIPTunnelTest(BaseTest):
 
         return unexpected_packet
 
-    def check_balance(self, pkt_distribution, hash_key):
+    def check_balance(self, pkt_distribution, hash_key, run_times):
+        self.logger.info("For {} times: pkt_distribution={}".format(run_times, pkt_distribution))
         portchannel_num = len(self.ptf_portchannel_indices)
-        expect_packet_num = PACKET_NUM / portchannel_num
+        expect_packet_num = ((PACKET_NUM//MAX_TIMES_CHECK)*run_times) / portchannel_num
         pkt_num_lo = expect_packet_num * (1.0 - DIFF)
         pkt_num_hi = expect_packet_num * (1.0 + DIFF)
         self.logger.info("hash key = {}".format(hash_key))
+        self.logger.info("low threshold {} high threshold {}".format(pkt_num_lo, pkt_num_hi))
         self.logger.info("%-10s \t %10s \t %10s \t" % ("port(s)", "exp_cnt", "act_cnt"))
         balance = True
         for portchannel, count in pkt_distribution.items():
@@ -191,8 +200,18 @@ class IpinIPTunnelTest(BaseTest):
             if count < pkt_num_lo or count > pkt_num_hi:
                 balance = False
         if not balance:
-            print("Check balance failed for {}".format(hash_key))
-        assert(balance)
+            self.logger.info("Check balance failed for {} in the {} times run".format(hash_key, run_times))
+        return balance
+
+    def check_received(self, pkt_distribution, hash_key):
+        not_received = True
+        for portchannel, count in pkt_distribution.items():
+            self.logger.info("%-10s \t %10s \t %10s \t" % (portchannel, ">0", str(count)))
+            if count <= 0:
+                not_received = False
+        if not not_received:
+            self.logger.info("Check balance failed for {}".format(hash_key))
+        assert(not_received)
 
     def send_and_verify_packets(self):
         """
@@ -202,7 +221,13 @@ class IpinIPTunnelTest(BaseTest):
         # Select the first ptf indice as src port
         src_port = dst_ports[0]
         # Step 1. verify no packet is received from standby_tor to server
-        for i in range(0, PACKET_NUM_FOR_NEGATIVE_CHECK):
+
+        if self.completeness_level == "thorough":
+            negative_packet_num = PACKET_NUM_FOR_NEGATIVE_CHECK
+        else:
+            negative_packet_num = BASIC_PACKET_NUM_FOR_NEGATIVE_CHECK
+        self.logger.info("Verify {} negative packets.".format(negative_packet_num))
+        for i in range(0, negative_packet_num):
             inner_pkt = self.generate_packet_to_server('src-ip')
             unexpected_packet = self.generate_unexpected_packet(inner_pkt)
             self.dataplane.flush()
@@ -216,19 +241,47 @@ class IpinIPTunnelTest(BaseTest):
         for hash_key in self.hash_key_list:
             self.logger.info("Verifying traffic balance for hash key {}".format(hash_key))
             pkt_distribution = {}
-            for i in range(0, PACKET_NUM):
-                inner_pkt = self.generate_packet_to_server(hash_key)
-                tunnel_pkt = self.generate_expected_packet(inner_pkt)
-                l3packet = inner_pkt.getlayer(IP) or inner_pkt.getlayer(IPv6)
-                self.logger.info("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
-                    .format(inner_pkt[Ether].dst, inner_pkt[Ether].src, l3packet.dst, l3packet.src, src_port))
-                self.dataplane.flush()
-                send_packet(self, src_port, inner_pkt)
-                # Verify packet is received from IPinIP tunnel
-                idx, count = verify_packet_any_port(test=self,
-                                                    pkt=tunnel_pkt,
-                                                    ports=dst_ports,
-                                                    device_number=0,
-                                                    timeout=TIMEOUT)
-                pkt_distribution[self.indice_to_portchannel[dst_ports[idx]]] = pkt_distribution.get(self.indice_to_portchannel[dst_ports[idx]], 0) + 1
-            self.check_balance(pkt_distribution, hash_key)
+            # For thorough completeness level, verify PACKET_NUM packets
+            if self.completeness_level == "thorough":
+                self.logger.info("Verifying traffic balance on {} completeness level, send {} packets every time.".format(self.completeness_level, PACKET_NUM//MAX_TIMES_CHECK))
+                for k in range(MAX_TIMES_CHECK):
+                    for i in range(0, PACKET_NUM//MAX_TIMES_CHECK):
+                        inner_pkt = self.generate_packet_to_server(hash_key)
+                        tunnel_pkt = self.generate_expected_packet(inner_pkt)
+                        l3packet = inner_pkt.getlayer(IP) or inner_pkt.getlayer(IPv6)
+                        self.logger.info("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
+                            .format(inner_pkt[Ether].dst, inner_pkt[Ether].src, l3packet.dst, l3packet.src, src_port))
+                        self.dataplane.flush()
+                        send_packet(self, src_port, inner_pkt)
+                        # Verify packet is received from IPinIP tunnel
+                        idx, count = verify_packet_any_port(test=self,
+                                                            pkt=tunnel_pkt,
+                                                            ports=dst_ports,
+                                                            device_number=0,
+                                                            timeout=TIMEOUT)
+                        pkt_distribution[self.indice_to_portchannel[dst_ports[idx]]] = pkt_distribution.get(self.indice_to_portchannel[dst_ports[idx]], 0) + 1
+                    is_balance = self.check_balance(pkt_distribution, hash_key, k+1)
+                    if is_balance:
+                        self.logger.info("After verification for {} times, the traffic is balanced.".format(k+1))
+                        return
+                assert(is_balance)
+            # For other completeness level, just do basic check
+            # if receive any expected packet on every portchannel then pass
+            else:
+                self.logger.info("Verifying traffic on {} completeness level, send {} packets.".format(self.completeness_level, BASIC_PACKET_NUM))
+                for i in range(0, BASIC_PACKET_NUM):
+                    inner_pkt = self.generate_packet_to_server(hash_key)
+                    tunnel_pkt = self.generate_expected_packet(inner_pkt)
+                    l3packet = inner_pkt.getlayer(IP) or inner_pkt.getlayer(IPv6)
+                    self.logger.info("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
+                        .format(inner_pkt[Ether].dst, inner_pkt[Ether].src, l3packet.dst, l3packet.src, src_port))
+                    self.dataplane.flush()
+                    send_packet(self, src_port, inner_pkt)
+                    # Verify packet is received from IPinIP tunnel
+                    idx, count = verify_packet_any_port(test=self,
+                                                        pkt=tunnel_pkt,
+                                                        ports=dst_ports,
+                                                        device_number=0,
+                                                        timeout=TIMEOUT)
+                    pkt_distribution[self.indice_to_portchannel[dst_ports[idx]]] = pkt_distribution.get(self.indice_to_portchannel[dst_ports[idx]], 0) + 1
+                self.check_received(pkt_distribution, hash_key)

--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -25,7 +25,7 @@ PACKET_NUM_FOR_NEGATIVE_CHECK = 100
 # max times we can try for verifying balanced traffic
 MAX_TIMES_CHECK = 100
 # basic packet count for verifying traffic is forwarded via IPinIP tunnel
-BASIC_PACKET_NUM = 10
+BASIC_PACKET_NUM = 20
 # basic packet count for verifying traffic is not forwarded from standby tor to server directly
 BASIC_PACKET_NUM_FOR_NEGATIVE_CHECK = 10
 

--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -25,7 +25,7 @@ PACKET_NUM_FOR_NEGATIVE_CHECK = 100
 # max times we can try for verifying balanced traffic
 MAX_TIMES_CHECK = 100
 # basic packet count for verifying traffic is forwarded via IPinIP tunnel
-BASIC_PACKET_NUM = 20
+BASIC_PACKET_NUM = 100
 # basic packet count for verifying traffic is not forwarded from standby tor to server directly
 BASIC_PACKET_NUM_FOR_NEGATIVE_CHECK = 10
 
@@ -240,7 +240,8 @@ class IpinIPTunnelTest(BaseTest):
         # Step 2. verify packet is received from IPinIP tunnel and check balance
         for hash_key in self.hash_key_list:
             self.logger.info("Verifying traffic balance for hash key {}".format(hash_key))
-            pkt_distribution = {}
+            for port in self.ptf_portchannel_indices.keys():
+                pkt_distribution[port] = 0
             # For thorough completeness level, verify PACKET_NUM packets
             if self.completeness_level == "thorough":
                 self.logger.info("Verifying traffic balance on {} completeness level, send {} packets every time.".format(self.completeness_level, PACKET_NUM//MAX_TIMES_CHECK))

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1100,7 +1100,7 @@ def get_crm_nexthop_counter(host):
     return crm_facts['resources']['ipv4_nexthop']['used']
 
 
-def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, get_function_completeness_level):
+def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, get_function_completeness_level=None):
     """
     @summary: A helper function for collecting info of dualtor testbed.
     @param ptfhost: The ptf host fixture

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -759,7 +759,8 @@ def mux_cable_server_ip(dut):
     return json.loads(mux_cable_config)
 
 
-def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, selected_port, target_server_ip, target_server_ipv6, target_server_port, ptf_portchannel_indices, check_ipv6=False):
+def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, selected_port, target_server_ip,
+                        target_server_ipv6, target_server_port, ptf_portchannel_indices, completeness_level, check_ipv6=False):
     """
     Function for testing traffic distribution among all avtive T1.
     A test script will be running on ptf to generate traffic to standby interface, and the traffic will be forwarded to
@@ -777,6 +778,7 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, stan
     Returns:
         None.
     """
+
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     params = {
         "server_ip": target_server_ip,
@@ -786,7 +788,8 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, stan
         "active_tor_ip": active_tor_ip,
         "standby_tor_ip": standby_tor_ip,
         "ptf_portchannel_indices": ptf_portchannel_indices,
-        "hash_key_list": HASH_KEYS
+        "hash_key_list": HASH_KEYS,
+        "completeness_level": completeness_level
     }
     if check_ipv6:
         params["server_ip"] = target_server_ipv6
@@ -1097,7 +1100,7 @@ def get_crm_nexthop_counter(host):
     return crm_facts['resources']['ipv4_nexthop']['used']
 
 
-def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
+def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, get_function_completeness_level):
     """
     @summary: A helper function for collecting info of dualtor testbed.
     @param ptfhost: The ptf host fixture
@@ -1139,6 +1142,9 @@ def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
     res['target_server_ip'] = servers[random_server_iface]['server_ipv4'].split('/')[0]
     res['target_server_ipv6'] = servers[random_server_iface]['server_ipv6'].split('/')[0]
     res['target_server_port'] = standby_tor_mg_facts['minigraph_ptf_indices'][random_server_iface]
+
+    normalize_level = get_function_completeness_level if get_function_completeness_level else 'thorough'
+    res['completeness_level'] = normalize_level
 
     logger.debug("dualtor info is generated {}".format(res))
     return res

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -53,12 +53,15 @@ def setup_testbed_ipv6(ip_version, request):
     if ip_version == "ipv6":
         request.getfixturevalue("run_arp_responder_ipv6")
 
+@pytest.fixture(scope='module')
+def get_function_completeness_level(pytestconfig):
+    return pytestconfig.getoption("--completeness_level")
 
 @pytest.fixture
-def get_testbed_params(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ip_version, setup_testbed_ipv6):
+def get_testbed_params(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ip_version, setup_testbed_ipv6, get_function_completeness_level):
     """Return a function to get testbed params."""
     def _get_testbed_params():
-        params = dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo)
+        params = dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, get_function_completeness_level)
         params["check_ipv6"] = (ip_version == "ipv6")
         return params
 


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, `test_orchagent_standby_tor_downstream_enhance` is running for more than 6 hours.
```
2022-11-15T23:36:37.2558396Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv4] PASSED [  8%]
2022-11-16T00:02:44.1139743Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv6] PASSED [ 16%]
2022-11-16T00:52:23.5691439Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv4] PASSED [ 25%]
2022-11-16T01:46:45.1021140Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv6] PASSED [ 33%]
2022-11-16T02:36:40.8328309Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv4] PASSED [ 41%]
2022-11-16T03:30:15.5301443Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv6] PASSED [ 50%]
2022-11-16T03:30:44.1128833Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv4] 
2022-11-16T03:31:45.0795905Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv6] ERROR [ 66%]
2022-11-16T03:33:57.0690942Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv4] PASSED [ 75%]
2022-11-16T03:36:05.0405057Z dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv6] PASSED [ 83%]
2022-11-16T04:26:15.1091945Z dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv4] XPASS [ 91%]
2022-11-16T05:20:23.7092144Z dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv6] XPASS [100%]
```
Need to reduce running time.

#### How did you do it?
Each case in `test_orchagent_standby_tor_downstream_enhance` will call ptf script `ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py`, so far it will cost more than 6 mins to complete.
That's because it verifies 100 negative packets and 10000 correct packets.
1. Introduce completeness level, except Friday run, nightly uses confident level and it will run basic test in `ip_in_ip_tunnel_test.py`. It will verify 10 negative packets and 10 correct packets, if receive packet on every selected portchannel, test case will pass.
2. For thorough level, verify 100 negative packets and then verify 100 correct packets every time, if fail to balance, will send 100 more packets and verify accumulated packets if balanced again.

After this change, we can save around 20 mins for each case, then in total, we can save more than 4 hours for `test_orchagent_standby_tor_downstream_enhance`.

#### How did you verify/test it?
Run `test_orchagent_standby_tor_downstream_enhance`
```
06:41:32.056  IPinIPTunnel: INFO    : For 1 times: pkt_distribution={'PortChannel104': 26, 'PortChannel103': 23, 'PortChannel101': 33, 'PortChannel102': 18}
06:41:32.056  IPinIPTunnel: INFO    : hash key = src-port
06:41:32.056  IPinIPTunnel: INFO    : low threshold 18.75 high threshold 31.25
06:41:32.056  IPinIPTunnel: INFO    : port(s)               exp_cnt         act_cnt
06:41:32.056  IPinIPTunnel: INFO    : PortChannel104           25.0              26
06:41:32.056  IPinIPTunnel: INFO    : PortChannel103           25.0              23
06:41:32.056  IPinIPTunnel: INFO    : PortChannel101           25.0              33
06:41:32.056  IPinIPTunnel: INFO    : PortChannel102           25.0              18
06:41:32.056  IPinIPTunnel: INFO    : Check balance failed for src-port in the 1 times run

06:41:36.857  IPinIPTunnel: INFO    : For 2 times: pkt_distribution={'PortChannel104': 45, 'PortChannel103': 49, 'PortChannel101': 58, 'PortChannel102': 48}
06:41:36.857  IPinIPTunnel: INFO    : hash key = src-port
06:41:36.857  IPinIPTunnel: INFO    : low threshold 37.5 high threshold 62.5
06:41:36.857  IPinIPTunnel: INFO    : port(s)               exp_cnt         act_cnt
06:41:36.857  IPinIPTunnel: INFO    : PortChannel104           50.0              45
06:41:36.857  IPinIPTunnel: INFO    : PortChannel103           50.0              49
06:41:36.857  IPinIPTunnel: INFO    : PortChannel101           50.0              58
06:41:36.857  IPinIPTunnel: INFO    : PortChannel102           50.0              48
06:41:36.857  IPinIPTunnel: INFO    : After verification for 2 times, the traffic is balanced.
06:41:36.857  root      : INFO    : ** END TEST CASE ip_in_ip_tunnel_test.IpinIPTunnelTest
```

```
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv4] PASSED [ 50%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv6] PASSED [ 100%]
========================= 2 passed in 1105.90 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
