### PR TITLE
Fix fwutil parametrization error

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -24,7 +24,7 @@ def check_path_exists(duthost, path):
 
 def pytest_generate_tests(metafunc):
     val = metafunc.config.getoption('--fw-pkg')
-    if 'fw_pkg_name' in metafunc.fixturenames and val is not None:
+    if 'fw_pkg_name' in metafunc.fixturenames:
         metafunc.parametrize('fw_pkg_name', [val], scope="module")
 
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When executing `platform_tests/fwutil/test_fwutil.py` without passing `--fw-pkg` argument, 6 test cases fail at setup stage with errors:
```
 @pytest.fixture(scope='module')
  def fw_pkg(fw_pkg_name):
E       fixture 'fw_pkg_name' not found
>       available fixtures: __pytest_repeat_step_number, active_active_ports, active_standby_ports, advanceboot_loganalyzer, advanceboot_neighbor_restore, ansible_adhoc, ansible_facts, ansible_module, backup_and_restore_config_db_session, bring_up_dut_interfaces, cable_type, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capture_interface_counters, check_bgp, check_dbmemory, check_dut_asic_type, check_interfaces, check_monit, check_mux_simulator, check_processes, check_secureboot, check_simulator_read_side, cleanup_cache_for_session, clear_neigh_entries, collect_db_dump, collect_techsupport, collect_techsupport_all_duts, conn_graph_facts, core_dump_and_config_check, creds, creds_all_duts, disable_container_autorestart, doctest_namespace, dut_test_params, duthost, duthost_console, duthosts, duts_minigraph_facts, duts_running_config_facts, enable_container_autorestart, enable_l2_mode, enhance_inventory, enum_asic_index, enum_backend_asic_index, enum_dut_feature, enum_dut_hostname, enum_frontend_asic_index, enum_frontend_dut_hostname, enum_rand_one_asic_index, enum_rand_one_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_per_hwsku_hostname, enum_supervisor_dut_hostname, eos, fanouthosts, force_active_tor, force_standby_tor, fw_pkg, get_advanced_reboot, get_mux_status, get_pdu_controller, get_reboot_cause, host_firmware, include_metadata_in_junit_xml, k8scluster, k8smasters, localhost, loganalyzer, lower_tor_host, metadata, monkeypatch, mux_config, mux_server_info, mux_server_url, mux_status_from_nic_simulator, nbr_device_numbers, nbr_ptfadapter, nbrhosts, next_image, nic_simulator_channel, nic_simulator_client, nic_simulator_info, nic_simulator_url, on_exit, patch_lldpctl, pdu, pdu_controller, ptf_portmap_file, ptf_server_intf, ptfadapter, ptfhost, pytestconfig, rand_one_dut_hostname, rand_one_dut_lossless_prio, rand_one_dut_portname_oper_up, rand_selected_dut, rand_unselected_dut, random_component, record_property, record_testsuite_property, record_xml_attribute, recover_all_directions, recwarn, reset_critical_services_list, reset_simulator_port, restart_mux_simulator, restart_nic_simulator, restart_nic_simulator_session, run_icmp_responder_session, sanity_check, selected_rand_one_per_hwsku_hostname, set_drop, set_drop_active_active, set_output, skip_on_simx, sonic, swapSyncd, t1_lower_tor_intfs, t1_upper_tor_intfs, tag_test_report, tbinfo, thermal_manager_enabled, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, toggle_active_all_ports_both_tors, toggle_all_simulator_ports, toggle_all_simulator_ports_to_another_side, toggle_all_simulator_ports_to_lower_tor, toggle_all_simulator_ports_to_random_side, toggle_all_simulator_ports_to_upper_tor, toggle_simulator_port_to_lower_tor, toggle_simulator_port_to_upper_tor, tor_mux_intf, tor_mux_intfs, unpatch_lldpctl, upper_tor_host, url, vmhost, worker_id, xcvr_skip_list
```
This happens due to parametrization fixture `fw_pkg_name` is passed as an argument to `fw_pkg` fixture, and when we don't pass in `--fw-pkg` option, TC doesn't create parametrization fixture.
With changes from this PR we will create parametrization fixture `fw_pkg_name` even if we don't use `--fw-pkg` argument, and TC will be skipped due to - `No fw package specified.`
Fixes #6489

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix setup error in platform_tests/fwutil/test_fwutil.py when test suite is executed without argument --fw-pkg
#### How did you do it?

#### How did you verify/test it?
Run `platform_tests/fwutil/test_fwutil.py` without passing `--fw-pkg` option:
```
PASSED platform_tests/fwutil/test_fwutil.py::test_fwutil_show
PASSED platform_tests/fwutil/test_fwutil.py::test_fwutil_install_bad_name
SKIPPED [2] platform_tests/fwutil/test_fwutil.py:123: Command not yet merged into sonic-utilites
SKIPPED [6] /var/user/jenkins/sonic-mgmt/tests/platform_tests/fwutil/conftest.py:35: No fw package specified.
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.185741-dirty-20221207.094630
Distribution: Debian 11.5
Kernel: 5.10.0-18-2-amd64
Build commit: 0711aea3a
Build date: Wed Dec  7 16:18:50 UTC 2022
Built by: AzDevOps@vmss-soni0003M2
Platform: x86_64-arista_7170_64c
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
