### PR TITLE
[multi-asic][vs]: Skip test_snmp_queue on multi-asic vs checks in 202205

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -834,6 +834,15 @@ snmp/test_snmp_queue.py:
     conditions:
       - "is_supervisor or topo_name in ['m0'] or asic_type in ['barefoot']"
 
+snmp/test_snmp_queue.py:
+  skip:
+    reason: "Test is flaky on multi-asic vs"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/13289
+      - "asic_type in ['vs']"
+      - "hwsku in ['msft_four_asic_vs', 'msft_multi_asic_vs']"
+      - "branch in ['202205']"
+
 #######################################
 #####            span             #####
 #######################################


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
test_snmp_queue is failing on multi-asic vs in 202205 branch.
https://github.com/sonic-net/sonic-buildimage/issues/13289
Skip this test until the issue is resolved.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
