### PR TITLE
Update port alias of Arista-7050-QX-32S

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -74,7 +74,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "Arista-7050-QX-32S":
             for i in range(0, 4):
-                port_alias_to_name_map["Ethernet1/%d" % (i + 1)] = "Ethernet%d" % i
+                port_alias_to_name_map["Ethernet%d" % (i + 1)] = "Ethernet%d" % i
             for i in range(6, 29):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 5) * 4)
             for i in range(29, 37):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
According to [port_config.ini](https://github.com/sonic-net/sonic-buildimage/blob/master/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/port_config.ini), the alias of 4 10G ports of `Arista-7050-QX-32S` should be `Ethernet1`, `Ethernet2`, `Ethernet3`, `Ethernet4`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Update the port alias of `Arista-7050-QX-32S`.

#### How did you do it?

Update port alias in `ansible/module_utils/port_utils.py`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
