### PR TITLE
Revert "Adding innovium(Marvell) specific changes to run PFCWD module tests"

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -130,8 +130,6 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     logger.info("Setting up storm params")
     pfc_queue_index = 4
     pfc_frames_count = 300000
-    if is_innovium_device(duthost):
-        pfc_frames_count = 500000
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                            pfc_frames_number=pfc_frames_count, peer_info=peer_params)
     storm_handle.deploy_pfc_gen()


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#6795

this test failed with below msg, pls fix it. @lokeshmarvell 

>       if is_innovium_device(duthost):
E       NameError: global name 'is_innovium_device' is not defined