### PR TITLE
tests/decap:Marvell specific changes

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -97,14 +97,15 @@ class DecapPacketTest(BaseTest):
         self.ttl_mode = self.test_params.get('ttl_mode')
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
         self.single_fib = self.test_params.get('single_fib_for_duts', False)
-
+        self.asic_type = self.test_params.get('asic_type')
         # multi asic platforms have internal routing hops
         # this param will be used to set the correct ttl values for inner packet
         # this value is zero for single asic platform
         self.max_internal_hops = self.test_params.get('max_internal_hops', 0)
         if self.max_internal_hops:
             self.TTL_RANGE = list(range(self.max_internal_hops + 1, 63))
-
+        if self.asic_type == "marvell":
+            fib.EXCLUDE_IPV4_PREFIXES.append("240.0.0.0/4")
         self.fibs = []
         for fib_info_file in self.test_params.get('fib_info_files'):
             self.fibs.append(fib.Fib(fib_info_file))
@@ -312,7 +313,6 @@ class DecapPacketTest(BaseTest):
         @outer_ttl: TTL for the outer layer
         @inner_ttl: TTL for the inner layer
         '''
-
         pkt, exp_pkt = self.create_encap_packet(dst_ip, src_port, dut_index, outer_pkt_type, triple_encap, outer_ttl, inner_ttl)
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -181,7 +181,7 @@ def set_mux_random(tbinfo, mux_server_url):
 def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mux_random, supported_ttl_dscp_params, ip_ver, loopback_ips,
                duts_running_config_facts, duts_minigraph_facts):
     setup_info = setup_teardown
-
+    asic_type = duthosts[0].facts["asic_type"]
     ecn_mode = "copy_from_outer"
     ttl_mode = supported_ttl_dscp_params['ttl']
     dscp_mode = supported_ttl_dscp_params['dscp']
@@ -215,6 +215,7 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mu
                             "lo_ipv6s": setup_info["lo_ipv6s"],
                             "ttl_mode": ttl_mode,
                             "dscp_mode": dscp_mode,
+                            "asic_type": asic_type,
                             "ignore_ttl": setup_info["ignore_ttl"],
                             "max_internal_hops": setup_info["max_internal_hops"],
                             "fib_info_files": setup_info["fib_info_files"],


### PR DESCRIPTION
Signed-off-by: sureshsekar28 <sureshsekar@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Marvell specific changes on tests/decap  for,
[decap] sonic is expecting to install reserved ip address(240.x) after decapsulation of ipinip packet #5284

Summary:
Fixes # Marvell specific changes on tests/decap for,
[decap] sonic is expecting to install reserved ip address(240.x) after decapsulation of ipinip packet #5284

### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [x ] 201911
- [x ] 202012
- [ x] 202205

### Approach
#### What is the motivation for this PR?
Marvell specific changes on tests/decap for
[decap] sonic is expecting to install reserved ip address(240.x) after decapsulation of ipinip packet #5284
#### How did you do it?
test script change 
#### How did you verify/test it?
test script is passing with the change
#### Any platform specific information?
Marvell
#### Supported testbed topology if it's a new test case?
modified existing test case
### Documentation
https://github.com/sonic-net/sonic-mgmt/issues/5284

