### PR TITLE
Set the job of t0-sonic and wan mandatory.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,7 +189,7 @@ stages:
     displayName: "kvmtest-t0-sonic by TestbedV2"
     timeoutInMinutes: 1080
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
@@ -264,7 +264,7 @@ stages:
     displayName: "kvmtest-wan by TestbedV2"
     timeoutInMinutes: 1080
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Recently, the job of t0-sonic and wan run stably, so in this pr, I set them mandatory in azure pipeline. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Recently, the job of t0-sonic and wan run stably, so in this pr, I set them mandatory in azure pipeline. 

#### How did you do it?
Modify the value of `continueOnError` in each job from `true` to `false`. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
