### PR TITLE
everflow interface not supported in Cisco x86_64-8800_lc_48h_o-r0,x86_64-8800_lc_48h-r0

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -329,6 +329,15 @@ ecmp/test_fgnhg.py:
       - "platform in ['x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn4600c-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6558
 
+#######################################
+#####         everflow            #####
+#######################################
+everflow/test_everflow_per_interface.py:
+  skip:
+    reason: "Skip running on unsupported platforms."
+    conditions:
+      - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
+
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:
     strict: True


### PR DESCRIPTION

### Description of PR
everflow interface feature is not supported in Cisco x86_64-8800_lc_48h_o-r0,  x86_64-8800_lc_48h-r0platform


Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
everflow interface feature is not supported in Cisco x86_64-8800_lc_48h_o-r0,  x86_64-8800_lc_48h-r0platform

#### How did you do it?

#### How did you verify/test it?
-------------------------- generated xml file: /data/tests/logs/everflow/test_everflow_per_interface_2023-01-04-20-54-50.xml --------------------------
INFO:root:Can not get Allure report URL. Please check logs

--------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------
20:55:08 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=============================================================== short test summary info ===============================================================
SKIPPED [2] everflow/test_everflow_per_interface.py: Skip running on dualtor testbed or unsupported platforms.
============================================================= 2 skipped in 15.27 seconds ==============================================================
vxr@sonic-ucs-m5-1:/data/tests$ 
#### Any platform specific information?
Cisco Q100 specific platforms

