### PR TITLE
fix setup for single asic lc

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -20,6 +20,7 @@ from tests.common.config_reload import config_reload
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +137,8 @@ def get_t2_info(duthosts, tbinfo):
                                                                              defaultdict(list), defaultdict(list))
 
         for sonic_host_or_asic_inst in duthost.get_sonic_host_and_frontend_asic_instance():
-            namespace = sonic_host_or_asic_inst.namespace if hasattr(sonic_host_or_asic_inst, 'namespace') else ''
-            if namespace == '':
+            namespace = sonic_host_or_asic_inst.namespace if hasattr(sonic_host_or_asic_inst, 'namespace') else DEFAULT_NAMESPACE
+            if duthost.sonichost.is_multi_asic and namespace == DEFAULT_NAMESPACE:
                 continue
             asic_id = duthost.get_asic_id_from_namespace(namespace)
             router_mac = duthost.asic_instance(asic_id).get_router_mac()


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6950 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Fix the setup function for t2 to handle single asic linecards
#### How did you verify/test it?
Run t2 tests on the T2 testbed with single and multi asic linecards
```
arlakshm@681605572cc8:/data/my-mgmt/tests$ sudo ANSIBLE_KEEP_REMOTE_FILES=1  ./run_tests.sh -c 'acl/test_acl.py'  -i '../ansible/str2,../ansible/veos' -n 'vms26-t2-sonic-1' -t 't2,any' -e '--skip_sanity'  -u
=== Running tests in groups ===
Running: pytest acl/test_acl.py --inventory ../ansible/str2,../ansible/veos --host-pattern str2-sonic-lc5-1,str2-sonic-lc6-1,str2-sonic-lc7-1,str2-sonic-sup-1 --testbed vms26-t2-sonic-1 --testbed_file /data/my-mgmt/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed
in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================== test session starts ============================================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/my-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed
in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed
in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed
in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed
in the next release.
  from cryptography.exceptions import InvalidSignature
collected 800 items

acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink] PASSED                                                                                                                                  [  0%]
acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-uplink->downlink] PASSED                                                                                                                                  [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-downlink->uplink] SKIPPED                                                                                                                                [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-uplink->downlink] SKIPPED                                                                                                                                [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                                                                  [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                                                                  [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                                                                   [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-uplink->downlink] PASSED     
....
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
