### PR TITLE
Calculate qos test's parameter in runtime

### DIFF
--- a/tests/qos/files/brcm/qos_param_generator.py
+++ b/tests/qos/files/brcm/qos_param_generator.py
@@ -1,0 +1,29 @@
+'''
+generate and update qos params for brcm platform
+so far, only return the original qos_params to testcase
+'''
+
+class QosParamBroadcom(object):
+
+    def __init__(self,
+                 qos_params,
+                 asic_type,
+                 speed_cable_len,
+                 dutConfig,
+                 ingressLosslessProfile,
+                 ingressLossyProfile,
+                 egressLosslessProfile,
+                 egressLossyProfile,
+                 sharedHeadroomPoolSize,
+                 dualTor,
+                 dutTopo,
+                 bufferConfig,
+                 asicConfig,
+                 testbedTopologyName,
+                 verbose=True):
+        self.qos_params = qos_params
+        return
+
+
+    def run(self):
+        return self.qos_params

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -881,6 +881,31 @@ class QosSaiBase(QosBase):
             duthost.command("docker exec syncd python /packets_aging.py enable")
             duthost.command("docker exec syncd rm -rf /packets_aging.py")
 
+    def dutBufferConfig(self, duthost):
+        bufferConfig = {}
+        try:
+            bufferConfig['BUFFER_POOL'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_POOL"')['stdout'])
+            bufferConfig['BUFFER_PROFILE'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_PROFILE"')['stdout'])
+            bufferConfig['BUFFER_QUEUE'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_QUEUE"')['stdout'])
+            bufferConfig['BUFFER_PG'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_PG"')['stdout'])
+        except Exception as err:
+            logger.info(err)
+        return bufferConfig
+
+    def dutAsicConfig(self, asic, duthost):
+        asicConfig = {}
+        # Only support to get brcm asic info, so far
+        if 'broadcom' in asic.lower():
+            output = duthost.shell('bcmcmd "g THDI_BUFFER_CELL_LIMIT_SP"', module_ignore_errors=True)
+            logger.info('Read ASIC THDI_BUFFER_CELL_LIMIT_SP register, output {}'.format(output))
+            for line in output['stdout'].replace('\r', '\n').split('\n'):
+                if line:
+                    m = re.match('THDI_BUFFER_CELL_LIMIT_SP\(0\).*\<LIMIT=(\S+)\>', line)
+                    if m:
+                        asicConfig['shared_limit_sp0'] = int(m.group(1), 0)
+                        break
+        return asicConfig
+
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
             self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
@@ -941,6 +966,37 @@ class QosSaiBase(QosBase):
                                                        dutConfig["dualTor"]
                                                        )
             qosParams = qpm.run()
+
+        elif 'broadcom' in duthost.facts['asic_type'].lower():
+            bufferConfig = self.dutBufferConfig(duthost)
+            pytest_assert(len(bufferConfig) == 4, "buffer config is incompleted")
+            pytest_assert('BUFFER_POOL' in bufferConfig, 'BUFFER_POOL is not exist in bufferConfig')
+            pytest_assert('BUFFER_PROFILE' in bufferConfig, 'BUFFER_PROFILE is not exist in bufferConfig')
+            pytest_assert('BUFFER_QUEUE' in bufferConfig, 'BUFFER_QUEUE is not exist in bufferConfig')
+            pytest_assert('BUFFER_PG' in bufferConfig, 'BUFFER_PG is not exist in bufferConfig')
+            asicConfig = self.dutAsicConfig(duthost.facts['asic_type'], duthost)
+
+            current_file_dir = os.path.dirname(os.path.realpath(__file__))
+            sub_folder_dir = os.path.join(current_file_dir, "files/brcm/")
+            if sub_folder_dir not in sys.path:
+                sys.path.append(sub_folder_dir)
+            import qos_param_generator
+            qpm = qos_param_generator.QosParamBroadcom(qosConfigs['qos_params'][dutAsic][dutTopo],
+                                                       dutAsic,
+                                                       portSpeedCableLength,
+                                                       dutConfig,
+                                                       ingressLosslessProfile,
+                                                       ingressLossyProfile,
+                                                       egressLosslessProfile,
+                                                       egressLossyProfile,
+                                                       sharedHeadroomPoolSize,
+                                                       dutConfig["dualTor"],
+                                                       dutTopo,
+                                                       bufferConfig,
+                                                       asicConfig,
+                                                       tbinfo["topo"]["name"])
+            qosParams = qpm.run()
+
         else:
             qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
         yield {

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -888,8 +888,8 @@ class QosSaiBase(QosBase):
             bufferConfig['BUFFER_PROFILE'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_PROFILE"')['stdout'])
             bufferConfig['BUFFER_QUEUE'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_QUEUE"')['stdout'])
             bufferConfig['BUFFER_PG'] = json.loads(duthost.shell('sonic-cfggen -d --var-json "BUFFER_PG"')['stdout'])
-        except:
-            logger.info('Failed to read buffer config')
+        except Exception as err:
+            logger.info(err)
         return bufferConfig
 
     def dutAsicConfig(self, asic, duthost):
@@ -908,19 +908,6 @@ class QosSaiBase(QosBase):
             except:
                 logger.info('Failed to read and parse ASIC THDI_BUFFER_CELL_LIMIT_SP register')
         return asicConfig
-
-    def dutArpProxyConfig(self, duthost):
-        # so far, only record ARP proxy config to logging for debug purpose
-        vlanInterface = {}
-        try:
-            vlanInterface = json.loads(duthost.shell('sonic-cfggen -d --var-json "VLAN_INTERFACE"')['stdout'])
-        except:
-            logger.info('Failed to read vlan interface config')
-        if not vlanInterface:
-            return
-        for key, value in vlanInterface.items():
-            if 'proxy_arp' in value:
-                logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
 
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
@@ -964,8 +951,6 @@ class QosSaiBase(QosBase):
         qosConfigs = dutConfig["qosConfigs"]
         dutAsic = dutConfig["dutAsic"]
         dutTopo = dutConfig["dutTopo"]
-
-        self.dutArpProxyConfig(duthost)
 
         if isMellanoxDevice(duthost):
             current_file_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -896,14 +896,17 @@ class QosSaiBase(QosBase):
         asicConfig = {}
         # Only support to get brcm asic info, so far
         if 'broadcom' in asic.lower():
-            output = duthost.shell('bcmcmd "g THDI_BUFFER_CELL_LIMIT_SP"', module_ignore_errors=True)
-            logger.info('Read ASIC THDI_BUFFER_CELL_LIMIT_SP register, output {}'.format(output))
-            for line in output['stdout'].replace('\r', '\n').split('\n'):
-                if line:
-                    m = re.match('THDI_BUFFER_CELL_LIMIT_SP\(0\).*\<LIMIT=(\S+)\>', line)
-                    if m:
-                        asicConfig['shared_limit_sp0'] = int(m.group(1), 0)
-                        break
+            try:
+                output = duthost.shell('bcmcmd "g THDI_BUFFER_CELL_LIMIT_SP"', module_ignore_errors=True)
+                logger.info('Read ASIC THDI_BUFFER_CELL_LIMIT_SP register, output {}'.format(output))
+                for line in output['stdout'].replace('\r', '\n').split('\n'):
+                    if line:
+                        m = re.match('THDI_BUFFER_CELL_LIMIT_SP\(0\).*\<LIMIT=(\S+)\>', line)
+                        if m:
+                            asicConfig['shared_limit_sp0'] = int(m.group(1), 0)
+                            break
+            except:
+                logger.info('Failed to read and parse ASIC THDI_BUFFER_CELL_LIMIT_SP register')
         return asicConfig
 
     @pytest.fixture(scope='class', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Calculate qos test's parameter in runtime

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

On brcm platfomr, qos testcase's parameter  is not static value.
have to calculate it dynamically.

#### How did you do it?

so far, only prepare invoking  of calculation utils.
so, just directly return qos param to testcase.

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
