### PR TITLE
Changes to enable skipped drop counters now supported on DNX

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -18,9 +18,27 @@ drop_packets/test_drop_counters.py::test_acl_egress_drop:
     conditions:
       - "asic_type in ['broadcom']"
 
+drop_packets/test_drop_counters.py::test_absent_ip_header:
+  skip:
+    reason: "Test case not supported on Broadcom DNX platform"
+    conditions:
+      - "asic_subtype in ['broadcom-dnx']"
+
+drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop:
+  skip:
+    reason: "Drop not enabled on chassis since internal traffic uses same smac & dmac"
+    conditions:
+      - "asic_subtype in ['broadcom-dnx']"
+
+drop_packets/test_drop_counters.py::test_dst_ip_absent:
+  skip:
+    reason: "Test case not supported on Broadcom DNX platform"
+    conditions:
+      "asic_subtype in ['broadcom-dnx']"
+
 drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
   skip:
-    reason: "Image issue on Boradcom dualtor testbeds"
+    reason: "Image issue on Broadcom dualtor testbeds"
     strict: True
     conditions:
       - "asic_type in ['broadcom']"
@@ -28,9 +46,9 @@ drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version"
+    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version. Test also not supported on Broadcom DNX"
     conditions:
-      - "asic_type=='cisco-8000' and release in ['202012']"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -42,9 +60,9 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP linklocal packets in 202012 version"
+    reason: "Cisco 8000 with 202012 version and broadcom DNX platforms do not drop DIP linklocal packets"
     conditions:
-      - "asic_type=='cisco-8000' and release in ['202012']"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
   skip:
@@ -119,6 +137,12 @@ drop_packets/test_drop_counters.py::test_src_ip_is_class_e:
     reason: "Cisco 8000 platform does not drop packets with source IP address in class E"
     conditions:
       - "asic_type=='cisco-8000'"
+
+drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr:
+  skip:
+    reason: "Test currently not supported on broadcom DNX platform"
+    conditions:
+      - "asic_subtype in ['broadcom-dnx']"
 
 drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members]:
   skip:

--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -28,9 +28,11 @@ l2_l3:
     - "x86_64-8.*"
     - "x86_64-cel_midstone-r0"
     - "x86_64-wistron_sw_to3200k-r0"
+    - "x86_64-nokia.*"
 
 acl_l2:
     - "x86_64-mlnx"
     - "x86_64-dell.*"
     - "x86_64-arista.*"
     - "x86_64-cel_seastone.*"
+    - "x86_64-nokia.*"

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -287,10 +287,6 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         )
 
         group = "L2"
-        # DNX platform DROP counters are not there yet
-        if setup.get("platform_asic") == "broadcom-dnx":
-            group = "NO_DROPS"
-
         do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
 
 def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Since SAI now has support for drop counters on Broadcom DNX, enabling drop counter validation for supported scenarios and skipping cases not yet supported

#### How did you do it?
Removed test skips added by https://github.com/sonic-net/sonic-mgmt/pull/5295

#### How did you verify/test it?
Run drop_counters/test_drop_counters.py on J2/J2c+

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
