### PR TITLE
Skipping reboot on Supervisor for Cisco 8000 distributed chassis

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1102,6 +1102,8 @@ class TestAclWithReboot(TestBasicAcl):
 
         """
         dut.command("config save -y")
+        if dut.is_supervisor_node and dut.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+            pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
         reboot(dut, localhost, wait=240)
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -263,6 +263,8 @@ class TestReboot():
     @pytest.mark.disable_loganalyzer
     def test_reboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds):
         duthost = duthosts[rand_one_dut_hostname]
+        if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+            pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost)
         pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started")

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -143,6 +143,8 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
         pytest.skip("Skip single-host dut for this test")
 
     duthost = duthosts[enum_supervisor_dut_hostname]
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     hostname = duthost.hostname
     # Before test, check all interfaces and services are up on all linecards
     check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list)
@@ -173,6 +175,8 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostn
                                     duts_running_config_facts, conn_graph_facts, 
                                     fanouthosts, xcvr_skip_list, tbinfo):
     duthost = duthosts[enum_frontend_dut_hostname]
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     hostname = duthost.hostname
 
     # Before test, check all interfaces and services are up

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -129,6 +129,8 @@ def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn
     @summary: This test case is to perform cold reboot and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
 
 
@@ -276,6 +278,8 @@ def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost
     @summary: This test case is to perform 3 cold reboot in a row
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     ls_starting_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     for i in range(3):
         reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -265,7 +265,8 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     watchdogutil_status_result = duthost.command("watchdogutil status", module_ignore_errors=True)
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -79,7 +79,8 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname, localhost,
     @summary: This test case is to test various system checks in config reload
     """
     duthost = duthosts[rand_one_dut_hostname]
-
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     if not config_force_option_supported(duthost):
         return
 

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -118,6 +118,8 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_supervisor_node and duthost.facts['platform'] in ['x86_64-8800_rp_o-r0']:
+        pytest.skip("Skip reboot for Supervisor card in Cisco 8000 distributed chassis")
     skip_release(duthost, ["201911", "201811"])
 
     dutip = duthost.mgmt_ip


### PR DESCRIPTION
### Description of PR
Skipping reboot on Supervisor for Cisco 8000 distributed chassis. 

Summary:
Fixes # (issue)

### Type of change

- Fill x for your type of change.
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently we are hitting an intermittent issue if Supervisor is rebooted during a test. To avoid tests to get errored out during nightly run, we are skipping reboot for supervisor node

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
