### PR TITLE
Fix QoS sai test for running with python3

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2615,7 +2615,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             cell_size = int(self.test_params['cell_size'])
             if packet_length != 64:
                 cell_occupancy = (packet_length + cell_size - 1) // cell_size
-                pkts_num_trig_egr_drp /= cell_occupancy
+                pkts_num_trig_egr_drp //= cell_occupancy
                 # It is possible that pkts_num_trig_egr_drp * cell_occupancy < original pkts_num_trig_egr_drp,
                 # which probably can fail the assert(xmit_counters[EGRESS_DROP] > xmit_counters_base[EGRESS_DROP])
                 # due to not sending enough packets.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR https://github.com/sonic-net/sonic-mgmt/pull/6786, there was one line missed(line 2618)
Need to use '//' instead of '/' for the floor division in python3.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix a bug in qos sai test.

#### How did you do it?
 use '//' instead of '/' for the floor division in python3

#### How did you verify/test it?
Verified by automation, test passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
