### PR TITLE
[chassis]fix errors with sonic-clear commands

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -36,10 +36,10 @@ def get_pkt_drops(duthost, cli_cmd, asic_index):
     # Frame the correct cli command
     # the L2 commands need _SUFFIX and L3 commands need _PREFIX
     if cli_cmd == GET_L3_COUNTERS:
-        CMD_PREFIX = NAMESPACE_PREFIX if duthost.is_multi_asic else ''
+        CMD_PREFIX = NAMESPACE_PREFIX if (namespace is not None and duthost.is_multi_asic) else ''
         cli_cmd = CMD_PREFIX + cli_cmd
     elif cli_cmd == GET_L2_COUNTERS:
-        CMD_SUFFIX = NAMESPACE_SUFFIX if duthost.is_multi_asic else ''
+        CMD_SUFFIX = NAMESPACE_SUFFIX if (namespace is not None and duthost.is_multi_asic) else ''
         cli_cmd = cli_cmd + CMD_SUFFIX
 
     stdout = duthost.command(cli_cmd.format(namespace))

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -60,8 +60,8 @@ def enable_counters(duthosts):
 
     yield
     for duthost in duthosts.frontend_nodes:
+        namespace_list = duthost.get_asic_namespace_list() if duthost.is_multi_asic else ['']
         for namespace in namespace_list:
-            namespace_list = duthost.get_asic_namespace_list() if duthost.is_multi_asic else ['']
             for port, status in previous_cnt_status[duthost][namespace].items():
                 if status == "disable":
                     logger.info("Restoring counter '{}' state to disable".format(port))
@@ -96,14 +96,14 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
     """
-    # Clear SONiC counters
+    # Clear SONiC counters all the asic on all the duts
     for duthost in duthosts.frontend_nodes:
         duthost.command("sonic-clear counters")
-
-        # Clear RIF counters per namespace.
-        namespace = duthost.get_namespace_from_asic_id(asic_index)
-        CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
-        duthost.command(CMD_PREFIX+"sonic-clear rifcounters")
+        namespace_list = duthost.get_asic_namespace_list() if duthost.is_multi_asic else ['']
+        for namespace in namespace_list:
+            # Clear RIF counters on all namespaces 
+            CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
+            duthost.command(CMD_PREFIX+"sonic-clear rifcounters")
 
     send_packets(pkt, ptfadapter, ports_info["ptf_tx_port_id"], PKT_NUMBER)
 


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7177 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
The tests in the `test_drop_counter.py` fail on the T2 testbed with both single and multi asic linecards. 
In `base_verification` the rif counters are cleared for all dut for a given asic_index.   In a test bed with mix of single and multi asic linecards the asic_index may not valid on all the linecards. This causes the sonic clear commands to fail and test exists.

Similar problem is present in the `get_pkt_drops` function

#### How did you do it?
in `base_verification` clear the counters for all the namespaces on all the duts in the testbed
in the `get_pkt_drops`, add check to add the namespace command suffix/prefix only when the namespace is valid.

#### How did you verify/test it?
Run the failing test on T2 chassis
```
arlakshm@681605572cc8:~/repos/my-mgmt/tests
>>sudo ANSIBLE_KEEP_REMOTE_FILES=1  ./run_tests.sh -c 'drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop'  -i '../ansible/str2,../ansible/veos' -n 'vms26-t2-sonic-1' -t 't2,any' -e '--pdb --skip_sanity'  -u
=== Running tests in groups ===
Running: pytest drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop --inventory ../ansible/str2,../ansible/veos --host-pattern str2-sonic-lc5-1,str2-sonic-lc6-1,str2-sonic-lc7-1,str2-sonic-sup-1 --testbed vms26-t2-sonic-1 --testbed_file /home/arlakshm/repos/my-mgmt/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --pdb --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================= test session starts ==============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/arlakshm/repos/my-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
[WARNING]: Platform linux on host str2-sonic-lc5-1 is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/
reference_appendices/interpreter_discovery.html for more information.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
[WARNING]: Platform linux on host str2-sonic-lc5-1 is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/
reference_appendices/interpreter_discovery.html for more information.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
[WARNING]: Platform linux on host str2-sonic-lc5-1 is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/
reference_appendices/interpreter_discovery.html for more information.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
[WARNING]: Platform linux on host str2-sonic-lc5-1 is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/
reference_appendices/interpreter_discovery.html for more information.
collected 9 items

drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members-str2-sonic-lc5-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:05:36 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet136
invalid literal for int() with base 10: '1,000'
06:05:36 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet128
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [ 11%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members-str2-sonic-lc5-1] SKIPPED                                                                                                                                [ 22%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members-str2-sonic-lc5-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:06:48 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet176
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [ 33%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members-str2-sonic-lc6-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:07:47 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet52
invalid literal for int() with base 10: '1,000'
06:07:47 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet56
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [ 44%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members-str2-sonic-lc6-1] SKIPPED                                                                                                                                [ 55%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members-str2-sonic-lc6-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:08:53 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet76
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [ 66%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members-str2-sonic-lc7-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:09:54 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet28
invalid literal for int() with base 10: '1,000'
06:09:54 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet24
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [ 77%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members-str2-sonic-lc7-1] SKIPPED                                                                                                                                [ 88%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members-str2-sonic-lc7-1]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
06:11:01 drop_counters.ensure_no_l2_drops         L0081 WARNING| Unable to verify L2 drops on iface Ethernet108
invalid literal for int() with base 10: '1,000'
PASSED                                                                                                                                                                                                                                   [100%]

-------------------------------------------------------------------------------------- generated xml file: /home/arlakshm/repos/my-mgmt/tests/logs/tr.xml --------------------------------------------------------------------------------------
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
