### PR TITLE
tests/bgp/test_bgp_speaker.py:Marvell Specific changes

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -112,6 +112,9 @@ class FibTest(BaseTest):
          - single_fib_for_duts:   have a single fib file for all DUTs in multi-dut case. Default: False
         '''
         self.dataplane = ptf.dataplane_instance
+        self.asic_type = self.test_params.get('asic_type')
+        if self.asic_type == "marvell":
+            fib.EXCLUDE_IPV4_PREFIXES.append("240.0.0.0/4")
 
         self.fibs = []
         for fib_info_file in self.test_params.get('fib_info_files'):

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -268,6 +268,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
     ptfip, mg_facts, interface_facts, vlan_ips, _, vlan_if_name, \
         speaker_ips, port_num, http_ready = common_setup_teardown
     assert http_ready
+    asic_type = duthost.facts["asic_type"]
 
     logger.info("announce route")
     peer_range = mg_facts['minigraph_bgp_peers_with_range'][0]['ip_range'][0]
@@ -333,6 +334,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
                            "ipv4": ipv4,
                            "ipv6": ipv6,
                            "testbed_mtu": mtu,
+                           "asic_type": asic_type,
                            "test_balancing": False},
                    log_file="/tmp/bgp_speaker_test.FibTest.log",
                    socket_recv_size=16384)


### PR DESCRIPTION
### Description of PR
Marvell specific changes on tests/tests/bgp/test_bgp_speaker.py
for PR:-
https://github.com/sonic-net/sonic-mgmt/issues/5284:- sonic is expecting to install reserved ip address(240.x)

Summary:
Fixes # (issue)

### Type of change
Test case(new/improvement)


### Back port request
- [ X] 201911
- [X ] 202012
- [ X] 202205

#### How did you do it?
Added marvell specific condition

#### How did you verify/test it?
Test case is passing on community testbed

#### Any platform specific information?
Yes

