### PR TITLE
[dualtor_io][soc_ipv4] Add dualtor IO test cases from traffic between T1 and SOC

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -141,19 +141,10 @@ def run_test(
         activehost, peerhost, ptfhost, ptfadapter, tbinfo,
         io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type
     )
-
-    if traffic_direction == "server_to_t1":
-        traffic_generator = tor_IO.generate_from_server_to_t1
-    elif traffic_direction == "t1_to_server":
-        traffic_generator = tor_IO.generate_from_t1_to_server
-    elif traffic_direction == "soc_to_t1":
-        traffic_generator = tor_IO.generate_from_soc_to_t1
-    elif traffic_direction == "t1_to_soc":
-        traffic_generator = tor_IO.generate_from_t1_to_soc
-
+    
     send_and_sniff = InterruptableThread(
         target=tor_IO.start_io_test,
-        kwargs={'traffic_generator': traffic_generator}
+        kwargs={'traffic_direction': traffic_direction}
     )
     send_and_sniff.set_error_handler(lambda *args, **kargs: io_ready.set())
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -148,7 +148,7 @@ def run_test(
         traffic_generator = tor_IO.generate_from_t1_to_server
     elif traffic_direction == "soc_to_t1":
         traffic_generator = tor_IO.generate_from_soc_to_t1
-    elif traffic_generator == "t1_to_soc":
+    elif traffic_direction == "t1_to_soc":
         traffic_generator = tor_IO.generate_from_t1_to_soc
 
     send_and_sniff = InterruptableThread(

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -226,6 +226,10 @@ class DualTorIO:
             self.generate_from_t1_to_server()
         elif self.traffic_generator == self.generate_from_server_to_t1:
             self.generate_from_server_to_t1()
+        elif self.traffic_generator == self.generate_from_soc_to_t1:
+            self.generate_from_soc_to_t1()
+        elif self.traffic_generator == self.generate_from_t1_to_soc:
+            self.generate_from_t1_to_soc()
         else:
             logger.error("Traffic generator not provided or invalid")
             return
@@ -685,6 +689,10 @@ class DualTorIO:
         if self.traffic_generator == self.generate_from_t1_to_server:
             server_addr = packet[scapyall.IP].dst
         elif self.traffic_generator == self.generate_from_server_to_t1:
+            server_addr = packet[scapyall.IP].src
+        elif self.traffic_generator == self.generate_from_t1_to_soc:
+            server_addr = packet[scapyall.IP].dst
+        elif self.traffic_generator == self.generate_from_soc_to_t1:
             server_addr = packet[scapyall.IP].src
         return server_addr
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -270,7 +270,7 @@ class DualTorIO:
             # Otherwise send packets to all servers/soc
             server_ip_list = ptf_intf_to_ip_map.values()
 
-        logger.info("-"*20 + "T1 to {} packet".format{dst} + "-"*20)
+        logger.info("-"*20 + "T1 to {} packet".format(dst) + "-"*20)
         logger.info("PTF source intf: {}".format('random' if random_source else ptf_t1_src_intf))
         logger.info("Ethernet address: dst: {} src: {}".format(eth_dst, 'random' if random_source else eth_src))
         logger.info("IP address: dst: {} src: random".format('all' if len(server_ip_list) > 1

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -235,3 +235,45 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
                             expected_standby_host=upper_tor_host,
                             expected_standby_health="unhealthy",
                             cable_type=cable_type)
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_normal_op_upstream_soc(upper_tor_host, lower_tor_host,
+                            send_soc_to_t1_with_action,
+                            cable_type):
+    """Send upstream traffic and confirm no disruption or switchover occurs"""
+    if cable_type == CableType.active_active:
+        send_soc_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
+                          expected_standby_host=None,
+                          cable_type=cable_type)
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_normal_op_downstream_upper_tor_soc(upper_tor_host, lower_tor_host,
+                                     send_t1_to_soc_with_action,
+                                     cable_type):
+    """
+    Send downstream traffic to the upper ToR and confirm no disruption or
+    switchover occurs
+    """
+    if cable_type == CableType.active_active:
+        send_t1_to_soc_with_action(upper_tor_host, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
+                            expected_standby_host=None,
+                            cable_type=cable_type)
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standbys
+def test_normal_op_downstream_lower_tor_soc(upper_tor_host, lower_tor_host,
+                                      send_t1_to_soc_with_action,
+                                      cable_type):
+    """
+    Send downstream traffic to the lower ToR and confirm no disruption or
+    switchover occurs
+    """
+    if cable_type == CableType.active_active:
+        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
+                            expected_standby_host=None,
+                            cable_type=cable_type)

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.common.config_reload import config_reload
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action, send_soc_to_t1_with_action, send_t1_to_soc_with_action
 from tests.common.dualtor.dual_tor_common import cable_type
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, force_active_tor, force_standby_tor
@@ -264,7 +264,7 @@ def test_normal_op_downstream_upper_tor_soc(upper_tor_host, lower_tor_host,
                             cable_type=cable_type)
 
 @pytest.mark.enable_active_active
-@pytest.mark.skip_active_standbys
+@pytest.mark.skip_active_standby
 def test_normal_op_downstream_lower_tor_soc(upper_tor_host, lower_tor_host,
                                       send_t1_to_soc_with_action,
                                       cable_type):
@@ -273,7 +273,7 @@ def test_normal_op_downstream_lower_tor_soc(upper_tor_host, lower_tor_host,
     switchover occurs
     """
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        send_t1_to_soc_with_action(lower_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -33,6 +33,7 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,
                           expected_standby_host=None,
                           cable_type=cable_type)
 
+
 @pytest.mark.enable_active_active
 def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,
                                      send_t1_to_server_with_action,
@@ -52,6 +53,7 @@ def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)
+
 
 @pytest.mark.enable_active_active
 def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,
@@ -184,6 +186,7 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,
                             expected_standby_health="unhealthy",
                             cable_type=cable_type)
 
+
 @pytest.mark.enable_active_active
 def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,
                                       send_t1_to_server_with_action,
@@ -209,6 +212,7 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,
                             expected_standby_host=upper_tor_host,
                             expected_standby_health="unhealthy",
                             cable_type=cable_type)
+
 
 @pytest.mark.enable_active_active
 def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
@@ -236,6 +240,7 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
                             expected_standby_health="unhealthy",
                             cable_type=cable_type)
 
+
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_normal_op_upstream_soc(upper_tor_host, lower_tor_host,
@@ -247,6 +252,7 @@ def test_normal_op_upstream_soc(upper_tor_host, lower_tor_host,
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
+
 
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
@@ -262,6 +268,7 @@ def test_normal_op_downstream_upper_tor_soc(upper_tor_host, lower_tor_host,
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)
+
 
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to cover the test gap https://github.com/sonic-net/sonic-mgmt/issues/7015.

Tests were added for active-active cable type to validate traffics below:
* T1 -> UT0 -> SOC in active-active scenario
* T1 -> LT0 -> SOC in active-active scenario 
* SOC -> T1 in active-active scenario 
* T1 -> UT0 -> SOC while UT0's interfaces are shutdown
* SOC -> T1 while UT0's interfaces are shutdown

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on mixed-topology testbeds:
* all tests passed for active-active cable type
* all tests were skipped for active-standby cable type

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
