### PR TITLE
Adding macsec feature to DEFAULT_ASIC_SERVICES list for each SonicHost

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -32,12 +32,13 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
-    DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
     def __init__(self, ansible_adhoc, hostname,
                  shell_user=None, shell_passwd=None,
                  ssh_user=None, ssh_passwd=None):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
+
+        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "macsec"]
 
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -38,7 +38,7 @@ class SonicHost(AnsibleHostBase):
                  ssh_user=None, ssh_passwd=None):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
 
-        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "macsec"]
+        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']
@@ -72,6 +72,8 @@ class SonicHost(AnsibleHostBase):
 
         self._facts = self._gather_facts()
         self._os_version = self._get_os_version()
+        if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
+            self.DEFAULT_ASIC_SERVICES.append("macsec")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False
         self._kernel_version = self._get_kernel_version()
@@ -183,6 +185,7 @@ class SonicHost(AnsibleHostBase):
         facts["modular_chassis"] = self._get_modular_chassis()
         facts["mgmt_interface"] = self._get_mgmt_interface()
         facts["switch_type"] = self._get_switch_type()
+        facts["router_type"] = self._get_router_type()
         asics_present = self.get_asics_present_from_inventory()
         facts["asics_present"] = asics_present if len(asics_present) != 0 else list(range(facts["num_asic"]))
 
@@ -257,6 +260,13 @@ class SonicHost(AnsibleHostBase):
     def _get_switch_type(self):
         try:
             return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.switch_type'")["stdout_lines"][0]\
+                .encode().decode("utf-8").lower()
+        except Exception:
+            return ''
+
+    def _get_router_type(self):
+        try:
+            return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.type'")["stdout_lines"][0] \
                 .encode().decode("utf-8").lower()
         except Exception:
             return ''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR addresses the following:
- 'macsec' Autorestart and Container_Checker test cases are not multi-asic aware.
- Adding the 'macsec' feature to DEFAULT_ASIC_SERVICES list for each SonicHost.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, Autorestart and Container_Checker test cases fail for 'macsec' feature since it is not multi-asic aware. Hence added a fix to make 'macsec' feature multi-asic aware.

#### How did you do it?
- Added the 'macsec' feature to DEFAULT_ASIC_SERVICES list for each SonicHost.

#### How did you verify/test it?
- Ran the tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![autorestart-result](https://user-images.githubusercontent.com/114024719/206737940-6bece91d-22a7-47cd-8a8d-050d1366b89a.PNG)
![container-checker-result](https://user-images.githubusercontent.com/114024719/206737942-4a6ca26b-4e0e-4ed4-a8cf-9aaae9e79cdd.PNG)
