### PR TITLE
[Python3] Py3 migration in tacacs/utils.py when test tacacs/test_accounting.py

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -87,7 +87,7 @@ def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path, path_to_be
         link_path_regex = re.escape(path_to_be_fix)
 
     target_path_regex = re.escape(target_path)
-    ptfhost.shell("sed -i 's/{0}/{1}/g' /etc/tacacs+/tac_plus.conf".format(link_path_regex, target_path_regex))
+    ptfhost.shell("sed -i 's|{0}|{1}|g' /etc/tacacs+/tac_plus.conf".format(link_path_regex, target_path_regex))
 
 def get_ld_path(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The error logs like below:
```
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {"changed": true, "cmd": "sed -i 's//usr/bin/python//usr/bin/python3\\.9/g' /etc/tacacs+/tac_plus.conf", "delta": "0:00:00.073510", "end": "2022-12-03 22:49:49.833181", "failed": true, "msg": "non-zero return code", "rc": 1}
```

Because in code use `re.escape` to Escape special characters in pattern. But **Py3** has differences with **Py2**. That is, 
```
Changed in version 3.7: Only characters that can have special meaning in a regular expression are escaped. As a result, '!', '"', '%', "'", ',', '/', ':', ';', '<', '=', '>', '@', and "`" are no longer escaped.
```

So `/usr/bin/python` after `re.escape` is also `/usr/bin/python`, but in **Python2** is `\\/usr\\/bin\\/python`.

So we change the delimiter in the substitute command to something that won't appear in path.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Migrate test_accounting.py to python3, and also adapt to Python2.

#### How did you do it?

Change the delimiter "/"  to "|" in the substitute command "sed -i 's/<old_str>/<new_str>/g'".

#### How did you verify/test it?

Run TC in Python3 and Python2, both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
