### PR TITLE
[Mellanox] Enhance Mellanox reboot cause test case

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -23,6 +23,9 @@ REBOOT_TYPE_POWEROFF = "power off"
 REBOOT_TYPE_WATCHDOG = "watchdog"
 REBOOT_TYPE_UNKNOWN = "Unknown"
 REBOOT_TYPE_THERMAL_OVERLOAD = "Thermal Overload"
+REBOOT_TYPE_CPU = "cpu"
+REBOOT_TYPE_BIOS = "bios"
+REBOOT_TYPE_ASIC = "asic"
 
 # Event to signal DUT activeness
 DUT_ACTIVE = threading.Event()
@@ -88,6 +91,24 @@ reboot_ctrl_dict = {
         "cause": "warm-reboot",
         "test_reboot_cause_only": False
     },
+    REBOOT_TYPE_CPU: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "CPU",
+        "test_reboot_cause_only": True
+    },
+    REBOOT_TYPE_BIOS: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "BIOS",
+        "test_reboot_cause_only": True
+    },
+    REBOOT_TYPE_ASIC: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "ASIC",
+        "test_reboot_cause_only": True
+    }
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
@@ -228,7 +249,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     pool.terminate()
     dut_uptime = duthost.get_up_time()
     logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
-    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot".format(hostname)
+    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
+        format(hostname)
 
 
 def get_reboot_cause(dut):
@@ -238,7 +260,7 @@ def get_reboot_cause(dut):
     """
     logging.info('Getting reboot cause from dut {}'.format(dut.hostname))
     output = dut.shell('show reboot-cause')
-    cause  = output['stdout']
+    cause = output['stdout']
 
     for type, ctrl in reboot_ctrl_dict.items():
         if re.search(ctrl['cause'], cause):
@@ -288,13 +310,13 @@ def sync_reboot_history_queue_with_dut(dut):
             dut_reboot_history_queue = dut.show_and_parse("show reboot-cause history")
             dut_reboot_history_received = True
             break
-        except Exception as e:
+        except Exception:
             e_type, e_value, e_traceback = sys.exc_info()
             logging.info("Exception type: %s" % e_type.__name__)
             logging.info("Exception message: %s" % e_value)
-            logging.info("Backing off for %d seconds before retrying", ((retry_count+1) * RETRY_BACKOFF_TIME))
+            logging.info("Backing off for %d seconds before retrying", ((retry_count + 1) * RETRY_BACKOFF_TIME))
 
-            time.sleep(((retry_count+1) * RETRY_BACKOFF_TIME))
+            time.sleep(((retry_count + 1) * RETRY_BACKOFF_TIME))
             continue
 
     # If retry logic did not yield reboot cause history from DUT,
@@ -355,21 +377,26 @@ def check_reboot_cause_history(dut, reboot_type_history_queue):
     logging.info("Verify reboot-cause history title")
     if reboot_cause_history_got:
         if not set(REBOOT_CAUSE_HISTORY_TITLE) == set(reboot_cause_history_got[0].keys()):
-            logging.error("Expected reboot-cause history title:{} not match actual reboot-cause history title:{}".format(
-                REBOOT_CAUSE_HISTORY_TITLE, reboot_cause_history_got[0].keys()))
+            logging.error("Expected reboot-cause history title:{} not match actual reboot-cause history title:{}".
+                          format(REBOOT_CAUSE_HISTORY_TITLE, reboot_cause_history_got[0].keys()))
             return False
 
-    logging.info("Verify reboot-cause output are sorted in reverse chronological order" )
+    logging.info("Verify reboot-cause output are sorted in reverse chronological order")
     reboot_type_history_len = len(reboot_type_history_queue)
     if reboot_type_history_len <= len(reboot_cause_history_got):
         for index, reboot_type in enumerate(reboot_type_history_queue):
             if reboot_type not in reboot_ctrl_dict:
-                logging.warn("Reboot type: {} not in dictionary. Skipping history check for this entry.".format(reboot_type))
+                logging.warn("Reboot type: {} not in dictionary. Skipping history check for this entry.".
+                             format(reboot_type))
                 continue
-            logging.info("index:  %d, reboot cause: %s, reboot cause from DUT: %s" % (index, reboot_ctrl_dict[reboot_type]["cause"], reboot_cause_history_got[reboot_type_history_len-index-1]["cause"]))
-            if not re.search(reboot_ctrl_dict[reboot_type]["cause"], reboot_cause_history_got[reboot_type_history_len-index-1]["cause"]):
+            logging.info("index:  %d, reboot cause: %s, reboot cause from DUT: %s" %
+                         (index, reboot_ctrl_dict[reboot_type]["cause"],
+                          reboot_cause_history_got[reboot_type_history_len - index - 1]["cause"]))
+            if not re.search(reboot_ctrl_dict[reboot_type]["cause"],
+                             reboot_cause_history_got[reboot_type_history_len - index - 1]["cause"]):
                 logging.error("The {} reboot-cause not match. expected_reboot type={}, actual_reboot_cause={}".format(
-                    index, reboot_ctrl_dict[reboot_type]["cause"], reboot_cause_history_got[reboot_type_history_len-index]["cause"]))
+                    index, reboot_ctrl_dict[reboot_type]["cause"],
+                    reboot_cause_history_got[reboot_type_history_len - index]["cause"]))
                 return False
         return True
     logging.error("The number of expected reboot-cause:{} is more than that of actual reboot-cuase:{}".format(

--- a/tests/platform_tests/mellanox/test_reboot_cause.py
+++ b/tests/platform_tests/mellanox/test_reboot_cause.py
@@ -1,0 +1,42 @@
+import allure
+import logging
+import pytest
+from tests.common.reboot import REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC, check_reboot_cause
+from tests.platform_tests.thermal_control_test_helper import mocker_factory  # noqa: F401
+
+pytestmark = [
+    pytest.mark.asic('mellanox'),
+    pytest.mark.topology('any')
+]
+
+logger = logging.getLogger(__name__)
+
+mocker = None
+REBOOT_CAUSE_TYPES = [REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC]
+
+
+@pytest.mark.parametrize("reboot_cause", REBOOT_CAUSE_TYPES)
+def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause):  # noqa: F811
+    """
+    Validate reboot cause from cpu/bios/asic
+    :param rand_selected_dut: The fixture returns a randomly selected DUT
+    :param mocker_factory: The fixture returns a mocker
+    :param reboot_cause: The specific reboot cause
+    """
+    duthost = rand_selected_dut
+    with allure.step('Create mocker - RebootCauseMocker'):
+        mocker = mocker_factory(duthost, 'RebootCauseMocker')
+
+    with allure.step('Mock reset from {}'.format(reboot_cause)):
+        if reboot_cause == REBOOT_TYPE_CPU:
+            mocker.mock_reset_from_comex()
+        elif reboot_cause == REBOOT_TYPE_BIOS:
+            mocker.mock_reset_reload_bios()
+        elif reboot_cause == REBOOT_TYPE_ASIC:
+            mocker.mock_reset_from_asic()
+
+    with allure.step('Restart determine-reboot-cause service'):
+        duthost.restart_service('determine-reboot-cause')
+
+    with allure.step('Check Reboot cause is {}'.format(reboot_cause)):
+        check_reboot_cause(duthost, reboot_cause)


### PR DESCRIPTION
Add new reboot cause script for additional bios cpu and asic causes
This is related with PR https://github.com/sonic-net/sonic-mgmt/pull/6944
Due to it did not backport to 202205, I create this PR for that.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add new script to cover following reboot cause scenarios:

BIOS - In case the BIOS upgrade process ended with failure and cause the switch to reset.
CPU - Reset is initiated by SW on the CPU. it could be that SW encountered some catastrophic situation like a memory leak, eventually, the kernel reset the whole switch.
Reset from ASIC - Reset which is caused by ASIC.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add test for https://github.com/sonic-net/sonic-platform-common/pull/277
#### How did you do it?

#### How did you verify/test it?
Add test script for enhance reboot cause

#### Any platform specific information?
Mellanox platforms, except for SPC1 and SIMX

#### Supported testbed topology if it's a new test case?
Any topology

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
