### PR TITLE
Extend the timeout for 'config_system_checks_passed' to 350 sec

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -93,7 +93,8 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname, localhost,
     # config reload command shouldn't work immediately after system reboot
     assert "Retry later" in out['stdout']
 
-    assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
+    # after reboot tacacs-config.timer need 5min 30 sec to run , extend timeout to 350 sec .
+    assert wait_until(350, 25, 0, config_system_checks_passed, duthost)
 
     # After the system checks succeed the config reload command should not throw error
     out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Extends the timeout for 'config_system_checks_passed' from 300 seconds to 350 seconds(5min50sec) because tacas-config.timer takes 5min 30sec to expire. The command "config reload" cannot be executed until the timer


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix bug .
#### How did you do it?
Extend timeout time .
#### How did you verify/test it?
Test with AS9716-32x
