### PR TITLE
Fix test toggle mux wait time incorrect issue

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1355,6 +1355,20 @@ def increase_linkmgrd_probe_interval(duthosts, tbinfo):
     cmds.append("config save -y")
     duthosts.shell_cmds(cmds=cmds)
 
+
+def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
+    '''
+    Temporarily modify linkmgrd probe interval
+    '''
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return
+
+    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
+    cmds = []
+    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'.format(probe_interval_ms))
+    duthosts.shell_cmds(cmds=cmds)
+
+
 @pytest.fixture(scope='module')
 def dualtor_ports(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     # Fetch dual ToR ports

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
+from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until
 
 
@@ -34,47 +35,41 @@ def get_interval_v4(duthosts):
     mux_linkmgr_output = duthosts.shell('sonic-cfggen -d --var-json MUX_LINKMGR')
     mux_linkmgr = list(mux_linkmgr_output.values())[0]['stdout']
     if len(mux_linkmgr) != 0:
-        Cur_interval_v4 = json.loads(mux_linkmgr)['LINK_PROBER']['interval_v4']
-        return Cur_interval_v4
+        cur_interval_v4 = json.loads(mux_linkmgr)['LINK_PROBER']['interval_v4']
+        return cur_interval_v4
     else:
         return None
 
 
 @pytest.mark.parametrize("active_side", [UPPER_TOR, LOWER_TOR])
-def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_ports,
+def test_toggle_mux_from_simulator(duthosts, tbinfo, active_side, toggle_all_simulator_ports,
                                    get_mux_status, get_interval_v4, restore_mux_auto_mode):
     logger.info('Set all muxcable to manual mode on all ToRs')
     duthosts.shell('config muxcable mode manual all')
 
-    Cur_interval_v4 = get_interval_v4
-    if Cur_interval_v4 is not None:
-        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                       .format(DEFAUL_INTERVAL_V4))
-        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
+    cur_interval_v4 = get_interval_v4
+    if cur_interval_v4 is not None:
+        update_linkmgrd_probe_interval(duthosts, tbinfo, DEFAUL_INTERVAL_V4)
 
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
     check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
-    if Cur_interval_v4 is not None:
-        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                       .format(Cur_interval_v4))
-        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
+    if cur_interval_v4 is not None:
+        update_linkmgrd_probe_interval(duthosts, tbinfo, cur_interval_v4)
 
     validate_check_result(check_result, duthosts, get_mux_status)
 
 
 @pytest.mark.parametrize("active_side", [UPPER_TOR, LOWER_TOR])
-def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, get_interval_v4, restore_mux_auto_mode):
+def test_toggle_mux_from_cli(duthosts, tbinfo, active_side, get_mux_status, get_interval_v4, restore_mux_auto_mode):
     logger.info('Reset muxcable mode to auto for all ports on all DUTs')
     duthosts.shell('config muxcable mode auto all')
 
-    Cur_interval_v4 = get_interval_v4
-    if Cur_interval_v4 is not None:
-        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                       .format(DEFAUL_INTERVAL_V4))
-        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
+    cur_interval_v4 = get_interval_v4
+    if cur_interval_v4 is not None:
+        update_linkmgrd_probe_interval(duthosts, tbinfo, DEFAUL_INTERVAL_V4)
 
     # Use cli to toggle muxcable active side
     if active_side == UPPER_TOR:
@@ -85,9 +80,7 @@ def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, get_interval
 
     check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
-    if Cur_interval_v4 is not None:
-        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                       .format(Cur_interval_v4))
-        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
+    if cur_interval_v4 is not None:
+        update_linkmgrd_probe_interval(duthosts, tbinfo, cur_interval_v4)
 
     validate_check_result(check_result, duthosts, get_mux_status)

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -1,5 +1,5 @@
 import logging
-
+import json
 import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
@@ -12,6 +12,8 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
+
+DEFAUL_INTERVAL_V4 = 100
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -27,24 +29,52 @@ def restore_mux_auto_mode(duthosts):
     duthosts.shell('config muxcable mode auto all')
 
 
+@pytest.fixture(scope="module")
+def get_interval_v4(duthosts):
+    mux_linkmgr_output = duthosts.shell('sonic-cfggen -d --var-json MUX_LINKMGR')
+    mux_linkmgr = list(mux_linkmgr_output.values())[0]['stdout']
+    if len(mux_linkmgr) != 0:
+        Cur_interval_v4 = json.loads(mux_linkmgr)['LINK_PROBER']['interval_v4']
+        return Cur_interval_v4
+    else:
+        return None
+
+
 @pytest.mark.parametrize("active_side", [UPPER_TOR, LOWER_TOR])
-def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_ports, get_mux_status, restore_mux_auto_mode):
+def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_ports,
+                                   get_mux_status, get_interval_v4, restore_mux_auto_mode):
     logger.info('Set all muxcable to manual mode on all ToRs')
     duthosts.shell('config muxcable mode manual all')
+
+    Cur_interval_v4 = get_interval_v4
+    if Cur_interval_v4 is not None:
+        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                       .format(DEFAUL_INTERVAL_V4))
+        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
 
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
     check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
+    if Cur_interval_v4 is not None:
+        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                       .format(Cur_interval_v4))
+        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
+
     validate_check_result(check_result, duthosts, get_mux_status)
 
 
 @pytest.mark.parametrize("active_side", [UPPER_TOR, LOWER_TOR])
-def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, restore_mux_auto_mode):
-
+def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, get_interval_v4, restore_mux_auto_mode):
     logger.info('Reset muxcable mode to auto for all ports on all DUTs')
     duthosts.shell('config muxcable mode auto all')
+
+    Cur_interval_v4 = get_interval_v4
+    if Cur_interval_v4 is not None:
+        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                       .format(DEFAUL_INTERVAL_V4))
+        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
 
     # Use cli to toggle muxcable active side
     if active_side == UPPER_TOR:
@@ -54,5 +84,10 @@ def test_toggle_mux_from_cli(duthosts, active_side, get_mux_status, restore_mux_
     mux_active_dut.shell('config muxcable mode active all')
 
     check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
+
+    if Cur_interval_v4 is not None:
+        duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                       .format(Cur_interval_v4))
+        duthosts.shell('docker exec -i mux supervisorctl restart linkmgrd')
 
     validate_check_result(check_result, duthosts, get_mux_status)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Link prober interval could be calculated by multiply of max backoff factor, retry count and heartbeat timeout interval. The default heartbeat timeout interval should be 100ms, but in fixture run_icmp_responder, it will be changed to 1000ms.
For testscript test_toggle_mux.py, it doesn't use run_icmp_responder, and the heartbeat timeout interval may be changed by other tests, which could cause link prober interval too hight and case fail for timeout.
#### How did you do it?
Check if heartbeat timeout interval were changed, if not, follow previous routine, if changed, change to default value and change back after test.
#### How did you verify/test it?
Run testcase
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
