### PR TITLE
Fix test_advanced_reboot: re-add missing import; do not run garp/icmp-responder on single TOR

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -257,11 +257,15 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request):
     """Run icmp_responder.py over ptfhost."""
     # No vlan is available on non-t0 testbed, so skip this fixture
     if 't0' not in tbinfo['topo']['type']:
         logger.info("Not running on a T0 testbed, not starting ICMP responder")
+        yield
+        return
+    elif 'dualtor' not in tbinfo['topo']['name'] and "test_advanced_reboot" in request.node.name:
+        logger.info("Skip ICMP responder for advanced-reboot test on non dualtor devices")
         yield
         return
 
@@ -352,6 +356,10 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
 
         ptf_indices = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_ptf_indices"]
         if 'dualtor' not in tbinfo['topo']['name']:
+            if "test_advanced_reboot" in request.node.name:
+                logger.info("Skip GARP service for advanced-reboot test on non dualtor devices")
+                yield
+                return
             # For mocked dualtor testbed
             mux_cable_table = {}
             server_ipv4_base_addr, server_ipv6_base_addr = request.getfixturevalue('mock_server_base_ip_addr')

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -4,6 +4,7 @@ import logging
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot # lgtm[py/unused-import]
 from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -34,7 +34,6 @@ def pytest_generate_tests(metafunc):
 
 
 ### Tetcases to verify normal reboot procedure ###
-@pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     advanceboot_loganalyzer, capture_interface_counters):
     '''
@@ -48,7 +47,6 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     advancedReboot.runRebootTestcase()
 
 
-@pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request, get_advanced_reboot, verify_dut_health,
     advanceboot_loganalyzer, capture_interface_counters):
     '''

--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import skip_release
 from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix recently introduced issues in test_advanced_reboot

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR fixes two recently introduced issues:

1. Fix https://github.com/sonic-net/sonic-mgmt/issues/7146 caused by https://github.com/sonic-net/sonic-mgmt/pull/6968
2. After merge of PR https://github.com/sonic-net/sonic-mgmt/pull/7049 , all testcases using `get_advanced_reboot` fixture are failing due to `fixture 'get_advanced_reboot' not found`

#### How did you do it?
To fix 7146, do not run GARP service and ICMP responder for non-dualtor advanced-reboot cases. I have not added a more simple skip for non-dualtor as these services are still needed for MOCK dualtor cases which run on single TOR testbeds.

To fix 2, added a new import in the test scripts directly.

#### How did you verify/test it?

Tested on single TOR and dual TOR devices, and failures are not seen anymore.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
