### PR TITLE
[202205][m0] Fix everflow related test failed on m0 (#7115)

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -316,7 +316,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
 
     """
     topo = tbinfo['topo']['name']
-    if 't1' in topo or 't0' in topo:
+    if 't1' in topo or 't0' in topo or 'm0' in topo:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
     elif 't2' in topo:
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick this PR: https://github.com/sonic-net/sonic-mgmt/pull/7115
Fix everflow related test failed on m0

#### How did you do it?
Add m0 support

#### How did you verify/test it?
Run everflow test on m0 testbed
```
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[cli] PASSED                                                                                                                                                                                     [  1%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[cli] PASSED                                                                                                                                                                                     [  3%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[cli] PASSED                                                                                                                                                                                  [  4%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[cli] PASSED                                                                                                                                                                                  [  6%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[cli] PASSED                                                                                                                                                                                  [  8%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[cli] PASSED                                                                                                                                                                            [  9%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[cli] PASSED                                                                                                                                                                            [ 11%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[cli] PASSED                                                                                                                                                                                    [ 12%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[cli] PASSED                                                                                                                                                                                         [ 14%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[cli] PASSED                                                                                                                                                                                     [ 16%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[cli] PASSED                                                                                                                                                                                 [ 17%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[cli] PASSED                                                                                                                                                                              [ 19%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[cli] PASSED                                                                                                                                                                              [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[cli] PASSED                                                                                                                                                                                           [ 22%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[cli] PASSED                                                                                                                                                                                 [ 24%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[cli] PASSED                                                                                                                                                                                       [ 25%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[cli] PASSED                                                                                                                                                                                          [ 27%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[cli] PASSED                                                                                                                                                                                            [ 29%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[cli] PASSED                                                                                                                                                                                           [ 30%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[cli] PASSED                                                                                                                                                                                          [ 32%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4] PASSED                                                                                                                                                                                                [ 33%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6] PASSED                                                                                                                                                                                                [ 35%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream] PASSED                                                                                                                                                  [ 37%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream] PASSED                                                                                                                                                    [ 38%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] PASSED                                                                                                                                               [ 40%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] PASSED                                                                                                                                                 [ 41%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] PASSED                                                                                                                                       [ 43%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] PASSED                                                                                                                                         [ 45%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                        [ 46%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] PASSED                                                                                                                                           [ 48%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream] PASSED                                                                                                                                                 [ 50%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] PASSED                                                                                                                                                   [ 51%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                                                                                                  [ 53%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                                                                                                    [ 54%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                                                                                                               [ 56%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                                                                                                 [ 58%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                       [ 59%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                         [ 61%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                         [ 62%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                           [ 64%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                                                                                                 [ 66%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                                                                                                   [ 67%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                                                                                                  [ 69%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                                                                                                    [ 70%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                                                                                                               [ 72%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                                                                                                 [ 74%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                       [ 75%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                         [ 77%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                         [ 79%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                           [ 80%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                                                                                                 [ 82%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                                                                                                   [ 83%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                                                                                                   [ 85%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                                                                                                     [ 87%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                                                                                                                [ 88%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                                                                                                  [ 90%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                        [ 91%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                          [ 93%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                                                                                                          [ 95%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                                                                                                            [ 96%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                                                                                                  [ 98%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                                                                                                    [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
