### PR TITLE
[SAI-Qualify]Support sai sdk version when run sai test

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -113,6 +113,23 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="If always stop the container after one \
                      test or not, true or false.")
+    parser.addoption("--sai_origin_version", action="store", default=None,
+                     type=str, help="SAI SDK originla version before upgrade.")
+    parser.addoption("--sai_upgrade_version", action="store", default=None,
+                     type=str, help="SAI SDK upgrade version.")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def tag_sai_test_report(
+        request, pytestconfig, tbinfo, duthost, record_testsuite_property):
+    if not request.config.getoption("--junit-xml"):
+        return
+
+    # Test run information
+    record_testsuite_property(
+        "sai_origin_version", request.config.option.sai_origin_version)
+    record_testsuite_property(
+        "sai_upgrade_version", request.config.option.sai_upgrade_version)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION


Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To add support the SAI validation with SAI sdk version, add two parameters for SAI test versions, considering will support warm reboot, add two version, origainal one and upgrade one.

#### How did you do it?

Add two parameters in the pytest running option, and default is None


#### How did you verify/test it?
Test Done:
Test in local container and pipeline
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
