### PR TITLE
Add streaming events test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -58,6 +58,7 @@ t0:
   - tacacs/test_ro_user.py
   - tacacs/test_rw_user.py
   - telemetry/test_telemetry.py
+  - telemetry/test_events.py
   - test_features.py
   - test_interfaces.py
   - test_procdockerstatsd.py

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -1,0 +1,65 @@
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.utilities import wait_until, wait_tcp_connection
+from telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
+
+logger = logging.getLogger(__name__)
+
+TELEMETRY_PORT = 50051
+
+@pytest.fixture(scope="module")
+def gnxi_path(ptfhost):
+    """
+    gnxi's location is updated from /gnxi to /root/gnxi
+    in RP https://github.com/sonic-net/sonic-buildimage/pull/10599.
+    But old docker-ptf images don't have this update,
+    test case will fail for these docker-ptf images,
+    because it should still call /gnxi files.
+    For avoiding this conflict, check gnxi path before test and set GNXI_PATH to correct value.
+    Add a new gnxi_path module fixture to make sure to set GNXI_PATH before test.
+    """
+    path_exists = ptfhost.stat(path="/root/gnxi/")
+    if path_exists["stat"]["exists"] and path_exists["stat"]["isdir"]:
+        gnxipath = "/root/gnxi/"
+    else:
+        gnxipath = "/gnxi/"
+    return gnxipath
+
+
+@pytest.fixture(scope="module", autouse=True)
+def verify_telemetry_dockerimage(duthosts, enum_rand_one_per_hwsku_hostname):
+    """If telemetry docker is available in image then return true
+    """
+    docker_out_list = []
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    docker_out = duthost.shell('docker images docker-sonic-telemetry', module_ignore_errors=False)['stdout_lines']
+    docker_out_list = get_list_stdout(docker_out)
+    matching = [s for s in docker_out_list if "docker-sonic-telemetry" in s]
+    if not (len(matching) > 0):
+        pytest.skip("docker-sonic-telemetry is not part of the image")
+
+
+@pytest.fixture(scope="module")
+def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localhost,  ptfhost, gnxi_path):
+    """
+    @summary: Post setting up the streaming telemetry before running the test.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    default_client_auth = setup_telemetry_forpyclient(duthost)
+
+    # Wait until telemetry was restarted
+    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started.")
+    logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
+
+    # Wait until the TCP port was opened
+    dut_ip = duthost.mgmt_ip
+    wait_tcp_connection(localhost, dut_ip, TELEMETRY_PORT, timeout_s=60)
+
+    # pyclient should be available on ptfhost. If it was not available, then fail pytest.
+    file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
+    py_assert(file_exists["stat"]["exists"] is True)
+
+    yield
+    restore_telemetry_forpyclient(duthost, default_client_auth)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 TELEMETRY_PORT = 50051
 
+
 @pytest.fixture(scope="module")
 def gnxi_path(ptfhost):
     """

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -1,0 +1,44 @@
+#! /usr/bin/env python3
+
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def test_event(duthost, localhost, run_cmd, data_dir, validate_yang):
+    op_file = os.path.join(data_dir, "bgp_state.json")
+
+    shutdownBGPNeighbors(duthost)
+    listenForBGPStateEvents(localhost, run_cmd, op_file)
+
+    data = {}
+    with open(op_file, "r") as f:
+        data = json.load(f)
+    logger.info("events received: ({})".format(json.dumps(data, indent=4)))
+    assert len(data) > 0, "Failed to check heartbeat"
+    duthost.copy(src=op_file, dest="/tmp/bgp_state.json")
+    validate_yang(duthost, "/tmp/bgp_state.json", "sonic-events-bgp")
+
+
+def listenForBGPStateEvents(localhost, run_cmd, op_file):
+    logger.info("Starting to listen for bgp event")
+    run_cmd(localhost, [ "heartbeat=5"], op_file=op_file,
+            filter_event="sonic-events-bgp:bgp-state",
+            event_cnt=1, timeout=20)
+
+
+def shutdownBGPNeighbors(duthost):
+    assert duthost.is_service_running("bgpcfgd", "bgp") is True and duthost.is_bgp_state_idle() is False
+    logger.info("Start all bgp sessions")
+    ret = duthost.shell("config bgp startup all")
+    assert ret["rc"] == 0, "Failing to startup"
+
+    ret = duthost.shell("config bgp shutdown all")
+    assert ret["rc"] == 0, "Failing to shutdown"
+
+    ret = duthost.shell("config bgp startup all")
+    assert ret["rc"] == 0, "Failing to startup"
+

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import time
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ def test_event(duthost, localhost, run_cmd, data_dir, validate_yang):
 
 def listenForBGPStateEvents(localhost, run_cmd, op_file):
     logger.info("Starting to listen for bgp event")
-    run_cmd(localhost, [ "heartbeat=5"], op_file=op_file,
+    run_cmd(localhost, ["heartbeat=5"], op_file=op_file,
             filter_event="sonic-events-bgp:bgp-state",
             event_cnt=1, timeout=20)
 

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -1,0 +1,81 @@
+import logging
+import pytest
+
+from pkg_resources import parse_version
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+TELEMETRY_PORT = 50051
+METHOD_GET = "get"
+METHOD_SUBSCRIBE = "subscribe"
+SUBSCRIBE_MODE_STREAM = 0
+SUBMODE_SAMPLE = 2
+
+
+def assert_equal(actual, expected, message):
+    """Helper method to compare an expected value vs the actual value.
+    """
+    pytest_assert(actual == expected, "{0}. Expected {1} vs actual {2}".format(message, expected, actual))
+
+
+def get_dict_stdout(gnmi_out, certs_out):
+    """ Extracts dictionary from redis output.
+    """
+    gnmi_list = []
+    gnmi_list = get_list_stdout(gnmi_out) + get_list_stdout(certs_out)
+    # Elements in list alternate between key and value. Separate them and combine into a dict.
+    key_list = gnmi_list[0::2]
+    value_list = gnmi_list[1::2]
+    params_dict = dict(zip(key_list, value_list))
+    return params_dict
+
+
+def get_list_stdout(cmd_out):
+    out_list = []
+    for x in cmd_out:
+        result = x.encode('UTF-8')
+        out_list.append(result)
+    return out_list
+
+
+def skip_201911_and_older(duthost):
+    """ Skip the current test if the DUT version is 201911 or older.
+    """
+    if parse_version(duthost.kernel_version) <= parse_version('4.9.0'):
+        pytest.skip("Test not supported for 201911 images. Skipping the test")
+
+
+def setup_telemetry_forpyclient(duthost):
+    """ Set client_auth=false. This is needed for pyclient to successfully set up channel with gnmi server.
+        Restart telemetry process
+    """
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
+    client_auth = str(client_auth_out[0])
+    if client_auth == "true":
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
+        duthost.service(name="telemetry", state="restarted")
+    else:
+        logger.info('client auth is false. No need to restart telemetry')
+    return client_auth
+
+
+def restore_telemetry_forpyclient(duthost, default_client_auth):
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
+    client_auth = str(client_auth_out[0])
+    if client_auth != default_client_auth:
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth), module_ignore_errors=False)
+        duthost.service(name="telemetry", state="restarted")
+
+
+def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/Ethernet0", target="COUNTERS_DB", subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE, intervalms=0, update_count=3):
+    """Generate the py_gnmicli command line based on the given params.
+    """
+    cmdFormat = 'python '+ gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
+    cmd = cmdFormat.format(duthost.mgmt_ip, TELEMETRY_PORT, method, xpath, target, "ndastreamingservertest")
+
+    if method == METHOD_SUBSCRIBE:
+        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(subscribe_mode, submode, intervalms, update_count)
+    return cmd
+
+

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -46,6 +46,14 @@ def skip_201911_and_older(duthost):
         pytest.skip("Test not supported for 201911 images. Skipping the test")
 
 
+def skip_arm_platform(duthost):
+    """ Skip the current test if DUT is arm platform.
+    """
+    platform = duthost.facts["platform"]
+    if 'arm' in platform:
+        pytest.skip("Test not supported for arm platform. Skipping the test")
+
+
 def setup_telemetry_forpyclient(duthost):
     """ Set client_auth=false. This is needed for pyclient to successfully set up channel with gnmi server.
         Restart telemetry process

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -51,7 +51,7 @@ def setup_telemetry_forpyclient(duthost):
         Restart telemetry process
     """
     client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
-            module_ignore_errors=False)['stdout_lines']
+                                    module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth == "true":
         duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
@@ -63,23 +63,25 @@ def setup_telemetry_forpyclient(duthost):
 
 def restore_telemetry_forpyclient(duthost, default_client_auth):
     client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
-            module_ignore_errors=False)['stdout_lines']
+                                    module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth != default_client_auth:
         duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth),
-                module_ignore_errors=False)
+                      module_ignore_errors=False)
         duthost.service(name="telemetry", state="restarted")
 
 
 def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/Ethernet0", target="COUNTERS_DB",
-        subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE,
-        intervalms=0, update_count=3):
+                        subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE,
+                        intervalms=0, update_count=3):
     """ Generate the py_gnmicli command line based on the given params.
     """
-    cmdFormat = 'python '+ gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
+    cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
     cmd = cmdFormat.format(duthost.mgmt_ip, TELEMETRY_PORT, method, xpath, target, "ndastreamingservertest")
 
     if method == METHOD_SUBSCRIBE:
-        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(subscribe_mode,
-                submode, intervalms, update_count)
+        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(
+                subscribe_mode,
+                submode, intervalms,
+                update_count)
     return cmd

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -50,7 +50,8 @@ def setup_telemetry_forpyclient(duthost):
     """ Set client_auth=false. This is needed for pyclient to successfully set up channel with gnmi server.
         Restart telemetry process
     """
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
+            module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth == "true":
         duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
@@ -61,21 +62,24 @@ def setup_telemetry_forpyclient(duthost):
 
 
 def restore_telemetry_forpyclient(duthost, default_client_auth):
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
+            module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth != default_client_auth:
-        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth), module_ignore_errors=False)
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth),
+                module_ignore_errors=False)
         duthost.service(name="telemetry", state="restarted")
 
 
-def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/Ethernet0", target="COUNTERS_DB", subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE, intervalms=0, update_count=3):
-    """Generate the py_gnmicli command line based on the given params.
+def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/Ethernet0", target="COUNTERS_DB",
+        subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE,
+        intervalms=0, update_count=3):
+    """ Generate the py_gnmicli command line based on the given params.
     """
     cmdFormat = 'python '+ gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
     cmd = cmdFormat.format(duthost.mgmt_ip, TELEMETRY_PORT, method, xpath, target, "ndastreamingservertest")
 
     if method == METHOD_SUBSCRIBE:
-        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(subscribe_mode, submode, intervalms, update_count)
+        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(subscribe_mode,
+                submode, intervalms, update_count)
     return cmd
-
-

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -50,8 +50,8 @@ def skip_arm_platform(duthost):
     """ Skip the current test if DUT is arm platform.
     """
     platform = duthost.facts["platform"]
-    if 'arm' in platform:
-        pytest.skip("Test not supported for arm platform. Skipping the test")
+    if 'x86_64' not in platform:
+        pytest.skip("Test not supported for current platform. Skipping the test")
 
 
 def setup_telemetry_forpyclient(duthost):

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -1,0 +1,117 @@
+import logging
+import pytest
+import json
+import os
+import sys
+import time
+
+from telemetry_utils import skip_201911_and_older
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+EVENTS_TESTS_PATH = "./telemetry/events"
+sys.path.append(EVENTS_TESTS_PATH)
+
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR = "logs/telemetry"
+DATA_DIR = os.path.join(BASE_DIR, "files")
+
+CMD_PREFIX_FMT = ("{} -client_types=gnmi -a {}:50051 -t EVENTS "
+                 "-logtostderr -insecure -v 7 -streaming_type ON_CHANGE "
+                 "-qt s -q all")
+CMD_PREFIX = ""
+
+GNMI_CLI_BIN = None
+
+
+def validate_yang(duthost, op_file="", yang_file=""):
+    assert op_file != "" and yang_file != "", "op_file path or yang_file name not provided"
+    cmd = "python /tmp/validate_yang_events.py -f {} -y {}".format(op_file, yang_file)
+    logger.info("Performing yang validation on {} for {}".format(op_file, yang_file))
+    ret = duthost.shell(cmd)
+    assert ret["rc"] == 0, "Yang validation failed for {}".format(yang_file)
+
+
+def run_cmd(localhost, params={}, op_file="", filter_event="", event_cnt=0, timeout=0):
+    cmd = CMD_PREFIX
+    for i in params:
+        cmd += "[{}]".format(i)
+
+    if (op_file != ""):
+        cmd += " -output_file={}".format(op_file)
+
+    if (filter_event != ""):
+        cmd += " -expected_event={}".format(filter_event)
+
+    if (event_cnt > 0):
+        cmd += " -expected_count={}".format(event_cnt)
+
+    if (timeout > 0):
+        cmd += " -streaming_timeout={}".format(timeout)
+
+    ret = localhost.shell(cmd)
+    assert ret["rc"] == 0, "Failed to run cmd {}".format(cmd)
+
+
+def do_init(duthost):
+    global CMD_PREFIX, GNMI_CLI_BIN
+
+    for i in [BASE_DIR, DATA_DIR]:
+        try:
+            os.mkdir(i)
+        except OSError as e:
+            pass
+
+    duthost.shell("docker cp telemetry:/usr/sbin/gnmi_cli /tmp")
+    ret = duthost.fetch(src="/tmp/gnmi_cli", dest=DATA_DIR)
+    GNMI_CLI_BIN = ret.get("dest", None)
+    assert GNMI_CLI_BIN != None, "Failing to get gnmi_cli"
+
+    os.system("chmod +x {}".format(GNMI_CLI_BIN))
+    logger.info("GNMI_CLI_BIN={}".format(GNMI_CLI_BIN))
+    CMD_PREFIX = CMD_PREFIX_FMT.format(GNMI_CLI_BIN, duthost.mgmt_ip)
+
+    ret = duthost.copy(src="telemetry/validate_yang_events.py", dest="/tmp")
+
+
+def drain_cache(duthost, localhost):
+    run_cmd(localhost, [ "heartbeat=2"], timeout=180)
+
+
+def check_heartbeat(duthost, localhost):
+    op_file = os.path.join(DATA_DIR, "check_heartbeat.json")
+    logger.info("Validating sonic-events-eventd:heartbeat is working")
+    run_cmd(localhost, [ "heartbeat=2"], op_file=op_file,
+            filter_event="sonic-events-eventd:heartbeat", event_cnt=1, 
+            timeout=60)
+    data = {}
+    with open(op_file, "r") as f:
+        data = json.load(f)
+    logger.info("events received: ({})".format(json.dumps(data, indent=4)))
+    assert len(data) > 0, "Failed to check heartbeat"
+
+
+def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, localhost, gnxi_path):
+    """ Run series of events inside duthost and validate that output is correct
+    and conforms to YANG schema
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    logger.info("Start events testing")
+
+    skip_201911_and_older(duthost)
+    do_init(duthost)
+
+    drain_cache(duthost, localhost)
+    check_heartbeat(duthost, localhost)
+
+    # Load all events test code and run
+    for file in os.listdir(EVENTS_TESTS_PATH):
+        if file.endswith(".py"):
+            time.sleep(5) # give time to teardown prev test
+            module = __import__(file[:len(file)-3])
+            module.test_event(duthost, localhost, run_cmd, DATA_DIR, validate_yang)
+            logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -21,8 +21,8 @@ BASE_DIR = "logs/telemetry"
 DATA_DIR = os.path.join(BASE_DIR, "files")
 
 CMD_PREFIX_FMT = ("{} -client_types=gnmi -a {}:50051 -t EVENTS "
-                 "-logtostderr -insecure -v 7 -streaming_type ON_CHANGE "
-                 "-qt s -q all")
+                  "-logtostderr -insecure -v 7 -streaming_type ON_CHANGE "
+                  "-qt s -q all")
 CMD_PREFIX = ""
 
 GNMI_CLI_BIN = None
@@ -64,12 +64,12 @@ def do_init(duthost):
         try:
             os.mkdir(i)
         except OSError as e:
-            pass
+            logger.info("Dir/file already exists: {}, skipping mkdir".format(e))
 
     duthost.shell("docker cp telemetry:/usr/sbin/gnmi_cli /tmp")
     ret = duthost.fetch(src="/tmp/gnmi_cli", dest=DATA_DIR)
     GNMI_CLI_BIN = ret.get("dest", None)
-    assert GNMI_CLI_BIN != None, "Failing to get gnmi_cli"
+    assert GNMI_CLI_BIN is not None, "Failing to get gnmi_cli"
 
     os.system("chmod +x {}".format(GNMI_CLI_BIN))
     logger.info("GNMI_CLI_BIN={}".format(GNMI_CLI_BIN))
@@ -79,13 +79,13 @@ def do_init(duthost):
 
 
 def drain_cache(duthost, localhost):
-    run_cmd(localhost, [ "heartbeat=2"], timeout=180)
+    run_cmd(localhost, ["heartbeat=2"], timeout=180)
 
 
 def check_heartbeat(duthost, localhost):
     op_file = os.path.join(DATA_DIR, "check_heartbeat.json")
     logger.info("Validating sonic-events-eventd:heartbeat is working")
-    run_cmd(localhost, [ "heartbeat=2"], op_file=op_file,
+    run_cmd(localhost, ["heartbeat=2"], op_file=op_file,
             filter_event="sonic-events-eventd:heartbeat", event_cnt=1, 
             timeout=60)
     data = {}
@@ -111,7 +111,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     # Load all events test code and run
     for file in os.listdir(EVENTS_TESTS_PATH):
         if file.endswith(".py"):
-            time.sleep(5) # give time to teardown prev test
+            time.sleep(5)  # give time to teardown prev test
             module = __import__(file[:len(file)-3])
             module.test_event(duthost, localhost, run_cmd, DATA_DIR, validate_yang)
             logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from telemetry_utils import skip_201911_and_older
+from telemetry_utils import skip_arm_platform
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -102,6 +103,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     logger.info("Start events testing")
 
     skip_201911_and_older(duthost)
+    skip_arm_platform(duthost)
     do_init(duthost)
 
     drain_cache(duthost, localhost)

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -3,7 +3,6 @@ import pytest
 import json
 import os
 import sys
-import time
 
 from telemetry_utils import skip_201911_and_older
 
@@ -111,7 +110,6 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     # Load all events test code and run
     for file in os.listdir(EVENTS_TESTS_PATH):
         if file.endswith(".py"):
-            time.sleep(5)  # give time to teardown prev test
             module = __import__(file[:len(file)-3])
             module.test_event(duthost, localhost, run_cmd, DATA_DIR, validate_yang)
             logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -4,9 +4,8 @@ import logging
 import re
 import pytest
 
-from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, wait_tcp_connection
+from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older, generate_client_cli
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -18,128 +17,7 @@ TELEMETRY_PORT = 50051
 METHOD_SUBSCRIBE = "subscribe"
 METHOD_GET = "get"
 
-SUBSCRIBE_MODE_STREAM = 0
-SUBSCRIBE_MODE_ONCE = 1
-SUBSCRIBE_MODE_POLL = 2
 
-SUBMODE_TARGET_DEFINED = 0
-SUBMODE_ON_CHANGE = 1
-SUBMODE_SAMPLE = 2
-
-# Helper functions
-def get_dict_stdout(gnmi_out, certs_out):
-    """ Extracts dictionary from redis output.
-    """
-    gnmi_list = []
-    gnmi_list = get_list_stdout(gnmi_out) + get_list_stdout(certs_out)
-    # Elements in list alternate between key and value. Separate them and combine into a dict.
-    key_list = gnmi_list[0::2]
-    value_list = gnmi_list[1::2]
-    params_dict = dict(zip(key_list, value_list))
-    return params_dict
-
-def get_list_stdout(cmd_out):
-    out_list = []
-    for x in cmd_out:
-        result = x.encode('UTF-8')
-        out_list.append(result)
-    return out_list
-
-def setup_telemetry_forpyclient(duthost):
-    """ Set client_auth=false. This is needed for pyclient to sucessfully set up channel with gnmi server.
-        Restart telemetry process
-    """
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
-    client_auth = str(client_auth_out[0])
-    if client_auth == "true":
-        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
-        duthost.service(name="telemetry", state="restarted")
-    else:
-        logger.info('client auth is false. No need to restart telemetry')
-    return client_auth
-
-def restore_telemetry_forpyclient(duthost, default_client_auth):
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
-    client_auth = str(client_auth_out[0])
-    if client_auth != default_client_auth:
-        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth), module_ignore_errors=False)
-        duthost.service(name="telemetry", state="restarted")
-
-def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/Ethernet0", target="COUNTERS_DB", subscribe_mode=SUBSCRIBE_MODE_STREAM, submode=SUBMODE_SAMPLE, intervalms=0, update_count=3):
-    """Generate the py_gnmicli command line based on the given params.
-    """
-    cmdFormat = 'python '+ gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
-    cmd = cmdFormat.format(duthost.mgmt_ip, TELEMETRY_PORT, method, xpath, target, "ndastreamingservertest")
-
-    if method == METHOD_SUBSCRIBE:
-        cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3}".format(subscribe_mode, submode, intervalms, update_count)
-    return cmd
-
-def assert_equal(actual, expected, message):
-    """Helper method to compare an expected value vs the actual value.
-    """
-    pytest_assert(actual == expected, "{0}. Expected {1} vs actual {2}".format(message, expected, actual))
-
-@pytest.fixture(scope="module")
-def gnxi_path(ptfhost):
-    """
-    gnxi's location is updated from /gnxi to /root/gnxi
-    in RP https://github.com/sonic-net/sonic-buildimage/pull/10599.
-    But old docker-ptf images don't have this update,
-    test case will fail for these docker-ptf images,
-    because it should still call /gnxi files.
-    For avoiding this conflict, check gnxi path before test and set GNXI_PATH to correct value.
-    Add a new gnxi_path module fixture to make sure to set GNXI_PATH before test.
-    """
-    path_exists = ptfhost.stat(path="/root/gnxi/")
-    if path_exists["stat"]["exists"] and path_exists["stat"]["isdir"]:
-        gnxipath = "/root/gnxi/"
-    else:
-        gnxipath = "/gnxi/"
-    return gnxipath
-
-@pytest.fixture(scope="module", autouse=True)
-def verify_telemetry_dockerimage(duthosts, enum_rand_one_per_hwsku_hostname):
-    """If telemetry docker is available in image then return true
-    """
-    docker_out_list = []
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    docker_out = duthost.shell('docker images docker-sonic-telemetry', module_ignore_errors=False)['stdout_lines']
-    docker_out_list = get_list_stdout(docker_out)
-    matching = [s for s in docker_out_list if "docker-sonic-telemetry" in s]
-    if not (len(matching) > 0):
-        pytest.skip("docker-sonic-telemetry is not part of the image")
-
-@pytest.fixture(scope="module")
-def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localhost,  ptfhost, gnxi_path):
-    """
-    @summary: Post setting up the streaming telemetry before running the test.
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    default_client_auth = setup_telemetry_forpyclient(duthost)
-
-    # Wait until telemetry was restarted
-    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started.")
-    logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
-
-    # Wait until the TCP port was opened
-    dut_ip = duthost.mgmt_ip
-    wait_tcp_connection(localhost, dut_ip, TELEMETRY_PORT, timeout_s=60)
-
-    # pyclient should be available on ptfhost. If it was not available, then fail pytest.
-    file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
-    pytest_assert(file_exists["stat"]["exists"] is True)
-
-    yield
-    restore_telemetry_forpyclient(duthost, default_client_auth)
-
-def skip_201911_and_older(duthost):
-    """ Skip the current test if the DUT version is 201911 or older.
-    """
-    if parse_version(duthost.kernel_version) <= parse_version('4.9.0'):
-        pytest.skip("Test not supported for 201911 images. Skipping the test")
-
-# Test functions
 def test_config_db_parameters(duthosts, enum_rand_one_per_hwsku_hostname):
     """Verifies required telemetry parameters from config_db.
     """

--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -58,7 +58,7 @@ class YangValidator:
 
             try:
                 self.ctx.parse_data_mem(data_json, ly.LYD_JSON,
-                        ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+                                        ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
             except Exception as e:
                 logging.info("Exception thrown: {}".format(e))
                 raise e

--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -8,7 +8,7 @@ from glob import glob
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers = [
+    handlers=[
         logging.FileHandler("debug.log"),
         logging.StreamHandler(sys.stdout)
     ]
@@ -18,6 +18,7 @@ YANG_DIR = "/usr/local/yang-models/"
 NO_FILE_ERROR = "No file provided for validation"
 INVALID_FILE_ERROR = "Could not load module from yang file"
 INVALID_YANG_ERROR = "Invalid file, empty json file"
+
 
 class YangValidator:
     def __init__(self, file, yangModule):
@@ -54,19 +55,19 @@ class YangValidator:
         for element in data:
             data_json = json.dumps(element, indent=2)
             data_json = "{\"" + self.yangModule + ":" + self.yangModule + "\":" + data_json + "}"
-            logging.info("CURRENT JSON_DATA: {}".format(data_json))
 
             try:
-                node = self.ctx.parse_data_mem(data_json, ly.LYD_JSON, \
-                    ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+                self.ctx.parse_data_mem(data_json, ly.LYD_JSON,
+                        ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
             except Exception as e:
                 logging.info("Exception thrown: {}".format(e))
                 raise e
         logging.info("Libyang validation for {} passed successfully".format(self.yangModule))
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--file", nargs='?', const='', default='', help="File containing event json for validation")
+    parser.add_argument("-f", "--file", nargs='?', const='', default='', help="File containing event json")
     parser.add_argument("-y", "--yang", nargs='?', const='', default='', help="YANG file name")
     args = parser.parse_args()
     if args.file == '' or args.yang == '':
@@ -74,6 +75,7 @@ def main():
         raise Exception(NO_FILE_ERROR)
     validator = YangValidator(args.file, args.yang)
     validator.validateJSON()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/telemetry/validate_yang_events.py
+++ b/tests/telemetry/validate_yang_events.py
@@ -1,0 +1,79 @@
+import yang as ly
+import sys
+import json
+import argparse
+import logging
+from glob import glob
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers = [
+        logging.FileHandler("debug.log"),
+        logging.StreamHandler(sys.stdout)
+    ]
+)
+
+YANG_DIR = "/usr/local/yang-models/"
+NO_FILE_ERROR = "No file provided for validation"
+INVALID_FILE_ERROR = "Could not load module from yang file"
+INVALID_YANG_ERROR = "Invalid file, empty json file"
+
+class YangValidator:
+    def __init__(self, file, yangModule):
+        self.file = file
+        self.yangModule = yangModule
+        self.ctx = ly.Context(YANG_DIR)
+
+    def loadYangModels(self):
+        try:
+            yangFiles = glob(YANG_DIR + "/*.yang")
+            for file in yangFiles:
+                module = self.ctx.parse_module_path(file, ly.LYS_IN_YANG)
+                if module is None:
+                    logging.info("Could not load module from file {}".format(file))
+                    raise Exception(INVALID_YANG_ERROR)
+        except Exception as e:
+            logging.info("Exception thrown: {}".format(e))
+            raise e
+
+    def validateJSON(self):
+        self.loadYangModels()
+
+        try:
+            with open(self.file, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            logging.info("Exception thrown: {}".format(e))
+            raise e
+
+        if data is None:
+            logging.info("INVALID FILE, empty json file.")
+            raise Exception(INVALID_FILE_ERROR)
+
+        for element in data:
+            data_json = json.dumps(element, indent=2)
+            data_json = "{\"" + self.yangModule + ":" + self.yangModule + "\":" + data_json + "}"
+            logging.info("CURRENT JSON_DATA: {}".format(data_json))
+
+            try:
+                node = self.ctx.parse_data_mem(data_json, ly.LYD_JSON, \
+                    ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            except Exception as e:
+                logging.info("Exception thrown: {}".format(e))
+                raise e
+        logging.info("Libyang validation for {} passed successfully".format(self.yangModule))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--file", nargs='?', const='', default='', help="File containing event json for validation")
+    parser.add_argument("-y", "--yang", nargs='?', const='', default='', help="YANG file name")
+    args = parser.parse_args()
+    if args.file == '' or args.yang == '':
+        logging.info("No file or yang name provided, please provide valid file path using -f and yang file using -y")
+        raise Exception(NO_FILE_ERROR)
+    validator = YangValidator(args.file, args.yang)
+    validator.validateJSON()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Add nightly tests for streaming events. Plan is to support all events to make sure events are generated correctly and are in accordance to YANG schema

#### How did you do it?

Simulate bgp state event, verify output and validate against YANG schema

#### How did you verify/test it?

Pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
