### PR TITLE
[testbed] Fix bugs in `port_config_gen.py` for deploying SONiC fanout

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -79,18 +79,15 @@ EXAMPLES='''
               "HwSku": "Arista-7260QX-64",
               "Type": "FanoutLeaf"
             },
-          "device_conn": [
-          {
-             "StartPort": "Ethernet0",
-             "EndPort": "Ethernet33",
-             "StartDevice": "str-s6000-on-1",
-             "VlanID": "233",
-             "BandWidth": "40000",
-             "VlanMode": "Access",
-             "EndDevice": "str-7260-01"
-           },
-           {...}
-           ],
+          "device_conn": {
+              "str-7260-11": {
+                  "Ethernet0": {
+                      "peerdevice": "str-7050qx-2",
+                      "peerport": "Ethernet4",
+                      "speed": "40000"
+                  },
+              }
+          },
            "device_vlan_range": {
               "VlanRange": "201-980,1041-1100"
             },

--- a/ansible/roles/fanout/library/port_config_gen.py
+++ b/ansible/roles/fanout/library/port_config_gen.py
@@ -11,7 +11,6 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from natsort import natsorted
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.port_utils import get_port_alias_to_name_map
 
 
 DOCUMENTATION = """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

1. `port_config_gen` is an ansible module used for deploying SONiC fanout. In this PR, I fixed the following bugs in it.
2. Some comment in [conn_graph_facts.py](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/library/conn_graph_facts.py) is outdated, I updated it in this PR.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Fix following bugs in `port_config_gen.py`:

1. `device_conn` is returned from ansible module `conn_graph_facts`. It's a python `dict` and uses port name as key. But `port_config_gen` mistakenly uses it as `port_alias`. It will raise Exception and make ansible playbook crash when deploying SONiC fanout switch.
3. Current code uses `update()` function to add the missing key/value from `hwsku_port_config` (generated from `port_config.ini`) to `port_config` (generated from connection graph). However, it also overwrites the values of existing keys, which causes the configurations from connection graph disappeared. Then the `config_db.json` generated for SONiC fanout is not correct.

Some comment in [conn_graph_facts.py](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/library/conn_graph_facts.py) is outdated, needs to update it.

#### How did you do it?

1. For 1st bug, I added some code to translate `port_name` to `port_alias` to make the script work correctly.
2. For 2nd bug, I added some code to ensure only add missing key/value to `port_config`, and not modify existing values.
4. Updated comments in `conn_graph_facts`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
