### PR TITLE
Ignore BGP and SWSS containers during service check due to issue #7151

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -120,7 +120,8 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_DEVICE_CHECK_CONFIG_FILE)):
         processes_status = duthost.all_critical_process_status()
-        containers = [x for x in list(processes_status.keys()) if "syncd" not in x and "database" not in x]
+        containers = [x for x in list(processes_status.keys()) if "syncd" not in x and "database" not in x and
+                      "bgp" not in x and "swss" not in x]
         logging.info('Test containers: {}'.format(containers))
         random.shuffle(containers)
         for container in containers:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- Ignore BGP and SWSS containers as part of '_test_service_checker_with_process_exit_' test case in system_health/test_system_health test suite.
- This is because, if '_bgpd_' and '_orchagent_' processes are chosen in random and if those processes are stopped and started again, the DUT configs are not restored as before. "_sonic-mgmt_" issue #7151

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- Ignore BGP and SWSS containers as part of '_test_service_checker_with_process_exit_' test case. This is done due to the issue #7151, so that '_bgpd_' and '_orchagent_' processes are not chosen in random.

#### How did you do it?
- Added 'bgp' and 'swss' containers to the 'ignore' list while selecting containers.

#### How did you verify/test it?
- Ran the system health tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
