### PR TITLE
Fixed observed counter logic and PORT_READY event capturing in advanced reboot tests

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -362,10 +362,11 @@ def verify_mac_jumping(test_name, timing_data, verification_errors):
 def verify_required_events(duthost, event_counters, timing_data, verification_errors):
     for key in ["time_span", "offset_from_kexec"]:
         for pattern in REQUIRED_PATTERNS.get(key):
-            observed_start_count = timing_data.get(key).get(pattern).get("Start count")
-            observed_end_count = timing_data.get(key).get(pattern).get("End count")
+            observed_start_count = timing_data.get(key, {}).get(pattern, {}).get("Start count", 0)
+            observed_end_count = timing_data.get(key, {}).get(pattern, {}).get("End count", 0)
             expected_count = event_counters.get(pattern)
-            if observed_start_count != expected_count:
+            if (observed_start_count != expected_count and pattern != 'PORT_READY') or\
+                    (observed_start_count > expected_count and pattern == 'PORT_READY'):
                 verification_errors.append("FAIL: Event {} was found {} times, when expected exactly {} times".
                                            format(pattern, observed_start_count, expected_count))
             if key == "time_span" and observed_start_count != observed_end_count:

--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -30,7 +30,8 @@ SERVICE_PATTERNS = {
 OTHER_PATTERNS = {
     "COMMON": {
         "PORT_INIT|Start": re.compile(r'.*NOTICE swss#orchagent.*initPort: Initialized port.*'),
-        "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set.* to up.*'),
+        "PORT_READY|Start": re.compile
+        (r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set down to up.*'),
         "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
         "FINALIZER|End": re.compile(
             r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),


### PR DESCRIPTION
Details:
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The fix changes the PORT_READY event to oper state from down to up only, so it will detect only link flap event. In addition, the 'verify_required_events' is fixed so the observed counter (start &stop) will have a default value of 0, and won't access a non-dictionary type in case the key doesn't exist.
This fix will raise an error when the observed PORT_READY event is higher than expected.

Summary:
Fixes issue: [advanced_reboot] test_warm_reboot - 'NoneType' object has no attribute 'get' #5864

### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the error of 'PORT_READY' event triggers more than needed.
#### How did you do it?
-Changed the regex format of 'PORT_READY' event to be from down to up, so it will detect link flap only.
-Changed the method of 'verify_required_events' so it will set the value of the observed count of events to 0 in case there are no events.
#### How did you verify/test it?
Ran full regression on the advanced reboot tests.


