### PR TITLE
[QoS] collect brcm asic info for egress qos test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -945,10 +945,22 @@ class QosSaiBase(QosBase):
                     if line:
                         m = re.match('THDI_BUFFER_CELL_LIMIT_SP\(0\).*\<LIMIT=(\S+)\>', line)
                         if m:
-                            asicConfig['shared_limit_sp0'] = int(m.group(1), 0)
+                            asicConfig['ingress_shared_limit_sp0'] = int(m.group(1), 0)
                             break
+
+                output = duthost.shell('bcmcmd "g MMU_THDM_DB_POOL_SHARED_LIMIT"', module_ignore_errors=True)
+                logger.info('Read ASIC MMU_THDM_DB_POOL_SHARED_LIMIT register, output {}'.format(output))
+                count = 0
+                for line in output['stdout'].replace('\r', '\n').split('\n'):
+                    if line:
+                        m = re.match('MMU_THDM_DB_POOL_SHARED_LIMIT\(([01])\).*\]\=(\S+)', line)
+                        if m:
+                            asicConfig['egress_shared_limit_sp{}'.format(m.group(1))] = int(m.group(2), 0)
+                            count += 1
+                            if count == 2:
+                                break
             except:
-                logger.info('Failed to read and parse ASIC THDI_BUFFER_CELL_LIMIT_SP register')
+                logger.info('Failed to read and parse ASIC THDI_BUFFER_CELL_LIMIT_SP/MMU_THDM_DB_POOL_SHARED_LIMIT register')
         return asicConfig
 
     @pytest.fixture(scope='class', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Collect egress shared buffer capacity for BRCM ASIC.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

To get accurate threshold for testQosSaiPgSharedWatermark and testQosSaiQSharedWatermark, need to know accurate egress share buffer capacity.

#### How did you do it?

collect register value on brcm asic.

#### How did you verify/test it?
pass local  test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
