### PR TITLE
[202012 qos] fix HdrmPoolSizeTest's upper bound, when margin is not zero

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -642,6 +642,14 @@ class TestQosSai(QosSaiBase):
             "hwsku":dutTestParams['hwsku']
         })
 
+        margin = qosConfig["hdrm_pool_size"].get("margin")
+        if margin:
+            testParams["margin"] = margin
+
+        dynamic_threshold = qosConfig["hdrm_pool_size"].get("dynamic_threshold", False)
+        if dynamic_threshold:
+            testParams["dynamic_threshold"] = dynamic_threshold
+
         if "pkts_num_egr_mem" in qosConfig.keys():
             testParams["pkts_num_egr_mem"] = qosConfig["pkts_num_egr_mem"]
 


### PR DESCRIPTION
… zeor

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix HdrmPoolSizeTest's upper bound, when margin is not zero

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Headroom watermark  testing failed, even though headroom size testing pass.
RCA:
during sending pkt to last PG, upper bound is hardcode to 2.
according to test logic, should correct to 2*margin +1.

#### How did you do it?

- correct watermark upper bound value to 2*margin+1
- add dynamic_threshold flag to qos parameter to support dynamic threshold

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
