### PR TITLE
Add override config test to kvm suite

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -30,6 +30,7 @@ t0:
   - lldp/test_lldp.py
   - monit/test_monit_status.py
   - ntp/test_ntp.py
+  - override_config_table/test_override_config_table.py
   - pc/test_po_cleanup.py
   - pc/test_po_update.py
   - platform_tests/test_advanced_reboot.py::test_warm_reboot
@@ -91,6 +92,7 @@ t1-lag:
   - ipfwd/test_mtu.py
   - lldp/test_lldp.py
   - monit/test_monit_status.py
+  - override_config_table/test_override_config_table.py
   - pc/test_lag_2.py
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -168,6 +168,7 @@ test_t0() {
       generic_config_updater/test_portchannel_interface.py \
       generic_config_updater/test_syslog.py \
       generic_config_updater/test_vlan_interface.py \
+      override_config_table/test_override_config_table.py \
       process_monitoring/test_critical_process_monitoring.py \
       show_techsupport/test_techsupport_no_secret.py \
       system_health/test_system_status.py \

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -242,6 +242,7 @@ test_t1_lag() {
     ipfwd/test_mtu.py \
     lldp/test_lldp.py \
     monit/test_monit_status.py \
+    override_config_table/test_override_config_table.py \
     pc/test_lag_2.py \
     platform_tests/test_cpu_memory_usage.py \
     process_monitoring/test_critical_process_monitoring.py \

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -14,6 +14,7 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
 ]
 

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -14,7 +14,7 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1', 'any'),
     pytest.mark.disable_loganalyzer,
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add override_config_table test to kvm test suite.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Before we start using the new load_minigraph workflow, we need to test the override correctness.
#### How did you do it?
Add the test to kvm test suite.
#### How did you verify/test it?
Run test on kvm machine.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
