### PR TITLE
fix missing fixture issue preventing advanced reboot TCs to start

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -7,6 +7,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot # lgtm[py/unused-import]
 from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
 from tests.common.fixtures.ptfhost_utils import run_garp_service
@@ -33,7 +34,6 @@ def pytest_generate_tests(metafunc):
 
 
 ### Tetcases to verify normal reboot procedure ###
-@pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     advanceboot_loganalyzer, capture_interface_counters):
     '''
@@ -47,7 +47,6 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     advancedReboot.runRebootTestcase()
 
 
-@pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request, get_advanced_reboot, verify_dut_health,
     advanceboot_loganalyzer, capture_interface_counters):
     '''
@@ -164,4 +163,3 @@ def flush_dbs(duthost):
                }
     for db in db_dic.keys():
         duthost.shell('redis-cli -n {} flushdb'.format(db))
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix missing fixture issue preventing advanced reboot TCs to start
Fixes # (issue)
Advanced reboot tests fail to start with output:
```
file /var/user/jenkins/sonic-mgmt/tests/platform_tests/test_advanced_reboot.py, line 35
  @pytest.mark.usefixtures('get_advanced_reboot')
  def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
[31mE       fixture 'get_advanced_reboot' not found[0m
```
It started to happen after `get_advanced_reboot` importing was removed from conftest file https://github.com/sonic-net/sonic-mgmt/pull/7049
Fixed by importing the fixture at the file it's used in

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

