### PR TITLE
[mx] Add support for mx in copp/everflow/bgp_update_timer

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -210,7 +210,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
             if _is_ipv4_address(vlan_intf["addr"]):
                 return vlan_intf
-        raise ValueError("No Vlan interface defined in T0.")
+        raise ValueError("No Vlan interface defined in current topo")
 
     def _find_loopback_interface(mg_facts):
         loopback_intf_name = "Loopback0"
@@ -260,7 +260,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
 
     @contextlib.contextmanager
-    def _setup_interfaces_t0(mg_facts, peer_count):
+    def _setup_interfaces_t0_or_mx(mg_facts, peer_count):
         try:
             connections = []
             is_backend_topo = "backend" in tbinfo["topo"]["name"]
@@ -447,8 +447,8 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     peer_count = getattr(request.module, "PEER_COUNT", 1)
     if "dualtor" in tbinfo["topo"]["name"]:
         setup_func = _setup_interfaces_dualtor
-    elif tbinfo["topo"]["type"] in ["t0"]:
-        setup_func = _setup_interfaces_t0
+    elif tbinfo["topo"]["type"] in ["t0", "mx"]:
+        setup_func = _setup_interfaces_t0_or_mx
     elif tbinfo["topo"]["type"] in set(["t1", "t2", "m0"]):
         setup_func = _setup_interfaces_t1_or_t2
     else:

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -11,6 +11,7 @@ UPSTREAM_NEIGHBOR_MAP = {
     "t0": "t1",
     "t1": "t2",
     "m0": "m1",
+    "mx": "m0",
     "t2": "t3"
 }
 # Describe downstream neighbor of dut in different topos
@@ -18,5 +19,6 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "t0": "server",
     "t1": "t0",
     "m0": "mx",
+    "mx": "server",
     "t2": "t1"
 }

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -275,7 +275,7 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True):
                testdir="ptftests",
                # Special Handling for DHCP if we are using T1 Topo
                testname="copp_tests.{}Test".format((protocol+"TopoT1")
-                         if protocol in _TOR_ONLY_PROTOCOL and dut_type not in ["ToRRouter", "MgmtToRRouter"] else protocol),
+                         if protocol in _TOR_ONLY_PROTOCOL and dut_type not in ["ToRRouter", "MgmtToRRouter", "BmcMgmtToRRouter"] else protocol),
                platform="nn",
                qlen=100000,
                params=params,

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -49,6 +49,7 @@ UPSTREAM_NEIGHBOR_MAP = {
     "t0": "t1",
     "t1": "t2",
     "m0": "m1",
+    "mx": "m0",
     "t2": "t3"
 }
 # Describe downstream neighbor of dut in different topos
@@ -56,6 +57,7 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "t0": "server",
     "t1": "t0",
     "m0": "mx",
+    "mx": "server",
     "t2": "t1"
 }
 # Topo that downstream neighbor of DUT are servers
@@ -322,7 +324,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
 
     """
     topo = tbinfo['topo']['name']
-    if 't1' in topo or 't0' in topo or 'm0' in topo or 'dualtor' in topo:
+    if 't1' in topo or 't0' in topo or 'm0' in topo or 'mx' in topo or 'dualtor' in topo:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
     elif 't2' in topo:
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -16,6 +16,7 @@ from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import find_duthost_on_role
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 import json
 
 # TODO: Add suport for CONFIGLET mode
@@ -44,22 +45,6 @@ DEFAULT_SERVER_IP = "192.168.0.3"
 VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
-# Describe upstream neighbor of dut in different topos
-UPSTREAM_NEIGHBOR_MAP = {
-    "t0": "t1",
-    "t1": "t2",
-    "m0": "m1",
-    "mx": "m0",
-    "t2": "t3"
-}
-# Describe downstream neighbor of dut in different topos
-DOWNSTREAM_NEIGHBOR_MAP = {
-    "t0": "server",
-    "t1": "t0",
-    "m0": "mx",
-    "mx": "server",
-    "t2": "t1"
-}
 # Topo that downstream neighbor of DUT are servers
 DOWNSTREAM_SERVER_TOPO = ["t0"]
 

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -43,7 +43,7 @@ def build_candidate_ports(duthost, tbinfo, ns):
     """
     candidate_ports = {}
     unselected_ports = {}
-    if tbinfo['topo']['type'] == 't0':
+    if tbinfo['topo']['type'] in ['t0', 'mx']:
         candidate_neigh_name = 'Server'
     elif tbinfo['topo']['type'] == 'm0':
         candidate_neigh_name = 'MX'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, copp/everflow/bgp_update_timer are not support mx topo.

#### How did you do it?
Add support for mx in copp/everflow/bgp_update_timer.

#### How did you verify/test it?
Run copp/everflow/bgp_update_timer test in mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
