### PR TITLE
[LogAnalyzer]Add ignore expected loganalyzer exceptions for techsupport

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -275,6 +275,30 @@ def execute_command(duthost, since):
     return True
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+    """
+        In Mellanox, when techsupport is taken, it invokes fw dump.
+        While taking the fw dump, the fw is busy and doesn't respond to other calls.
+        The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields
+        every 60 seconds which fails during the fw dump.
+        This is a temporary issue and this log can be ignored. 
+    """
+    ignoreRegex = [
+        ".*ERR kernel:.*Reg cmd access status failed.*",
+        ".*ERR kernel:.*Reg cmd access failed.*",
+        ".*ERR kernel:.*Eeprom query failed.*",
+        ".*ERR kernel:.*Fails to access.*register MCIA.*",
+        ".*ERR kernel:.*Fails to read module eeprom.*",
+        ".*ERR kernel:.*Fails to access.*module eeprom.*",
+        ".*ERR kernel:.*Fails to get module type.*",
+        ".*ERR pmon#xcvrd:.*Failed to read sfp.*"
+    ]
+
+    if loganalyzer:
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
+
+
 def test_techsupport(request, config, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     test the "show techsupport" command in a loop

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -283,6 +283,7 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
         The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields
         every 60 seconds which fails during the fw dump.
         This is a temporary issue and this log can be ignored. 
+        Issue link: https://github.com/sonic-net/sonic-buildimage/issues/12621
     """
     ignoreRegex = [
         ".*ERR kernel:.*Reg cmd access status failed.*",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In Mellanox, when techsupport is taken, it invokes fw dump. While taking the fw dump, the fw is busy and doesn't respond to other calls. The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields every 60 seconds which fails during the fw dump. This is a temporary issue and this log can be ignored.
Issue link: https://github.com/sonic-net/sonic-buildimage/issues/12621
#### How did you do it?
Add ignore expected loganalyzer exceptions for techsupport
#### How did you verify/test it?
Run techsupport testscript
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
