### PR TITLE
[202205] correct choice of random dut 

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -751,7 +751,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def stopServices(
-            self, duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
+            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
             swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status,
             tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
         """


### PR DESCRIPTION
…_hostname for 202205 branch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
correct choice of random dut for branch 202205
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Failed to run qos testcase, because of undefined random choosing function.

```
    def stopServices(
            self, duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
            swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status,
            tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
        """
            Stop services (lldp-syncs, lldpd, bgpd) on DUT host prior to test start
    
            Args:
                duthost (AnsibleHost): Device Under Test (DUT)
                swapSyncd (Fxiture): swapSyncd fixture is required to run prior to stopping services
    
            Returns:
                None
        """
        if 'dualtor' in tbinfo['topo']['name']:
            duthost = lower_tor_host
            duthost_upper = upper_tor_host
        else:
>           duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
E           NameError: global name 'enum_rand_one_per_hwsku_frontend_hostname' is not defined
```

#### How did you do it?

correct input fixture as enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname.

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
