### PR TITLE
Added logic which store controlplane downtime into test logs in case of fast-reboot test

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1256,7 +1256,11 @@ class ReloadTest(BaseTest):
                 self.handle_post_reboot_health_check_kvm()
             else:
                 if self.reboot_type == 'fast-reboot':
+                    thr = threading.Thread(target=self.wait_until_control_plane_up)
+                    thr.setDaemon(True)
+                    thr.start()
                     self.handle_fast_reboot_health_check()
+                    thr.join()
                 if 'warm-reboot' in self.reboot_type or 'service-warm-restart' == self.reboot_type:
                     self.handle_warm_reboot_health_check()
                 self.handle_post_reboot_health_check()


### PR DESCRIPTION
### Description of PR
Added logic which store controlplane downtime into test logs in case of fast-reboot test

Previously we did not store controlpnale downtime into PTF logs TEST-NAME-report.json in case of fast-reboot(we did store only in case of warm-reboot) Now we store controlplane downtime into PTF logs also for fast-reboot test case

Summary: Added logic which store controlplane downtime into test logs in case of fast-reboot test
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
It will allow to store fast-reboot controlplane downtime into PTF host json report in /tmp folder TEST-NAME-report.json

#### How did you do it?
Added call for method self.wait_until_control_plane_up

#### How did you verify/test it?
Executed fast-reboot test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
