### PR TITLE
[dualtor] Add `test_dualtor_bgp_update_delay`

### DIFF
--- a/tests/dualtor/test_dualtor_bgp_update_delay.py
+++ b/tests/dualtor/test_dualtor_bgp_update_delay.py
@@ -1,0 +1,144 @@
+import contextlib
+import ipaddress
+import pytest
+import tempfile
+import time
+
+from scapy.all import EDecimal
+from scapy.all import IP
+from scapy.all import IPv6
+from scapy.all import sniff
+from scapy.contrib import bgp
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+BGP_LOG_TMPL = "/tmp/bgp_neighbor_%s.pcap"
+
+
+@contextlib.contextmanager
+def log_bgp_updates(duthost, iface, save_path):
+    """Capture bgp packets to file."""
+    if iface == "any":
+        # Scapy doesn't support LINUX_SLL2 (Linux cooked v2), and tcpdump on Bullseye
+        # defaults to writing in that format when listening on any interface. Therefore,
+        # have it use LINUX_SLL (Linux cooked) instead.
+        start_pcap = "tcpdump -y LINUX_SLL -i %s -w %s port 179" % (iface, save_path)
+    else:
+        start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)
+    # for multi-asic dut, add 'ip netns exec asicx' to the beggining of tcpdump cmd 
+    stop_pcap = "sudo pkill -f '%s'" %  start_pcap
+    start_pcap = "nohup {} &".format(start_pcap)
+    duthost.shell(start_pcap)
+    try:
+        yield
+    finally:
+        duthost.shell(stop_pcap, module_ignore_errors=True)
+
+
+@pytest.fixture(params=["ipv4", "ipv6"])
+def ip_version(request):
+    return request.param
+
+
+@pytest.fixture
+def select_bgp_neighbor(ip_version, duthost):
+    config_facts = duthost.get_running_config_facts()
+
+    for bgp_neighbor, neighbor_details in config_facts["BGP_NEIGHBOR"].items():
+        bgp_neighbor_addr = ipaddress.ip_address(bgp_neighbor)
+        is_ipv4_neighbor = isinstance(bgp_neighbor_addr, ipaddress.IPv4Address)
+        if ip_version == "ipv4" and is_ipv4_neighbor:
+            break
+        elif ip_version == "ipv6" and not is_ipv4_neighbor:
+            break
+    else:
+        raise ValueError("Failed to find")            
+
+    return bgp_neighbor, neighbor_details
+
+
+@pytest.fixture(autouse=True)
+def restore_bgp_sessions(duthost):
+    yield
+
+    duthost.shell("config bgp startup all")
+
+
+def test_dualtor_bgp_update_delay(duthost, ip_version, select_bgp_neighbor):
+    """
+    This testcase aims to validate that, for a dualtor T0, after startup BGP sessions, it should always sleep for 10 seconds
+    delay before sending out any BGP updates. And the BGP updates come from T1s should comes earlier than the BGP update to
+    the T1s, so the T0 could always have default route ready before T1 learns any route from T0.
+    """
+
+    def verify_bgp_session(duthost, bgp_neighbor, admin, state):
+        bgp_facts = duthost.bgp_facts()["ansible_facts"]["bgp_neighbors"]
+        return bgp_neighbor in bgp_facts and bgp_facts[bgp_neighbor]["admin"] == admin and bgp_facts[bgp_neighbor]["state"] == state
+
+    def bgp_update_packets(pcap_file):
+        """Get bgp update packets from pcap file."""
+        packets = sniff(
+            offline=pcap_file,
+            lfilter=lambda p: ip_packet in p and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 2
+        )
+        return packets
+
+    bgp_neighbor, bgp_details = select_bgp_neighbor
+    local_address = bgp_details["local_addr"]
+    ip_packet = IP if ip_version == "ipv4" else IPv6
+
+    duthost.shell("config bgp shutdown neighbor %s" % bgp_neighbor)
+    pytest_assert(
+        wait_until(10, 2, 2, verify_bgp_session, duthost, bgp_neighbor, "down", "idle"),
+        "Could not shutdown neighbor %s" % bgp_neighbor
+    )
+
+    bgp_pcap = BGP_LOG_TMPL % bgp_neighbor
+    with log_bgp_updates(duthost, "any", bgp_pcap):
+        bgp_startup_time = EDecimal(time.time())
+        duthost.shell("config bgp startup neighbor %s" % bgp_neighbor)
+        pytest_assert(
+            wait_until(10, 2, 2, verify_bgp_session, duthost, bgp_neighbor, "up", "established"),
+            "Could not startup neighbor %s" % bgp_neighbor
+        )
+
+        time.sleep(20)
+
+    with tempfile.NamedTemporaryFile() as tmp_pcap:
+        duthost.fetch(src=bgp_pcap, dest=tmp_pcap.name, flat=True)
+        duthost.file(path=bgp_pcap, state="absent")
+        bgp_updates = bgp_update_packets(tmp_pcap.name)
+
+    first_update_to_peer = None
+    first_update_from_peer = None
+    for bgp_update in bgp_updates:
+        if bgp_update[ip_packet].src == bgp_neighbor and bgp_update[ip_packet].dst == local_address:
+            # update from peer
+            if first_update_from_peer is None:
+                first_update_from_peer = bgp_update
+        elif bgp_update[ip_packet].src == local_address and bgp_update[ip_packet].dst == bgp_neighbor:
+            # update to peer
+            if first_update_to_peer is None:
+                first_update_to_peer = bgp_update
+
+    pytest_assert(
+        first_update_from_peer is not None,
+        "Could not find any BGP updates from %s" % bgp_neighbor
+    )
+    pytest_assert(
+        first_update_to_peer is not None,
+        "Could not find any BGP updates to %s" % bgp_neighbor
+    )
+    pytest_assert(
+        first_update_to_peer.time - bgp_startup_time >= 10,
+        "There should be at least 10 seconds of delay between startup BGP session and the first out BGP update"
+    )
+    pytest_assert(
+        first_update_to_peer.time > first_update_from_peer.time,
+        "Dualtor T0 should receive BGP update from peer first"
+    )


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Validate that after startup BGP sessions on the dualtor T0, the T0 will always sleep for 10 seconds before sending out BGP updates, so it could have BGP updates from peer T1s received earlier than any BGP updates from itself.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add a new testcase `test_dualtor_bgp_update_delay`

#### How did you verify/test it?
```
dualtor/test_dualtor_bgp_update_delay.py::test_dualtor_bgp_update_delay[ipv4] PASSED                                                                                                                                                                                   [ 50%]
dualtor/test_dualtor_bgp_update_delay.py::test_dualtor_bgp_update_delay[ipv6] PASSED                                                                                                                                                                                   [100%]

========================================================================================================================= 2 passed in 204.90 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
