### PR TITLE
[dualtor][test_toggle_mux] skip active-active interfaces for `toggle_mux` tests

### DIFF
--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -35,7 +35,7 @@ def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_p
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
-    check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(400, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)
 

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -35,7 +35,7 @@ def test_toggle_mux_from_simulator(duthosts, active_side, toggle_all_simulator_p
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
 
-    check_result = wait_until(400, 5, 2, check_mux_status, duthosts, active_side)
+    check_result = wait_until(60, 5, 2, check_mux_status, duthosts, active_side)
 
     validate_check_result(check_result, duthosts, get_mux_status)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix the flaky test `test_toggle_mux_from_simulator` by:
* Skipping active-active interfaces in `check_mux_status` as they will always be active on both sides.
* ~~Incrementing wait time to 400s as in test environment we increase icmp heartbeat interval to 1000ms, which causes mux probing interval to be 384s (at most).~~ 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the test on mixed topology testbed. 

```
01:03:52 mux_simulator_control.check_mux_status   L0696 INFO   | Check mux status on DUTs passed
01:03:52 mux_simulator_control.check_mux_status   L0697 INFO   | Active side active muxcables: [u'Ethernet96', u'Ethernet92', u'Ethernet64', u'Ethernet52', u'Ethernet56', u'Ethernet76', u'Ethernet72', u'Ethernet88', u'Ethernet80', u'Ethernet84', u'Ethernet60', u'Ethernet68']
01:03:52 mux_simulator_control.check_mux_status   L0698 INFO   | Active side standby muxcables: []
01:03:52 mux_simulator_control.check_mux_status   L0699 INFO   | Standby side active muxcables: []
01:03:52 mux_simulator_control.check_mux_status   L0700 INFO   | Standby side standby muxcables: [u'Ethernet96', u'Ethernet92', u'Ethernet64', u'Ethernet52', u'Ethernet56', u'Ethernet76', u'Ethernet72', u'Ethernet88', u'Ethernet80', u'Ethernet84', u'Ethernet60', u'Ethernet68']
PASSED                                                                                                             [100%]
--------------------------------------------------- live log teardown ----------------------------------------------------
01:03:52 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture restore_mux_auto_mode teardown starts --------------------
01:03:52 test_toggle_mux.restore_mux_auto_mode    L0026 INFO   | Set all muxcable to auto mode on all ToRs
01:03:56 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture restore_mux_auto_mode teardown ends --------------------
01:03:56 ptfhost_utils.run_garp_service           L0352 INFO   | Stopping GARP service on PTF host
01:04:00 conftest.core_dump_and_config_check      L1805 INFO   | Collecting core dumps after test on svcstr-7050-acs-1
01:04:01 conftest.core_dump_and_config_check      L1818 INFO   | Collecting running config after test on svcstr-7050-acs-1
01:04:02 conftest.core_dump_and_config_check      L1805 INFO   | Collecting core dumps after test on svcstr-7050-acs-2
01:04:03 conftest.core_dump_and_config_check      L1818 INFO   | Collecting running config after test on svcstr-7050-acs-2
01:04:05 conftest.core_dump_and_config_check      L1903 INFO   | Core dump and config check passed for dualtor/test_toggle_mux.py
01:04:07 ptfhost_utils.copy_arp_responder_py      L0159 INFO   | Delete arp_responder.py from ptfhost 'svc1-3'


- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor/test_toggle_mux.py::test_toggle_mux_from_simulator[upper_tor].xml -
------------------------------------------------- live log sessionfinish -------------------------------------------------
01:04:07 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 1 passed in 512.97 seconds ==========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
