### PR TITLE
Update the port mapping logic with interface name in Nokia LCs

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -199,8 +199,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(0, 52):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Nokia-IXR7250E-36x400G" or hwsku == "Nokia-IXR7250E-36x100G":
-            for i in range(0, 36):
-                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+            for i in range(1, 36):
+                sonic_name = "Ethernet%d" % ((i - 1) * 8)
+                port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = sonic_name
         elif hwsku == 'Nokia-IXR7250E-SUP-10':
             port_alias_to_name_map = {}
         elif hwsku == "newport":

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -199,7 +199,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(0, 52):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Nokia-IXR7250E-36x400G" or hwsku == "Nokia-IXR7250E-36x100G":
-            for i in range(1, 36):
+            for i in range(1, 37):
                 sonic_name = "Ethernet%d" % ((i - 1) * 8)
                 port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = sonic_name
         elif hwsku == 'Nokia-IXR7250E-SUP-10':


### PR DESCRIPTION

### Description of PR
### Approach
#### What is the motivation for this PR?

With this PR https://github.com/sonic-net/sonic-buildimage/pull/13053, the interface names were changed for Nokia LC SKU's based on J2C+. Changed the logic as per the new naming format

```
admin@str2-7250-lc2-1:~$ cat /usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/port_config.ini 
# name         lanes                            alias         index  role  speed   asic_port_name  coreid  coreportid  numvoq
Ethernet0      72,73,74,75,76,77,78,79          Ethernet1/1   1      Ext   400000  Eth0-ASIC0            1       1           8     
Ethernet8      80,81,82,83,84,85,86,87          Ethernet2/1   2      Ext   400000  Eth8-ASIC0            1       2           8     
Ethernet16     88,89,90,91,92,93,94,95          Ethernet3/1   3      Ext   400000  Eth16-ASIC0           1       3           8
Ethernet24     96,97,98,99,100,101,102,103      Ethernet4/1   4      Ext   400000  Eth24-ASIC0           1       4           8
Ethernet32     104,105,106,107,108,109,110,111  Ethernet5/1   5      Ext   400000  Eth32-ASIC0           1       5           8
Ethernet40     112,113,114,115,116,117,118,119  Ethernet6/1   6      Ext   400000  Eth40-ASIC0           1       6           8
Ethernet48     120,121,122,123,124,125,126,127  Ethernet7/1   7      Ext   400000  Eth48-ASIC0           1       7           8
Ethernet56     128,129,130,131,132,133,134,135  Ethernet8/1   8      Ext   400000  Eth56-ASIC0           1       8           8
Ethernet64     136,137,138,139,140,141,142,143  Ethernet9/1   9      Ext   400000  Eth64-ASIC0           1       9           8
Ethernet72     64,65,66,67,68,69,70,71          Ethernet10/1  10     Ext   400000  Eth72-ASIC0           0       10          8
Ethernet80     56,57,58,59,60,61,62,63          Ethernet11/1  11     Ext   400000  Eth80-ASIC0           0       11          8
Ethernet88     48,49,50,51,52,53,54,55          Ethernet12/1  12     Ext   400000  Eth88-ASIC0           0       12          8
Ethernet96     40,41,42,43,44,45,46,47          Ethernet13/1  13     Ext   400000  Eth96-ASIC0           0       13          8
Ethernet104    32,33,34,35,36,37,38,39          Ethernet14/1  14     Ext   400000  Eth104-ASIC0          0       14          8
Ethernet112    24,25,26,27,28,29,30,31          Ethernet15/1  15     Ext   400000  Eth112-ASIC0          0       15          8
Ethernet120    16,17,18,19,20,21,22,23          Ethernet16/1  16     Ext   400000  Eth120-ASIC0          0       16          8
Ethernet128    8,9,10,11,12,13,14,15            Ethernet17/1  17     Ext   400000  Eth128-ASIC0          0       17          8
Ethernet136    0,1,2,3,4,5,6,7                  Ethernet18/1  18     Ext   400000  Eth136-ASIC0          0       18          8
Ethernet-IB0   115                              Recirc0/0     37     Inb   10000   Rcy0-ASIC0            0       19          8
Ethernet-Rec0  116                              Recirc0/1     39     Rec   10000   Rcy1-ASIC0            1       20          8
admin@str2-7250-lc2-1:~$ cat /usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/port_config.ini 
# name         lanes                            alias         index  role  speed   asic_port_name  coreid  coreportid  numvoq
Ethernet144    72,73,74,75,76,77,78,79          Ethernet19/1  19     Ext   400000  Eth0-ASIC1            1       1           8
Ethernet152    80,81,82,83,84,85,86,87          Ethernet20/1  20     Ext   400000  Eth8-ASIC1            1       2           8
Ethernet160    88,89,90,91,92,93,94,95          Ethernet21/1  21     Ext   400000  Eth16-ASIC1           1       3           8
Ethernet168    96,97,98,99,100,101,102,103      Ethernet22/1  22     Ext   400000  Eth24-ASIC1           1       4           8
Ethernet176    104,105,106,107,108,109,110,111  Ethernet23/1  23     Ext   400000  Eth32-ASIC1           1       5           8
Ethernet184    112,113,114,115,116,117,118,119  Ethernet24/1  24     Ext   400000  Eth40-ASIC1           1       6           8
Ethernet192    120,121,122,123,124,125,126,127  Ethernet25/1  25     Ext   400000  Eth48-ASIC1           1       7           8
Ethernet200    128,129,130,131,132,133,134,135  Ethernet26/1  26     Ext   400000  Eth56-ASIC1           1       8           8
Ethernet208    136,137,138,139,140,141,142,143  Ethernet27/1  27     Ext   400000  Eth64-ASIC1           1       9           8
Ethernet216    64,65,66,67,68,69,70,71          Ethernet28/1  28     Ext   400000  Eth72-ASIC1           0       10          8
Ethernet224    56,57,58,59,60,61,62,63          Ethernet29/1  29     Ext   400000  Eth80-ASIC1           0       11          8
Ethernet232    48,49,50,51,52,53,54,55          Ethernet30/1  30     Ext   400000  Eth88-ASIC1           0       12          8
Ethernet240    40,41,42,43,44,45,46,47          Ethernet31/1  31     Ext   400000  Eth96-ASIC1           0       13          8
Ethernet248    32,33,34,35,36,37,38,39          Ethernet32/1  32     Ext   400000  Eth104-ASIC1          0       14          8
Ethernet256    24,25,26,27,28,29,30,31          Ethernet33/1  33     Ext   400000  Eth112-ASIC1          0       15          8
Ethernet264    16,17,18,19,20,21,22,23          Ethernet34/1  34     Ext   400000  Eth120-ASIC1          0       16          8
Ethernet272    8,9,10,11,12,13,14,15            Ethernet35/1  35     Ext   400000  Eth128-ASIC1          0       17          8
Ethernet280    0,1,2,3,4,5,6,7                  Ethernet36/1  36     Ext   400000  Eth136-ASIC1          0       18          8
Ethernet-IB1   115                              Recirc1/0     38     Inb   10000   Rcy0-ASIC1            0       19          8
Ethernet-Rec1  116                              Recirc1/1     40     Rec   10000   Rcy1-ASIC1            1       20          8
admin@str2-7250-lc2-1:~$ 
```



#### How did you do it?

#### How did you verify/test it?
Tested with add-topo, deploy-mg

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
