### PR TITLE
Enhance Mellanox reboot cause test case

### DIFF
--- a/tests/platform_tests/mellanox/test_reboot_cause.py
+++ b/tests/platform_tests/mellanox/test_reboot_cause.py
@@ -1,0 +1,42 @@
+import allure
+import logging
+import pytest
+from tests.common.reboot import REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC, check_reboot_cause
+from tests.platform_tests.thermal_control_test_helper import mocker_factory  # noqa: F401
+
+pytestmark = [
+    pytest.mark.asic('mellanox'),
+    pytest.mark.topology('any')
+]
+
+logger = logging.getLogger(__name__)
+
+mocker = None
+REBOOT_CAUSE_TYPES = [REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC]
+
+
+@pytest.mark.parametrize("reboot_cause", REBOOT_CAUSE_TYPES)
+def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause):  # noqa: F811
+    """
+    Validate reboot cause from cpu/bios/asic
+    :param rand_selected_dut: The fixture returns a randomly selected DUT
+    :param mocker_factory: The fixture returns a mocker
+    :param reboot_cause: The specific reboot cause
+    """
+    duthost = rand_selected_dut
+    with allure.step('Create mocker - RebootCauseMocker'):
+        mocker = mocker_factory(duthost, 'RebootCauseMocker')
+
+    with allure.step('Mock reset from {}'.format(reboot_cause)):
+        if reboot_cause == REBOOT_TYPE_CPU:
+            mocker.mock_reset_from_comex()
+        elif reboot_cause == REBOOT_TYPE_BIOS:
+            mocker.mock_reset_reload_bios()
+        elif reboot_cause == REBOOT_TYPE_ASIC:
+            mocker.mock_reset_from_asic()
+
+    with allure.step('Restart determine-reboot-cause service'):
+        duthost.restart_service('determine-reboot-cause')
+
+    with allure.step('Check Reboot cause is {}'.format(reboot_cause)):
+        check_reboot_cause(duthost, reboot_cause)


### PR DESCRIPTION
Add new reboot cause script for additional bios cpu and asic causes

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add new script to cover following reboot cause scenarios:

BIOS - In case the BIOS upgrade process ended with failure and cause the switch to reset.
CPU - Reset is initiated by SW on the CPU. it could be that SW encountered some catastrophic situation like a memory leak, eventually, the kernel reset the whole switch.
Reset from ASIC - Reset which is caused by ASIC.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add test for https://github.com/sonic-net/sonic-platform-common/pull/277
#### How did you do it?

#### How did you verify/test it?
Add test script for enhance reboot cause

#### Any platform specific information?
Mellanox platforms, except for SPC1 and SIMX

#### Supported testbed topology if it's a new test case?
Any topology

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
