### PR TITLE
correct test traffic's DMAC for dualtor qos test scenario

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -894,6 +894,19 @@ class QosSaiBase(QosBase):
             duthost.command("docker exec syncd python /packets_aging.py enable")
             duthost.command("docker exec syncd rm -rf /packets_aging.py")
 
+    def dutArpProxyConfig(self, duthost):
+        # so far, only record ARP proxy config to logging for debug purpose
+        vlanInterface = {}
+        try:
+            vlanInterface = json.loads(duthost.shell('sonic-cfggen -d --var-json "VLAN_INTERFACE"')['stdout'])
+        except:
+            logger.info('Failed to read vlan interface config')
+        if not vlanInterface:
+            return
+        for key, value in vlanInterface.items():
+            if 'proxy_arp' in value:
+                logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
+
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
             self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
@@ -936,6 +949,8 @@ class QosSaiBase(QosBase):
         qosConfigs = dutConfig["qosConfigs"]
         dutAsic = dutConfig["dutAsic"]
         dutTopo = dutConfig["dutTopo"]
+
+        self.dutArpProxyConfig(duthost)
 
         if isMellanoxDevice(duthost):
             current_file_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -86,7 +86,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
         self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLosslessProfile, tbinfo
+        ingressLosslessProfile, egressLosslessProfile
     ):
         """
             Test QoS SAI XOFF limits
@@ -146,19 +146,6 @@ class TestQosSai(QosSaiBase):
 
         if 'cell_size' in qosConfig[xoffProfile].keys():
             testParams["cell_size"] = qosConfig[xoffProfile]["cell_size"]
-
-        if "dualtor" in tbinfo["topo"]["name"]:
-            testParams["is_dualtor"] = True
-            if tbinfo["topo"]["type"] == 't0':
-                testParams["is_t0"] = True
-            vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
-            if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
-                default_vlan_name = vlan_cfgs['default_vlan_config']
-                if default_vlan_name:
-                    for vlan in vlan_cfgs[default_vlan_name].values():
-                        if 'mac' in vlan and vlan['mac']:
-                            testParams["def_vlan_mac"] = vlan['mac']
-                            break
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -924,10 +924,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             cell_occupancy = 1
 
-        is_dualtor = bool(self.test_params.get('is_dualtor', False))
-        is_t0 = bool(self.test_params.get('is_t0', False))
+        is_dualtor = self.test_params.get('is_dualtor', False)
         def_vlan_mac = self.test_params.get('def_vlan_mac', None)
-        if is_dualtor and is_t0 and bool(def_vlan_mac):
+        if is_dualtor and def_vlan_mac != None:
             pkt_dst_mac = def_vlan_mac
 
         pkt = construct_ip_pkt(packet_length,
@@ -1553,6 +1552,16 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             cell_occupancy = 1
 
+        pkt_dst_mac2 = router_mac if router_mac != '' else dst_port_2_mac
+        pkt_dst_mac3 = router_mac if router_mac != '' else dst_port_3_mac
+
+        is_dualtor = self.test_params.get('is_dualtor', False)
+        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
+        if is_dualtor and def_vlan_mac != None:
+            pkt_dst_mac = def_vlan_mac
+            pkt_dst_mac2 = def_vlan_mac
+            pkt_dst_mac3 = def_vlan_mac
+
         pkt = construct_ip_pkt(packet_length,
                                pkt_dst_mac,
                                src_port_mac,
@@ -1567,7 +1576,6 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         )
 
         # create packet
-        pkt_dst_mac2 = router_mac if router_mac != '' else dst_port_2_mac
         pkt2 = construct_ip_pkt(packet_length,
                                 pkt_dst_mac2,
                                 src_port_mac,
@@ -1582,7 +1590,6 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         )
 
         # create packet
-        pkt_dst_mac3 = router_mac if router_mac != '' else dst_port_3_mac
         pkt3 = construct_ip_pkt(packet_length,
                                 pkt_dst_mac3,
                                 src_port_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Correct test traffic's DMAC for dualtor qos test scenario

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Failed to forward test traffic on dut for dualtor's xon qos test. It caused QoS relevant test case failure.

RCA: 
for dualtor scenario, DMAC of traffic from ptf is dut's physical interface addrss.
Should use DUT's vlan interface address.

#### How did you do it?

pass is_dualtor, default vlan mac to sai_qos_test, to correct dmac of frame for dualtor qos test scenario.

And there is a similar fix for xoff test in past. To reduce duplicated code, refactor relevant common code.

#### How did you verify/test it?

passed local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
