### PR TITLE
Remove test_tor_ecn from xfail condition mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -38,11 +38,6 @@ dualtor/test_standby_tor_upstream_mux_toggle.py:
       - "release in ['202012']"
       - "'dualtor' not in topo_name"
 
-dualtor/test_tor_ecn.py:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
 
 dualtor_io/test_normal_op.py:
   xfail:


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In https://github.com/sonic-net/sonic-mgmt/pull/6906, it fixed test_tor_ecn failures.
No need to xfail it.

#### How did you do it?
Remove test_tor_ecn from xfail condition mark

#### How did you verify/test it?
Run `dualtor/test_tor_ecn.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
