### PR TITLE
[bgp] Add constant DEPLOYMENT_ID in test_bgp_allow_list

### DIFF
--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -19,14 +19,15 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+DEPLOYMENT_ID = '0'
 ALLOW_LIST = {
     'BGP_ALLOWED_PREFIXES': {
-        'DEPLOYMENT_ID|0|{}'.format(TEST_COMMUNITY): {
+        'DEPLOYMENT_ID|{}|{}'.format(DEPLOYMENT_ID, TEST_COMMUNITY): {
             'prefixes_v4': PREFIX_LISTS['ALLOWED_WITH_COMMUNITY'],
             'prefixes_v6': PREFIX_LISTS['ALLOWED_WITH_COMMUNITY_V6'],
             'default_action': ''
         },
-        'DEPLOYMENT_ID|0': {
+        'DEPLOYMENT_ID|{}'.format(DEPLOYMENT_ID): {
             'prefixes_v4': PREFIX_LISTS['ALLOWED'],
             'prefixes_v6': PREFIX_LISTS['ALLOWED_V6'],
             'default_action': ''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Deployment id may change due to different devices or topologies, so use constants instead of str

#### How did you do it?
Add constant DEPLOYMENT_ID

#### How did you verify/test it?
Run test on t1 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
