### PR TITLE
Fix KeyError: u'MUX_LINKMGR' when comparing pre config and current config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1872,9 +1872,6 @@ def core_dump_and_config_check(duthosts, request):
                 pre_running_config = duts_data[duthost.hostname]["pre_running_config"][cfg_context]
                 cur_running_config = duts_data[duthost.hostname]["cur_running_config"][cfg_context]
 
-                pre_running_config_keys = set(pre_running_config.keys())
-                cur_running_config_keys = set(cur_running_config.keys())
-
                 # Remove ignored keys from base config
                 for exclude_key in EXCLUDE_CONFIG_KEY_NAMES:
                     fields = exclude_key.split('|')
@@ -1883,17 +1880,20 @@ def core_dump_and_config_check(duthosts, request):
                     _remove_entry(fields[0], fields[1], pre_running_config)
                     _remove_entry(fields[0], fields[1], cur_running_config)
 
+                pre_running_config_keys = set(pre_running_config.keys())
+                cur_running_config_keys = set(cur_running_config.keys())
+
                 # Check if there are extra keys in pre running config
                 pre_config_extra_keys = list(
                     pre_running_config_keys - cur_running_config_keys - EXCLUDE_CONFIG_TABLE_NAMES)
                 for key in pre_config_extra_keys:
-                    pre_only_config[duthost.hostname].update({key: pre_running_config[key]})
+                    pre_only_config[duthost.hostname][cfg_context].update({key: pre_running_config[key]})
 
                 # Check if there are extra keys in cur running config
                 cur_config_extra_keys = list(
                     cur_running_config_keys - pre_running_config_keys - EXCLUDE_CONFIG_TABLE_NAMES)
                 for key in cur_config_extra_keys:
-                    cur_only_config[duthost.hostname].update({key: cur_running_config[key]})
+                    cur_only_config[duthost.hostname][cfg_context].update({key: cur_running_config[key]})
 
                 # Get common keys in pre running config and cur running config
                 common_config_keys = list(pre_running_config_keys & cur_running_config_keys -


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some test cases failed at teardown when comparing pre config and current config:
```
                    for key in cur_config_extra_keys:
>                       cur_only_config[duthost.hostname].update({key: cur_running_config[key]})
E                       KeyError: u'MUX_LINKMGR'
```
The issue is introduced by #6527.
#### How did you do it?
Get previous and current config keys after removing exclusive keys.
Also add [cfg_context] for cur_only_config and pre_only_config

#### How did you verify/test it?
Run dualtor case,such as `dualtor/test_tor_ecn.py::test_dscp_to_queue_during_encap_on_standby`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
