### PR TITLE
Fix the term test for chassisd to make sure the daemon actually restarted

### DIFF
--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -67,6 +67,10 @@ def check_expected_daemon_status(duthost, expected_daemon_status):
     daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status
 
+def check_if_daemon_restarted(duthost, daemon_name, pre_daemon_pid):
+    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+    return (daemon_pid > pre_daemon_pid)
+
 def collect_data(duthost):
     keys = duthost.shell('sonic-db-cli STATE_DB KEYS "CHASSIS_*TABLE|*"')['stdout_lines']
 
@@ -164,6 +168,7 @@ def test_pmon_chassisd_term_and_start_status(check_daemon_status, duthosts, enum
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(50, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)


### PR DESCRIPTION

### Description of PR
Fix the term test for chassisd to make sure the daemon actually restarted

Summary:
Along with the code PR : https://github.com/sonic-net/sonic-platform-daemons/pull/328


### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added a new wait_for logic to make sure the daemon is restarted and pid is greater than the earlier one. 

#### How did you verify/test it?

platform_tests/daemon/test_chassisd.py::test_pmon_chassisd_term_and_start_status[str2-7250-sup-1] PASSED  

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
