### PR TITLE
[deploy-mg] Sync DUT system time with NTP server while deploying minigraph

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -527,6 +527,33 @@
           timeout: 600
         changed_when: false
 
+      - name: Sync DUT system time with NTP server
+        block:
+          - name: Wait for ntp.service restart after reload minigraph
+            shell: systemctl is-active ntp.service
+            register: status
+            until: status.stdout.find('inactive') == -1
+            delay: 10
+            retries: 30
+
+          - name: Stop ntp.service on DUT
+            become: true
+            command: systemctl stop ntp.service
+
+          - name: Sync DUT system time with NTP server
+            become: True
+            command: ntpd -gq
+            async: 300
+            poll: 10
+
+          - name: Start ntp.service on DUT
+            become: true
+            command:  systemctl start ntp.service
+            register: result
+            retries: 3
+            delay: 10
+            until: result is not failed
+
       - name: config static route for trex traffic passthrough
         become: true
         command: "{{ item }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
If DUT system time not synchronized with NTP server, some testcases may fail due to tricky issues. Since NTP long jump is disabled on DUT, if the time offset between DUT and NTP server is large, it'll take a long time (maybe days) to sync. So, we need some method to ensure the DUT system time is synced with NTP server after DUT is setup and ready to run test pipelines. In this PR, I add some ansible steps to sync DUT system time with NTP server while deploying minigraph.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Sync DUT system time with NTP server while deploying minigraph.

#### How did you do it?

Added some steps in deploy-mg ansible playbook.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
