### PR TITLE
Skip test_reboot_cause for unsupported platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -900,6 +900,12 @@ platform_tests/mellanox:
     conditions:
       - "'marvell' in asic_type"
 
+platform_tests/mellanox/test_reboot_cause.py:
+  skip:
+    reason: "Does not support platform_tests/mellanox/test_reboot_cause.py"
+    conditions:
+      - "platform in ['x86_64-mlnx_msn2010-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2100-r0', 'x86_64-mlnx_msn2410-r0', 'x86_64-nvidia_sn2201-r0']"
+
 #######################################
 #####    test_platform_info.py    #####
 #######################################


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/7181

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_reboot_cause doesn't support 2700.
skip these nodes, they are not support this test_reboot_cause feature:
'x86_64-mlnx_msn2010-r0',
'x86_64-mlnx_msn2700-r0',
'x86_64-mlnx_msn2100-r0',
'x86_64-mlnx_msn2410-r0',
'x86_64-nvidia_sn2201-r0'

#### How did you do it?
Add skip condition in test_mark_conditions yml file.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
