### PR TITLE
[SAI-PTF] fix a route case name

### DIFF
--- a/tests/sai_qualify/cases_brcm_t0.py
+++ b/tests/sai_qualify/cases_brcm_t0.py
@@ -85,7 +85,7 @@ TEST_CASE = [
         "sai_route_test.SviMacFloodingTest",
         "sai_route_test.SviMacFloodingv6Test",
         "sai_route_test.SviDirectBroadcastTest",
-        "sai_route_test.RemoveRouteTest",
+        "sai_route_test.RemoveRouteV4Test",
         "sai_route_test.DefaultRouteV4Test",
         "sai_route_test.DefaultRouteV6Test",
         "sai_route_test.RouteSameSipDipv4Test",


### PR DESCRIPTION
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix a route case which mismatching with the name in the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Change a route case name in the case list which mismatched in the test.

#### How did you do it?
Change route case sai_route_test.RemoveRouteTest to sai_route_test.RemoveRouteV4Test.

#### How did you verify/test it?
Manually run RemoveRouteV4Test case and passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
