### PR TITLE
Changed validation that device was rebooted in case of reboot

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -225,7 +225,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
 
-    reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
+    uptime_before_reboot = duthost.get_uptime()
+    reboot_res, _ = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
     # if wait_for_ssh flag is False, do not wait for dut to boot up
@@ -247,10 +248,11 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     pool.terminate()
-    dut_uptime = duthost.get_up_time()
-    logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
-    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
-        format(hostname)
+    uptime_after_reboot = duthost.get_uptime()
+    logger.info('DUT {} uptime before reboot: {} minutes, uptime after reboot: {} minutes'.format(hostname,
+                                                                                                  uptime_before_reboot,
+                                                                                                  uptime_after_reboot))
+    assert uptime_before_reboot > uptime_after_reboot, "Device {} did not reboot".format(hostname)
 
 
 def get_reboot_cause(dut):


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Changed validation that device was rebooted in case of reboot

Previously we did check by checking time on DUT before reboot and after reboot by checking "uptime since" time. Then we checked that "uptime since" time bigger than time from DUT before reboot.  In some cases after reboot time on DUT may be not synchronized as result "uptime since" after reboot may be less than time before reboot DUT.

Now we do check using next logic: Get DUT uptime in seconds before reboot, get DUT uptime in seconds after reboot - then check that uptime after reboot less than uptime before reboot

Summary: Changed validation that device was rebooted in case of reboot
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Previously we did check by checking time on DUT before reboot and after reboot by checking "uptime since" time. Then we checked that "uptime since" time bigger than time from DUT before reboot.  In some cases after reboot time on DUT may be not synchronized as result "uptime since" after reboot may be less than time before reboot DUT.

#### How did you do it?
Now we do check using next logic: Get DUT uptime in seconds before reboot, get DUT uptime in seconds after reboot - then check that uptime after reboot less than uptime before reboot

#### How did you verify/test it?
Executed reboot tests(fast-reboot, warm-reboot)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
