### PR TITLE
[override_config_table] Ignore non user config table in full compare

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -10,6 +10,7 @@ GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
 CONFIG_DB = "/etc/sonic/config_db.json"
 CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
+NON_USER_CONFIG_TABLES = ["FLEX_COUNTER_TABLE"]
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,8 @@ def load_minigraph_with_golden_full_config(duthost, full_config):
 
     current_config = get_running_config(duthost)
     for table in full_config:
+        if table in NON_USER_CONFIG_TABLES:
+            continue
         pytest_assert(
             full_config[table] == current_config[table],
             "full config override fail! {}".format(table)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Bypass non user config table in full config override test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The full config override failed in FLEX_COUNTER_TABLE comparison. This specific table will have derivative change after load_minigraph. We can skip it as it is not user config.
#### How did you do it?
Bypass non user config table in full config override.
#### How did you verify/test it?
Local test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
