### PR TITLE
Add new test case test_separated_qos_map_on_tor

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -73,13 +73,11 @@ def get_queue_counter(duthost, port, queue, clear_before_read=False):
 
 def check_queue_counter(duthost, intfs, queue, counter):
     output = duthost.shell('show queue counters')['stdout_lines']
-
-    for intf in intfs:
-        for line in output:
-            fields = line.split()
-            if len(fields) == 6 and fields[0] == intf and fields[1] == 'UC{}'.format(queue):
-                if int(fields[2]) >= counter:
-                    return True
+    for line in output:
+        fields = line.split()
+        if len(fields) == 6 and fields[0] in intfs and fields[1] == 'UC{}'.format(queue):
+            if int(fields[2]) >= counter:
+                return True
     
     return False
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to check in a new test case `test_separated_qos_map_on_tor`.
From PR https://github.com/sonic-net/sonic-buildimage/pull/12730, sepatared QoS map are applied to uplink/downlink ports on dualtor. 
The test case is to verify separated DSCP_TO_TC_MAP/TC_TO_QUEUE_MAP on uplink and downlink ports of dualtor
Test steps
1. Build IPinIP encapsulated packet with dummy src ip and dst ip (must not be the loopback address of dualtor)
2. Ingress the packet from uplink port, verify the packets egressed from expected queue
3. Build regular packet with dst_ip = dummy IP (routed by default route)
4. Ingress the packet from downlink port, verify the packets egressed from expected queue 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to check in a new test case `test_separated_qos_map_on_tor`.

#### How did you do it?

#### How did you verify/test it?
Verified on a dualtor testbed
```
collected 1 item                                                                                                                                                                                                                                               
qos/test_tunnel_qos_remap.py::test_separated_qos_map_on_tor PASSED                                                                                                                                                                                       [100%]
============================================================================================================ 1 passed, 2 warnings in 264.63 seconds ============================================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Dualtor topo specific.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
