### PR TITLE
Fix problem with analyzing logs-files

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -495,11 +495,15 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
                     logging.error("kexec regex \"Rebooting with /sbin/kexec\" not found in syslog. " +
                                   "Skipping log_analyzer checks..")
                     return
-                analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
+                syslog_messages = messages
             elif "bgpd.log" in key:
-                analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
+                bgpd_log_messages = messages
             elif "sairedis.rec" in key:
-                analyze_sairedis_rec(messages, analyze_result, offset_from_kexec)
+                sairedis_rec_messages = messages
+
+        analyze_log_file(duthost, syslog_messages, analyze_result, offset_from_kexec)
+        analyze_log_file(duthost, bgpd_log_messages, analyze_result, offset_from_kexec)
+        analyze_sairedis_rec(sairedis_rec_messages, analyze_result, offset_from_kexec)
 
         for marker, time_data in analyze_result["offset_from_kexec"].items():
             marker_start_time = time_data.get("timestamp", {}).get("Start")

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -501,6 +501,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
             elif "sairedis.rec" in key:
                 sairedis_rec_messages = messages
 
+        # analyze_sairedis_rec() use information from syslog and must be called after analyzing syslog
         analyze_log_file(duthost, syslog_messages, analyze_result, offset_from_kexec)
         analyze_log_file(duthost, bgpd_log_messages, analyze_result, offset_from_kexec)
         analyze_sairedis_rec(sairedis_rec_messages, analyze_result, offset_from_kexec)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Sometimes  `test_warm_reboot_mac_jump` fails with the next error:
> E       Failed: Advanced-reboot failure. Failed test: test_warm_reboot_mac_jump[cab18-4-dut], failure summary:            
E       [('test_warm_reboot_mac_jump[cab18-4-dut]None', ['MAC jumping not detected when expected for address: 00-06-07-08-09-0A'])]  

But `sairedis.rec` file includes records with **_SAI_FDB_EVENT_LEARNED_**  00-06-07-08-09-0A.

The problem reproduces when the test checks the `sairedis.rec` file before `syslog`: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/conftest.py#L490-L502


Ordering logfiles, when issue reproduses:
> result["expect_messages"].keys()
['/tmp/bgpd.log.2022-12-20-16:15:09', '/tmp/sairedis.rec.2022-12-20-16:15:09', '/tmp/syslog.cab18-1-dut.2022-12-20-16:15:09']

 `analyze_sairedis_rec()` function has dependent on some records from `syslog` and must be invoked after `get_kexec_time()`

Need to fix analyze ordering.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Failing `test_warm_reboot_mac_jump` SONiC TC
 
#### How did you do it?
Set explicit order for analyzing logfiles:
1. `syslog`
2. `bgpd.log`
3. `sairedis.rec` 

#### How did you verify/test it?
Run  `platform_tests/test_advanced_reboot.py -k "test_warm_reboot_mac_jump"`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
