### PR TITLE
remove redundant VNET route checks in VxLAN tests

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -324,6 +324,40 @@ def fixture_setUp(duthosts,
     setup_crm_interval(data['duthost'], int(data['original_crm_interval']))
 
 
+@pytest.fixture(scope="module")
+def default_routes(fixture_setUp, encap_type):
+    vnet = fixture_setUp[encap_type]['vnet_vni_map'].keys()[0]
+    return fixture_setUp[encap_type]['dest_to_nh_map'][vnet]
+
+
+@pytest.fixture(scope="module")
+def routes_for_cleanup(fixture_setUp, encap_type):
+    routes = {}
+
+    yield routes
+
+    # prepare for route cleanup by fixture_setUp on module finish
+    vnet = fixture_setUp[encap_type]['vnet_vni_map'].keys()[0]
+    fixture_setUp[encap_type]['dest_to_nh_map'][vnet] = routes
+
+
+@pytest.fixture(autouse=True)
+def reset_test_routes(fixture_setUp, encap_type, default_routes, routes_for_cleanup):
+    """
+    The fixture makes sure each test uses the same route config not affected by previous test runs
+    """
+    vnet = fixture_setUp[encap_type]['vnet_vni_map'].keys()[0]
+
+    test_routes = {}
+    test_routes.update(default_routes)
+    fixture_setUp[encap_type]['dest_to_nh_map'][vnet] = test_routes
+
+    yield
+
+    test_made_routes = fixture_setUp[encap_type]['dest_to_nh_map'][vnet]
+    routes_for_cleanup.update(test_made_routes)
+
+
 class Test_VxLAN():
     '''
         Base class for all VxLAN+BFD tests.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: remove redundant VNET route checks in VxLAN tests
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/7050
Avoided checking of the same routes checked by previous tests run in the same suite.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Save test exec time, avoid execution of the same route checks
#### How did you do it?
Identified repeated checks and reset routes to be checked before each test run
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
