### PR TITLE
Fix missing definition in ip_in_ip_tunnel_test.py

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -240,6 +240,7 @@ class IpinIPTunnelTest(BaseTest):
         # Step 2. verify packet is received from IPinIP tunnel and check balance
         for hash_key in self.hash_key_list:
             self.logger.info("Verifying traffic balance for hash key {}".format(hash_key))
+            pkt_distribution = {}
             for port in self.ptf_portchannel_indices.keys():
                 pkt_distribution[port] = 0
             # For thorough completeness level, verify PACKET_NUM packets


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In https://github.com/sonic-net/sonic-mgmt/pull/6870, removed pkt_distribution definition by accident.
#### How did you do it?
Define pkt_distribution.

#### How did you verify/test it?
Run `dualtor/test_orchagent_standby_tor_downstream.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
