### PR TITLE
[double commit 202012] dynamically compensation for leakout in xon testcase

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -874,8 +874,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -894,8 +894,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
             # actual leakout by sending packets and reading actual leakout from HW.
-            # And apply this behavior to all Arista device using Broadcom ASIC.
-            if ('arista' in hwsku.lower() and 'broadcom' in asic_type.lower()) or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+            # And apply dynamically compensation to all device using Broadcom ASIC.
+            if 'broadcom' in asic_type.lower() or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 pkts_num_leak_out = 0
 
             # send packets short of triggering pfc
@@ -913,17 +913,22 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
 
-            if ('arista' in hwsku.lower() and 'broadcom' in asic_type.lower()) or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] -  xmit_counters_base[TRANSMITTED_PKTS]
-                send_packet(self, src_port_id, pkt, actual_pkts_num_leak_out)
-                sys.stderr.write('Send {} packets as leakout compensation'.format(actual_pkts_num_leak_out))
-                time.sleep(8)
+            if 'broadcom' in asic_type.lower() or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+                xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+                counters_base = xmit_counters_base
+                actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+                while actual_pkts_num_leak_out > 0:
+                    send_packet(self, src_port_id, pkt, actual_pkts_num_leak_out)
+                    sys.stderr.write('Dynamically compensate {} packets, because of leakout\n'.format(actual_pkts_num_leak_out))
+                    counters_base = xmit_counters
+                    xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+                    actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+                    time.sleep(8)
 
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
@@ -942,8 +947,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             test_stage = 'after send a few packets to trigger PFC'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
@@ -962,8 +967,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             test_stage = 'after send packets short of ingress drop'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
@@ -982,8 +987,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
@@ -1390,7 +1395,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(
+        recv_counters_base, _ = sai_thrift_read_port_counters(
             self.client, port_list[src_port_id]
         )
 
@@ -1463,14 +1468,15 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             # send packets to dst port 1, occupying the "xon"
-            xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
+            xmit_counters_base, _ = sai_thrift_read_port_counters(
                 self.client, port_list[dst_port_id]
             )
 
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
-            # actual leakout by sending packets and reading actual leakout from HW
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+            # actual leakout by sending packets and reading actual leakout from HW.
+            # And apply dynamically compensation to all device using Broadcom ASIC.
+            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 pkts_num_leak_out = 0
 
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
@@ -1490,13 +1496,19 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis
                 )
 
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                actual_port_leak_out = xmit_counters[TRANSMITTED_PKTS] -  xmit_counters_base[TRANSMITTED_PKTS]
-                send_packet(self, src_port_id, pkt, actual_port_leak_out)
+            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+                xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+                counters_base = xmit_counters_base
+                actual_port_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+                while actual_port_leak_out > 0:
+                    send_packet(self, src_port_id, pkt, actual_port_leak_out)
+                    sys.stderr.write('Dynamically compensate {} packets to dst port 1, because of leakout\n'.format(actual_port_leak_out))
+                    counters_base = xmit_counters
+                    xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+                    actual_port_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
 
             # send packets to dst port 2, occupying the shared buffer
-            xmit_2_counters_base, queue_counters = sai_thrift_read_port_counters(
+            xmit_2_counters_base, _ = sai_thrift_read_port_counters(
                 self.client, port_list[dst_port_2_id]
             )
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
@@ -1516,11 +1528,19 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis
                 )
 
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                send_packet(self, src_port_id, pkt2, actual_port_leak_out)
+            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+                xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
+                counters_base = xmit_2_counters_base
+                actual_port_2_leak_out = xmit_2_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+                while actual_port_2_leak_out > 0:
+                    send_packet(self, src_port_id, pkt2, actual_port_2_leak_out)
+                    sys.stderr.write('Dynamically compensate {} packets to dst port 2, because of leakout\n'.format(actual_port_2_leak_out))
+                    counters_base = xmit_2_counters
+                    xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
+                    actual_port_2_leak_out = xmit_2_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
 
             # send 1 packet to dst port 3, triggering PFC
-            xmit_3_counters_base, queue_counters = sai_thrift_read_port_counters(
+            xmit_3_counters_base, _ = sai_thrift_read_port_counters(
                 self.client, port_list[dst_port_3_id]
             )
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
@@ -1531,17 +1551,25 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 send_packet(self, src_port_id, pkt3, pkts_num_leak_out + 1)
 
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                send_packet(self, src_port_id, pkt3, actual_port_leak_out)
+            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+                xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
+                counters_base = xmit_3_counters_base
+                actual_port_3_leak_out = xmit_3_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+                while actual_port_3_leak_out > 0:
+                    send_packet(self, src_port_id, pkt3, actual_port_3_leak_out)
+                    sys.stderr.write('Dynamically compensate {} packets to dst port 3, because of leakout\n'.format(actual_port_3_leak_out))
+                    counters_base = xmit_3_counters
+                    xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
+                    actual_port_3_leak_out = xmit_3_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-            xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-            xmit_3_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
@@ -1560,10 +1588,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-            xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-            xmit_3_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
@@ -1581,7 +1609,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get new base counter values at recv ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
             for cntr in ingress_counters:
                 assert(recv_counters[cntr] == recv_counters_base[cntr])
             recv_counters_base = recv_counters
@@ -1589,10 +1617,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(30)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-            xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-            xmit_3_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -83,7 +83,7 @@ def dynamically_compensate_leakout(thrift_client, counter_checker, check_port, c
         sys.stderr.write('Compensate {} packets to port {}\n'.format(leakout_num, compensate_port))
         prev = curr
         curr, _ = counter_checker(thrift_client, check_port)
-        leakout_num = curr[check_field] - base[check_field]
+        leakout_num = curr[check_field] - prev[check_field]
         retry += 1
 
 

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -66,6 +66,27 @@ RELEASE_PORT_MAX_RATE = 0
 ECN_INDEX_IN_HEADER = 53 # Fits the ptf hex_dump_buffer() parse function
 DSCP_INDEX_IN_HEADER = 52 # Fits the ptf hex_dump_buffer() parse function
 
+
+def check_leackout_compensation_support(asic, hwsku):
+    if 'broadcom' in asic.lower():
+        return True
+    return False
+
+
+def dynamically_compensate_leakout(thrift_client, counter_checker, check_port, check_field, base, ptf_test, compensate_port, compensate_pkt, max_retry):
+    prev = base
+    curr, _ = counter_checker(thrift_client, check_port)
+    leakout_num = curr[check_field] - prev[check_field]
+    retry = 0
+    while leakout_num > 0 and retry < max_retry:
+        send_packet(ptf_test, compensate_port, compensate_pkt, leakout_num)
+        sys.stderr.write('Compensate {} packets to port {}\n'.format(leakout_num, compensate_port))
+        prev = curr
+        curr, _ = counter_checker(thrift_client, check_port)
+        leakout_num = curr[check_field] - base[check_field]
+        retry += 1
+
+
 def construct_ip_pkt(pkt_len, dst_mac, src_mac, src_ip, dst_ip, dscp, src_vlan, **kwargs):
     ecn = kwargs.get('ecn', 1)
     ip_id = kwargs.get('ip_id', None)
@@ -895,7 +916,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
             # actual leakout by sending packets and reading actual leakout from HW.
             # And apply dynamically compensation to all device using Broadcom ASIC.
-            if 'broadcom' in asic_type.lower() or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+            if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
             # send packets short of triggering pfc
@@ -913,17 +934,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
 
-            if 'broadcom' in asic_type.lower() or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                counters_base = xmit_counters_base
-                actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
-                while actual_pkts_num_leak_out > 0:
-                    send_packet(self, src_port_id, pkt, actual_pkts_num_leak_out)
-                    sys.stderr.write('Dynamically compensate {} packets, because of leakout\n'.format(actual_pkts_num_leak_out))
-                    counters_base = xmit_counters
-                    xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                    actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
-                    time.sleep(8)
+            if check_leackout_compensation_support(asic_type, hwsku):
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 10)
 
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
@@ -1476,7 +1488,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
             # actual leakout by sending packets and reading actual leakout from HW.
             # And apply dynamically compensation to all device using Broadcom ASIC.
-            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
+            if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
@@ -1496,16 +1508,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out + pkts_num_trig_pfc - pkts_num_dismiss_pfc - hysteresis
                 )
 
-            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                counters_base = xmit_counters_base
-                actual_port_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
-                while actual_port_leak_out > 0:
-                    send_packet(self, src_port_id, pkt, actual_port_leak_out)
-                    sys.stderr.write('Dynamically compensate {} packets to dst port 1, because of leakout\n'.format(actual_port_leak_out))
-                    counters_base = xmit_counters
-                    xmit_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
-                    actual_port_leak_out = xmit_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+            if check_leackout_compensation_support(asic_type, hwsku):
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 40)
 
             # send packets to dst port 2, occupying the shared buffer
             xmit_2_counters_base, _ = sai_thrift_read_port_counters(
@@ -1528,16 +1532,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out + margin + pkts_num_dismiss_pfc - 1 + hysteresis
                 )
 
-            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-                counters_base = xmit_2_counters_base
-                actual_port_2_leak_out = xmit_2_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
-                while actual_port_2_leak_out > 0:
-                    send_packet(self, src_port_id, pkt2, actual_port_2_leak_out)
-                    sys.stderr.write('Dynamically compensate {} packets to dst port 2, because of leakout\n'.format(actual_port_2_leak_out))
-                    counters_base = xmit_2_counters
-                    xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-                    actual_port_2_leak_out = xmit_2_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+            if check_leackout_compensation_support(asic_type, hwsku):
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_2_id], TRANSMITTED_PKTS, xmit_2_counters_base, self, src_port_id, pkt2, 40)
 
             # send 1 packet to dst port 3, triggering PFC
             xmit_3_counters_base, _ = sai_thrift_read_port_counters(
@@ -1551,16 +1547,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 send_packet(self, src_port_id, pkt3, pkts_num_leak_out + 1)
 
-            if 'broadcom' in asic_type.lower() or hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
-                xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
-                counters_base = xmit_3_counters_base
-                actual_port_3_leak_out = xmit_3_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
-                while actual_port_3_leak_out > 0:
-                    send_packet(self, src_port_id, pkt3, actual_port_3_leak_out)
-                    sys.stderr.write('Dynamically compensate {} packets to dst port 3, because of leakout\n'.format(actual_port_3_leak_out))
-                    counters_base = xmit_3_counters
-                    xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, port_list[dst_port_3_id])
-                    actual_port_3_leak_out = xmit_3_counters[TRANSMITTED_PKTS] - counters_base[TRANSMITTED_PKTS]
+            if check_leackout_compensation_support(asic_type, hwsku):
+                dynamically_compensate_leakout(self.client, sai_thrift_read_port_counters, port_list[dst_port_3_id], TRANSMITTED_PKTS, xmit_3_counters_base, self, src_port_id, pkt3, 40)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

dynamically compensation for leakout packet in xon testcase

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During run PFCXonTest on broadcom platfom, found random number of packet leakout even after tx disable,
And sometime, there are more bad case which need compensate packet multiple time.
So dyanmically compensate Actual leakout packets.
#### How did you do it?
leverage compensation logic in past, add below two enhancement:

- apply the compensation to all brcm platform.
- add retry, if one compensation is not enough
#### How did you verify/test it?
passed local test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
