### PR TITLE
init port FECs before starting port autoneg tests on EOS fanout

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -258,6 +258,10 @@ class EosHost(AnsibleHostBase):
             return True
 
         if enabled:
+            # configure all FECs to be auto-chosen on port autoneg
+            self._append_port_fec(interface_name, 'fc')
+            self._append_port_fec(interface_name, 'rs')
+
             speed_to_advertise = self.get_supported_speeds(interface_name)[-1]
             speed_to_advertise = speed_to_advertise[:-3] + 'gfull'
             out = self.eos_config(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: init port FECs before starting port autoneg tests on EOS fanout
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/7038

Avoid possible port autoneg test failure that may happen when EOS fanout has wrong FEC setup.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Make sure test prepares fanout properly before checking port autoneg
#### How did you do it?
Reset FEC config on EOS fanout to all supported values
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
