### PR TITLE
Celestica E1031: fix test_crm_fdb_entry failure issue

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -132,6 +132,10 @@ def generate_mac(num):
     return mac_list
 
 
+def is_cel_e1031_device(duthost):
+    return duthost.facts["platform"] == "x86_64-cel_e1031-r0"
+
+
 def generate_fdb_config(duthost, entry_num, vlan_id, iface, op, dest):
     """ Generate FDB config file to apply it using 'swssconfig' tool.
     Generated config file template:
@@ -996,6 +1000,9 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     cmd = "fdbclear"
     duthost.command(cmd)
     time.sleep(5)
+    if is_cel_e1031_device(duthost):
+        # Sleep more time for E1031 device after fdbclear
+        time.sleep(10)
 
     # Get "crm_stats_fdb_entry" used and available counter value
     crm_stats_fdb_entry_used, crm_stats_fdb_entry_available = get_crm_stats(get_fdb_stats, duthost)
@@ -1008,7 +1015,9 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Verify "crm_stats_fdb_entry_used" counter was incremented
     # For Cisco-8000 devices, hardware FDB counter is statistical-based with +/- 1 entry tolerance.
     # Hence, the used counter can increase by more than 1.
-    if is_cisco_device(duthost):
+    # For E1031, refer CS00012270660, SDK for Helix4 chip does not support retrieving  max l2 entry,
+    # HW and SW CRM available counter would be out of sync and increase by more than 1.
+    if is_cisco_device(duthost) or is_cel_e1031_device(duthost):
         pytest_assert(new_crm_stats_fdb_entry_used - crm_stats_fdb_entry_used >= 1, \
             "Counter 'crm_stats_fdb_entry_used' was not incremented")
     else:
@@ -1018,7 +1027,9 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     # Verify "crm_stats_fdb_entry_available" counter was decremented
     # For Cisco-8000 devices, hardware FDB counter is statistical-based with +/- 1 entry tolerance.
     # Hence, the available counter can decrease by more than 1.
-    if is_cisco_device(duthost):
+    # For E1031, refer CS00012270660, SDK for Helix4 chip does not support retrieving  max l2 entry,
+    # HW and SW CRM available counter would be out of sync and decrease by more than 1.
+    if is_cisco_device(duthost) or is_cel_e1031_device(duthost):
         pytest_assert(crm_stats_fdb_entry_available - new_crm_stats_fdb_entry_available >= 1, \
             "Counter 'crm_stats_fdb_entry_available' was not decremented")
     else:
@@ -1064,5 +1075,8 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
         Used == {}".format(new_crm_stats_fdb_entry_used))
 
     # Verify "crm_stats_fdb_entry_available" counter was incremented
-    pytest_assert(new_crm_stats_fdb_entry_available - crm_stats_fdb_entry_available >= 0, \
-        "Counter 'crm_stats_fdb_entry_available' was not incremented")
+    # For E1031, refer CS00012270660, SDK for Helix4 chip does not support retrieving max l2 entry, HW and
+    # SW CRM available counter would be out of sync, so this is not applicable for e1031 device
+    if not is_cel_e1031_device(duthost):
+        pytest_assert(new_crm_stats_fdb_entry_available - crm_stats_fdb_entry_available >= 0, \
+            "Counter 'crm_stats_fdb_entry_available' was not incremented")


### PR DESCRIPTION
### Description of PR
Celestica E1031: fix test_crm_fdb_entry failure issue for sonic-mgmt 202012 branch.

Summary:
Fixes # (issue)
This is a backport fix of [PR#7217](https://github.com/sonic-net/sonic-mgmt/pull/7217) for branch 202012.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
fix Celestica E1031 platform test_crm_fdb_entry failure issue.

#### How did you do it?
For E1031 platform, SDK for Helix4 chip does not support retrieving max l2 entry(refer CSP CS00012270660), HW and SW CRM available counter would be out of sync, we need to customize this case for E1031.

#### How did you verify/test it?
./run_tests.sh -d cel-e1031-01 -n cel_e1031_t0 -t t0,any -u -c crm/test_crm.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
