### PR TITLE
[dualtor] Add `test_ingress_drop.py`

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -104,6 +104,20 @@ def restart_nic_simulator(nic_simulator_info, vmhost):
     return lambda: _restart_nic_simulator(vmhost, vmset_name)
 
 
+@pytest.fixture(scope="module")
+def stop_nic_simulator(nic_simulator_info, vmhost):
+    """Fixture to stop nic_simulator service on the VM server host."""
+
+    def _stop_nic_simulator(vmhost, vmset_name):
+        if vmset_name is not None:
+            vmhost.command("systemctl stop nic-simulator-%s" % vmset_name)
+
+    _, _, vmset_name = nic_simulator_info
+    yield lambda: _stop_nic_simulator(vmhost, vmset_name)
+
+    _restart_nic_simulator(vmhost, vmset_name)
+
+
 @pytest.fixture(scope="session")
 def nic_simulator_channel(nic_simulator_info):
     """Setup connection to the nic_simulator."""

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -111,3 +111,14 @@ def run_arp_responder(rand_selected_dut, ptfhost, tbinfo):
     yield
 
     ptfhost.shell('supervisorctl stop arp_responder')
+
+
+def pytest_configure(config):
+
+    config.addinivalue_line(
+        "markers", "enable_active_active: mark test to run with 'active_active' ports"
+    )
+
+    config.addinivalue_line(
+        "markers", "skip_active_standby: mark test to skip running with 'active_standby' ports"
+    )

--- a/tests/dualtor/test_ingress_drop.py
+++ b/tests/dualtor/test_ingress_drop.py
@@ -22,7 +22,7 @@ from tests.common.utilities import wait_until
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor-mixed")
+    pytest.mark.topology("dualtor")
 ]
 
 

--- a/tests/dualtor/test_ingress_drop.py
+++ b/tests/dualtor/test_ingress_drop.py
@@ -91,7 +91,7 @@ def setup_mux(
 
 
 @pytest.fixture
-def test_port(cable_type, active_active_ports, active_standby_ports):
+def selected_mux_port(cable_type, active_active_ports, active_standby_ports):
     all_ports = []
     if cable_type == CableType.active_active:
         all_ports = active_active_ports
@@ -102,7 +102,7 @@ def test_port(cable_type, active_active_ports, active_standby_ports):
 
 
 @pytest.mark.enable_active_active
-def test_ingress_drop_acl(cable_type, ptfadapter, setup_mux, tbinfo, test_port, upper_tor_host):
+def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_port, upper_tor_host):
     """
     Aims to verify if orchagent installs ingress drop ACL when the port comes to standby.
 
@@ -127,6 +127,6 @@ def test_ingress_drop_acl(cable_type, ptfadapter, setup_mux, tbinfo, test_port, 
     server_ip = "10.10.0.100"
 
     if cable_type == CableType.active_active:
-        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, test_port, server_ip, pkt_num=10, drop=False)
+        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port, server_ip, pkt_num=10, drop=False)
     elif cable_type == CableType.active_standby:
-        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, test_port, server_ip, pkt_num=10, drop=True)
+        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port, server_ip, pkt_num=10, drop=True)

--- a/tests/dualtor/test_ingress_drop.py
+++ b/tests/dualtor/test_ingress_drop.py
@@ -1,0 +1,132 @@
+import logging
+import json
+import pytest
+import random
+
+from tests.common.dualtor.dual_tor_common import active_active_ports
+from tests.common.dualtor.dual_tor_common import active_standby_ports
+from tests.common.dualtor.dual_tor_common import ActiveActivePortID
+from tests.common.dualtor.dual_tor_common import cable_type
+from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.dual_tor_utils import upper_tor_host
+from tests.common.dualtor.dual_tor_utils import lower_tor_host
+from tests.common.dualtor.dual_tor_utils import verify_upstream_traffic
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_lower_tor
+from tests.common.dualtor.nic_simulator_control import ForwardingState
+from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator
+from tests.common.dualtor.nic_simulator_control import stop_nic_simulator
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+pytestmark = [
+    pytest.mark.topology("dualtor-mixed")
+]
+
+
+@pytest.fixture
+def setup_mux(
+    active_active_ports, cable_type,
+    mux_status_from_nic_simulator,
+    stop_nic_simulator,
+    toggle_all_simulator_ports_to_lower_tor,
+    upper_tor_host, lower_tor_host
+):
+
+    def _check_active_active_mux_status_from_nic_simulator(upper_tor_forwarding_state, lower_tor_forwarding_state):
+        mux_status = mux_status_from_nic_simulator()
+        logging.debug("Mux status from nic_simulator:\n%s", json.dumps(mux_status))
+        for port in mux_status:
+            if ((mux_status[port][ActiveActivePortID.UPPER_TOR] != upper_tor_forwarding_state) or
+                    (mux_status[port][ActiveActivePortID.LOWER_TOR] != lower_tor_forwarding_state)):
+                logging.debug("Port %s mux status is not expected", port)
+                return False
+        return True
+
+    def _check_active_active_mux_status_from_dut(duthost, forwarding_state):
+        all_mux_status = json.loads(duthost.shell("show mux status --json")["stdout"])["MUX_CABLE"]
+        mux_status = {port: status for port, status in all_mux_status.items() if port in active_active_ports}
+        target_status = "active" if forwarding_state else "standby"
+        for port in mux_status:
+            status = mux_status[port]["STATUS"].lower()
+            if status != target_status:
+                return False
+        return True
+
+    def _restore_mux_config_auto():
+        upper_tor_host.shell("config mux mode auto all")
+        lower_tor_host.shell("config mux mode auto all")
+
+    try:
+        if cable_type == CableType.active_active:
+            pytest_assert(
+                _check_active_active_mux_status_from_nic_simulator(ForwardingState.ACTIVE, ForwardingState.ACTIVE),
+                "Not all 'active-active' ports are in active state."
+            )
+
+            lower_tor_host.shell("config mux mode standby all")
+
+            pytest_assert(
+                wait_until(15, 3, 3, _check_active_active_mux_status_from_nic_simulator, ForwardingState.ACTIVE, ForwardingState.STANDBY),
+                "failed to toggle the lower ToR 'active-active' ports to standby" 
+            )
+
+            stop_nic_simulator()
+
+            upper_tor_host.shell("config mux mode standby all")
+
+            pytest_assert(
+                wait_until(15, 3, 3, _check_active_active_mux_status_from_dut, upper_tor_host, ForwardingState.STANDBY),
+                "failed to toggle the lower ToR 'active-active' ports to standby" 
+            )
+    except Exception:
+        _restore_mux_config_auto()
+
+    yield
+
+    if cable_type == CableType.active_active:
+        _restore_mux_config_auto()
+
+
+@pytest.fixture
+def test_port(cable_type, active_active_ports, active_standby_ports):
+    all_ports = []
+    if cable_type == CableType.active_active:
+        all_ports = active_active_ports
+    elif cable_type == CableType.active_standby:
+        all_ports = active_standby_ports
+
+    return random.choice(all_ports)
+
+
+@pytest.mark.enable_active_active
+def test_ingress_drop_acl(cable_type, ptfadapter, setup_mux, tbinfo, test_port, upper_tor_host):
+    """
+    Aims to verify if orchagent installs ingress drop ACL when the port comes to standby.
+
+    For 'active-standby' mux ports, an ingress drop ACL is installed if the port comes to standby.
+    For 'active-active' mux ports, no such ingress drop ACL is installed if the port comes to standby.
+
+    Test steps:
+
+    'active-standby':
+        1) make the upper ToR as standby
+        2) send upstream packets from the ptf(as the mux duplicates packets to both ToR)
+        3) verify no packets are received from the T1 injected ptf ports connected to the upper ToR
+
+    'active-active':
+        1) make the lower ToR standby
+        2) stop the nic simulator to freeze the forwarding behavior(for upstream packet, the mux only send packet to the upper ToR)
+        3) make the upper ToR standby
+        4) send upstream packets from the ptf
+        5) verify those upstream packets could be received from the T1 injected ptf ports connected to the upper ToR
+    """
+
+    server_ip = "10.10.0.100"
+
+    if cable_type == CableType.active_active:
+        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, test_port, server_ip, pkt_num=10, drop=False)
+    elif cable_type == CableType.active_standby:
+        verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, test_port, server_ip, pkt_num=10, drop=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7028 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add testcase to verify ingress drop ACL installation.

When the port comes to standby:
If the port is cable type `active-standby`, ingress drop ACL is installed.
If the port is cable type `active-active`, no ingress drop ACL is installed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add `test_ingress_acl.py` to verify it.

After the port comes to standby, send upstream traffic to the mux port, and verify the traffic forwarding.


#### How did you verify/test it?
```
dualtor/test_ingress_drop.py::test_ingress_drop_acl[active-standby] PASSED                                                                                                                                                                                             [ 50%]
dualtor/test_ingress_drop.py::test_ingress_drop_acl[active-active] PASSED                                                                                                                                                                                              [100%]

========================================================================================================================= 2 passed in 157.02 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
