### PR TITLE
[override_config_table] ignore non user config table in empty input test

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -104,8 +104,13 @@ def load_minigraph_with_golden_empty_input(duthost):
     reload_minigraph_with_golden_config(duthost, empty_input)
 
     current_config = get_running_config(duthost)
-    pytest_assert(initial_config == current_config,
-                  "Running config differs.")
+    for table in initial_config:
+        if table in NON_USER_CONFIG_TABLES:
+            continue
+        pytest_assert(
+            initial_config[table] == current_config[table],
+            "empty input compare fail! {}".format(table)
+        )
 
 
 def load_minigraph_with_golden_partial_config(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Bypass non user config table in empty intput test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The empty input compare failed in FLEX_COUNTER_TABLE comparison. This specific table will have derivative change after load_minigraph. We can skip it as it is not user config.
#### How did you do it?
Bypass non user config table in empty input compare.
#### How did you verify/test it?
Local test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
