### PR TITLE
[VLAN] Fixed vlan_ping test failure in case FDB table is empty before the test

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -166,8 +166,8 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter)
     static_neighbor_entry(duthost, ptfhost_info, "add")
     logger.info("Checking connectivity to ptf ports")
     for member in ptfhost_info:
-        verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter)
         verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter)
+        verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter)
 
     # flushing and re-adding ipv6 static arp entry
     static_neighbor_entry(duthost, ptfhost_info, "del", "6")
@@ -184,5 +184,5 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter)
     # Checking for connectivity
     logger.info("Check connectivity to both ptfhost")
     for member in ptfhost_info:
-        verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter)
         verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter)
+        verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixed vlan_ping test failure in case FDB table is empty before the test. 
Previously, the test was sending the first packet from PTF through the PortChannel interface to the interface in VLAN, and the packet was flooded to all interfaces in VLAN. Originally, `testutils.verify_packet` didn't check if the packets are received form unexpected interfaces besides the provided one, but when we replaced that method to `testutils.verify_packet_any_port` the issue has arised.
Now, first we send packets from VLAN to PortChannel which populates FDB entry, then vice versa packet won't be flooded anymore.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixing the case when FDB table doesn't contain related entries, so the packets were flooded to all interfaces and were captured by PTF on unexpected port.

#### How did you do it?
Changed the order of test packets. Now we send packets from VLAN to PortChannel first.

#### How did you verify/test it?
By running the test and checking that FDB entries are added.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
