### PR TITLE
Fix test failure - test_active_tor_remove_neighbor_downstream_active

### DIFF
--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -14,12 +14,7 @@ from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import get_interface_server_map
 from tests.common.dualtor.dual_tor_utils import check_nexthops_balance
 from tests.common.dualtor.dual_tor_utils import add_nexthop_routes, remove_static_routes
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports
 from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
-from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder
-from tests.common.fixtures.ptfhost_utils import run_garp_service
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
@@ -60,7 +55,7 @@ def neighbor_reachable(duthost, neighbor_ip):
     neigh_table = duthost.switch_arptable()['ansible_facts']['arptable']
     ip_version = 'v4' if ip_address(neighbor_ip).version == 4 else 'v6'
     neigh_status = neigh_table[ip_version][neighbor_ip]['state'].lower()
-    return "reachable" in neigh_status
+    return "reachable" in neigh_status or "permanent" in neigh_status
 
 
 def test_active_tor_remove_neighbor_downstream_active(
@@ -79,7 +74,7 @@ def test_active_tor_remove_neighbor_downstream_active(
     @contextlib.contextmanager
     def remove_neighbor(ptfhost, duthost, server_ip, ip_version, neighbor_details):
         # restore ipv4 neighbor since it is statically configured
-        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version == "ipv4")
+        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version == "ipv4" or "ipv6")
         try:
             ptfhost.shell("supervisorctl stop arp_responder")
             # stop garp_service since there is no equivalent in production


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test case failure:
[dualtor.test_orchagent_active_tor_downstream][test_active_tor_remove_neighbor_downstream_active][20201231]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test case failure due to test script parsing the arp table incorrectly.

#### How did you do it?
Fix the test script with correct parsing arp table logic.
Also remove unused import.

#### How did you verify/test it?
Manually run test_active_tor_remove_neighbor_downstream_active successfully.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

