### PR TITLE
Add port alias to name map for hwsku Celestica-DX010-D48C8

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -1,3 +1,5 @@
+
+
 def _port_alias_to_name_map_50G(all_ports, s100G_ports,):
     new_map = {}
     # 50G ports
@@ -12,6 +14,7 @@ def _port_alias_to_name_map_50G(all_ports, s100G_ports,):
 
     return new_map
 
+
 def get_port_alias_to_name_map(hwsku, asic_name=None):
     port_alias_to_name_map = {}
     port_alias_asic_map = {}
@@ -19,7 +22,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
     HWSKU_WITH_PORT_INDEX_FROM_PORT_CONFIG = ["8800-LC-48H-O", "88-LC0-36FH-MO"]
     try:
         from sonic_py_common import multi_asic
-        from ansible.module_utils.multi_asic_utils  import load_db_config
+        from ansible.module_utils.multi_asic_utils import load_db_config
         load_db_config()
         ports_info = multi_asic.get_port_table(namespace=asic_name)
         for port, port_data in ports_info.items():
@@ -88,8 +91,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Arista-7260CX3-C64" or hwsku == "Arista-7170-64C" or hwsku == "Arista-7260CX3-Q64":
             for i in range(1, 65):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
-        elif hwsku == "Arista-7060CX-32S-C32" or hwsku == "Arista-7060CX-32S-Q32" or hwsku == "Arista-7060CX-32S-C32-T1" or hwsku == "Arista-7170-32CD-C32" \
-            or hwsku == "Arista-7050CX3-32S-C32":
+        elif hwsku == "Arista-7060CX-32S-C32" or hwsku == "Arista-7060CX-32S-Q32" \
+                or hwsku == "Arista-7060CX-32S-C32-T1" or hwsku == "Arista-7170-32CD-C32" \
+                or hwsku == "Arista-7050CX3-32S-C32":
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "Mellanox-SN2700-D40C8S8":
@@ -157,10 +161,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             s100G_ports = [x for x in range(13, 21)]
 
             port_alias_to_name_map = _port_alias_to_name_map_50G(all_ports, s100G_ports)
-        elif hwsku == "Arista-7800R3-48CQ-LC" or\
-             hwsku == "Arista-7800R3K-48CQ-LC":
-             for i in range(1, 48):
-                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+        elif hwsku == "Arista-7800R3-48CQ-LC" or hwsku == "Arista-7800R3K-48CQ-LC":
+            for i in range(1, 48):
+                port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "INGRASYS-S9100-C32":
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
@@ -191,15 +194,18 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "Celestica-DX010-D48C8":
             for i in range(1, 21):
-                port_alias_to_name_map["etp{}{}".format((i + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i - 1) * 2)
+                port_alias_to_name_map["etp{}{}".format((i + 1)//2, "a" if i % 2 == 1 else "b")] = \
+                    "Ethernet%d" % ((i - 1) * 2)
             for i in range(21, 25):
                 port_alias_to_name_map["etp{}".format(i - 10)] = "Ethernet%d" % ((i - 10 - 1) * 4)
             for i in range(25, 33):
-                port_alias_to_name_map["etp{}{}".format((i + 4 + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i + 4 - 1) * 2)
+                port_alias_to_name_map["etp{}{}".format((i + 4 + 1)//2, "a" if i % 2 == 1 else "b")] = \
+                    "Ethernet%d" % ((i + 4 - 1) * 2)
             for i in range(33, 37):
                 port_alias_to_name_map["etp{}".format(i - 14)] = "Ethernet%d" % ((i - 14 - 1) * 4)
             for i in range(37, 57):
-                port_alias_to_name_map["etp{}{}".format((i + 8 + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i + 8 - 1) * 2)
+                port_alias_to_name_map["etp{}{}".format((i + 8 + 1)//2, "a" if i % 2 == 1 else "b")] = \
+                    "Ethernet%d" % ((i + 8 - 1) * 2)
         elif hwsku == "Seastone-DX010":
             for i in range(1, 33):
                 port_alias_to_name_map["Eth%d" % i] = "Ethernet%d" % ((i - 1) * 4)
@@ -233,26 +239,26 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(0, 36, 1):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % (i * 8)
         elif hwsku in ["msft_multi_asic_vs"]:
-            for i in range(1,65):
+            for i in range(1, 65):
                 port_alias_to_name_map["Ethernet1/%d" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "msft_four_asic_vs":
-            for i in range(1,9):
+            for i in range(1, 9):
                 port_alias_to_name_map["Ethernet1/%d" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "B6510-48VS8CQ" or hwsku == "RA-B6510-48V8C":
-            for i in range(1,49):
+            for i in range(1, 49):
                 port_alias_to_name_map["twentyfiveGigE0/%d" % i] = "Ethernet%d" % i
-            for i in range(49,57):
+            for i in range(49, 57):
                 port_alias_to_name_map["hundredGigE0/%d" % (i-48)] = "Ethernet%d" % i
         elif hwsku == "RA-B6510-32C":
-            for i in range(1,33):
+            for i in range(1, 33):
                 port_alias_to_name_map["hundredGigE%d" % i] = "Ethernet%d" % i
         elif hwsku == "RA-B6910-64C":
-            for i in range(1,65):
+            for i in range(1, 65):
                 port_alias_to_name_map["hundredGigE%d" % i] = "Ethernet%d" % i
         elif hwsku == "RA-B6920-4S":
-            for i in range(1,129):
+            for i in range(1, 129):
                 port_alias_to_name_map["hundredGigE%d" % i] = "Ethernet%d" % i
-        elif hwsku in ["Wistron_sw_to3200k_32x100","Wistron_sw_to3200k"]:
+        elif hwsku in ["Wistron_sw_to3200k_32x100", "Wistron_sw_to3200k"]:
             for i in range(0, 256, 8):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Arista-720DT-48S":
@@ -272,7 +278,7 @@ def get_port_indices_for_asic(asic_id, port_name_list_sorted):
     # Create mapping between port alias and physical index
     port_index_map = {}
     if asic_id:
-        index_offset = int(asic_id) *len(front_end_port_name_list)
+        index_offset = int(asic_id) * len(front_end_port_name_list)
     for idx, val in enumerate(front_end_port_name_list, index_offset):
         port_index_map[val] = idx
     for idx, val in enumerate(back_end_port_name_list, index_offset):

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -15,7 +15,7 @@ def _port_alias_to_name_map_50G(all_ports, s100G_ports,):
 def get_port_alias_to_name_map(hwsku, asic_name=None):
     port_alias_to_name_map = {}
     port_alias_asic_map = {}
-    port_name_to_index_map = {} 
+    port_name_to_index_map = {}
     HWSKU_WITH_PORT_INDEX_FROM_PORT_CONFIG = ["8800-LC-48H-O", "88-LC0-36FH-MO"]
     try:
         from sonic_py_common import multi_asic
@@ -189,6 +189,17 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Celestica-DX010-C32":
             for i in range(1, 33):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1) * 4)
+        elif hwsku == "Celestica-DX010-D48C8":
+            for i in range(1, 21):
+                port_alias_to_name_map["etp{}{}".format((i + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i - 1) * 2)
+            for i in range(21, 25):
+                port_alias_to_name_map["etp{}".format(i - 10)] = "Ethernet%d" % ((i - 10 - 1) * 4)
+            for i in range(25, 33):
+                port_alias_to_name_map["etp{}{}".format((i + 4 + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i + 4 - 1) * 2)
+            for i in range(33, 37):
+                port_alias_to_name_map["etp{}".format(i - 14)] = "Ethernet%d" % ((i - 14 - 1) * 4)
+            for i in range(37, 57):
+                port_alias_to_name_map["etp{}{}".format((i + 8 + 1)//2, "a" if i % 2 == 1 else "b")] = "Ethernet%d" % ((i + 8 - 1) * 2)
         elif hwsku == "Seastone-DX010":
             for i in range(1, 33):
                 port_alias_to_name_map["Eth%d" % i] = "Ethernet%d" % ((i - 1) * 4)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Port alias to name map for hwsku Celestica-DX010-D48C8 is not supported in `ansible/module_utils/port_utils.py`.

#### How did you do it?
This change is to add port alias to name map for hwsku Celestica-DX010-D48C8.
This change also fixed style issues reported by pre-commit.

#### How did you verify/test it?
Verified that the generated port alias to name map matches `/usr/share/sonic/device/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/port_config.ini`:
```
{
    "etp1a": "Ethernet0",
    "etp1b": "Ethernet2",
    "etp2a": "Ethernet4",
    "etp2b": "Ethernet6",
    "etp3a": "Ethernet8",
    "etp3b": "Ethernet10",
    "etp4a": "Ethernet12",
    "etp4b": "Ethernet14",
    "etp5a": "Ethernet16",
    "etp5b": "Ethernet18",
    "etp6a": "Ethernet20",
    "etp6b": "Ethernet22",
    "etp7a": "Ethernet24",
    "etp7b": "Ethernet26",
    "etp8a": "Ethernet28",
    "etp8b": "Ethernet30",
    "etp9a": "Ethernet32",
    "etp9b": "Ethernet34",
    "etp10a": "Ethernet36",
    "etp10b": "Ethernet38",
    "etp11": "Ethernet40",
    "etp12": "Ethernet44",
    "etp13": "Ethernet48",
    "etp14": "Ethernet52",
    "etp15a": "Ethernet56",
    "etp15b": "Ethernet58",
    "etp16a": "Ethernet60",
    "etp16b": "Ethernet62",
    "etp17a": "Ethernet64",
    "etp17b": "Ethernet66",
    "etp18a": "Ethernet68",
    "etp18b": "Ethernet70",
    "etp19": "Ethernet72",
    "etp20": "Ethernet76",
    "etp21": "Ethernet80",
    "etp22": "Ethernet84",
    "etp23a": "Ethernet88",
    "etp23b": "Ethernet90",
    "etp24a": "Ethernet92",
    "etp24b": "Ethernet94",
    "etp25a": "Ethernet96",
    "etp25b": "Ethernet98",
    "etp26a": "Ethernet100",
    "etp26b": "Ethernet102",
    "etp27a": "Ethernet104",
    "etp27b": "Ethernet106",
    "etp28a": "Ethernet108",
    "etp28b": "Ethernet110",
    "etp29a": "Ethernet112",
    "etp29b": "Ethernet114",
    "etp30a": "Ethernet116",
    "etp30b": "Ethernet118",
    "etp31a": "Ethernet120",
    "etp31b": "Ethernet122",
    "etp32a": "Ethernet124",
    "etp32b": "Ethernet126"
}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
