### PR TITLE
[Testbed] Filter key-value pairs while retrieving SONiC version from /etc/sonic/sonic_version.yml

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -4,7 +4,7 @@
   set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
 
 - name: retrieve SONiC version
-  shell: cat /etc/sonic/sonic_version.yml
+  shell: cat /etc/sonic/sonic_version.yml | grep ":"
   register: sonic_version_content
 
 - name: format SONiC version content


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The `/etc/sonic/sonic_version.yml` of SONiC 202205 looks like below:

```yaml
---
build_version: '202205'
debian_version: '11.6'
kernel_version: '5.10.0-18-2-amd64'
asic_type: broadcom
asic_subtype: 'broadcom'
# ...
```

There is a `---` line at the beginning of file and it causes the ansible playbook crush when deploying SONiC 202205 fanout switches. As we only need the key-value lines, I added `grep ":"` to filter the key-value lines when reading this file.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

There is a `---` line at the beginning of `/etc/sonic/sonic_version.yml` in SONiC 202205 image, and it causes the ansible playbook crush when deploying fanout switches. I opened this PR to fix this issue.

#### How did you do it?

Added `grep ":"` to filter the key-value lines when reading this file.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
