### PR TITLE
[dualtor][active-active] Add testcase to cover gRPC server failure

### DIFF
--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -9,7 +9,8 @@ __all__ = [
     'mux_config',
     'active_standby_ports',
     'active_active_ports',
-    'ActiveActivePortID'
+    'ActiveActivePortID',
+    'active_active_ports_config'
 ]
 
 
@@ -87,3 +88,16 @@ def active_standby_ports(mux_config, tbinfo):
             active_standby_ports.append(port)
 
     return active_standby_ports
+
+
+@pytest.fixture(scope="session")
+def active_active_ports_config(mux_config, tbinfo):
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return {}
+
+    active_active_ports_config = {}
+    for port, port_config in mux_config.items():
+        if port_config["SERVER"].get("cable_type", CableType.default_type) == CableType.active_active:
+            active_active_ports_config[port] = port_config
+
+    return active_active_ports_config

--- a/tests/common/dualtor/icmp_responder_control.py
+++ b/tests/common/dualtor/icmp_responder_control.py
@@ -1,0 +1,42 @@
+import json
+import pytest
+
+from tests.common.dualtor.dual_tor_common import mux_config    # lgtm[py/unused-import]
+
+
+ICMP_RESPONDER_PIPE = "/tmp/icmp_responder.pipe"
+
+
+@pytest.fixture
+def pause_icmp_responder(duthost, mux_config, ptfhost, tbinfo):
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    ptf_port_index = mg_facts['minigraph_ptf_indices']
+    ptf_ports = {k: ("eth%s" % v) for k, v in ptf_port_index.items()}
+
+    paused_ports = set()
+
+    def _pause_icmp_respond(mux_ports):
+        if not mux_ports:
+            return
+
+        icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
+        if "RUNNING" not in icmp_responder_status:
+            raise RuntimeError("icmp_responder not running in ptf")
+    
+        for mux_port in mux_ports:
+            if mux_port not in mux_config:
+                raise ValueError("port %s is not configured as mux port" % mux_port)
+
+        pause_dict = {}
+        for mux_port in mux_ports:
+            ptf_port = ptf_ports[mux_port]
+            paused_ports.add(ptf_port)
+            pause_dict[ptf_port] = True
+
+        pause_message = json.dumps(pause_dict)
+        ptfhost.shell("echo '%s' > %s" % (pause_message, ICMP_RESPONDER_PIPE), module_ignore_errors=True)
+
+    yield _pause_icmp_respond
+
+    ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)

--- a/tests/common/dualtor/icmp_responder_control.py
+++ b/tests/common/dualtor/icmp_responder_control.py
@@ -14,8 +14,6 @@ def pause_icmp_responder(duthost, mux_config, ptfhost, tbinfo):
     ptf_port_index = mg_facts['minigraph_ptf_indices']
     ptf_ports = {k: ("eth%s" % v) for k, v in ptf_port_index.items()}
 
-    paused_ports = set()
-
     def _pause_icmp_respond(mux_ports):
         if not mux_ports:
             return
@@ -23,7 +21,7 @@ def pause_icmp_responder(duthost, mux_config, ptfhost, tbinfo):
         icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
         if "RUNNING" not in icmp_responder_status:
             raise RuntimeError("icmp_responder not running in ptf")
-    
+
         for mux_port in mux_ports:
             if mux_port not in mux_config:
                 raise ValueError("port %s is not configured as mux port" % mux_port)
@@ -31,7 +29,6 @@ def pause_icmp_responder(duthost, mux_config, ptfhost, tbinfo):
         pause_dict = {}
         for mux_port in mux_ports:
             ptf_port = ptf_ports[mux_port]
-            paused_ports.add(ptf_port)
             pause_dict[ptf_port] = True
 
         pause_message = json.dumps(pause_dict)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -120,6 +120,10 @@ def change_mac_addresses(ptfhost):
     """
     logger.info("Change interface MAC addresses on ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.change_mac_addresses()
+    # NOTE: up/down ptf interfaces in change_mac_address will interrupt icmp_responder
+    # socket read/write operations, so let's restart icmp_responder
+    logging.debug("restart icmp_responder after change ptf port mac addresses")
+    ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/dualtor/test_grpc_server_failure.py
+++ b/tests/dualtor/test_grpc_server_failure.py
@@ -1,0 +1,131 @@
+import logging
+import datetime
+import json
+import pytest
+import random
+import time
+
+from tests.common.dualtor.dual_tor_common import active_active_ports                        # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import ActiveActivePortID
+from tests.common.dualtor.dual_tor_utils import upper_tor_host                              # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import lower_tor_host                              # lgtm[py/unused-import]
+from tests.common.dualtor.icmp_responder_control import pause_icmp_responder
+from tests.common.dualtor.nic_simulator_control import ForwardingState
+from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator        # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import toggle_active_active_simulator_ports # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                          # lgtm[py/unused-import]
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+TEST_COUNT = 4
+
+
+@pytest.fixture(scope="module")
+def test_duthost(upper_tor_host, lower_tor_host):
+    today = datetime.datetime.fromtimestamp(time.time())
+    if today.day % 2 == 1:
+        duthost = upper_tor_host
+        portid = ActiveActivePortID.UPPER_TOR
+    else:
+        duthost = lower_tor_host
+        portid = ActiveActivePortID.LOWER_TOR
+    return duthost, portid
+
+
+@pytest.fixture(scope="module")
+def test_mux_ports(active_active_ports):
+    if not active_active_ports:
+        pytest.skip("Skip as no 'active-active' mux ports available")
+    test_ports = random.sample(active_active_ports, min(len(active_active_ports), TEST_COUNT))
+    logging.info("Select ports %s to test", test_ports)
+    return random.sample(active_active_ports, TEST_COUNT)
+
+
+@pytest.fixture(params=[ForwardingState.ACTIVE, ForwardingState.STANDBY])
+def init_port_state(request):
+    return request.param
+
+
+@pytest.fixture
+def setup_test_ports(init_port_state, mux_status_from_nic_simulator, pause_icmp_responder, test_mux_ports):
+
+    def check_forwarding_state(mux_ports, upper_tor_forwarding_state, lower_tor_forwarding_state):
+        mux_status = mux_status_from_nic_simulator(mux_ports)
+        logging.debug(
+            "Check forwarding state of mux ports %s, upper ToR state: %s, lower ToR state: %s",
+            mux_ports,
+            upper_tor_forwarding_state,
+            lower_tor_forwarding_state
+        )
+        logging.debug("Mux status from nic_simulator:\n%s", mux_status)
+        for port in mux_status:
+            if ((mux_status[port][ActiveActivePortID.UPPER_TOR] != upper_tor_forwarding_state) or
+                (mux_status[port][ActiveActivePortID.LOWER_TOR] != lower_tor_forwarding_state)):
+                logging.debug("Port %s mux status is not expected", port)
+                return False
+        return True
+
+    if init_port_state == ForwardingState.STANDBY:
+        pause_icmp_responder(test_mux_ports)
+
+    pytest_assert(
+        wait_until(60, 5, 0, check_forwarding_state, test_mux_ports, init_port_state, init_port_state),
+        "failed to toggle ports %s to %s" % (test_mux_ports, "active" if init_port_state == ForwardingState.ACTIVE else "standby")
+    )
+
+    return test_mux_ports
+
+
+def test_grpc_server_failure(
+    init_port_state, setup_test_ports, test_duthost, toggle_active_active_simulator_ports
+):
+    """
+    This testcase aims to verify that, if the nic_simulator arbitrarily toggles a
+    port, SONiC could detect and recover the mux status.
+
+    Steps:
+    1. set the initial mux status(active or standby) for the selected active-active mux ports
+    2. set the nic_simulator mux status to the opposite
+    3. verify that SONiC does recover the mux status
+        3.1 verify mux status from show mux status
+        3.2 verify SONiC does request extra toggles to recover via the last switchover time from show mux status
+        3.3 verify the mux status from nic_simulator
+    """
+
+
+    def get_mux_status(duthost, mux_ports):
+        all_mux_status = json.loads(duthost.shell("show mux status --json")["stdout"])["MUX_CABLE"]
+        return {port: status for port, status in all_mux_status.items() if port in mux_ports}
+
+    def check_mux_status_recovery(duthost, mux_ports, orig_mux_status):
+        current_mux_status = get_mux_status(duthost, mux_ports)
+        logging.debug("Current mux status:\n%s\n", json.dumps(current_mux_status))
+        for port, status in current_mux_status.items():
+            orig_status = orig_mux_status[port]
+            # check if both linkmgrd status and server status are stored
+            if status["STATUS"] != orig_status["STATUS"] or status["SERVER_STATUS"] != orig_status["STATUS"]:
+                return False
+            # check if there is a newer switchover
+            if status["LAST_SWITCHOVER_TIME"] == orig_status["LAST_SWITCHOVER_TIME"]:
+                return False
+        return True
+
+    duthost, portid = test_duthost
+    mux_ports = setup_test_ports
+    orig_mux_status = get_mux_status(duthost, mux_ports)
+    logging.debug("Original mux status:\n%s\n", json.dumps(orig_mux_status))
+
+    if init_port_state == ForwardingState.ACTIVE:
+        toggle_active_active_simulator_ports(mux_ports, portid, ForwardingState.STANDBY)
+    elif init_port_state == ForwardingState.STANDBY:
+        toggle_active_active_simulator_ports(mux_ports, portid, ForwardingState.ACTIVE)
+
+    pytest_assert(
+        wait_until(30, 5, 5, check_mux_status_recovery, duthost, mux_ports, orig_mux_status),
+        "Failed to recover mux status from gRPC server failure"
+    )

--- a/tests/dualtor/test_grpc_server_failure.py
+++ b/tests/dualtor/test_grpc_server_failure.py
@@ -5,15 +5,15 @@ import pytest
 import random
 import time
 
-from tests.common.dualtor.dual_tor_common import active_active_ports                        # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import active_active_ports                            # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
-from tests.common.dualtor.dual_tor_utils import upper_tor_host                              # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_utils import lower_tor_host                              # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host                                  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import lower_tor_host                                  # lgtm[py/unused-import]
 from tests.common.dualtor.icmp_responder_control import pause_icmp_responder
 from tests.common.dualtor.nic_simulator_control import ForwardingState
-from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator        # lgtm[py/unused-import]
-from tests.common.dualtor.nic_simulator_control import toggle_active_active_simulator_ports # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder                          # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator            # lgtm[py/unused-import]
+from tests.common.dualtor.nic_simulator_control import toggle_active_active_simulator_ports     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # lgtm[py/unused-import]
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -43,7 +43,7 @@ def test_mux_ports(active_active_ports):
         pytest.skip("Skip as no 'active-active' mux ports available")
     test_ports = random.sample(active_active_ports, min(len(active_active_ports), TEST_COUNT))
     logging.info("Select ports %s to test", test_ports)
-    return random.sample(active_active_ports, TEST_COUNT)
+    return test_ports
 
 
 @pytest.fixture(params=[ForwardingState.ACTIVE, ForwardingState.STANDBY])
@@ -65,7 +65,7 @@ def setup_test_ports(init_port_state, mux_status_from_nic_simulator, pause_icmp_
         logging.debug("Mux status from nic_simulator:\n%s", mux_status)
         for port in mux_status:
             if ((mux_status[port][ActiveActivePortID.UPPER_TOR] != upper_tor_forwarding_state) or
-                (mux_status[port][ActiveActivePortID.LOWER_TOR] != lower_tor_forwarding_state)):
+                    (mux_status[port][ActiveActivePortID.LOWER_TOR] != lower_tor_forwarding_state)):
                 logging.debug("Port %s mux status is not expected", port)
                 return False
         return True
@@ -75,7 +75,8 @@ def setup_test_ports(init_port_state, mux_status_from_nic_simulator, pause_icmp_
 
     pytest_assert(
         wait_until(60, 5, 0, check_forwarding_state, test_mux_ports, init_port_state, init_port_state),
-        "failed to toggle ports %s to %s" % (test_mux_ports, "active" if init_port_state == ForwardingState.ACTIVE else "standby")
+        "failed to set ports %s initial state to %s" %
+        (test_mux_ports, "active" if init_port_state == ForwardingState.ACTIVE else "standby")
     )
 
     return test_mux_ports
@@ -96,7 +97,6 @@ def test_grpc_server_failure(
         3.2 verify SONiC does request extra toggles to recover via the last switchover time from show mux status
         3.3 verify the mux status from nic_simulator
     """
-
 
     def get_mux_status(duthost, mux_ports):
         all_mux_status = json.loads(duthost.shell("show mux status --json")["stdout"])["MUX_CABLE"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7027

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To verify that SONiC could recover from the arbitrary toggles of the gRPC server.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add testcase `test_grpc_server_failure.py`

#### How did you verify/test it?
Run on `dualtor-mixed` testbed.
```
dualtor/test_grpc_server_failure.py::test_grpc_server_failure[True] PASSED                                                                                                                                                                                             [ 50%]
dualtor/test_grpc_server_failure.py::test_grpc_server_failure[False] PASSED                                                                                                                                                                                            [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
