### PR TITLE
Updated loganalyzer logic in test sfputil

### DIFF
--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import os
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 ans_host = None
 
@@ -13,16 +12,22 @@ def teardown_module():
 
 
 @pytest.fixture(autouse=True)
-def update_la_ignore_errors_list_for_mlnx(duthost):
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
-        loganalyzer.load_common_config()
-        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
-        # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
-        loganalyzer.ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
-        marker = loganalyzer.init()
+def update_la_ignore_errors_list_for_mlnx(duthost, loganalyzer):
+    extended_ignore_list = []
+
+    if loganalyzer:
+        if duthost.facts["asic_type"] in ["mellanox"]:
+            extended_ignore_list.append("kernel.*Eeprom query failed*")
+            # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
+            extended_ignore_list.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
+
+            for host in loganalyzer:
+                loganalyzer[host].ignore_regex.extend(extended_ignore_list)
 
     yield
 
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer.analyze(marker)
+    if loganalyzer:
+        if duthost.facts["asic_type"] in ["mellanox"]:
+            for host in loganalyzer:
+                for ignore_regexp in extended_ignore_list:
+                    loganalyzer[host].ignore_regex.remove(ignore_regexp)


### PR DESCRIPTION
### Description of PR
Updated loganalyzer logic in test sfputil

Original logic created loganalyzer for mellanox devices inside in conftest.py and did not use global loganalyzer fixture Now we use global loganalyzer fixture

Summary: Updated loganalyzer logic in test sfputil
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Now we use global loganalyzer fixture, no need to create new LogAnalyzer instance in conftest

#### How did you do it?
See code

#### How did you verify/test it?
Executed tests from sfp folder

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
