### PR TITLE
Add support to checkout internal repo when internal PR testing

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -337,7 +337,7 @@ if __name__ == "__main__":
         dest="azp_access_token",
         default="",
         required=False,
-        help="A special variable that carries the security token used by the running build"
+        help="Token to download the artifacts of Azure Pipelines"
     )
     parser_create.add_argument(
         "--azp-repo-access-token",
@@ -345,7 +345,7 @@ if __name__ == "__main__":
         dest="azp_repo_access_token",
         default="",
         required=False,
-        help="Authorization token to access internal repo"
+        help="Token to download the repo from Azure DevOps"
     )
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -95,7 +95,7 @@ class TestPlanManager(object):
                 },
                 "secrets": {
                     "azp_access_token": kwargs["azp_access_token"],
-                    "sonic_mgmt_int_access_token": kwargs["sonic_mgmt_int_access_token"],
+                    "azp_repo_access_token": kwargs["azp_repo_access_token"],
                 }
             },
             "priority": 10,
@@ -337,15 +337,15 @@ if __name__ == "__main__":
         dest="azp_access_token",
         default="",
         required=False,
-        help="Authorization token to access internal resource (azure pipeline)"
+        help="A special variable that carries the security token used by the running build"
     )
     parser_create.add_argument(
-        "--sonic-mgmt-int-access-token",
+        "--azp-repo-access-token",
         type=str,
-        dest="sonic_mgmt_int_access_token",
+        dest="azp_repo_access_token",
         default="",
         required=False,
-        help="Authorization token to access sonic-mgmt-int resource"
+        help="Authorization token to access internal repo"
     )
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
@@ -457,7 +457,7 @@ if __name__ == "__main__":
                 specified_params=args.specified_params,
                 vm_type=args.vm_type,
                 azp_access_token=args.azp_access_token,
-                sonic_mgmt_int_access_token=args.sonic_mgmt_int_access_token
+                azp_repo_access_token=args.azp_repo_access_token
             )
         elif args.action == "poll":
             tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_states)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -94,7 +94,8 @@ class TestPlanManager(object):
                     "vm_type": kwargs["vm_type"]
                 },
                 "secrets": {
-                    "azp_access_token": kwargs["access_token"]
+                    "azp_access_token": kwargs["azp_access_token"],
+                    "sonic_mgmt_int_access_token": kwargs["sonic_mgmt_int_access_token"],
                 }
             },
             "priority": 10,
@@ -331,12 +332,20 @@ if __name__ == "__main__":
         help="The asic number of dut"
     )
     parser_create.add_argument(
-        "--access-token",
+        "--azp-access-token",
         type=str,
-        dest="access_token",
+        dest="azp_access_token",
         default="",
         required=False,
-        help="Authorization token to access internal resource (image, etc)"
+        help="Authorization token to access internal resource (azure pipeline)"
+    )
+    parser_create.add_argument(
+        "--sonic-mgmt-int-access-token",
+        type=str,
+        dest="sonic_mgmt_int_access_token",
+        default="",
+        required=False,
+        help="Authorization token to access sonic-mgmt-int resource"
     )
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
@@ -447,7 +456,8 @@ if __name__ == "__main__":
                 num_asic=args.num_asic,
                 specified_params=args.specified_params,
                 vm_type=args.vm_type,
-                access_token=args.access_token
+                azp_access_token=args.azp_access_token,
+                sonic_mgmt_int_access_token=args.sonic_mgmt_int_access_token
             )
         elif args.action == "poll":
             tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_states)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add support to checkout internal repo when internal PR testing. In PR #6859 , we add azp_access_token when download internal image. In this PR, we add azp_repo_access_token to access internal repo.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Add support to checkout internal repo when internal PR testing. In PR #6859 , we add azp_access_token when download internal image. In this PR, we add azp_repo_access_token to access internal repo.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
