### PR TITLE
fix VxLAN BFD skip flag

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -154,7 +154,7 @@ def pytest_addoption(parser):
         "--bfd",
         action="store",
         default=True,
-        type=bool,
+        type=str2bool,
         help="BFD Status"
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix VxLAN BFD skip flag
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/7087
Fix to let a user skip BFD config on test run

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Let a user skip testing BFD feature
#### How did you do it?
Fixed a dedicated skip flag
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
