### PR TITLE
Use facts for ports in test_stress_acl

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -65,8 +65,8 @@ def generate_acl_rule(duthost, ip_type):
 def test_acl_add_del_stress(duthosts, rand_one_dut_hostname, get_function_conpleteness_level):
     duthost = duthosts[rand_one_dut_hostname]
     generate_acl_rule(duthost, "ipv4")
-    duthost.shell("config acl add table -p PortChannel101,PortChannel102,PortChannel103,PortChannel104 \
-                  IP_STRESS_ACL L3")
+    table_ports = ",".join(duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]["DATAACL"]["ports"])
+    duthost.shell("config acl add table -p {} IP_STRESS_ACL L3".format(table_ports))
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:
         normalized_level = 'basic'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use facts instead of hardcoded values for table ports in test_stress_acl
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_acl_add_del_stress uses hardcoded port names for the `config acl add table` cmd, which may not always be appropriate on some platforms and result in a test failure with message 'Cannot bind ACL to specified port...' We should instead make it something generic.

#### How did you do it?
Used duthost.acl_facts to retrieve the appropriate port names for the platform.

#### How did you verify/test it?
Tested on 720DT-48S.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
