### PR TITLE
[sai_qualify]Set PTF interface parameters

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -181,7 +181,7 @@ def start_sai_test_container(duthost, creds, request,
 
 
 @pytest.fixture(scope="module")
-def prepare_ptf_server(ptfhost, duthost, request):
+def prepare_ptf_server(ptfhost, duthost, tbinfo, enum_asic_index, request):
     """
     Prepare the PTF Server.
 
@@ -197,24 +197,30 @@ def prepare_ptf_server(ptfhost, duthost, request):
     else:
         if not request.config.option.sai_test_skip_setup_env:
             update_saithrift_ptf(request, ptfhost)
-            __create_sai_port_map_file(ptfhost, duthost)
+            __create_sai_port_map_file(
+                ptfhost, duthost, tbinfo, enum_asic_index)
     yield
     if not request.config.option.sai_test_keep_test_env:
         __delete_sai_port_map_file(ptfhost)
 
 
 @pytest.fixture(scope="module")
-def create_sai_test_interface_param(duthost):
+def create_sai_test_interface_param(duthost, tbinfo, enum_asic_index):
     """
     Create port interface list.
 
     Args:
         duthost (SonicHost): The target device.
     """
-    port_numbers = len(__create_sai_test_interface_info(duthost))
+    port_numbers = len(
+        __get_dut_minigraph_interface_info(
+            duthost, tbinfo, enum_asic_index))
     logger.info("Creating {} port interface list".format(port_numbers))
     interfaces_list = []
 
+    # Todo, check if we need to use the order for generate the PTF port maps
+    # Todo, sample of the order in __create_sai_port_map_file
+    # now, we ordered them by port name and map to the natural index number
     for port_number in range(port_numbers):
         interface_tmp = "\'0-{0}@eth{0}\'".format(port_number)
         interfaces_list.append(interface_tmp)
@@ -786,16 +792,21 @@ def get_sai_running_vendor_id(duthost):
     return vendor_id
 
 
-def __create_sai_port_map_file(ptfhost, duthost):
+def __create_sai_port_map_file(ptfhost, duthost, tbinfo, enum_asic_index):
     """
     Create port mapping file on PTF server.
 
     Args:
         ptfhost (AnsibleHost): The PTF server.
         duthost (SonicHost): The target device.
+        tbinfo: (Testbedinfo): Tested info
+        enum_asic_index: the asic index, which is used in multi asic device
     """
 
-    intfInfo = __create_sai_test_interface_info(duthost)
+    intfInfo = __get_dut_minigraph_interface_info(
+        duthost, tbinfo, enum_asic_index)
+    # Todo, check if we need to use the order for generate the PTF port maps
+    # now, we ordered them by port name
     portList = natsorted(
         [port for port in intfInfo if port.startswith('Ethernet')])
 
@@ -837,16 +848,39 @@ def update_saithrift_ptf(request, ptfhost):
     logging.info("Python saithrift package installed successfully")
 
 
-def __create_sai_test_interface_info(duthost):
+def __get_dut_interface_stat_info(duthost):
     """
-        Create sai test interface info
+        Create dut interface status info.
+        This method will run Command: show interface status
 
         Args:
             duthost (SonicHost): The target device.
     """
     logger.info(
-        "Creating {0} for SAI test on PTF server."
-        .format(PORT_MAP_FILE_PATH))
+        "Get host interface status on dut: {0}."
+        .format(duthost.hostname))
     intfInfo = duthost.show_interface(
         command="status")['ansible_facts']['int_status']
     return intfInfo
+
+
+def __get_dut_minigraph_interface_info(duthost, tbinfo, enum_asic_index):
+    """
+        Create dut interface status info.
+        This method will run Command: show interface status
+
+        Args:
+            duthost (SonicHost): The target device.
+            tbinfo: (Testbedinfo): Tested info
+            enum_asic_index: the asic index, which is used in multi asic device
+    """
+    logger.info(
+        "Get host minigraph info for dut: {0}."
+        .format(duthost.hostname))
+    asic_host = duthost.asic_instance(enum_asic_index)
+    mg_facts = asic_host.get_extended_minigraph_facts(tbinfo)
+    # the interface info can be get from many keys
+    # like minigraph_ports and minigraph_port_name_to_alias_map
+    # Here use the minigraph_ports(with more info) to get the information
+    # Todo: Generate the ptf to dut port mapping
+    return mg_facts['minigraph_ports']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Cause in some cases, need to debug and test sai binary when sonic container cannot start, so show interface command in sonic cannot work. In those situation, we get the port number from the minigraph.

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cause in some cases, need to debug and test sai binary when sonic container cannot start, so show interface command in sonic cannot work. In those situation, we get the port number from the minigraph.

#### How did you do it?

instead use the port info from running command show interface status, use the local minigraph to get the interface info

#### How did you verify/test it?

Local container
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
