### PR TITLE
Disable post sanity check for vxlan test

### DIFF
--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology("t0"),
-    pytest.mark.sanity_check(post_check=True),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -77,8 +77,7 @@ NEXTHOP_PREFIX = 100
 
 pytestmark = [
     # This script supports any T1 topology: t1, t1-64-lag, t1-lag.
-    pytest.mark.topology("t1", "t1-64-lag", "t1-lag"),
-    pytest.mark.sanity_check(post_check=True)
+    pytest.mark.topology("t1", "t1-64-lag", "t1-lag")
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Nightly test failed for post sanity check, some processes can't start in test environment.

#### How did you do it?
Disable post sanity check for vxlan test.

#### How did you verify/test it?
Run tests with sonic-mgmt.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
