### PR TITLE
Update qos test param for dualtor topology

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -827,7 +827,190 @@ qos_params:
                 lossless_weight: 30
             hdrm_pool_wm_multiplier: 1
             cell_size: 256
-        topo-any:
+        topo-dualtor:
+            100000_300m:
+                pkts_num_leak_out: 32
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 60204
+                    pkts_num_trig_ingr_drp: 60829
+                    pkts_num_margin: 4
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    dst_port_id: 10
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 6301
+                    pkts_num_hdrm_full: 362
+                    pkts_num_hdrm_partial: 182
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_trig_ingr_drp: 60076
+                    cell_size: 256
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_dismiss_pfc: 18
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_dismiss_pfc: 18
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 84935
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 18
+                    pkts_num_trig_pfc: 59714
+                    packet_size: 64
+                    cell_size: 256
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 84935
+                    packet_size: 64
+                    cell_size: 256
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 60076
+                    cell_size: 256
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_trig_ingr_drp: 60076
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 256
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 84935
+                    cell_size: 256
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 84930
+                    pkts_num_fill_egr_min: 14
+                    cell_size: 256
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 256
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 256
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 256
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 256
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 256
+        topo-dualtor-56:
             50000_300m:
                 pkts_num_leak_out: 32
                 xoff_1:
@@ -973,6 +1156,259 @@ qos_params:
                     pg: 6
                     pkts_num_trig_pfc: 58620
                     pkts_num_trig_ingr_drp: 59245
+                    pkts_num_margin: 4
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    dst_port_id: 10
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 6301
+                    pkts_num_hdrm_full: 362
+                    pkts_num_hdrm_partial: 182
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_trig_ingr_drp: 60076
+                    cell_size: 256
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_dismiss_pfc: 18
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_dismiss_pfc: 18
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 84935
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 18
+                    pkts_num_trig_pfc: 59714
+                    packet_size: 64
+                    cell_size: 256
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 84935
+                    packet_size: 64
+                    cell_size: 256
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 60076
+                    cell_size: 256
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 59714
+                    pkts_num_trig_ingr_drp: 60076
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 256
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 84935
+                    cell_size: 256
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 84930
+                    pkts_num_fill_egr_min: 14
+                    cell_size: 256
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 256
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 256
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 256
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 256
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 256
+        topo-any:
+            50000_300m:
+                pkts_num_leak_out: 32
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 58576
+                    pkts_num_trig_ingr_drp: 58816
+                    pkts_num_margin: 50
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 58576
+                    pkts_num_trig_ingr_drp: 58816
+                    pkts_num_margin: 50
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    dst_port_id: 10
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 4478
+                    pkts_num_hdrm_full: 240
+                    pkts_num_hdrm_partial: 182
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 58276
+                    pkts_num_trig_ingr_drp: 58516
+                    cell_size: 256
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 58276
+                    pkts_num_dismiss_pfc: 18
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 58276
+                    pkts_num_dismiss_pfc: 18
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 112302
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 18
+                    pkts_num_trig_pfc: 58276
+                    packet_size: 64
+                    cell_size: 256
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 112302
+                    packet_size: 64
+                    cell_size: 256
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 58516
+                    cell_size: 256
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 58276
+                    pkts_num_trig_ingr_drp: 58516
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 256
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 58516
+                    cell_size: 256
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 58516
+                    pkts_num_fill_egr_min: 14
+                    cell_size: 256
+            100000_300m:
+                pkts_num_leak_out: 32
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 59784
+                    pkts_num_trig_ingr_drp: 60410
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 59784
+                    pkts_num_trig_ingr_drp: 60410
                     pkts_num_margin: 4
                 hdrm_pool_size:
                     dscps: [3, 4]

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -382,7 +382,8 @@ def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_
     5. Verify regular traffic can trigger PFC at expected queue
     """
     toggle_mux_to_host(rand_selected_dut)
-
+    # Delay 5 seconds between each test run
+    time.sleep(5)
     test_params = dict()
     test_params.update({
             "src_port_id": dut_config["lag_port_ptf_id"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add separated QoS params for different topologies.
The buffer pool size is different on different dualtor topologies. To support different topologies, two sets of parameters are added for topology `dualtor` and `dualtor-56`. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to add separated QoS params for different topologies.

#### How did you do it?
Update `qos.yml` to add different parameters for `dualtor` and `dualtor-56` topology.

#### How did you verify/test it?
Verified on both `dualtor` and `dualtor-56` topology.
```
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1] PASSED                                                                                                                                                                                     [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2] PASSED                                                                                                                                                                                     [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED                                                                                                                                                                                     [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_4] PASSED                                                                                                                                                                                     [100%]
```
#### Any platform specific information?
Broadcom platform specific.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
