### PR TITLE
[202012 qos] support dynamic threshold for testcase testQosSaiHeadroomPoolSize

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -512,6 +512,10 @@ class TestQosSai(QosSaiBase):
         if margin:
             testParams["margin"] = margin
 
+        dynamic_threshold = qosConfig["hdrm_pool_size"].get("dynamic_threshold", False)
+        if dynamic_threshold:
+            testParams["dynamic_threshold"] = dynamic_threshold
+
         if "pkts_num_egr_mem" in qosConfig.keys():
             testParams["pkts_num_egr_mem"] = qosConfig["pkts_num_egr_mem"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

workaround for testQosSaiHeadroomPoolSize to support dynamic threshold

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

testQosSaiHeadroomPoolSize alwasy fail on platform which support dynamic threshold for available shared buffer.

RCA:
Script try to fill shared buffer by injecting constant number of packets in multiple src port. In this testcase, this constant number is pkts_num_trig_pfc.

Since in dynamic threshold mode, each port's available shared buffer and pfc threshold are dynamic ranther than static. and the actual pfc threshold will become smaller with consumption of free buffer.
As below:
```
Memory can be allocated from shared buffer for pgi  for port p if 
           Alpha * free buffer > Bp,i
Bp,i: Buffer allocated for pgi of ingress port p
```
Filling shared buffer with constant value which equal pfc threshold will cause ingress drop for last src port.

#### How did you do it?

It's not easy to quickly workout  an group accurate number for multiple src port case.
So workaround is only support ONE src port for testQosSaiHeadroomPoolSize.
Later, will calculate a dynamic number group for multiple src port test scenario.

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
