### PR TITLE
[BGP] Fix BGP BBR route check

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -301,6 +301,19 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
                 vm_route['failed'] = True
                 vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
         results[node] = vm_route
+        
+    def route_check():
+        results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted}, other_vms, timeout=120)
+
+        failed_results = {}
+        for node, result in results.items():
+            if result['failed']:
+                failed_results[node] = result
+
+        if not failed_results:
+            return True
+        else:
+            return False
 
     other_vms = setup['other_vms']
     bgp_neighbors = json.loads(duthost.shell("sonic-cfggen -d --var-json 'BGP_NEIGHBOR'")['stdout'])
@@ -311,16 +324,9 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
     # check DUT
     pytest_assert(wait_until(5, 1, 0, check_dut, duthost, other_vms, bgp_neighbors,
                   setup, route, accepted=accepted), 'DUT check failed')
-
-    results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted}, other_vms, timeout=120)
-
-    failed_results = {}
-    for node, result in results.items():
-        if result['failed']:
-            failed_results[node] = result
-
-    pytest_assert(not failed_results, 'Checking route {} failed, failed_results: {}'
-                  .format(str(route), json.dumps(failed_results, indent=2)))
+    
+    # check route
+    pytest_assert(wait_until(30, 1, 0, route_check), 'Checking route failed')
 
 
 def test_bbr_enabled_dut_asn_in_aspath(duthosts, rand_one_dut_hostname, nbrhosts,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes bgp/test_bgp_bbr.py::test_bbr_enabled_dut_asn_in_aspath

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

In rare cases, we have failed TC due to lack of time given to route addition before check. As a result, TC can fail with error message `No route for [prefix] found on [device]`. This fix ensures there is enough time given to update info before the route check.

#### How did you do it?

Turned route check into a function with `wait_until` to ensure there is another route check before failing the TC.

#### How did you verify/test it?

Run `bgp/test_bgp_bbr.py::test_bbr_enabled_dut_asn_in_aspath` on **t1 topology**
Pass rate increased from 90% to 100%

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
