### PR TITLE
dynamically compensation for leakout in xon testcase

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -68,7 +68,7 @@ DSCP_INDEX_IN_HEADER = 52  # Fits the ptf hex_dump_buffer() parse function
 
 
 def check_leackout_compensation_support(asic, hwsku):
-    if 'broadcom' in asic.lower() or hwsku in ['Arista-7050CX3-32S-D48C8', 'Arista-7050CX3-32S-C32', 'DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32']:
+    if 'broadcom' in asic.lower():
         return True
     return False
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -83,7 +83,7 @@ def dynamically_compensate_leakout(thrift_client, counter_checker, check_port, c
         sys.stderr.write('Compensate {} packets to port {}\n'.format(leakout_num, compensate_port))
         prev = curr
         curr, _ = counter_checker(thrift_client, check_port)
-        leakout_num = curr[check_field] - base[check_field]
+        leakout_num = curr[check_field] - prev[check_field]
         retry += 1
 
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1652,7 +1652,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 )
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters_dbg, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 40)
 
             # send packets to dst port 2, occupying the shared buffer
             xmit_2_counters_base, _ = sai_thrift_read_port_counters(
@@ -1680,7 +1680,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 )
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters_dbg, port_list[dst_port_2_id], TRANSMITTED_PKTS, xmit_2_counters_base, self, src_port_id, pkt2, 40)
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_2_id], TRANSMITTED_PKTS, xmit_2_counters_base, self, src_port_id, pkt2, 40)
 
             # send 1 packet to dst port 3, triggering PFC
             xmit_3_counters_base, _ = sai_thrift_read_port_counters(
@@ -1697,7 +1697,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt3, pkts_num_leak_out + 1)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters_dbg, port_list[dst_port_3_id], TRANSMITTED_PKTS, xmit_3_counters_base, self, src_port_id, pkt3, 40)
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_3_id], TRANSMITTED_PKTS, xmit_3_counters_base, self, src_port_id, pkt3, 40)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

dynamically compensation for leakout packet in xon testcase

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

During run PFCXonTest on broadcom platfom, found random number of packet leakout even after tx disable,
And sometime, there are more bad case which need compensate packet multiple time.
So dyanmically compensate Actual leakout packets.



#### How did you do it?

leverage compensation logic in past, add below two enhancement:
- apply the compensation to all brcm platform.
- add retry, if one compensation is not enough

#### How did you verify/test it?
passed local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
