### PR TITLE
[Mellanox] Limit max_numbers_of_sub_ports to max supported on Nvidia Spectrum1

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import ipaddress
 import time
@@ -11,6 +12,7 @@ from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.common.ptf_agent_updater import PtfAgentUpdater
+from tests.common.mellanox_data import is_mellanox_device, get_chip_type
 from tests.common import constants
 from sub_ports_helpers import DUT_TMP_DIR
 from sub_ports_helpers import TEMPLATE_DIR
@@ -41,6 +43,7 @@ from sub_ports_helpers import add_static_route_to_dut
 from sub_ports_helpers import remove_static_route_from_dut
 from sub_ports_helpers import update_dut_arp_table
 
+logger = logging.getLogger(__name__)
 
 def pytest_addoption(parser):
     """
@@ -107,6 +110,11 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
     """
     sub_ports_config = {}
     max_numbers_of_sub_ports = request.config.getoption("--max_numbers_of_sub_ports")
+    if is_mellanox_device(duthost) and get_chip_type(duthost) == 'spectrum1':
+        if max_numbers_of_sub_ports > 215:
+            logger.info("Maximum number of sub ports provided by user is {} not supported on SPC1, "
+                        "will be used value: 215".format(max_numbers_of_sub_ports))
+            max_numbers_of_sub_ports = 215
     vlan_ranges_dut = range(20, 60, 10)
     vlan_ranges_ptf = range(20, 60, 10)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The error is happening as RIFs running out. When ISSU is enabled, Spectrum-1 switches are limited to 500 RIFs entries
(12 are double entries for v6, so max 488 RIFs)
As SONiC test suit usually creates router port for most ports (56 ports in case of t0-56), so ~430 remain for other stuff

Summary: The test should be updated accordingly to configure only 430 instead of 560 subinterfaces when running on Nvidia Spectrum-1 switches as most SKUs are ISSU enabled by default

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Limit max_numbers_of_sub_ports to max supported on Nvidia Spectrum1

#### How did you do it?
Created a condition which checks if the DUT is Nvidia's Spectrum1 and limit max subports number

#### How did you verify/test it?
By running the test on SPC1 device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
