### PR TITLE
[ansible] make deployment j2cli installation safe

### DIFF
--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -11,7 +11,7 @@ echo
 echo "STEP 1: Checking for j2cli package..."
 if ! command -v j2; then
     echo "j2cli not found, installing j2cli"
-    cmd="install j2cli==0.3.10"
+    cmd="install --user j2cli==0.3.10"
     if ! command -v pip &> /dev/null; then
         pip3 $cmd
     else

--- a/docs/testbed/README.testbed.IxANVL.VsSetup.md
+++ b/docs/testbed/README.testbed.IxANVL.VsSetup.md
@@ -29,7 +29,7 @@
      ```
      git clone https://github.com/sonic-net/sonic-mgmt
      cd sonic-mgmt/ansible
-     sudo ./setup-management-network.sh
+     sudo -H ./setup-management-network.sh
      ```
 
      **NOTE** setup-management-network.sh can fail on a check of br1 exists or not. In that case you can modify the script and comment out if checks of line 45 and line 49 until the issue is fixed.

--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -144,7 +144,7 @@ Managing the testbed and running tests requires various dependencies to be insta
     alternatively use this script but settings will be lost on reboot
 
     ```
-    sudo bash ./sonic-mgmt/ansible/setup-management-network.sh
+    sudo -H ./sonic-mgmt/ansible/setup-management-network.sh
     ```
 4. Reboot the setup just to be sure the networking is ok
 

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -30,7 +30,7 @@ First, we need to prepare the host where we will be configuring the virtual test
 ```
 git clone https://github.com/sonic-net/sonic-mgmt
 cd sonic-mgmt/ansible
-sudo ./setup-management-network.sh
+sudo -H ./setup-management-network.sh
 ```
 
 4. [Install Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/). Be sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/) so that you don't need sudo privileges to run docker commands.

--- a/docs/testbed/README.testbed.WANSetup.md
+++ b/docs/testbed/README.testbed.WANSetup.md
@@ -22,7 +22,7 @@ First, we need to prepare the host where we will be configuring the virtual test
    ```
    git clone https://github.com/sonic-net/sonic-mgmt
    cd sonic-mgmt/ansible
-   sudo ./setup-management-network.sh
+   sudo -H ./setup-management-network.sh
    ```
 
 4. [Install Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/). Be sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/) so that you don't need sudo privileges to run docker commands.

--- a/docs/testbed/README.testbed.k8s.Setup.md
+++ b/docs/testbed/README.testbed.k8s.Setup.md
@@ -139,7 +139,7 @@ k8s_server_19:
 ```
 $ git clone https://github.com/sonic-net/sonic-mgmt
 $ cd sonic-mgmt/ansible
-$ sudo ./setup-management-network.sh
+$ sudo -H ./setup-management-network.sh
 $ sudo ./setup-br1-nat.sh <name of server's external facing port>
 ```
 2. Setup virtual switch testbed as described [here](README.testbed.VsSetup.md). **Note:** if the host machine is a VM, nested virtualization must be enabled.


### PR DESCRIPTION
When no j2cli executable can be detected, the deployment script ansible/setup-management-network.sh tries to install it using pip.

According to the documentation at docs/testbed/README.testbed.Setup.md this script must be launched with sudo during the deployment process.

Running "sudo pip install" can be OK in a CI or inside a test container but it generates a clear warning.
It is strongly disadvised to run "pip install" under root in a user or a production environment because it can break the host packages system. "pip install --user" or venv are usually prefered in most situations.

sudo -H / --set-home option can ensure the HOME variable is set to the user home directory so that "pip install --user" called from a script with sudo does not use /root.
This way, installed executables remains available to the user w/o sudo.

Issue https://github.com/sonic-net/sonic-mgmt/issues/7318
