### PR TITLE
[buffer] To save execution time, optimize test_buffer_deployment

### DIFF
--- a/tests/qos/buffer_helpers.py
+++ b/tests/qos/buffer_helpers.py
@@ -1,0 +1,43 @@
+import ast
+
+class DutDbInfo:
+    def __init__(self, duthost):
+        self.duthost = duthost
+        self.update_db_info()
+
+    def get_asic_db(self):
+         return ast.literal_eval(self.duthost.shell('sonic-db-dump -n ASIC_DB -y')['stdout'])
+
+    def get_appl_db(self):
+        return ast.literal_eval(self.duthost.shell('sonic-db-dump -n APPL_DB -y')['stdout'])
+
+    def get_config_db(self):
+        return ast.literal_eval(self.duthost.shell('sonic-db-dump -n CONFIG_DB -y ')['stdout'])
+
+    def get_port_info_from_config_db(self, port):
+        return self.config_db.get("PORT|{}".format(port)).get("value")
+
+    def get_profile_name_from_appl_db(self, table, port, ids):
+        return self.appl_db.get("{}:{}:{}".format(table, port, ids)).get("value").get("profile")
+
+    def get_buffer_profile_oid_in_pg_from_asic_db(self, buffer_item_asic_key, asic_key_name):
+        return self.asic_db.get(buffer_item_asic_key).get("value").get(asic_key_name)
+
+    def get_profile_info_from_appl_db(self, expected_profile_key):
+        return self.appl_db.get(expected_profile_key).get("value")
+
+    def get_buffer_profile_key_from_asic_db(self, buffer_profile_oid):
+        for key in self.asic_db.keys():
+            if buffer_profile_oid in key:
+                return key
+        return exception("Not find the profile key for {}".format(buffer_profile_oid))
+
+    def get_buffer_profile_info_from_asic_db(self, buffer_profile_key):
+        return self.asic_db.get(buffer_profile_key).get("value")
+
+    def update_db_info(self):
+        self.config_db = self.get_config_db()
+        self.appl_db = self.get_appl_db()
+        self.asic_db = self.get_asic_db()
+
+

--- a/tests/qos/buffer_helpers.py
+++ b/tests/qos/buffer_helpers.py
@@ -1,12 +1,13 @@
 import ast
 
+
 class DutDbInfo:
     def __init__(self, duthost):
         self.duthost = duthost
         self.update_db_info()
 
     def get_asic_db(self):
-         return ast.literal_eval(self.duthost.shell('sonic-db-dump -n ASIC_DB -y')['stdout'])
+        return ast.literal_eval(self.duthost.shell('sonic-db-dump -n ASIC_DB -y')['stdout'])
 
     def get_appl_db(self):
         return ast.literal_eval(self.duthost.shell('sonic-db-dump -n APPL_DB -y')['stdout'])
@@ -30,7 +31,7 @@ class DutDbInfo:
         for key in self.asic_db.keys():
             if buffer_profile_oid in key:
                 return key
-        return exception("Not find the profile key for {}".format(buffer_profile_oid))
+        raise Exception("Not find the profile key for {}".format(buffer_profile_oid))
 
     def get_buffer_profile_info_from_asic_db(self, buffer_profile_key):
         return self.asic_db.get(buffer_profile_key).get("value")
@@ -39,5 +40,3 @@ class DutDbInfo:
         self.config_db = self.get_config_db()
         self.appl_db = self.get_appl_db()
         self.asic_db = self.get_asic_db()
-
-

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -20,6 +20,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import check_qos_db_fv_reference_with_table
 from tests.common.utilities import skip_release
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # lgtm[py/unused-import]
+from tests.qos.buffer_helpers import DutDbInfo
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -2266,7 +2267,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
 
         return True
 
-    def _check_buffer_item_in_asic_db(duthost, port, buffer_item, name_map, buffer_profile_oid, asic_key_name, should_have_profile, use_assert):
+    def _check_buffer_item_in_asic_db(dut_db_info, port, buffer_item, name_map, buffer_profile_oid, asic_key_name, should_have_profile, use_assert):
         """Check whether the buffer queues or priority groups align between APPL_DB and ASIC_DB
 
         Args:
@@ -2281,8 +2282,8 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
                         It should return false if it is called in a wait_until loop
         """
         buffer_item_asic_oid = name_map['{}:{}'.format(port, buffer_item)]
-        buffer_item_asic_key = duthost.shell('redis-cli -n 1 keys *{}*'.format(buffer_item_asic_oid))['stdout']
-        buffer_profile_oid_in_pg = duthost.shell('redis-cli -n 1 hget {} {}'.format(buffer_item_asic_key, asic_key_name))['stdout']
+        buffer_item_asic_key = dut_db_info.get_buffer_profile_key_from_asic_db(buffer_item_asic_oid)
+        buffer_profile_oid_in_pg = dut_db_info.get_buffer_profile_oid_in_pg_from_asic_db(buffer_item_asic_key, asic_key_name)
         if should_have_profile:
             if buffer_profile_oid:
                 if not _check_condition(buffer_profile_oid == buffer_profile_oid_in_pg,
@@ -2314,11 +2315,11 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
             upper = upper[1:]
         return [str(x) for x in range(int(lower), int(upper) + 1)]
 
-    def _check_port_buffer_info_and_get_profile_oid(duthost, table, ids, port, expected_profile, use_assert=True):
+    def _check_port_buffer_info_and_get_profile_oid(dut_db_info, table, ids, port, expected_profile, use_assert=True):
         """Check port's buffer information against APPL_DB and ASIC_DB
 
         Args:
-            duthost: The duthost object
+            dut_db_info: The dut db info object
             table: BUFFER_QUEUE or BUFFER_PG
             ids: The ID map, like "3-4" or "0-2"
             port: The port to test in string
@@ -2328,7 +2329,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
         Return:
             A tuple consisting of the OID of buffer profile and whether there is any check failed
         """
-        profile_in_db = duthost.shell('redis-cli hget "{}:{}:{}" profile'.format(table, port, ids))['stdout']
+        profile_in_db = dut_db_info.get_profile_name_from_appl_db(table, port, ids)
         buffer_profile_oid = None
         if table == 'BUFFER_PG_TABLE':
             sai_field = 'SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE'
@@ -2346,8 +2347,8 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
             if buffer_name_map:
                 buffer_profile_oid = None
                 for item in id_list:
-                    logging.info("Checking {}:{}:{} in ASIC_DB".format(table, port, item))
-                    buffer_profile_oid, success = _check_buffer_item_in_asic_db(duthost, port, item, buffer_name_map, buffer_profile_oid, sai_field, True, use_assert)
+                    logging.info("Checking {}:{}:{} in ASIC_DB, expected_profile:{}".format(table, port, item, expected_profile))
+                    buffer_profile_oid, success = _check_buffer_item_in_asic_db(dut_db_info, port, item, buffer_name_map, buffer_profile_oid, sai_field, True, use_assert)
                     if not success:
                         return None, False
         else:
@@ -2356,24 +2357,25 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
             if buffer_name_map:
                 for item in id_list:
                     logging.info("Checking {}:{}:{} in ASIC_DB".format(table, port, item))
-                    buffer_profile_oid, success = _check_buffer_item_in_asic_db(duthost, port, item, buffer_name_map, None, sai_field, False, use_assert)
+                    buffer_profile_oid, success = _check_buffer_item_in_asic_db(dut_db_info, port, item, buffer_name_map, None, sai_field, False, use_assert)
 
         return buffer_profile_oid, True
 
-    def _check_port_buffer_info_and_return(duthost, table, ids, port, expected_profile):
+    def _check_port_buffer_info_and_return(dut_db_info, table, ids, port, expected_profile):
         """Check port's buffer information against CONFIG_DB and ASIC_DB and return the result
 
         This is called from wait_until
 
         Args:
-            duthost: The duthost object
+            duthost: The dut db info object
             port: The port to test in string
             expected_profile: The expected profile in string
 
         Return:
             Whether all the checks passed
         """
-        _, result = _check_port_buffer_info_and_get_profile_oid(duthost, table, ids, port, expected_profile, False)
+        dut_db_info.update_db_info()
+        _, result = _check_port_buffer_info_and_get_profile_oid(dut_db_info, table, ids, port, expected_profile, False)
         return result
 
     duthost = duthosts[rand_one_dut_hostname]
@@ -2381,6 +2383,9 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
 
     # Skip the legacy branches
     skip_release(duthost, ["201811", "201911"])
+
+    # Get dut asic, config, and appl db information
+    dut_db_info = DutDbInfo(duthost)
 
     # Check whether the COUNTERS_PG_NAME_MAP and COUNTERS_QUEUE_NAME_MAP exists. Skip ASIC_DB checking if it isn't
     pg_name_map = _compose_dict_from_cli(duthost.shell('redis-cli -n 2 hgetall COUNTERS_PG_NAME_MAP')['stdout'].split())
@@ -2458,7 +2463,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
     admin_up_ports = set()
     for port in configdb_ports:
         logging.info("Checking port buffer information: {}".format(port))
-        port_config = _compose_dict_from_cli(duthost.shell('redis-cli -n 4 hgetall "PORT|{}"'.format(port))['stdout'].split())
+        port_config = dut_db_info.get_port_info_from_config_db(port)
         cable_length = cable_length_map[port]
         speed = port_config['speed']
         expected_profile = make_expected_profile_name(speed, cable_length, number_of_lanes=len(port_config['lanes'].split(',')))
@@ -2485,12 +2490,12 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
                 buffer_items_to_check = [(None, None, None)]
 
         for table, ids, expected_profile in buffer_items_to_check:
-            logging.info("Checking buffer item {}:{}:{}".format(table, port, ids))
+            logging.info("Checking buffer item {}:{}:{}, expected_profile:{}".format(table, port, ids, expected_profile))
 
             if not expected_profile:
                 continue
 
-            buffer_profile_oid, _ = _check_port_buffer_info_and_get_profile_oid(duthost, table, ids, port, expected_profile)
+            buffer_profile_oid, _ = _check_port_buffer_info_and_get_profile_oid(dut_db_info, table, ids, port, expected_profile)
 
             if is_qos_db_reference_with_table:
                 expected_profile_key = expected_profile[1:-1]
@@ -2498,7 +2503,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
                 expected_profile_key = "BUFFER_PROFILE_TABLE:{}".format(expected_profile)
 
             if expected_profile not in profiles_checked:
-                profile_info = _compose_dict_from_cli(duthost.shell('redis-cli hgetall "{}"'.format(expected_profile_key))['stdout'].split())
+                profile_info = dut_db_info.get_profile_info_from_appl_db(expected_profile_key)
                 is_ingress_lossless = expected_profile[:12] == 'pg_lossless_'
                 if is_ingress_lossless and not BUFFER_MODEL_DYNAMIC:
                     std_profiles_for_speed = DEFAULT_LOSSLESS_HEADROOM_DATA.get(speed)
@@ -2513,8 +2518,8 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
                 if buffer_profile_oid:
                     # Further check the buffer profile in ASIC_DB
                     logging.info("Checking profile {} oid {}".format(expected_profile, buffer_profile_oid))
-                    buffer_profile_key = duthost.shell('redis-cli -n 1 keys *{}*'.format(buffer_profile_oid))['stdout']
-                    buffer_profile_asic_info = _compose_dict_from_cli(duthost.shell('redis-cli -n 1 hgetall {}'.format(buffer_profile_key))['stdout'].split())
+                    buffer_profile_key = dut_db_info.get_buffer_profile_key_from_asic_db(buffer_profile_oid)
+                    buffer_profile_asic_info = dut_db_info.get_buffer_profile_info_from_asic_db(buffer_profile_key)
                     pytest_assert(buffer_profile_asic_info.get('SAI_BUFFER_PROFILE_ATTR_XON_TH') == profile_info.get('xon') and
                                   buffer_profile_asic_info.get('SAI_BUFFER_PROFILE_ATTR_XOFF_TH') == profile_info.get('xoff') and
                                   buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE'] == profile_info['size'] and
@@ -2555,12 +2560,12 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
             logging.info("Shut down an admin-up port {} and check its buffer information".format(port_to_shutdown))
             duthost.shell('config interface shutdown {}'.format(port_to_shutdown))
             for pg_id_name in pg_id_names:
-                wait_until(60, 5, 0, _check_port_buffer_info_and_return, duthost, 'BUFFER_PG_TABLE', pg_id_name, port_to_shutdown, _profile_name(duthost, port, pg_id_name))
+                wait_until(60, 5, 0, _check_port_buffer_info_and_return, dut_db_info, 'BUFFER_PG_TABLE', pg_id_name, port_to_shutdown, _profile_name(duthost, port, pg_id_name))
             # Startup the port and check whether the lossless PG has been reconfigured
             logging.info("Re-startup the port {} and check its buffer information".format(port_to_shutdown))
             duthost.shell('config interface startup {}'.format(port_to_shutdown))
             for pg_id_name in pg_id_names:
-                wait_until(60, 5, 0, _check_port_buffer_info_and_return, duthost, 'BUFFER_PG_TABLE', pg_id_name, port_to_shutdown, _profile_name(duthost, port, pg_id_name))
+                wait_until(60, 5, 0, _check_port_buffer_info_and_return, dut_db_info, 'BUFFER_PG_TABLE', pg_id_name, port_to_shutdown, _profile_name(duthost, port, pg_id_name))
         finally:
             duthost.shell('config interface startup {}'.format(port_to_shutdown), module_ignore_errors=True)
 


### PR DESCRIPTION
1. In old implementation It will fetch the db info from dut for more than 10  times and take about 30~40s for very port to check the buffer config, and most of time is spent fetching data from dut. So, the bigger the total number of port is, the longer the execution time is.
2. Since during the time of test, there is no config and status change, so we can fetch all db info one time for all ports instead of fetching info more times for one port. So, It can save much time.  How much time is saved depends on the total number of port. The bigger the total number of port is, the longer the saved time is. Take sn3800 with 70 ports as an example: previously about 22 minutes, now about 2 minutes


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Save test execution time

#### How did you do it?
Fetch all db info one time for all ports instead of fetch it more times for one port

#### How did you verify/test it?
Compare the time before and after

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
