### PR TITLE
[fanout vlan] to enhance the vlan configuration for fanout switch

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -30,7 +30,7 @@
 - name: Collect DUTs vlans
   set_fact:
     dev_vlans: "{{ dev_vlans|default([]) + item.value }}"
-  loop: "{{ devinfo['ansible_facts']['device_vlan_range'] | dict2items }}"
+  loop: "{{ devinfo['ansible_facts']['device_vlan_range'] | default ({}) | dict2items }}"
 
 - name: Find the root fanout switch
   set_fact:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Current fanout yml will crash when deal with empty Vlan configuration.

#### How did you do it?
To add default {} when the vlan is empty

#### How did you verify/test it?
Run deploy minigraph for leaf fanout

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
