### PR TITLE
port alias mapping for hwsku Cisco-8101-C64 and Cisco-8101-C48T8

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -215,6 +215,21 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
+        elif hwsku == "Cisco-8101-T32":
+            for i in range(0, 32):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
+        elif hwsku == "Cisco-8101-C48T8":
+            for i in range(0, 24, 2):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
+                port_alias_to_name_map["etp%d" % i+1] = "Ethernet%d" % ((i+1) * 4)
+            for i in range(0, 8):
+                port_alias_to_name_map["etp%d" % i+24] = "Ethernet%d" % ((i+12) * 8)
+            for i in range(0, 24, 2):
+                port_alias_to_name_map["etp%d" % i+32] = "Ethernet%d" % ((i+40) * 4)
+                port_alias_to_name_map["etp%d" % i+33] = "Ethernet%d" % ((i+41) * 4)
+        elif hwsku == "Cisco-8101-C64":
+            for i in range(0, 64):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
         elif hwsku in ["8800-LC-48H-O", "88-LC0-36FH-MO"]:
             for i in range(0, 48, 1):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION

### Description of PR

This PR covers the port alias mapping for the hwsku introduced for the cisco platform 8101-32fh-0.


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

This PR is used to enhance the port alias mapping for the hwsku Cisco-8101-C64 and Cisco-8101-C48T8 for the paltform 8101-32fh-0


#### How did you verify/test it?

This logic is tested in a standalone method to verify the generated mapping.

 