### PR TITLE
Improve sonic get uptime

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -8,7 +8,7 @@ import socket
 import time
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ansible import constants as ansible_constants
 from ansible.plugins.loader import connection_loader
@@ -955,7 +955,8 @@ class SonicHost(AnsibleHostBase):
         return datetime.strptime(now_time_text, "%Y-%m-%d %H:%M:%S")
 
     def get_uptime(self):
-        return self.get_now_time() - self.get_up_time()
+        uptime_text = self.command("</proc/uptime awk '{print $1}'")["stdout"]
+        return timedelta(seconds=float(uptime_text))
 
     def get_networking_uptime(self):
         start_time = self.get_service_props("networking", props=["ExecMainStartTimestamp", ])

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -955,7 +955,7 @@ class SonicHost(AnsibleHostBase):
         return datetime.strptime(now_time_text, "%Y-%m-%d %H:%M:%S")
 
     def get_uptime(self):
-        uptime_text = self.command("</proc/uptime awk '{print $1}'")["stdout"]
+        uptime_text = self.command("awk '{print $1}' /proc/uptime")["stdout"]
         return timedelta(seconds=float(uptime_text))
 
     def get_networking_uptime(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Improve the `get_uptime` function in [sonic.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/devices/sonic.py).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Improve the `get_uptime` function in `tests/common/devices/sonic.py`. 

#### How did you do it?

Let this function directly read uptime from `/proc/uptime` of DUT, and convert it to python `timedelta`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
