### PR TITLE
T2-Route Announce: Increase v4/v6 scale from 8k prefixes each afi to 32k prefixes each afi..

### DIFF
--- a/ansible/vars/topo_t2-vs.yml
+++ b/ansible/vars/topo_t2-vs.yml
@@ -48,9 +48,9 @@ topology:
 
 configuration_properties:
   common:
-    podset_number: 50
+    podset_number: 400
     tor_number: 16
-    tor_subnet_number: 2
+    tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
     dut_asn: 65100

--- a/ansible/vars/topo_t2.yml
+++ b/ansible/vars/topo_t2.yml
@@ -333,7 +333,7 @@ configuration_properties:
   common:
     podset_number: 400
     tor_number: 16
-    tor_subnet_number: 2
+    tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
     dut_asn: 65100

--- a/ansible/vars/topo_t2_2lc_36p-masic.yml
+++ b/ansible/vars/topo_t2_2lc_36p-masic.yml
@@ -1480,5 +1480,3 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.112/24
       ipv6: fc0a::90/64
-
-

--- a/ansible/vars/topo_t2_2lc_36p-masic.yml
+++ b/ansible/vars/topo_t2_2lc_36p-masic.yml
@@ -250,7 +250,7 @@ configuration_properties:
   common:
     podset_number: 400
     tor_number: 16
-    tor_subnet_number: 2
+    tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
     dut_asn: 65100

--- a/ansible/vars/topo_t2_2lc_min_ports-masic.yml
+++ b/ansible/vars/topo_t2_2lc_min_ports-masic.yml
@@ -284,5 +284,3 @@ configuration:
         prefixes:
           - 200.0.1.0/26
         asn: 64700
-
-

--- a/ansible/vars/topo_t2_2lc_min_ports-masic.yml
+++ b/ansible/vars/topo_t2_2lc_min_ports-masic.yml
@@ -57,9 +57,9 @@ topology:
 
 configuration_properties:
   common:
-    podset_number: 50
+    podset_number: 400
     tor_number: 16
-    tor_subnet_number: 2
+    tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
     dut_asn: 65100


### PR DESCRIPTION
**Summary:**
Increased route announcement scale to 32k for each afi on T2 chassis.  Also made sure the prefix scale remains similar for different t2 topology types.
  
### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
On T2 chassis, the current v4/v6 prefixes announced(8k prefixes for topo_t2, 1k prefixes for topo_t2_2lc_min_ports) weren't enough. 

#### How did you do it?
* As per the route_announce script, the route scale is dependent on 3 factors. (number_of_podsets, number_of_tors_per_podset, number_of_subnets_per_tor).
* The number of podsets defined in topo_t2 is 400 whereas in t2_2lc_min_ports-masic its 50.

I increased the number_of_subnets_per_tor from 2 to 8. This gives 4 times increase in route scale. Also for t2_2lc_min_ports-masic modified the no_of_podsets to 400, so that on this topo_type as well the scale remains same as topo_t2.


#### How did you verify/test it?
Executed the announce_route script and verified the route scale on T2 Chassis(verified on both topo_t2 as well as on topo_t2_2lc_min_ports-masic).

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
NA

