### PR TITLE
[202205][m0] Treat M0 as T1 in bgp test (#7126)

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -402,10 +402,14 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
                 conn["loopback_ip"] = loopback_ip
-                if 'namespace' in mg_facts['minigraph_neighbors'][intf] and mg_facts['minigraph_neighbors'][intf]['namespace']:
+
+                if intf in mg_facts['minigraph_neighbors'] and \
+                        'namespace' in mg_facts['minigraph_neighbors'][intf] and \
+                        mg_facts['minigraph_neighbors'][intf]['namespace']:
                     conn["namespace"] = mg_facts['minigraph_neighbors'][intf]['namespace']
                 else:
                     conn["namespace"] = DEFAULT_NAMESPACE
+
                 if intf.startswith("PortChannel"):
                     member_intf = mg_facts["minigraph_portchannels"][intf]["members"][0]
                     conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_ptf_indices"][member_intf]
@@ -461,9 +465,9 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     peer_count = getattr(request.module, "PEER_COUNT", 1)
     if "dualtor" in tbinfo["topo"]["name"]:
         setup_func = _setup_interfaces_dualtor
-    elif tbinfo["topo"]["type"] in ["t0", "m0"]:
+    elif tbinfo["topo"]["type"] in ["t0"]:
         setup_func = _setup_interfaces_t0
-    elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m0"]):
         setup_func = _setup_interfaces_t1_or_t2
     else:
         raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/7126
Currently M0 is treated as T0 in bgp conftest, but it should be treated as T1.

How did you do it?
Setup interface for M0 as T1.

How did you verify/test it?
Run bgp test in M0 testbed.
```
collected 27 items
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_default_allow_list_preconfig[bjw-can-720dt-1] SKIPPED                                                                                              [  3%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_allow_list[bjw-can-720dt-1-permit] SKIPPED                                                                                                         [  7%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_allow_list[bjw-can-720dt-1-deny] SKIPPED                                                                                                           [ 11%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_default_allow_list_postconfig[bjw-can-720dt-1] SKIPPED                                                                                             [ 14%]
bgp/test_bgp_allow_list_m0_olt.py::TestBGPAllowListBase::test_default_allow_list_preconfig[bjw-can-720dt-1] PASSED                                                                                        [ 18%]
bgp/test_bgp_allow_list_m0_olt.py::TestBGPAllowListBase::test_allow_list[bjw-can-720dt-1] PASSED                                                                                                          [ 22%]
bgp/test_bgp_allow_list_m0_olt.py::TestBGPAllowListBase::test_default_allow_list_postconfig[bjw-can-720dt-1] PASSED                                                                                       [ 25%]
bgp/test_bgp_bbr.py::test_bbr_enabled_dut_asn_in_aspath SKIPPED                                                                                                                                           [ 29%]
bgp/test_bgp_bbr.py::test_bbr_enabled_dual_dut_asn_in_aspath SKIPPED                                                                                                                                      [ 33%]
bgp/test_bgp_bbr.py::test_bbr_disabled_dut_asn_in_aspath SKIPPED                                                                                                                                          [ 37%]
bgp/test_bgp_bounce.py::test_bgp_bounce SKIPPED                                                                                                                                                           [ 40%]
bgp/test_bgp_fact.py::test_bgp_facts[bjw-can-720dt-1-None] PASSED                                                                                                                                         [ 44%]
bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved PASSED                                                                                                                                     [ 48%]
bgp/test_bgp_multipath_relax.py::test_bgp_multipath_relax SKIPPED                                                                                                                                         [ 51%]
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[warm-bjw-can-720dt-1] SKIPPED                                                                                               [ 55%]
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[fast-bjw-can-720dt-1] SKIPPED                                                                                               [ 59%]
bgp/test_bgp_speaker.py::test_bgp_speaker_bgp_sessions SKIPPED                                                                                                                                            [ 62%]
bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes[bjw-can-720dt-1-True-False-9114] SKIPPED                                                                                                        [ 66%]
bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes_v6[bjw-can-720dt-1-False-True-9114] SKIPPED                                                                                                     [ 70%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer[bjw-can-720dt-1] PASSED                                                                                                                               [ 74%]
bgp/test_bgpmon.py::test_bgpmon[bjw-can-720dt-1-None] PASSED                                                                                                                                              [ 77%]
bgp/test_bgpmon.py::test_bgpmon_no_resolve_via_default[bjw-can-720dt-1-None] PASSED                                                                                                                       [ 81%]
bgp/test_traffic_shift.py::test_TSA[bjw-can-720dt-1] SKIPPED                                                                                                                                              [ 85%]
bgp/test_traffic_shift.py::test_TSB[bjw-can-720dt-1] SKIPPED                                                                                                                                              [ 88%]
bgp/test_traffic_shift.py::test_TSA_B_C_with_no_neighbors[bjw-can-720dt-1] SKIPPED                                                                                                                        [ 92%]
bgp/test_traffic_shift.py::test_TSA_TSB_with_config_reload[bjw-can-720dt-1] SKIPPED                                                                                                                       [ 96%]
bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away[bjw-can-720dt-1] SKIPPED                                                                                                           [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
