### PR TITLE
Update EVERFLOW test to support dualtor testbed

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -122,6 +122,10 @@ class EverflowPolicerTest(BaseTest):
         self.dataplane = ptf.dataplane_instance
         self.hwsku = self.test_params['hwsku']
         self.asic_type = self.test_params['asic_type']
+        # The router MAC is the VLAN MAC for upstream traffic on dualtor testbed
+        self.dualtor_upstream = self.test_params.get('dualtor_upstream', False)
+        if self.dualtor_upstream:
+            self.vlan_mac = self.test_params['vlan_mac']
         self.router_mac = self.test_params['router_mac']
         self.mirror_stage = self.test_params['mirror_stage']
         self.session_src_ip = self.test_params['session_src_ip']
@@ -137,7 +141,7 @@ class EverflowPolicerTest(BaseTest):
         self.send_time = int(self.test_params['send_time'])
         self.tolerance = int(self.test_params['tolerance'])
         self.check_ttl = self.test_params['check_ttl']
-
+        
         assert_str = "meter_type({0}) not in {1}".format(self.meter_type, str(self.METER_TYPES))
         assert self.meter_type in self.METER_TYPES, assert_str
         assert_str = "cir({}) > 0".format(self.cir)
@@ -147,7 +151,7 @@ class EverflowPolicerTest(BaseTest):
 
         self.min_rx_pps, self.max_rx_pps = self.cbs * (1 - self.tolerance/100.), self.cbs * (1 + self.tolerance/100.)
 
-        self.base_pkt = testutils.simple_tcp_packet(eth_dst=self.router_mac,
+        self.base_pkt = testutils.simple_tcp_packet(eth_dst=self.vlan_mac if self.dualtor_upstream else self.router_mac,
                                                     eth_src=self.dataplane.get_mac(0, 0),
                                                     ip_src="20.0.0.1",
                                                     ip_dst="30.0.0.1",

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -329,15 +329,6 @@ ecmp/test_fgnhg.py:
       - "platform in ['x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn4600c-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6558
 
-#######################################
-#####         everflow            #####
-#######################################
-everflow/test_everflow_per_interface.py:
-  skip:
-    reason: "Skip running on dualtor testbed."
-    conditions:
-      - "'dualtor' in topo_name"
-
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:
     strict: True

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -290,6 +290,12 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo):
                 "server_dest_ports_ptf_id": downstream_dest_ports_ptf_id
             }
         )
+    # Update the VLAN MAC for dualtor testbed. The VLAN MAC will be used as dst MAC in upstream traffic
+    if 'dualtor' in topo:
+        vlan_name = mg_facts_list[0]['minigraph_vlans'].keys()[0]
+        vlan_mac = downStreamDutHost.get_dut_iface_mac(vlan_name)
+        setup_information.update({"dualtor": True})
+        setup_information[UP_STREAM]['ingress_router_mac'] = vlan_mac
 
     return setup_information
 
@@ -316,7 +322,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
 
     """
     topo = tbinfo['topo']['name']
-    if 't1' in topo or 't0' in topo:
+    if 't1' in topo or 't0' in topo or 'dualtor' in topo:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
     elif 't2' in topo:
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
@@ -459,18 +465,6 @@ class BaseEverflowTest(object):
     Contains common methods for setting up the mirror session and describing the
     mirror and ACL stage for the tests.
     """
-    @pytest.fixture(scope="class", autouse=True)
-    def skip_on_dualtor(self, tbinfo):
-        """
-        Skip dualtor topo for now
-        """
-        if 'dualtor' in tbinfo['topo']['name']:
-            pytest.skip("Dualtor testbed is not supported yet")
-        
-        self.is_t0 = False
-        if 't0' in tbinfo['topo']['name']:
-            self.is_t0 = True
-
     @pytest.fixture(scope="class", params=[CONFIG_MODE_CLI])
     def config_method(self, request):
         """Get the configuration method for this set of test cases.

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -7,7 +7,7 @@ from everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM
 
 # Module-level fixtures
 from everflow_test_utilities import setup_info  # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
-
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
 ]
@@ -83,7 +83,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
 
 
-    def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on Source IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -98,7 +98,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on Destination IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -113,7 +113,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on the Next Header field."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, next_header=0x7E)
 
@@ -124,7 +124,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on the L4 Source Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=9000)
 
@@ -135,7 +135,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on the L4 Destination Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=9001)
 
@@ -146,7 +146,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on a range of L4 Source Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=10200)
 
@@ -157,7 +157,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on a range of L4 Destination Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=10700)
 
@@ -168,7 +168,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on TCP Flags."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, flags=0x1B)
 
@@ -179,7 +179,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on DSCP."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dscp=37)
 
@@ -190,7 +190,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -224,7 +224,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match a SYN -> SYN-ACK pattern."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -256,7 +256,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match a TCP handshake between a client and server."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -292,7 +292,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match UDP traffic between a client and server application."""
         test_packet = self._base_udpv6_packet(everflow_direction, 
             ptfadapter,
@@ -327,7 +327,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -372,7 +372,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -406,7 +406,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
         pass
 
@@ -415,7 +415,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         # will not crash if such a rule is installed. If this does happen, we expect the whole test
         # suite + loganaylzer + the sanity check to fail.
 
-    def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with a Source IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -433,7 +433,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with a Destination IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -451,7 +451,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with both source and destination subnets."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,
@@ -469,7 +469,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-    def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction):
+    def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with non-standard subnet sizes."""
         test_packet = self._base_tcpv6_packet(everflow_direction, 
             ptfadapter,

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -11,6 +11,7 @@ from everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE,
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 
 from everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -181,7 +182,7 @@ def send_and_verify_packet(ptfadapter, packet, expected_packet, tx_port, rx_port
         testutils.verify_no_packet_any(ptfadapter, pkt=expected_packet, ports=rx_ports)
 
 
-def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo):
+def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor):
     """Verify packet ingress from candidate ports are captured by EVERFLOW, while packets
     ingress from unselected ports are not captured
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6610 
This PR is to update EVERFLOW test cases to support dualtor testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to update EVERFLOW test cases to support dualtor testbed.

#### How did you do it?

- The mux simulator is toggled to the randomly selected ToR before each test running.
- For downstream traffic test, the logic is exactly the same with regular T0 testbed
- For upstream traffic test, the destination MAC address in testing packet must be VLAN MAC, and the source MAC address in mirrored packet must be router MAC.

#### How did you verify/test it?
Verified on a dualtor tesbed
```
collected 62 items                                                                                                                                                                                    

everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[cli] PASSED                                                                                                    [  1%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[cli] PASSED                                                                                                    [  3%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[cli] PASSED                                                                                                 [  4%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[cli] PASSED                                                                                                 [  6%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[cli] PASSED                                                                                                 [  8%] ^H
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[cli] PASSED                                                                                           [  9%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[cli] PASSED                                                                                           [ 11%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[cli] PASSED                                                                                                   [ 12%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[cli] PASSED                                                                                                        [ 14%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[cli] PASSED                                                                                                    [ 16%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[cli] PASSED                                                                                                [ 17%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[cli] PASSED                                                                                             [ 19%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[cli] PASSED                                                                                             [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[cli] PASSED                                                                                                          [ 22%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[cli] PASSED                                                                                                [ 24%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[cli] PASSED                                                                                                      [ 25%] ^H
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[cli] PASSED                                                                                                         [ 27%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[cli] PASSED                                                                                                           [ 29%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[cli] PASSED                                                                                                          [ 30%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[cli] PASSED                                                                                                         [ 32%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4]  ^HPASSED                                                                                                               [ 33%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6] PASSED                                                                                                               [ 35%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream]  ^HPASSED                                                                 [ 37%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream] PASSED                                                                   [ 38%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] PASSED                                                              [ 40%] ^H
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] PASSED                                                                [ 41%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] PASSED                                                      [ 43%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream]  ^HPASSED                                                        [ 45%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] PASSED                                                        [ 46%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] PASSED                                                          [ 48%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream]  ^HPASSED                                                                [ 50%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] PASSED                                                                  [ 51%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                 [ 53%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                   [ 54%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                              [ 56%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                [ 58%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                      [ 59%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                        [ 61%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                        [ 62%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                          [ 64%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                [ 66%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                  [ 67%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                 [ 69%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                   [ 70%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                              [ 72%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                [ 74%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                      [ 75%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                        [ 77%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                        [ 79%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                          [ 80%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                [ 82%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                  [ 83%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                  [ 85%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                    [ 87%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                               [ 88%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                 [ 90%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                       [ 91%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                         [ 93%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                         [ 95%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                           [ 96%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                 [ 98%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                   [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
