### PR TITLE
[chassis] Skip test_ser for t2 testbeds

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -642,7 +642,8 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
   skip:
     reason: "platform does not support sfp reset"
     conditions:
-      - "platform in ['x86_64-cel_e1031-r0']"
+      - "platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6218
 
 platform_tests/test_auto_negotiation.py:
   skip:


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6977 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
This test cannot be run Asics of Chassis linecards as they from different asic family or vendor. So `test_ser` needs to skipped for T2 
#### How did you do it?
update the conditional marker
#### How did you verify/test it?
Running the test on T2 testbed to verify if the test is skipped
```
arlakshm@681605572cc8:/data/my-mgmt/tests$ sudo ANSIBLE_KEEP_REMOTE_FILES=1  ./run_tests.sh -c 'platform_tests/broadcom/test_ser.py::test_ser'  -i '../ansible/str2,../ansible/veos' -n 'vms26-t2-sonic-1' -t 't2,any' -e '--pdb --skip_sanity'  -u
=== Running tests in groups ===
Running: pytest platform_tests/broadcom/test_ser.py::test_ser --inventory ../ansible/str2,../ansible/veos --host-pattern str2-sonic-lc5-1,str2-sonic-lc6-1,str2-sonic-lc7-1,str2-sonic-sup-1 --testbed vms26-t2-sonic-1 --testbed_file /data/my-mgmt/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --pdb --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================== test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/my-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, allure-pytest-2.8.22, ansible-2.2.2
collecting ...
----------------------------------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------------------------------
00:03:15 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
00:03:15 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
00:03:32 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
00:03:32 testbed.get_testbed_type                 L0266 WARNING| Unsupported testbed type - appliance
collected 2 items

platform_tests/broadcom/test_ser.py::test_ser[0] SKIPPED                                                                                                                                                                             [ 50%]
platform_tests/broadcom/test_ser.py::test_ser[1] SKIPPED                                                                                                                                                                             [100%]

------------------------------------------------------------------------------------------- generated xml file: /data/my-mgmt/tests/logs/tr.xml --------------------------------------------------------------------------------------------
========================================================================================================= short test summary info ==========================================================================================================
SKIPPED [2] platform_tests/broadcom/test_ser.py:68: platform does not support test_ser
======================================================================================================= 2 skipped in 143.09 seconds ========================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
