### PR TITLE
[qos 202012] reenable xfailed qos tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -59,36 +59,6 @@ platform_tests/test_advanced_reboot.py:
     conditions:
       - "release in ['202012']"
 
-qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
 vxlan/test_vxlan_ecmp.py:
   skip:
     reason: "test issue or image issue, to be RCA'ed"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
reenable xfailed qos tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

most qos test is working in 202012 branch now, reenable them

#### How did you do it?
remove xfail condition for these qos tests

#### How did you verify/test it?
pass local tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
