### PR TITLE
[Python3] Py3 migration in snmp_pdu_controllers when run TC test_memory_exhaustion

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -36,7 +36,7 @@ class snmpPduController(PduControllerBase):
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161), timeout=5.0),
             cmdgen.MibVariable(pSYSDESCR)
-            )
+        )
         if errorIndication:
             logging.error("Failed to get pdu controller type, exception: " + str(errorIndication))
         for oid, val in varBinds:
@@ -94,23 +94,23 @@ class snmpPduController(PduControllerBase):
         self.max_lanes = 5
         self.PORT_POWER_BASE_OID = None
         if self.pduType == "APC":
-            self.PORT_NAME_BASE_OID      = APC_PORT_NAME_BASE_OID
-            self.PORT_STATUS_BASE_OID    = APC_PORT_STATUS_BASE_OID
-            self.PORT_CONTROL_BASE_OID   = APC_PORT_CONTROL_BASE_OID
+            self.PORT_NAME_BASE_OID = APC_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID = APC_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID = APC_PORT_CONTROL_BASE_OID
         elif self.pduType == "SENTRY":
-            self.PORT_NAME_BASE_OID      = SENTRY_PORT_NAME_BASE_OID
-            self.PORT_STATUS_BASE_OID    = SENTRY_PORT_STATUS_BASE_OID
-            self.PORT_CONTROL_BASE_OID   = SENTRY_PORT_CONTROL_BASE_OID
+            self.PORT_NAME_BASE_OID = SENTRY_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID = SENTRY_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID = SENTRY_PORT_CONTROL_BASE_OID
         elif self.pduType == "Emerson":
-            self.PORT_NAME_BASE_OID      = EMERSON_PORT_NAME_BASE_OID
-            self.PORT_STATUS_BASE_OID    = EMERSON_PORT_STATUS_BASE_OID
-            self.PORT_CONTROL_BASE_OID   = EMERSON_PORT_CONTROL_BASE_OID
-            self.CONTROL_OFF             = "0"
+            self.PORT_NAME_BASE_OID = EMERSON_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID = EMERSON_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID = EMERSON_PORT_CONTROL_BASE_OID
+            self.CONTROL_OFF = "0"
         elif self.pduType == "SENTRY4":
-            self.PORT_NAME_BASE_OID      = SENTRY4_PORT_NAME_BASE_OID
-            self.PORT_STATUS_BASE_OID    = SENTRY4_PORT_STATUS_BASE_OID
-            self.PORT_CONTROL_BASE_OID   = SENTRY4_PORT_CONTROL_BASE_OID
-            self.PORT_POWER_BASE_OID     = SENTRY4_PORT_POWER_BASE_OID
+            self.PORT_NAME_BASE_OID = SENTRY4_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID = SENTRY4_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID = SENTRY4_PORT_CONTROL_BASE_OID
+            self.PORT_POWER_BASE_OID = SENTRY4_PORT_POWER_BASE_OID
             self.has_lanes = False
             self.max_lanes = 1
         elif self.pduType == "Vertiv":
@@ -127,8 +127,8 @@ class snmpPduController(PduControllerBase):
             pass
 
     def _build_outlet_maps(self, port_oid, label):
-        self.port_oid_dict[port_oid] = { 'label' : label }
-        self.port_label_dict[label] = { 'port_oid' : port_oid }
+        self.port_oid_dict[port_oid] = {'label': label}
+        self.port_label_dict[label] = {'port_oid': port_oid}
 
     def _probe_lane(self, lane_id, cmdGen, snmp_auth):
         pdu_port_base = self.PORT_NAME_BASE_OID
@@ -140,7 +140,7 @@ class snmpPduController(PduControllerBase):
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161)),
             cmdgen.MibVariable(query_oid)
-            )
+        )
         if errorIndication:
             logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
         else:
@@ -202,11 +202,11 @@ class snmpPduController(PduControllerBase):
 
         port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
         errorIndication, errorStatus, _, _ = \
-        cmdgen.CommandGenerator().setCmd(
-            cmdgen.CommunityData(self.snmp_rwcommunity),
-            cmdgen.UdpTransportTarget((self.controller, 161)),
-            (port_oid, rfc1902.Integer(self.CONTROL_ON))
-        )
+            cmdgen.CommandGenerator().setCmd(
+                cmdgen.CommunityData(self.snmp_rwcommunity),
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, rfc1902.Integer(self.CONTROL_ON))
+            )
         if errorIndication or errorStatus != 0:
             logging.debug("Failed to turn on outlet %s, exception: %s" % (str(outlet), str(errorStatus)))
             return False
@@ -231,11 +231,11 @@ class snmpPduController(PduControllerBase):
 
         port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
         errorIndication, errorStatus, _, _ = \
-        cmdgen.CommandGenerator().setCmd(
-            cmdgen.CommunityData(self.snmp_rwcommunity),
-            cmdgen.UdpTransportTarget((self.controller, 161)),
-            (port_oid, rfc1902.Integer(self.CONTROL_OFF))
-        )
+            cmdgen.CommandGenerator().setCmd(
+                cmdgen.CommunityData(self.snmp_rwcommunity),
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, rfc1902.Integer(self.CONTROL_OFF))
+            )
         if errorIndication or errorStatus != 0:
             logging.debug("Failed to turn off outlet %s, exception: %s" % (str(outlet), str(errorStatus)))
             return False
@@ -250,7 +250,7 @@ class snmpPduController(PduControllerBase):
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161)),
             cmdgen.MibVariable(query_id)
-            )
+        )
         if errorIndication:
             logging.debug("Failed to get outlet power level of DUT outlet, exception: " + str(errorIndication))
 
@@ -269,7 +269,7 @@ class snmpPduController(PduControllerBase):
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161)),
             cmdgen.MibVariable(query_id)
-            )
+        )
         if errorIndication:
             logging.debug("Failed to outlet status of PDU, exception: " + str(errorIndication))
 
@@ -310,12 +310,12 @@ class snmpPduController(PduControllerBase):
             # Return status of all outlets
             ports = self.port_oid_dict.keys()
         elif outlet:
-            ports = [ oid for oid in self.port_oid_dict.keys() if oid.endswith(outlet) ]
+            ports = [oid for oid in self.port_oid_dict.keys() if oid.endswith(outlet)]
             if not ports:
                 logging.error("Outlet ID {} doesn't belong to PDU {}".format(outlet, self.controller))
         elif hostname:
             hn = hostname.lower()
-            ports = [ self.port_label_dict[label]['port_oid'] for label in self.port_label_dict.keys() if hn in label ]
+            ports = [self.port_label_dict[label]['port_oid'] for label in self.port_label_dict.keys() if hn in label]
             if not ports:
                 logging.error("{} device is not attached to any outlet of PDU {}".format(hn, self.controller))
 

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -40,6 +40,7 @@ class snmpPduController(PduControllerBase):
         if errorIndication:
             logging.error("Failed to get pdu controller type, exception: " + str(errorIndication))
         for oid, val in varBinds:
+            oid = oid.getOid() if hasattr(oid, 'getoid') else oid
             current_oid = oid.prettyPrint()
             current_val = val.prettyPrint()
             if current_oid == SYSDESCR:
@@ -145,6 +146,7 @@ class snmpPduController(PduControllerBase):
         else:
             for varBinds in varTable:
                 for oid, val in varBinds:
+                    oid = oid.getOid() if hasattr(oid, 'getoid') else oid
                     current_oid = oid.prettyPrint()
                     port_oid = current_oid.replace(pdu_port_base, '')
                     label = val.prettyPrint().lower()
@@ -253,6 +255,7 @@ class snmpPduController(PduControllerBase):
             logging.debug("Failed to get outlet power level of DUT outlet, exception: " + str(errorIndication))
 
         for oid, val in varBinds:
+            oid = oid.getOid() if hasattr(oid, 'getoid') else oid
             current_oid = oid.prettyPrint()
             current_val = val.prettyPrint()
             port_oid = current_oid.replace(self.PORT_POWER_BASE_OID, '')
@@ -271,6 +274,7 @@ class snmpPduController(PduControllerBase):
             logging.debug("Failed to outlet status of PDU, exception: " + str(errorIndication))
 
         for oid, val in varBinds:
+            oid = oid.getOid() if hasattr(oid, 'getoid') else oid
             current_oid = oid.prettyPrint()
             current_val = val.prettyPrint()
             port_oid = current_oid.replace(self.PORT_STATUS_BASE_OID, '')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

In py2, `oid` is `<type 'instance'>`, but in py3 is `<class 'pysnmp.smi.rfc1902.ObjectIdentity'>`;
Actually, it's caused by `pysnmp`, in py2 its version is 4.2.5, but in py3 is 4.4.12. After two version updates, some features have been different.
In terms of `oid`'s type `ObjectIdentity` in py3, it's a new class type in 4.3.0 version. You can reference revision update details in this cite: [Changelog — SNMP library for Python 4.4 documentation (pysnmp.readthedocs.io)](https://pysnmp.readthedocs.io/en/latest/changelog.html)

And for `ObjectIdentity` type, it has an attribute `getOid()` (reference: https://pysnmp.readthedocs.io/en/latest/docs/api-reference.html), so we get the right `oid` type according to different python env.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Python3 migration when run TC test_memeory_exhaustion.

#### How did you do it?

Before invoke `oid` object, check its type first. If it has attribute 'getOid', assign it to oid.getOid(), else itself.

#### How did you verify/test it?

Run TC in both Py3 and Py2, both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
