### PR TITLE
[advanced-reboot][dualtor] Select the rebooting DUT peer for log analysis

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -396,7 +396,7 @@ def get_current_sonic_version(duthost):
 
 
 @pytest.fixture()
-def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
+def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname, request):
     """
     Advance reboot log analysis.
     This fixture starts log analysis at the beginning of the test. At the end,
@@ -404,9 +404,9 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
 
     Args:
         duthosts : List of DUT hosts
-        rand_one_dut_hostname: hostname of a randomly selected DUT
+        enum_rand_one_per_hwsku_frontend_hostname: hostname of a randomly selected DUT
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     test_name = request.node.name
     if "warm" in test_name:
         reboot_type = "warm"
@@ -546,7 +546,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
 
 
 @pytest.fixture()
-def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
+def advanceboot_neighbor_restore(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrhosts, tbinfo):
     """
     This fixture is invoked at the test teardown for advanced-reboot SAD cases.
     If a SAD case fails or crashes for some reason, the neighbor VMs can be left in
@@ -554,13 +554,13 @@ def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbin
     and BGP sessions that were shutdown during the test.
     """
     yield
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     neighbor_vm_restore(duthost, nbrhosts, tbinfo)
 
 
 @pytest.fixture()
-def capture_interface_counters(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def capture_interface_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logging.info("Run commands to print logs")
 
     show_counter_cmds = [


### PR DESCRIPTION
…ysis

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the test_advanced_reboot case for dualtor where a non-rebooting peer can be selected for log analysis.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

The test_advanced_reboot picks one of the DUT in a dualtor pair for the test.
The DUT selected for rebooting can differ from DUT selected for running log analyzer checks.

This is because `get_advanced_reboot` fixture uses `enum_rand_one_per_hwsku_frontend_hostname` for DUT selection and 
`advanceboot_loganalyzer` uses `rand_one_dut_hostname`.

https://github.com/sonic-net/sonic-mgmt/blob/39a2c1eff2d637f1554c8c0ab9f345c735a7769f/tests/common/fixtures/advanced_reboot.py#L824

https://github.com/sonic-net/sonic-mgmt/blob/39a2c1eff2d637f1554c8c0ab9f345c735a7769f/tests/platform_tests/conftest.py#L409


The devices returned by these fixtures can differ, and hence cause the test to fail or produce unintended results.

#### How did you do it?

Use a common fixture for DUT selection for rebooting and for log analysis.

#### How did you verify/test it?
Tested on a physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
