### PR TITLE
skip t1-lag VxLAN ECMP test from running for t1 topo

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -63,6 +63,7 @@ from tests.common.fixtures.ptfhost_utils \
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.helpers.assertions import pytest_require
 
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -1737,7 +1738,8 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
     def test_underlay_portchannel_shutdown(self,
                                            setUp,
                                            minigraph_facts,
-                                           encap_type):
+                                           encap_type,
+                                           skip_for_non_t1lag):
         '''
             Bring down one of the port-channels.
             Packets are equally recieved at c1, c2 or c3
@@ -1911,3 +1913,8 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_dport=False,
             random_src_ip=True,
             tolerance=0.03)
+
+
+@pytest.fixture
+def skip_for_non_t1lag(tbinfo):
+    pytest_require(tbinfo["topo"]["name"] == 't1-lag', "Test is intented for t1-lag")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skip t1-lag VxLAN ECMP test from running for t1 topo
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/6929
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Avoid running a test on topo's it is not intended for
#### How did you do it?
Skipped test_underlay_portchannel_shutdown for topos other than t1-lag
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
