### PR TITLE
Get bgp neighbor information only if bgp service is in critical process

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -482,6 +482,8 @@ class MultiAsicSonicHost(object):
         """
         bgp_neigh = {}
         for asic in self.asics:
+            if asic.get_docker_name("bgp") not  in self.critical_services:
+                continue
             bgp_info = asic.bgp_facts()
             bgp_neigh.update(bgp_info["ansible_facts"]["bgp_neighbors"])
 
@@ -499,6 +501,8 @@ class MultiAsicSonicHost(object):
         bgp_neigh = {}
         for asic in self.asics:
             bgp_neigh[asic.namespace] = {}
+            if asic.get_docker_name("bgp") not  in self.critical_services:
+                continue
             bgp_info = asic.bgp_facts()["ansible_facts"]["bgp_neighbors"]
             for k, v in bgp_info.items():
                 if v["state"] != state:
@@ -518,6 +522,8 @@ class MultiAsicSonicHost(object):
         neigh_ok = []
 
         for asic in self.asics:
+            if asic.get_docker_name("bgp") not  in self.critical_services:
+                continue
             bgp_facts = asic.bgp_facts()['ansible_facts']
             for k, v in bgp_facts['bgp_neighbors'].items():
                 if v['state'] == state:
@@ -538,6 +544,8 @@ class MultiAsicSonicHost(object):
         @param state: target state
         """
         for asic in self.asics:
+            if asic.get_docker_name("bgp") not  in self.critical_services:
+                continue
             if asic.namespace in bgp_neighbors:
                 neigh_ips = [k.lower() for k, v in bgp_neighbors[asic.namespace].items() if v["state"] == state]
                 if not asic.check_bgp_session_state(neigh_ips, state):

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -482,7 +482,7 @@ class MultiAsicSonicHost(object):
         """
         bgp_neigh = {}
         for asic in self.asics:
-            if asic.get_docker_name("bgp") not  in self.critical_services:
+            if asic.get_docker_name("bgp") not in self.critical_services:
                 continue
             bgp_info = asic.bgp_facts()
             bgp_neigh.update(bgp_info["ansible_facts"]["bgp_neighbors"])
@@ -501,7 +501,7 @@ class MultiAsicSonicHost(object):
         bgp_neigh = {}
         for asic in self.asics:
             bgp_neigh[asic.namespace] = {}
-            if asic.get_docker_name("bgp") not  in self.critical_services:
+            if asic.get_docker_name("bgp") not in self.critical_services:
                 continue
             bgp_info = asic.bgp_facts()["ansible_facts"]["bgp_neighbors"]
             for k, v in bgp_info.items():
@@ -522,7 +522,7 @@ class MultiAsicSonicHost(object):
         neigh_ok = []
 
         for asic in self.asics:
-            if asic.get_docker_name("bgp") not  in self.critical_services:
+            if asic.get_docker_name("bgp") not in self.critical_services:
                 continue
             bgp_facts = asic.bgp_facts()['ansible_facts']
             for k, v in bgp_facts['bgp_neighbors'].items():
@@ -544,7 +544,7 @@ class MultiAsicSonicHost(object):
         @param state: target state
         """
         for asic in self.asics:
-            if asic.get_docker_name("bgp") not  in self.critical_services:
+            if asic.get_docker_name("bgp") not in self.critical_services:
                 continue
             if asic.namespace in bgp_neighbors:
                 neigh_ips = [k.lower() for k, v in bgp_neighbors[asic.namespace].items() if v["state"] == state]


### PR DESCRIPTION

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>
(cherry picked from commit 39f1d5a8c41f678f876952da7f48492fa5873635)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Container autorestart test fails on supervisor with error:
RunAnsibleModuleFail: run module bgp_facts failed, Ansible Results => {"changed": false, "failed": true, "msg": "Command failed rc=1, out=, err=Error response from daemon: Container f494b23f9428414d38b7ad8604a712914cbfee9dda5e9294f442779b6a1c1101 is not running\n"}
[autorestart/test_container_autorestart.py:419: in run_test_on_single_container](https://dev.azure.com/mssonic/internal/_git/5380e8f7-6e2a-4154-8dee-f3be7b096894?path=autorestart%2Ftest_container_autorestart.py&version=GBnokia_internal_new%231&_a=contents&line=419&lineEnd=420&lineStartColumn=1&lineEndColumn=1&lineStyle=plain)
up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
This is seen after https://github.com/sonic-net/sonic-buildimage/pull/11796 where bgp service is disabled on supervisor.

#### How did you do it?
get bgp neighbor information only if bgp container name is in the duthost critical_service list.

#### How did you verify/test it?
Ran autorestart test on chassis platform and test passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
