### PR TITLE
[pikez] Add syslog error ignore for pikez

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -165,3 +165,5 @@ r, ".* ERR kernel:.* Set it down before adding it as a team port.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/16703529
 r, ".* ERR CCmisApi:.*system_service.*Broken pipe.*"
+
+r, ".*ERR kernel: \[.*\] AMD-Vi: Event logged \[IO_PAGE_FAULT device=00:13.1 domain=0x0009 address=0x0 flags=0x0000\].*"

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -125,7 +125,6 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
             ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
             ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
-            ".*WARNING kernel: \[.*\] Modules linked in: linux_ngbde\(OE\) linux_knet_cb\(OE-\) linux_bcm_knet\(OE\).*"
     ]
     ignore_regex_dict = {
         'common': [

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -118,7 +118,15 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR snmp#snmpd.*",
             ".*ERR dhcp_relay#dhcp6?relay.*bind: Failed to bind socket to link local ipv6 address on interface .* "
             "after [0-9]+ retries",
-        ]
+            ".*ERR gbsyncd#syncd: :- updateNotificationsPointers: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not "
+            "handled.*",
+            ".*ERR gbsyncd#syncd: :- updateNotificationsPointers: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not "
+            "handled.*",
+            ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
+            ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
+            ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
+            ".*WARNING kernel: \[.*\] Modules linked in: linux_ngbde\(OE\) linux_knet_cb\(OE-\) linux_bcm_knet\(OE\).*"
+    ]
     ignore_regex_dict = {
         'common': [
             ".*ERR monit.*",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There are some err in sys log for pikez which is no effect on test results.
```
WARNING kernel: [ 3012.257937] Modules linked in: linux_ngbde(OE) linux_knet_cb(OE-) linux_bcm_knet(OE) linux_user_bde(OE) linux_kernel_bde(OE) xt_TCPMSS(E) 8021q(E) garp(E) mrp(E) dummy(E) team_mode_loadbalance(E) team(E) xt_hl(E) xt_tcpudp(E) ip6_tables(E) xt_conntrack(E) ebt_vlan(E) nft_compat(E) nft_counter(E) nf_tables(E) psample(E) bridge(E) stp(E) llc(E) nf_conntrack_netlink(E) nf_conntrack(E) nf_defrag_ipv6(E) nf_defrag_ipv4(E) libcrc32c(E) xfrm_user(E) xfrm_algo(E) optoe(E) scd_hwmon(OE) mdio(E) lm75(E) i2c_dev(E) amd64_edac_mod(E) edac_mce_amd(E) eeprom(E) kvm_amd(E) kvm(E) irqbypass(E) snd_hda_intel(E) snd_intel_dspcfg(E) soundwire_intel(E) soundwire_generic_allocation(E) ghash_clmulni_intel(E) soundwire_cadence(E) bonding(E) snd_hda_codec(E) aesni_intel(E) libaes(E) snd_hda_core(E) crypto_simd(E) cryptd(E) snd_hwdep(E) glue_helper(E) snd_soc_core(E) snd_compress(E) soundwire_bus(E) rapl(E) snd_pcm(E) tpm_tis(E) ccp(E) tpm_tis_core(E) snd_timer(E) snd(E) tpm(E) snd_rn_pci_acp3x(E) wdat_wdt(E)
gbsyncd#syncd: :- updateNotificationsPointers: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled, FIXME!
gbsyncd#syncd: :- updateNotificationsPointers: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled, FIXME!
ERR kernel: [ 9570.394716] AMD-Vi: Event logged [IO_PAGE_FAULT device=00:13.1 domain=0x0009 address=0x0 flags=0x0000]
gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED
swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled, FIXME!
```

#### How did you do it?
Add ignore regex for these log.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
