### PR TITLE
Skip testQosSaiSeparatedDscpToPgMapping and testQosSaiSeparatedDscpQueueMapping on dualtor

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -923,9 +923,11 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        # Only run this test when separated DSCP_TO_TC_MAP is defined
+        # Only run this test on T1 testbed when separated DSCP_TO_TC_MAP is defined
         if not separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
             pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is not applied")
+        if "dualtor" in dutTestParams['topo']:
+            pytest.skip("Skip this test case on dualtor testbed")
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1383,7 +1385,9 @@ class TestQosSai(QosSaiBase):
         """
         if not separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
             pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is not applied")
-
+        if "dualtor" in dutTestParams['topo']:
+            pytest.skip("Skip this test case on dualtor testbed")
+            
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         if direction == "downstream":


### PR DESCRIPTION
…eueMapping on dualtor

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip `testQosSaiSeparatedDscpToPgMapping` and `testQosSaiSeparatedDscpQueueMapping` on dualtor testbed.
The scenario on dualtor is covered by test case `test_separated_qos_map_on_tor`
https://github.com/sonic-net/sonic-mgmt/blob/c05753cfe68313805c24fe4607645b528e17611c/tests/qos/test_tunnel_qos_remap.py#L205

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip `testQosSaiSeparatedDscpToPgMapping` and `testQosSaiSeparatedDscpQueueMapping` on dualtor testbed.

#### How did you do it?
Check the topo name before test running.

#### How did you verify/test it?
Verified on dualtor testbed. Confirm both test cases are skipped.

#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
