### PR TITLE
[Python3][test_memory_exhaustion] 

### DIFF
--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -1,3 +1,5 @@
+import re
+
 REQUIRED_PATTERNS = {
     "time_span": [
         "SAI_CREATE_SWITCH",
@@ -30,13 +32,17 @@ OTHER_PATTERNS = {
         "PORT_INIT|Start": re.compile(r'.*NOTICE swss#orchagent.*initPort: Initialized port.*'),
         "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set.* to up.*'),
         "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
-        "FINALIZER|End": re.compile(r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),
+        "FINALIZER|End": re.compile(
+            r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),
         "FPMSYNCD_RECONCILIATION|Start": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer started.*'),
-        "FPMSYNCD_RECONCILIATION|End": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart reconciliation processed.*'),
+        "FPMSYNCD_RECONCILIATION|End": re.compile(
+            r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart reconciliation processed.*'),
         "ROUTE_DEFERRAL_TIMER|Start": re.compile(r'.*ADJCHANGE: neighbor .* in vrf default Up.*'),
         "ROUTE_DEFERRAL_TIMER|End": re.compile(r'.*rcvd End-of-RIB for .* Unicast from.*'),
-        "FDB_AGING_DISABLE|Start": re.compile(r'.*NOTICE swss#orchagent.*setAgingFDB: Set switch.*fdb_aging_time 0 sec'),
-        "FDB_AGING_DISABLE|End": re.compile(r'.*NOTICE swss#orchagent.*do.*Task: Set switch attribute fdb_aging_time to 600')
+        "FDB_AGING_DISABLE|Start": re.compile(
+            r'.*NOTICE swss#orchagent.*setAgingFDB: Set switch.*fdb_aging_time 0 sec'),
+        "FDB_AGING_DISABLE|End": re.compile(
+            r'.*NOTICE swss#orchagent.*do.*Task: Set switch attribute fdb_aging_time to 600')
     },
     "LATEST": {
         "INIT_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*INIT_VIEW.*'),
@@ -50,17 +56,24 @@ OTHER_PATTERNS = {
         "INIT_VIEW|End": re.compile(r'.*swss#orchagent.*initSaiRedis.*Notify syncd INIT_VIEW.*'),
         "APPLY_VIEW|Start": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*sending syncd.*APPLY view.*'),
         "APPLY_VIEW|End": re.compile(r'.*syncd#SDK.*notifySyncd.*setting very first run to FALSE, op = APPLY_VIEW.*'),
-        "LAG_READY|Start": re.compile(r'.*teamd#teammgrd.*setLagAdminStatus.*Set port channel PortChannel.*admin status to up')
+        "LAG_READY|Start": re.compile(
+            r'.*teamd#teammgrd.*setLagAdminStatus.*Set port channel PortChannel.*admin status to up')
     },
     "BRCM": {
-        "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd#syncd.*performWarmRestart: switches defined in warm restart.*'),
-        "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
-        "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac (?!00-06-07-08-09-0A).*"),
-        "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac 00-06-07-08-09-0A.*")
+        "SYNCD_CREATE_SWITCH|Start": re.compile(
+            r'.*syncd#syncd.*performWarmRestart: switches defined in warm restart.*'),
+        "SYNCD_CREATE_SWITCH|End": re.compile(
+            r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
+        "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(
+            r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac (?!00-06-07-08-09-0A).*"),
+        "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(
+            r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac 00-06-07-08-09-0A.*")
     },
     "MLNX": {
-        "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd.*mlnx_sai_switch.*mlnx_create_switch: Create switch.*INIT_SWITCH=true.*'),
-        "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#SDK.*mlnx_sai_switch.*mlnx_create_switch.*Created switch Switch ID.*')
+        "SYNCD_CREATE_SWITCH|Start": re.compile(
+            r'.*syncd.*mlnx_sai_switch.*mlnx_create_switch: Create switch.*INIT_SWITCH=true.*'),
+        "SYNCD_CREATE_SWITCH|End": re.compile(
+            r'.*syncd#SDK.*mlnx_sai_switch.*mlnx_create_switch.*Created switch Switch ID.*')
     }
 }
 
@@ -68,18 +81,21 @@ SAIREDIS_PATTERNS = {
     "SAI_CREATE_SWITCH|Start": re.compile(r'.*\|c\|SAI_OBJECT_TYPE_SWITCH.*'),
     "SAI_CREATE_SWITCH|End": re.compile(r'.*\|g\|SAI_OBJECT_TYPE_SWITCH.*SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID.*'),
     "NEIGHBOR_ENTRY|Start": re.compile(r'.*\|c\|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY.*'),
-    "DEFAULT_ROUTE_SET|Start": re.compile(r'.*\|(S|s)\|SAI_OBJECT_TYPE_ROUTE_ENTRY.*0\.0\.0\.0/0.*SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD.*'),
+    "DEFAULT_ROUTE_SET|Start": re.compile(
+        r'.*\|(S|s)\|SAI_OBJECT_TYPE_ROUTE_ENTRY.*0\.0\.0\.0/0.*SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD.*'),
     "FDB_RESTORE|Start": re.compile(r'.*\|c\|SAI_OBJECT_TYPE_FDB_ENTRY.*'),
-    "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(r".*\|n\|fdb_event.*fdb_entry.*mac.*(?!00:06:07:08:09:0A).*fdb_event.*SAI_FDB_EVENT_LEARNED.*SAI_FDB_ENTRY_ATTR_TYPE.*SAI_FDB_ENTRY_TYPE_DYNAMIC.*SAI_FDB_ENTRY_ATTR_PACKET_ACTION.*SAI_PACKET_ACTION_FORWARD.*"),
-    "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(r".*\|n\|fdb_event.*fdb_entry.*mac.*00:06:07:08:09:0A.*fdb_event.*SAI_FDB_EVENT_LEARNED.*SAI_FDB_ENTRY_ATTR_TYPE.*SAI_FDB_ENTRY_TYPE_DYNAMIC.*SAI_FDB_ENTRY_ATTR_PACKET_ACTION.*SAI_PACKET_ACTION_FORWARD.*"),
+    "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(
+        r".*\|n\|fdb_event.*fdb_entry.*mac.*(?!00:06:07:08:09:0A).*fdb_event.*SAI_FDB_EVENT_LEARNED.*SAI_FDB_ENTRY_ATTR_TYPE.*SAI_FDB_ENTRY_TYPE_DYNAMIC.*SAI_FDB_ENTRY_ATTR_PACKET_ACTION.*SAI_PACKET_ACTION_FORWARD.*"),
+    "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(
+        r".*\|n\|fdb_event.*fdb_entry.*mac.*00:06:07:08:09:0A.*fdb_event.*SAI_FDB_EVENT_LEARNED.*SAI_FDB_ENTRY_ATTR_TYPE.*SAI_FDB_ENTRY_TYPE_DYNAMIC.*SAI_FDB_ENTRY_ATTR_PACKET_ACTION.*SAI_PACKET_ACTION_FORWARD.*"),
 }
 
 OFFSET_ITEMS = ['DATABASE', 'FINALIZER', 'INIT_VIEW', 'SYNCD_CREATE_SWITCH',
-    'FPMSYNCD_RECONCILIATION', 'PORT_INIT', 'PORT_READY', 'SAI_CREATE_SWITCH',
-    'NEIGHBOR_ENTRY', 'DEFAULT_ROUTE_SET', 'APPLY_VIEW', 'LAG_READY',
-    'FDB_RESTORE', 'ROUTE_DEFERRAL_TIMER']
+                'FPMSYNCD_RECONCILIATION', 'PORT_INIT', 'PORT_READY', 'SAI_CREATE_SWITCH',
+                'NEIGHBOR_ENTRY', 'DEFAULT_ROUTE_SET', 'APPLY_VIEW', 'LAG_READY',
+                'FDB_RESTORE', 'ROUTE_DEFERRAL_TIMER']
 
 TIME_SPAN_ITEMS = ['RADV', 'BGP', 'SYNCD', 'SWSS', 'TEAMD', 'DATABASE',
-    'SYNCD_CREATE_SWITCH', 'SAI_CREATE_SWITCH', 'APPLY_VIEW', 'INIT_VIEW',
-    'NEIGHBOR_ENTRY', 'PORT_INIT', 'PORT_READY', 'FINALIZER', 'LAG_READY',
-    'FPMSYNCD_RECONCILIATION', 'ROUTE_DEFERRAL_TIMER', 'FDB_RESTORE']
+                   'SYNCD_CREATE_SWITCH', 'SAI_CREATE_SWITCH', 'APPLY_VIEW', 'INIT_VIEW',
+                   'NEIGHBOR_ENTRY', 'PORT_INIT', 'PORT_READY', 'FINALIZER', 'LAG_READY',
+                   'FPMSYNCD_RECONCILIATION', 'ROUTE_DEFERRAL_TIMER', 'FDB_RESTORE']

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -24,7 +24,7 @@ class TestMemoryExhaustion:
     """
 
     @pytest.fixture(autouse=True)
-    def teardown(self, duthost, localhost, pdu_controller):
+    def tearDown(self, duthost, localhost, pdu_controller):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix two issues found in Python3 env.
1. NameError: name 're' is not defined
2. Fixture "teardown" called directly. Fixtures are not meant to be called directly

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Fix two issues found in Python3 env.
1. NameError: name 're' is not defined
2. Fixture "teardown" called directly. Fixtures are not meant to be called directly

#### How did you do it?

1. `import re` in `tests/platform_tests/reboot_timing_constants.py`
2. Rename `teardown` to `tearDown`

#### How did you verify/test it?

Run TC in py3/py2, both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
