### PR TITLE
[macsec]: Return recent packets in macsec_dp_poll

### DIFF
--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -406,18 +406,19 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
         if ret.device != 0 or exp_pkt is None:
             return ret
         pkt = scapy.Ether(ret.packet)
-        if pkt.haslayer(scapy.Ether) and pkt[scapy.Ether].type != 0x88e5:
-            if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
-                return ret
-        else:
-            macsec_info = load_macsec_info(test.duthost, find_portname_from_ptf_id(test.mg_facts, ret.port), force_reload[ret.port])
-            if macsec_info:
-                encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
-                force_reload[ret.port] = False
-                pkt = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
-                                    send_sci, 0, xpn_en, ssci, salt)
-                if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+        if pkt.haslayer(scapy.Ether):
+            if pkt[scapy.Ether].type != 0x88e5:
+                if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                     return ret
+            else:
+                macsec_info = load_macsec_info(test.duthost, find_portname_from_ptf_id(test.mg_facts, ret.port), force_reload[ret.port])
+                if macsec_info:
+                    encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
+                    force_reload[ret.port] = False
+                    pkt = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
+                                        send_sci, 0, xpn_en, ssci, salt)
+                    if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+                        return ret
         # Normally, if __origin_dp_poll returns a PollFailure, the PollFailure object will contain a list of recently received packets
         # to help with debugging. However, since we call __origin_dp_poll multiple times, only the packets from the most recent call is retained.
         # If we don't find a matching packet (either with or without MACsec decoding), we need to manually store the packet we received.

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -395,29 +395,33 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
         ret = __origin_dp_poll(
             test, device_number=device_number, port_number=port_number, timeout=timeout, exp_pkt=None)
         timeout -= time.time() - start_time
+        # Since we call __origin_dp_poll with exp_pkt=None, it should only ever fail if no packets are received at all. In this case, continue normally
+        # until we exceed the timeout value provided to macsec_dp_poll.
+        if isinstance(ret, test.dataplane.PollFailure):
+            if timeout <= 0:
+                break
+            else:
+                continue
         # The device number of PTF host is 0, if the target port isn't a injected port(belong to ptf host), Don't need to do MACsec further.
-        if ret.device != 0 \
-            or isinstance(ret, test.dataplane.PollFailure) \
-                or exp_pkt is None:
+        if ret.device != 0 or exp_pkt is None:
             return ret
         pkt = scapy.Ether(ret.packet)
-        if pkt.haslayer(scapy.Ether):
-            if pkt[scapy.Ether].type != 0x88e5:
-                if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
-                    return ret
-                else:
-                    continue
-        else:
-            continue
-
-        macsec_info = load_macsec_info(test.duthost, find_portname_from_ptf_id(test.mg_facts, ret.port), force_reload[ret.port])
-        if macsec_info:
-            encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
-            force_reload[ret.port] = False
-            pkt = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
-                                send_sci, 0, xpn_en, ssci, salt)
-            if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+        if pkt.haslayer(scapy.Ether) and pkt[scapy.Ether].type != 0x88e5:
+            if ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                 return ret
+        else:
+            macsec_info = load_macsec_info(test.duthost, find_portname_from_ptf_id(test.mg_facts, ret.port), force_reload[ret.port])
+            if macsec_info:
+                encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
+                force_reload[ret.port] = False
+                pkt = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
+                                    send_sci, 0, xpn_en, ssci, salt)
+                if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+                    return ret
+        # Normally, if __origin_dp_poll returns a PollFailure, the PollFailure object will contain a list of recently received packets
+        # to help with debugging. However, since we call __origin_dp_poll multiple times, only the packets from the most recent call is retained.
+        # If we don't find a matching packet (either with or without MACsec decoding), we need to manually store the packet we received.
+        # Later if we return a PollFailure, we can provide the received packets to emulate the behavior of __origin_dp_poll.
         recent_packets.append(pkt)
         packet_count += 1
         if timeout <= 0:


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
`macsec_dp_poll` replaces the original `dp_poll` function from the PTF library in all test cases (this is used by methods such as `ptf.testutils.verify_packet`). When `macsec_dp_poll` doesn't find a packet matching the expected packet, it doesn't return a list of recently received packets (the original `dp_poll` does), which makes debugging difficult. Instead, it will raise an error with the following message:

```
E       AssertionError: Expected packet was not received on device 0, port 1.
E       ========== RECEIVED ==========
E       0 total packets.
E       ==============================
```

#### How did you do it?
Always store received packets in case they need to be returned in a `PollFailure` object later.

#### How did you verify/test it?
Call `ptf.testutils.verify_packet` and provide some expected packet which will not be received. The method should fail with a message similar to below:

```
E       AssertionError: Expected packet was not received on device 0, port 1.
E       ========== EXPECTED ==========
E       Mask:
E       0000  4E E0 F6 98 88 DD 08 C0 EB 20 38 EC 08 00 45 00  N........ 8...E.
E       0010  00 88 00 00 00 00 00 11 A4 43 0A 01 00 20 0A 00  .........C... ..
E       0020  02 02 04 D2 12 B5 00 74 A2 60 08 00 00 00 00 07  .......t.`......
E       0030  D0 00 F9 22 83 99 22 A2 F4 93 9F EF C4 7E 08 00  ...".."......~..
E       0040  45 00 00 56 00 01 00 00 40 11 58 91 0B 01 01 01  E..V....@.X.....
E       0050  14 02 02 02 04 D2 00 50 00 42 00 00 74 65 73 74  .......P.B..test
E       0060  73 2E 64 61 73 68 2E 74 65 73 74 5F 64 61 73 68  s.dash.test_dash
E       0070  20 74 65 73 74 73 2E 64 61 73 68 2E 74 65 73 74   tests.dash.test
E       0080  5F 64 61 73 68 20 74 65 73 74 73 2E 64 61 73 68  _dash tests.dash
E       0090  2E 74 65 73 74 5F                                .test_
E       mask = ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0010   00 00 ff ff ff ff ff ff  00 00 ff ff ff ff ff ff
E       0020   ff ff 00 00 ff ff ff ff  00 00 00 ff ff ff ff ff
E       0030   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0040   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0050   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0060   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0070   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0080   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
E       0090   ff ff ff ff ff ff
E
E       ========== RECEIVED ==========
E       3 total packets. Displaying most recent 3 packets:
E       ------------------------------
E       0000  4E E0 F6 98 88 DD 08 C0 EB 20 38 14 08 00 45 C0  N........ 8...E.
E       0010  00 34 E2 07 40 00 01 06 7E FA 0A 00 02 01 0A 00  .4..@...~.......
E       0020  02 02 C3 4C 00 B3 50 B5 61 90 CB C4 A9 7F 80 10  ...L..P.a.......
E       0030  01 F0 45 C5 00 00 01 01 08 0A 03 EC 26 CA 1B FC  ..E.........&...
E       0040  E4 C9                                            ..
E       ------------------------------
E       0000  4E E0 F6 98 88 DD 08 C0 EB 20 38 14 08 00 45 C0  N........ 8...E.
E       0010  00 47 E2 08 40 00 01 06 7E E6 0A 00 02 01 0A 00  .G..@...~.......
E       0020  02 02 C3 4C 00 B3 50 B5 61 90 CB C4 A9 7F 80 18  ...L..P.a.......
E       0030  01 F0 3E CC 00 00 01 01 08 0A 03 EC 29 95 1B FC  ..>.........)...
E       0040  E4 C9 FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
E       0050  FF FF 00 13 04                                   .....
...
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
