### PR TITLE
Use "config bgp shutdown all" to shutdown bgp sessions in copp test

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -81,6 +81,7 @@ def limit_policer(dut, pps_limit, nn_target_namespace):
     else:
         dut.command("cp {} {}".format(_TEMP_COPP_CONFIG, _DEFAULT_COPP_TEMPLATE))
 
+
 def restore_policer(dut, nn_target_namespace):
     """
         Reloads the default COPP configuration in the SWSS container.
@@ -114,7 +115,9 @@ def configure_ptf(ptf, test_params, is_backend_topology=False):
 
     ptf.script(cmd=_REMOVE_IP_SCRIPT)
     if is_backend_topology:
-        ip_command = "ip address add %s/31 dev \"eth%s.%s\"" % (test_params.myip, test_params.nn_target_port, test_params.nn_target_vlanid)
+        ip_command = "ip address add %s/31 dev \"eth%s.%s\"" % (test_params.myip,
+                                                                test_params.nn_target_port,
+                                                                test_params.nn_target_vlanid)
     else:
         ip_command = "ip address add %s/31 dev eth%s" % (test_params.myip, test_params.nn_target_port)
 
@@ -129,6 +132,7 @@ def configure_ptf(ptf, test_params, is_backend_topology=False):
     ptf.template(src=_PTF_NN_TEMPLATE, dest=_PTF_NN_DEST)
 
     ptf.supervisorctl(name="ptf_nn_agent", state="restarted")
+
 
 def restore_ptf(ptf):
     """
@@ -149,6 +153,7 @@ def restore_ptf(ptf):
     ptf.template(src=_PTF_NN_TEMPLATE, dest=_PTF_NN_DEST)
 
     ptf.supervisorctl(name="ptf_nn_agent", state="restarted")
+
 
 def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid, swap_syncd, creds):
     """
@@ -188,6 +193,7 @@ def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespac
     dut.command("docker exec {} supervisorctl reread".format(syncd_docker_name))
     dut.command("docker exec {} supervisorctl update".format(syncd_docker_name))
 
+
 def restore_syncd(dut, nn_target_namespace):
     asichost = dut.asic_instance_from_namespace(nn_target_namespace)
 
@@ -206,7 +212,9 @@ def _install_nano(dut, creds,  syncd_docker_name):
             dut (SonicHost): The target device.
             creds (dict): Credential information according to the dut inventory
     """
-    output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || echo copp'".format(syncd_docker_name))
+    output = dut.command(
+        "docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || echo copp'".format(
+            syncd_docker_name))
 
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
@@ -217,35 +225,41 @@ def _install_nano(dut, creds,  syncd_docker_name):
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                     rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
-                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python-setuptools wget cmake python-is-python3 \
+                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
+                    python3-dev python-setuptools wget cmake python-is-python3 \
                     && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    && mkdir -p /opt && cd /opt && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
         else:
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                     rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
-                    && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
+                    && apt-get install -y python-pip build-essential libssl-dev libffi-dev \
+                    python-dev python-setuptools wget cmake \
                     && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
-                    && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade \
+                    cffi==1.7.0 && pip2 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
 
         try:
             # Stop bgp sessions
-            dut.command("sudo config feature autorestart bgp disabled")
-            dut.command("sudo config feature state bgp disabled")
+            dut.command("sudo config bgp shutdown all")
             dut.command(cmd)
         finally:
-            dut.command("sudo config feature state bgp enabled")
-            dut.command("sudo config feature autorestart bgp enabled")
+            dut.command("sudo config bgp startup all")
+
 
 def _map_port_number_to_interface(dut, nn_target_port):
     """
@@ -254,6 +268,7 @@ def _map_port_number_to_interface(dut, nn_target_port):
 
     interfaces = dut.command("portstat")["stdout_lines"][2:]
     return interfaces[nn_target_port].split()[0]
+
 
 def _get_http_and_https_proxy_ip(creds):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. When installing the nanomsg before test, need to shutdown bgp to get access to the dns servers. The current way to do that is disabling the bgp feature, but there is delay between the feature is disabled and the default route is actually cleared, so the install may fail. If use the cli "config bgp shutdown all", the default route will be cleared immediately.

2. Other changes for pre-commit check

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Use "config bgp shutdown all" to shutdown bgp sessions in copp test to make sure nanomsg is installed successfully.
#### How did you do it?
1. Use "config bgp shutdown all" instead of disabling the bgp feature. (line 258, 261)
2. Other minor changes for pre-commit check.
#### How did you verify/test it?
By automation, test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
