### PR TITLE
Added check for status_led in case of outdated platform.json file

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -94,11 +94,6 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
-  xfail:
-    reason: "Testcase consistently fails, raised issue to track"
-    conditions:
-      - "hwsku in ['Celestica-DX010-C32']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
 #####   api/test_chassis_fans.py  #####

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -487,6 +487,8 @@ class TestChassisApi(PlatformApiTestBase):
             if status_led:
                 led_controllable = status_led.get("controllable", True)
                 led_supported_colors = status_led.get("colors")
+            else:
+                led_controllable = False
 
         if led_controllable:
             led_type_skipped = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added check for status_led in case of outdated platform.json file
Removed corresponding xfail in the conditional mark file

Fixes [Failed_Case][platform_tests.api.test_chassis.TestChassisApi][test_get_revision] and [test_status_led]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Failed_Case][platform_tests.api.test_chassis.TestChassisApi][test_get_revision] and [test_status_led]

#### How did you do it?
Added a check to see if status_led is present in platform.json. If not, set the led_controllable flag to false.

#### How did you verify/test it?
Tested on dx010 platform running 202012 image and verified that test was skipped.
