### PR TITLE
[dhcp_server] Skip dhcp_relay check in pretest if dhcp_server is enabled

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -157,8 +157,13 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
         # We don't want to fail here because it's an util
         logging.warn("Failed to retrieve feature status")
         return
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")
+    is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
     for feature_name, state in features_dict.items():
         if 'enabled' not in state:
+            continue
+        # Skip dhcp_relay check if dhcp_server is enabled
+        if "enabled" in is_dhcp_server_enable and feature_name == "dhcp_relay":
             continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -158,12 +158,15 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
         logging.warn("Failed to retrieve feature status")
         return
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")
-    is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
+    try:
+        is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
+    except KeyError:
+        is_dhcp_server_enable = None
     for feature_name, state in features_dict.items():
         if 'enabled' not in state:
             continue
         # Skip dhcp_relay check if dhcp_server is enabled
-        if "enabled" in is_dhcp_server_enable and feature_name == "dhcp_relay":
+        if is_dhcp_server_enable is not None and "enabled" in is_dhcp_server_enable and feature_name == "dhcp_relay":
             continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Skip dhcp_relay check in pretest if dhcp_server is enabled

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
