### PR TITLE
Remove MGMT_INTERFACE from ip2me block rule list

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -318,9 +318,6 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
         "PORTCHANNEL_INTERFACE",
         "INTERFACE"
     ]
-    incl_mgmt_if_branch = ['201911', '202012', '202111', '202205']
-    if any(branch in duthost.os_version for branch in incl_mgmt_if_branch):
-        INTERFACE_TABLE_NAME_LIST.append("MGMT_INTERFACE")
 
     # Gather device configuration facts
     namespace = duthost.get_namespace_from_asic_id(asic_index)

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -314,11 +314,13 @@ def get_cacl_tables_and_rules(duthost):
 def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6tables_rules, asic_index):
     INTERFACE_TABLE_NAME_LIST = [
         "LOOPBACK_INTERFACE",
-        "MGMT_INTERFACE",
         "VLAN_INTERFACE",
         "PORTCHANNEL_INTERFACE",
         "INTERFACE"
     ]
+    incl_mgmt_if_branch = ['201911', '202012', '202111', '202205']
+    if any(branch in duthost.os_version for branch in incl_mgmt_if_branch):
+        INTERFACE_TABLE_NAME_LIST.append("MGMT_INTERFACE")
 
     # Gather device configuration facts
     namespace = duthost.get_namespace_from_asic_id(asic_index)


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #[12464](https://github.com/sonic-net/sonic-buildimage/issues/12464)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Provides fix for https://github.com/sonic-net/sonic-buildimage/issues/12464
MGMT_INTERFACE was removed from default ip2me block rules in PR https://github.com/sonic-net/sonic-host-services/pull/6
This PR is to modify the test case according to the change in caclmgrd
#### How did you do it?
Remove MGMT_INTERFACE when generating ip2me block rule list.

#### How did you verify/test it?
Ran test on multi-asic vs DUT, without skipping this test:
..
cacl/test_cacl_application.py::test_cacl_application_nondualtor[vlab-08-1]
PASSED                                                                                                                                                                        [ 70%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[active_tor-vlab-08-1] SKIPPED                                                                                                                                                               [ 80%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[standby_tor-vlab-08-1] SKIPPED                                                                                                                                                              [ 90%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[vlab-08-1]
PASSED                                                          
SKIPPED [4] cacl/test_cacl_application.py: test_cacl_application_dualtor is only supported on dualtor topology
SKIPPED [1] cacl/test_cacl_application.py: caclmgrd may crash after loading scale ipv4 cacl rules.
SKIPPED [1] cacl/test_cacl_application.py: caclmgrd may crash after loading scale ipv6 cacl rules.
============================================================================================================ 4 passed, 6 skipped in 769.78 seconds =============================================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
