### PR TITLE
Fix the timeout issue of downloading saithrift deb file

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -251,7 +251,7 @@ def test_update_saithrift_ptf(request, ptfhost):
         pytest.skip("No URL specified for python saithrift package")
     pkg_name = py_saithrift_url.split("/")[-1]
     ptfhost.shell("rm -f {}".format(pkg_name))
-    result = ptfhost.get_url(url=py_saithrift_url, dest="/root", module_ignore_errors=True)
+    result = ptfhost.get_url(url=py_saithrift_url, dest="/root", module_ignore_errors=True, timeout=60)
     if result["failed"] or "OK" not in result["msg"]:
         pytest.skip("Download failed/error while installing python saithrift package")
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test case test_pretest.py::test_update_saithrift_ptf failed to download saithrift deb file for some testbeds, the error message looks like this:
`"msg": "Connection failure: timed out"`
I searched the ansible document, the default timeout is 10s, under some condition, it's not enough. 
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#:~:text=for%20URL%20request.-,Default%3A%2010,-tmp_dest

#### How did you do it?
Add timeout parameter and set it to 60s.

#### How did you verify/test it?
Run `test_pretest.py::test_update_saithrift_ptf`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
