### PR TITLE
Adding workaround fix for syslog issue found in test_sequential_restart.py

### DIFF
--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -8,8 +8,8 @@ import logging
 
 import pytest
 
-from tests.common import config_reload
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common import config_reload  # noqa F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.processes_utils import check_critical_processes
@@ -31,8 +31,11 @@ def heal_testbed(duthosts, rand_one_dut_hostname):
     yield
     status, details = get_critical_processes_status(duthost)
     if not status:
-        logging.info("Restoring dut with critical process failure: {}".format(details))
-        config_reload(duthost, config_source='config_db', wait=120)
+        logging.info("One or more critical process failed: Details - {}".format(details))
+    # After this test run, rsyslogd is going down if all BGP session established and routes populated
+    # restarting syslog to over come this issue, so that subsequent test run will not have errors/failures
+    duthost.shell("sudo systemctl restart syslog")
+
 
 def is_service_hiting_start_limit(duthost, container_name):
     """
@@ -46,11 +49,12 @@ def is_service_hiting_start_limit(duthost, container_name):
 
     return False
 
+
 def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces, xcvr_skip_list):
     """
     Restart specified service and check platform status
     """
-    logging.info("Restart the %s service on asic %s" %(service, enum_frontend_asic_index))
+    logging.info("Restart the %s service on asic %s" % (service, enum_frontend_asic_index))
 
     asichost = dut.asic_instance(enum_frontend_asic_index)
     service_name = asichost.get_service_name(service)
@@ -66,7 +70,8 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     wait_critical_processes(dut)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    pytest_assert(wait_until(300, 20, 0, check_interface_information, dut, enum_frontend_asic_index, interfaces, xcvr_skip_list),
+    pytest_assert(wait_until(300, 20, 0, check_interface_information, dut,
+                  enum_frontend_asic_index, interfaces, xcvr_skip_list),
                   "Not all interface information are detected within 300 seconds")
 
     logging.info("Check transceiver status on asic %s" % enum_frontend_asic_index)
@@ -87,7 +92,8 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     check_critical_processes(dut, 60)
 
 
-def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, localhost, conn_graph_facts, xcvr_skip_list):
+def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
+                      localhost, conn_graph_facts, xcvr_skip_list):            # noqa F811
     """
     @summary: This test case is to restart the swss service and check platform status
     """
@@ -99,16 +105,18 @@ def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
         interface_list = get_port_map(duthost, enum_frontend_asic_index)
 
         # Check if the interfaces of this AISC is present in conn_graph_facts
-        new_intf_dict = {k:v for k, v in interface_list.items() if k in all_interfaces}
+        new_intf_dict = {k: v for k, v in interface_list.items() if k in all_interfaces}
         all_interfaces = new_intf_dict
         logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, all_interfaces))
 
     restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces, xcvr_skip_list)
 
 
-def test_restart_syncd(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, localhost, conn_graph_facts, xcvr_skip_list):
+def test_restart_syncd(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
+                       localhost, conn_graph_facts, xcvr_skip_list):           # noqa F811
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
     duthost = duthosts[rand_one_dut_hostname]
-    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "syncd", conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list)
+    restart_service_and_check(localhost, duthost, enum_frontend_asic_index,
+                              "syncd", conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list)


### PR DESCRIPTION
### Description of PR

Adding workaround fix for syslog issue found in test_sequential_restart.py

Summary:

In 202111 PTF T1 topo, after running platform_tests/test_sequential_restart.py with all BGP session established and routes populated,  log messages are not getting written in to /var/log/syslog. The log messages are getting stuck. When we execute “systemctl stop syslog”, the stuck messages are getting written in to /var/log/syslog. This issue happens only when we had BGP session up and all the neighbors in T1 setup being up.

Adding "sudo systemctl restart syslog" at the end of test to fix the issue.

Fixes # 6995

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To fix the issue reported in 6995
#### How did you do it?

#### How did you verify/test it?
Run the test and reported issue is not seen

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
