### PR TITLE
Return empty BGP neighbors list if BGP feature is not enabled

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+import re
 
 DOCUMENTATION = '''
 module:         bgp_facts
@@ -78,7 +79,8 @@ class BgpModule(object):
         """
 
         # Check if bgp is enabled as a feature, and if not return facts with empty bgp_neighbors.
-        rc, self.out, err = self.module.run_command("show feature status bgp", executable='/bin/bash', use_unsafe_shell=True)
+        rc, self.out, err = self.module.run_command("show feature status bgp", executable='/bin/bash',
+                                                    use_unsafe_shell=True)
         regex_bgp = re.compile(r'bgp\s+disabled')
         if regex_bgp.search(self.out):
             self.module.exit_json(ansible_facts=self.facts)

--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -76,6 +76,13 @@ class BgpModule(object):
         """
             Main method of the class
         """
+
+        # Check if bgp is enabled as a feature, and if not return facts with empty bgp_neighbors.
+        rc, self.out, err = self.module.run_command("show feature status bgp", executable='/bin/bash', use_unsafe_shell=True)
+        regex_bgp = re.compile(r'bgp\s+disabled')
+        if regex_bgp.search(self.out):
+            self.module.exit_json(ansible_facts=self.facts)
+
         for instance in self.instances:
             self.collect_data('summary', instance)
             self.parse_summary()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- If BGP feature status is disabled on DUT, return bgp_facts with empty bgp_neighbors
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- To return bgp_facts with empty list of bgp_neighbors if the bgp feature state is disabled on DUT. For example, on supervisor card.

#### How did you do it?
- By running command, "show feature status bgp" on DUT and if the feature state is disabled, return bgp_facts with empty bgp_neighbors list.

#### How did you verify/test it?
- Tested by running 'test_bgp_fact.py' test case against supervisor card on a T2 chassis with bgp feature state as 'disabled'.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
![bgp_fact_check](https://user-images.githubusercontent.com/114024719/207921029-c003c0bc-89fe-48b2-8589-27245d8135c6.PNG)
[bgp-console.txt](https://github.com/sonic-net/sonic-mgmt/files/10239054/bgp-console.txt)
<!--

(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?

Link to the wiki page?

-->
