### PR TITLE
[GCU Testing] Remove "PFCWD POLL_INTERVAL field removal" test

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -126,7 +126,7 @@ def get_new_interval(duthost, is_valid):
 def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, operation, field_pre_status, is_valid_config_update):
     new_interval = get_new_interval(duthost, is_valid_config_update)
 
-    operation_to_new_value_map = {"add": "{}".format(new_interval), "replace": "{}".format(new_interval), "remove": ""}
+    operation_to_new_value_map = {"add": "{}".format(new_interval), "replace": "{}".format(new_interval)}
     detection_time, restoration_time = get_detection_restoration_times(duthost)
     pre_status = max(detection_time, restoration_time)
     field_pre_status_to_value_map = {"existing": "{}".format(pre_status), "nonexistent": ""}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PFC_WD POLL_INTERVAL removal should not expect successful removal. Prohibition of field removal is added in this PR: https://github.com/sonic-net/sonic-utilities/pull/2545
This new update is tested in unit tests, not integration tests
#### How did you do it?
remove previous removal test
#### How did you verify/test it?
this test should not be run
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
