### PR TITLE
Don't fail if logrotate cron job file isn't present

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -35,8 +35,8 @@ class DisableLogrotateCronContext:
         # Disable logrotate systemd timer by best effort. The reason is that logrotate.timer service is not
         # available in older version like 201911.
         self.ansible_host.command("systemctl stop logrotate.timer", module_ignore_errors=True)
-        # Disable logrotate cron task
-        self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate")
+        # Disable logrotate cron task. Bullseye-based images will not have this file, so ignore any errors.
+        self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate", module_ignore_errors=True)
         logging.debug("Waiting for logrotate from previous cron task or systemd timer run to finish")
         # Wait for logrotate from previous cron task run to finish
         end = time.time() + 60
@@ -56,8 +56,8 @@ class DisableLogrotateCronContext:
         """
         Restore logrotate cron task and systemd timer.
         """
-        # Enable logrotate cron task back
-        self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate")
+        # Enable logrotate cron task back. Bullseye-based images will not have this file, so ignore any errors.
+        self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate", module_ignore_errors=True)
         # Enable logrotate systemd timer by best effort. The reason is that logrotate.timer service is not
         # available in older version like 201911.
         self.ansible_host.command("systemctl start logrotate.timer", module_ignore_errors=True)


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Work on sonic-net/sonic-buildimage#12392.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Bullseye-based images currently have both a cronjob task and a systemd timer configured for the logrotate rotation. This can cause conflicts with two simultaneous log rotations happening (in the worst case; I think there's some check somewhere to prevent this from happening).

#### How did you do it?

To fix this, the cronjob task will be removed. This means that this file will no longer exist. Therefore, don't fail if this file doesn't exist.

#### How did you verify/test it?

Verified that KVM T0 part 1 tests pass with an image without `/etc/cron.d/logrotate`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
