### PR TITLE
enabled bfd tests

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -153,7 +153,7 @@ def pytest_addoption(parser):
     vxlan_group.addoption(
         "--bfd",
         action="store",
-        default=False,
+        default=True,
         type=bool,
         help="BFD Status"
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The BFD tests in the vxlan_ecmp_tests were covered with parameters as not all builds for the 8102 platforms supported BFD.  The mainstream build now fully supports BFD hence the tests are being enabled by default.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
