### PR TITLE
Fix the issue of arp/test_arp_extended

### DIFF
--- a/tests/common/devices/ptf.py
+++ b/tests/common/devices/ptf.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 CHANGE_MAC_ADDRESS_SCRIPT = "scripts/change_mac.sh"
 REMOVE_IP_ADDRESS_SCRIPT = "scripts/remove_ip.sh"
+RESTART_INTERFACE_SCRIPT = "scripts/restart_interface.sh"
 MACSEC_INFO_FILE = "macsec_info.pickle"
 
 
@@ -30,6 +31,9 @@ class PTFHost(AnsibleHostBase):
 
     def remove_ip_addresses(self):
         self.script(REMOVE_IP_ADDRESS_SCRIPT)
+
+    def restart_interfaces(self):
+        self.script(RESTART_INTERFACE_SCRIPT)
 
     def create_macsec_info(self):
         macsec_info = {}

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -139,6 +139,8 @@ def remove_ip_addresses(ptfhost):
 
     logger.info("Remove IPs to restore ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.remove_ip_addresses()
+    # Interfaces restart is required, otherwise the ipv6 link-addresses won't back.
+    ptfhost.restart_interfaces()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/scripts/restart_interface.sh
+++ b/tests/scripts/restart_interface.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+(\.[0-9]+)?$")
+
+for INTF in ${INTF_LIST}; do
+    echo "Restart interface: ${INTF}"
+    ifconfig "${INTF}" down
+    ifconfig "${INTF}" up
+done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes occasionally arp/test_arp_extended.py failure in PR  t0 test jobs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Recently there's a chance(around 20% to 30%) that arp/test_arp_extended.py fails in the PR t0 test jobs,
It's because the ipv6 link-addresses of the ptf interfaces are deleted by "scripts/remove_ip.sh" but not recovered.

On a test instance:
1. bgp/test_bgp_speaker.py imports the fixture remove_ip_addresses causes the ipv6 link-addresses disappear.
2. arp/test_arp_extended.py failed because the ptf port can't receive and reply broadcast IPV6 ARP packet, then IPV6 test case fails.

The problem got obviously from Dec 6th, guess it's because https://github.com/sonic-net/sonic-mgmt/pull/6955 added a new test case and changed the sequence of test modules, then the 2 test cases get a larger chance to be distributed and executed on the same test instance.

#### How did you do it?
Restart ptf interfaces to get back the deleted link-addresses.
#### How did you verify/test it?
Run 40 rounds t0 test jobs on TestbedV2 DEV env, the issue is not reproduced.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
