### PR TITLE
[SAI_Qualify]Change parameter for skipping reboot container after eah case

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -109,9 +109,9 @@ def pytest_addoption(parser):
                      default=None, type=str,
                      help="SAI test port config file to map \
                      the relationship between lanes and interface.")
-    parser.addoption("--always_stop_sai_test_container",
+    parser.addoption("--skip_stop_sai_test_container",
                      action="store_true",
-                     help="If always stop the container after one \
+                     help="If skip stop the container after one \
                      test or not, true or false.")
     parser.addoption("--sai_origin_version", action="store", default=None,
                      type=str, help="SAI SDK originla version before upgrade.")

--- a/tests/sai_qualify/test_brcm_t0.py
+++ b/tests/sai_qualify/test_brcm_t0.py
@@ -48,17 +48,16 @@ def test_sai(sai_testbed,
         run_case_from_ptf(
             duthost, dut_ip, ptfhost,
             sai_test_case, sai_test_interface_para, request)
-        stop_and_rm_sai_test_container(
-            duthost, get_sai_test_container_name(request))
     except BaseException as e:
-        logger.info("Test case [{}] failed, trying to restart \
-            sai test container, failed as {}.".format(sai_test_case, e))
+        logger.info("Test case [{}] failed, \
+            trying to restart sai test container, \
+                failed as {}.".format(sai_test_case, e))
         test_fail = True
-        stop_and_rm_sai_test_container(
-            duthost, get_sai_test_container_name(request))
         pytest.fail("Test case [{}] failed".format(sai_test_case), e)
     finally:
-        if test_fail or request.config.option.always_stop_sai_test_container:
+        logger.info("skip_stop_sai_test_container [{}]".format(
+            request.config.option.skip_stop_sai_test_container))
+        if test_fail or not request.config.option.skip_stop_sai_test_container:
             stop_and_rm_sai_test_container(
                 duthost, get_sai_test_container_name(request))
         store_test_result(ptfhost)

--- a/tests/sai_qualify/test_sai_ptf.py
+++ b/tests/sai_qualify/test_sai_ptf.py
@@ -55,7 +55,9 @@ def test_sai(sai_testbed,
         test_fail = True
         pytest.fail("Test case [{}] failed".format(ptf_sai_test_case), e)
     finally:
-        if test_fail or request.config.option.always_stop_sai_test_container:
+        logger.info("skip_stop_sai_test_container [{}]".format(
+            request.config.option.skip_stop_sai_test_container))
+        if test_fail or not request.config.option.skip_stop_sai_test_container:
             stop_and_rm_sai_test_container(
                 duthost, get_sai_test_container_name(request))
         store_test_result(ptfhost)

--- a/tests/sai_qualify/test_warm_reboot.py
+++ b/tests/sai_qualify/test_warm_reboot.py
@@ -57,7 +57,7 @@ def test_sai(
         test_fail = True
         pytest.fail("Test case [{}] failed".format(ptf_sai_test_case), e)
     finally:
-        if test_fail or request.config.option.always_stop_sai_test_container:
+        if test_fail or not request.config.option.skip_stop_sai_test_container:
             stop_and_rm_sai_test_container(
                 duthost, get_sai_test_container_name(request))
         store_test_result(ptfhost)


### PR DESCRIPTION
Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Why
In current structure, we always need to restart test container. Then change the reboot skip option to false.


#### How did you do it?
How
change the always_stop_sai_test_container to skip_stop_sai_test_container


#### How did you verify/test it?

Verify
Local testing
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
