### PR TITLE
enlarge the pfc frame count

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -129,7 +129,7 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     """
     logger.info("Setting up storm params")
     pfc_queue_index = 4
-    pfc_frames_count = 300000
+    pfc_frames_count = 1000000
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                            pfc_frames_number=pfc_frames_count, peer_info=peer_params)
     storm_handle.deploy_pfc_gen()


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Sometimes test_pfcwd_timer_accuracy.py case would failed on certain testbed.
After debugging, the failure was caused by OS image not detect PFC storm.
Since the PFC frame count is 300000 and the detect time is 400ms, so the Lua script only has one chance to detect the storm.
In failure case, the register pfc_on2off value was changed so Lua detect script did not consider it was a PFC storm.
It should be an expect and correct behavior.

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<p style='margin:0in;font-family:Calibri;font-size:11.0pt'>No detect, due to
on2off value changed. 96-&gt;97</p>

<p style='margin:0in;font-family:Calibri;font-size:11.0pt'>&nbsp;</p>

<div style='direction:ltr'>



  |   |   |   |   |   | pfc_rx_packets_last | pfc_on2off_last | queue_pause_status_last |   | pfc_rx_packets | pfc_on2off | queue_pause_status |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
20221207_14:20:54:854:  35892) | Storm_LOG | 321 | 4 | oid:0x1000000000007 | 0 | 27300000 | 95 | FALSE | curr | 27423720 | 96 | TRUE | time | 400000
20221207_14:20:40:040:   8722) | Storm_LOG | 323 | 4 | oid:0x1000000000007 | 0 | 27423720 | 96 | TRUE | curr | 27539514 | 97 | TRUE | time | 400000
20221207_14:20:48:695:  25016) | Storm_LOG | 325 | 4 | oid:0x1000000000007 | 0 | 27539514 | 97 | TRUE | curr | 27600000 | 97 | FALSE | time | 400000



</div>

<p style='margin:0in;font-family:Calibri;font-size:11.0pt'>&nbsp;</p>

<!--EndFragment-->
</body>

</html>



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Expected behavior, should not return failure in such condition.

#### How did you do it?
Enlarge the PFC frame count to let Lua detect script has another chance to detect the PFC storm if register pfc_on2off value changed.

#### How did you verify/test it?
Run failure case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
