### PR TITLE
[chassis] update the neighbor type  for T2 device_type

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -86,11 +86,19 @@ def common_setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         if k == duthost.hostname:
             dut_type = v['type']
 
-    if 'ToRRouter' in dut_type:
+    if  dut_type in ['ToRRouter', 'SpineRouter']:
         neigh_type = 'LeafRouter'
     else:
         neigh_type = 'ToRRouter'
 
+    logging.info(
+        "pseudoswitch0 neigh_addr {} ns {} dut_asn {} local_addr {} neigh_type {}"
+        .format(conn0["neighbor_addr"].split("/")[0], conn0_ns, dut_asn,
+                conn0["local_addr"].split("/")[0], neigh_type))
+    logging.info(
+        "pseudoswitch1 neigh_addr {} ns {} dut_asn {} local_addr {} neigh_type {}"
+        .format(conn1["neighbor_addr"].split("/")[0], conn1_ns, dut_asn,
+                conn1["local_addr"].split("/")[0], neigh_type))
     bgp_neighbors = (
         BGPNeighbor(
             duthost,


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The neighbor device type is not correctly set when the DUT is a T2 device.  It was incorreclty set to `ToRRouter` it should be set to `LeafRouter`. 
#### How did you do it?
Change the test to set the neighbor device type to correct value when the dut is T2.
#### How did you verify/test it?
Run the test on T2 testbed with single and multi asic linecards
```
arlakshm@681605572cc8:/data/my-mgmt/tests$ sudo ANSIBLE_KEEP_REMOTE_FILES=1  ./run_tests.sh -c 'bgp/test_bgp_update_timer.py'  -i '../ansible/str2,../ansible/veos' -n 'vms26-t2-sonic-1' -t 't2,any' -e '--pdb --skip_sanity'  -u
=== Running tests in groups ===
Running: pytest bgp/test_bgp_update_timer.py --inventory ../ansible/str2,../ansible/veos --host-pattern str2-sonic-lc5-1,str2-sonic-lc6-1,str2-sonic-lc7-1,str2-sonic-sup-1 --testbed vms26-t2-sonic-1 --testbed_file /data/my-mgmt/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --pdb --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================== test session starts ============================================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/my-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, allure-pytest-2.8.22, ansible-2.2.2
collecting ...
----------------------------------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------------------------------22:27:25 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
22:27:25 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
22:27:39 bgp.<module>                             L2530 WARNING| [bgp.py] use_2_bytes_asn: True
22:27:41 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
22:27:41 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
collected 3 items

bgp/test_bgp_update_timer.py::test_bgp_update_timer[str2-sonic-lc5-1] PASSED                                                                                                                                                          [ 33%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer[str2-sonic-lc6-1] PASSED                                                                                                                                                          [ 66%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer[str2-sonic-lc7-1] PASSED                                                                                                                                                          [100%]

------------------------------------------------------------------------------------------- generated xml file: /data/my-mgmt/tests/logs/tr.xml --------------------------------------------------------------------------------------------======================================================================================================== 3 passed in 963.36 seconds ========================================================================================================INFO:root:Can not get Allure report URL. Please check logs
arlakshm@681605572cc8:/data/my-mgmt/tests$
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
