### PR TITLE
Fix show_techsupport test for QOS file copy on 720DT-48S

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -399,7 +399,8 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
             }
         )
-        if duthost.facts["platform"] in ['x86_64-cel_e1031-r0']:
+        if duthost.facts["platform"] in ['x86_64-cel_e1031-r0',
+                                         'x86_64-arista_720dt_48s']:
             cmds_to_check.update(
                 {
                     "copy_config_cmds":


### PR DESCRIPTION
Summary:
There is no intent to add support for QOS on 720DT-48S, so use copy_config_cmds_no_qos instead of copy_config_cmds on 720DT-48S.  With this fix the 720DT-48S now passes test_techsupport_commands.

### Type of change
- [X] Bug fix

### Back port request
- [X] 202205