### PR TITLE
Fixed regexp in auto_techsupport history parser to support what-just-happened docker name

### DIFF
--- a/tests/common/multibranch/cli/auto_techsupport.py
+++ b/tests/common/multibranch/cli/auto_techsupport.py
@@ -117,7 +117,7 @@ class AutoTechSupportCliDefault:
         """
         with allure.step('Parsing "show auto-techsupport history" output'):
             result_dict = {}
-            regexp = r'(sonic_dump_.*)\s+(\w+|\w+\W\w+)\s+(\w+)\s+(\w+\.\d+\.\d+\.core\.gz)'
+            regexp = r'(sonic_dump_.*)\s+(\w+|\w+\W\w+|\w+\W\w+\W\w+)\s+(\w+)\s+(\w+\.\d+\.\d+\.core\.gz)'
             cmd_output = self.show_auto_techsupport_history()
 
             dump_name_index = 0


### PR DESCRIPTION
### Description of PR

Summary: Fixed regexp in auto_techsupport history parser to support what-just-happened docker name
Old regexp did not support docker name with 2 "-" inside, fixed regexp to support docker names with 2 minuses in name

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Bug fix for supporte docker names with 2 '-' in name, for example: 'what-just-happened'

#### How did you do it?
Modified regexp

#### How did you verify/test it?
Executed auto_techsupport tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
