### PR TITLE
[bgp] Fix 'KeyError' in method _setup_interfaces_t1_or_t2(original change #6715)

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -17,34 +17,15 @@ from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.utilities import wait_until
 from tests.common.utilities import wait_tcp_connection
 from tests.common import config_reload
-from bgp_helpers import define_config
-from bgp_helpers import apply_default_bgp_config
-from bgp_helpers import DUT_TMP_DIR
-from bgp_helpers import TEMPLATE_DIR
-from bgp_helpers import BGP_PLAIN_TEMPLATE
-from bgp_helpers import BGP_NO_EXPORT_TEMPLATE
-from bgp_helpers import DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST, BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
+from bgp_helpers import define_config, apply_default_bgp_config, DUT_TMP_DIR, TEMPLATE_DIR, BGP_PLAIN_TEMPLATE,\
+    BGP_NO_EXPORT_TEMPLATE, DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST,\
+    BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
 
 
 logger = logging.getLogger(__name__)
-
-@pytest.fixture(scope='module')
-def setup_keepalive_and_hold_timer(duthosts, rand_one_dut_hostname, nbrhosts):
-    duthost = duthosts[rand_one_dut_hostname]
-    # incrase the keepalive and hold timer
-    duthost.command("vtysh -c \"configure terminal\" \
-                           -c \"router bgp {}\" \
-                           -c \"neighbor {} timers 60 180\"".format(
-                               metadata['localhost']['bgp_asn'], \
-                               bgp_nbr_ip))
-
-    for k, nbr in nbrhosts.items():
-        nbr['host'].eos_config(lines=["timers 60 180"], parents=["router bgp {}".format(bgp_nbr['asn'])])
-
-    yield
 
 
 def check_results(results):
@@ -402,7 +383,9 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
                 conn["loopback_ip"] = loopback_ip
-                if 'namespace' in mg_facts['minigraph_neighbors'][intf] and mg_facts['minigraph_neighbors'][intf]['namespace']:
+                if intf in mg_facts['minigraph_neighbors'] and \
+                        'namespace' in mg_facts['minigraph_neighbors'][intf] and \
+                        mg_facts['minigraph_neighbors'][intf]['namespace']:
                     conn["namespace"] = mg_facts['minigraph_neighbors'][intf]['namespace']
                 else:
                     conn["namespace"] = DEFAULT_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The change is a manual "cherry-pick" of PR #6715


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
stabilize the bgp tests

#### How did you do it?
added additional checker in "if" condition

#### How did you verify/test it?
tests executed on topology, where previously failed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
