### PR TITLE
[Testbed] Shutdown `arp_update` process in swss while deploying SONiC fanout

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
@@ -28,6 +28,10 @@
   pause:
     seconds: 180
 
+- name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
+  shell: docker exec -i swss supervisorctl stop arp_update
+  become: yes
+
 - name: Setup broadcom based fanouts
   block:
     - name: configure TPID of access ports

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -28,6 +28,10 @@
   pause:
     seconds: 180
 
+- name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
+  shell: docker exec -i swss supervisorctl stop arp_update
+  become: yes
+
 - name: Setup broadcom based fanouts
   block:
     - name: configure TPID of access ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
To avoid fanout switch broadcasting it's MAC address, I added a step in ansible playbook to shutdown `arp_update` process in swss while deploying SONiC fanout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Avoid fanout switch broadcasting it's MAC address.

#### How did you do it?

Added a step in ansible playbook to shutdown `arp_update` process in swss while deploying SONiC fanout.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
