### PR TITLE
Fix typo in run_tests.sh for checking sanity check RC

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -330,7 +330,7 @@ function run_individual_tests()
             fi
         else
             # rc 10 means pre-test sanity check failed, rc 12 means boths pre-test and post-test sanity check failed
-            if [ ${ret_code} -eq 10 ] || [${ret_code} -eq 12 ]; then
+            if [ ${ret_code} -eq 10 ] || [ ${ret_code} -eq 12 ]; then
                 echo "=== Sanity check failed for $test_script. Skip rest of the scripts if there is any. ==="
                 return ${ret_code}
             fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #6860 added support of return different return code in post sanity check. However, that PR introduced a typo in the run_tests.sh.

#### How did you do it?
This change is to fix the typo.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
