### PR TITLE
[testbed] Convert port alias to name when generating connection graph

### DIFF
--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -31,11 +31,10 @@ class LabGraph(object):
     """
 
     def __init__(self, dev_csvfile=None, link_csvfile=None, cons_csvfile=None, pdu_csvfile=None, graph_xmlfile=None):
-        #TODO:make generated xml file name as parameters in the future to make it more flexible
         self.devices = {}
-        self.links =  []
-        self.consoles =  []
-        self.pdus =  []
+        self.links = []
+        self.consoles = []
+        self.pdus = []
         self.devcsv = dev_csvfile
         self.linkcsv = link_csvfile
         self.conscsv = cons_csvfile
@@ -62,31 +61,31 @@ class LabGraph(object):
 
     def read_devices(self):
         with open(self.devcsv) as csv_dev:
-            csv_devices = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_dev))
+            csv_devices = csv.DictReader(filter(lambda row: row[0] != '#' and len(row.strip()) != 0, csv_dev))
             devices_root = etree.SubElement(self.pngroot, 'Devices')
             pdus_root = etree.SubElement(self.pcgroot, 'DevicesPowerControlInfo')
             cons_root = etree.SubElement(self.csgroot, 'DevicesConsoleInfo')
             for row in csv_devices:
                 attrs = {}
                 self.devices[row['Hostname']] = row
-                devtype=row['Type'].lower()
+                devtype = row['Type'].lower()
                 if 'pdu' in devtype:
-                    for  key in row:
-                        attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(pdus_root, 'DevicePowerControlInfo', attrs)
                 elif 'consoleserver' in devtype:
-                    for  key in row:
-                        attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
                 else:
-                    for  key in row:
-                        if key.lower() != 'managementip' and key.lower() !='protocol':
-                            attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        if key.lower() != 'managementip' and key.lower() != 'protocol':
+                            attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(devices_root, 'Device', attrs)
 
     def read_links(self):
         with open(self.linkcsv) as csv_file:
-            csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
+            csv_links = csv.DictReader(filter(lambda row: row[0] != '#' and len(row.strip()) != 0, csv_file))
             links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
             for link in csv_links:
                 link['StartPort'] = self.translate_port_alias(link['StartDevice'], link['StartPort'])
@@ -94,7 +93,7 @@ class LabGraph(object):
                 attrs = {}
                 for key in link:
                     if key.lower() != 'vlanid' and key.lower() != 'vlanmode':
-                        attrs[key]=link[key].decode('utf-8')
+                        attrs[key] = link[key].decode('utf-8')
                 etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
                 self.links.append(link)
 
@@ -107,7 +106,7 @@ class LabGraph(object):
             for cons in csv_cons:
                 attrs = {}
                 for key in cons:
-                    attrs[key]=cons[key].decode('utf-8')
+                    attrs[key] = cons[key].decode('utf-8')
                 etree.SubElement(conslinks_root, 'ConsoleLinkInfo', attrs)
                 self.consoles.append(cons)
 
@@ -120,7 +119,7 @@ class LabGraph(object):
             for pdu_link in csv_pdus:
                 attrs = {}
                 for key in pdu_link:
-                    attrs[key]=pdu_link[key].decode('utf-8')
+                    attrs[key] = pdu_link[key].decode('utf-8')
                 etree.SubElement(pduslinks_root, 'PowerControlLinkInfo', attrs)
                 self.pdus.append(pdu_link)
 
@@ -174,6 +173,7 @@ class LabGraph(object):
         result = etree.tostring(root, pretty_print=True)
         onexml.write(result)
 
+
 def get_file_names(args):
     if not args.inventory:
         device, links, console, pdu = args.device, args.links, args.console, args.pdu
@@ -184,6 +184,7 @@ def get_file_names(args):
         pdu = 'sonic_{}_pdu_links.csv'.format(args.inventory)
 
     return device, links, console, pdu
+
 
 def main():
 

--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -24,10 +24,10 @@ LAB_CONNECTION_GRAPH_DPGL2_NAME = 'DevicesL2Info'
 
 class LabGraph(object):
 
-    """ 
+    """
     This is used to create "graph" file of lab for all connections and vlan info from csv file
     We(both engineer and lab technician) maintian and modify the csv file to keep track of the lab
-    infrastucture for Sonic development and testing environment. 
+    infrastucture for Sonic development and testing environment.
     """
 
     def __init__(self, dev_csvfile=None, link_csvfile=None, cons_csvfile=None, pdu_csvfile=None, graph_xmlfile=None):
@@ -83,7 +83,7 @@ class LabGraph(object):
                         if key.lower() != 'managementip' and key.lower() !='protocol':
                             attrs[key]=row[key].decode('utf-8')
                     etree.SubElement(devices_root, 'Device', attrs)
- 
+
     def read_links(self):
         with open(self.linkcsv) as csv_file:
             csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
@@ -97,7 +97,7 @@ class LabGraph(object):
                         attrs[key]=link[key].decode('utf-8')
                 etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
                 self.links.append(link)
- 
+
     def read_consolelinks(self):
         if not os.path.exists(self.conscsv):
             return

--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -48,7 +48,7 @@ class LabGraph(object):
         self.csgroot = etree.Element('ConsoleGraphDeclaration')
         self.pcgroot = etree.Element('PowerControlGraphDeclaration')
 
-    def translate_port_name(self, device_hostname, device_port):
+    def translate_port_alias(self, device_hostname, device_port):
         """
         If device_port is port alias, return the corresponding port name.
         Otherwise, return as is.
@@ -89,8 +89,8 @@ class LabGraph(object):
             csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
             links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
             for link in csv_links:
-                link['StartPort'] = self.translate_port_name(link['StartDevice'], link['StartPort'])
-                link['EndPort'] = self.translate_port_name(link['EndDevice'], link['EndPort'])
+                link['StartPort'] = self.translate_port_alias(link['StartDevice'], link['StartPort'])
+                link['EndPort'] = self.translate_port_alias(link['EndDevice'], link['EndPort'])
                 attrs = {}
                 for key in link:
                     if key.lower() != 'vlanid' and key.lower() != 'vlanmode':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Using port alias instead of name in `sonic_lab_links.csv` will make connecting cables more convenient. But `connection_graph.xml` requires using port name. So, I improved the `creategraph.py` to support converting port alias to port name when generating `connection_graph.xml`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Using port alias instead of name in `sonic_lab_links.csv` will make connecting cables more convenient. But `connection_graph.xml` requires using port name. So, I improved the `creategraph.py` to support converting port alias to port name when generating `connection_graph.xml`.

#### How did you do it?

Improve the `creategraph.py` to support converting port alias to port name when generating `connection_graph.xml`.

#### How did you verify/test it?

Verified in physical lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
