### PR TITLE
[m0] Remove skip watchdog reboot test for m0

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -934,12 +934,6 @@ platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus:
 #######################################
 #####        test_reboot.py       #####
 #######################################
-platform_tests/test_reboot.py:
-  skip:
-    reason: "Skip reboot test for Celestica"
-    conditions:
-      - "hwsku in ['Celestica-E1031-T48S4']"
-
 platform_tests/test_reboot.py::test_cold_reboot:
   xfail:
     reason: "case failed and waiting for fix"
@@ -995,13 +989,9 @@ platform_tests/test_reboot.py::test_warm_reboot:
 
 platform_tests/test_reboot.py::test_watchdog_reboot:
   skip:
-    reason: "Skip watchdog reboot test for Wistron"
+    reason: "Skip watchdog reboot test for Wistron / Nokia 7215"
     conditions:
-      - "hwsku in ['Celestica-E1031-T48S4'] or 'sw_to3200k' in hwsku"
-  skip:
-    reason: "Skip watchdog reboot test for m0/mx"
-    conditions:
-      - "topo_name in ['m0', 'mx']"
+      - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 #######################################
 #####   test_reload_config.py     #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enable watchdog reboot test for m0 and E1031

#### How did you do it?
Remove skip condition about watchdog reboot test for m0 and E1031. Skip this test for Nokia 7215 as itdoes not support show reboot-cause history

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
