### PR TITLE
[Testbed] Improve config template for arista-7260 root fanout

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260_connect.j2
+++ b/ansible/roles/fanout/templates/arista_7260_connect.j2
@@ -3,13 +3,13 @@ config
 {% if deploy_leaf %}
 vlan {{ dev_vlans | list | join(',') }}
 {% endif %}
-{% for i in range(1,65) %}
-{% set intf =  'Ethernet' + i|string  %}
-{% if intf in root_conn %}
+
+{% for intf in root_conn %}
 {% set peer_dev = root_conn[intf]['peerdevice'] %}
 {% set peer_port = root_conn[intf]['peerport'] %}
+{% set peer_speed = root_conn[intf]['speed'] %}
 {% if peer_dev in lab_devices and 'Fanout' not in lab_devices[peer_dev]['Type'] and not deploy_leaf %}
- interface {{ intf }}
+interface {{ intf }}
   switchport
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == server and peer_port == server_port %}
@@ -19,15 +19,20 @@ vlan {{ dev_vlans | list | join(',') }}
 {% endif %}
 {% endif %}
 {% if peer_dev in lab_devices and 'Fanout' in lab_devices[peer_dev]['Type']  and deploy_leaf %}
- interface {{ intf }}
+interface {{ intf }}
   switchport
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == leaf_name %}
   description {{ peer_dev }}-{{ peer_port }}
+  speed forced {{ peer_speed }}full
   switchport mode trunk
-  switchport trunk allowed vlan add {{ dev_vlans | list | join(',') }}
+  switchport trunk allowed vlan {{ dev_vlans | list | join(',') }}
   no shutdown
-{% endif %}
+{%     if peer_speed == "100000" %}
+  error-correction encoding reed-solomon
+{%     else %}
+  no error-correction encoding
+{%     endif %}
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix bugs and do some improvements for `Arista-7260` root fanout config template.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

When deploying leaf fanout with [ansible/roles/fanout/tasks/main.yml](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/fanout/tasks/main.yml), it also update the configuration of the corresponding interface on the `Arista-7260` root fanout. In this PR, I fixed the following bugs:

1. Current code only iterates all the physical ports (`EthernetXX/1`), so it cannot correctly configure logical ports (e.g. `EthernetXX/3`) generated by breaking out physical ports.
2. For ports connected to leaf fanout, current code uses `switchport trunk allowed vlan add <vlan_ids>` to update the vlan ids it allowed. Since the vlan ids previously configured on this port are not removed, it causes the port joins more vlans than the connection graph expects.

I also improved this template from following two points:

1. Set port speed according to connection graph.
2. Set `error-correction encoding` method to port according to port speed.

#### How did you do it?

* For the 1st bug, I changed the iteration logic. In this PR, I iterate all the interfaces appear in the connection graph to include the logical ports (e.g. `EthernetXX/3`).
* For the 2nd bug, I use `switchport trunk allowed vlan <vlan_ids>` to set allowed vlan ids directly. This will overwrite the old configuration.
* For the improvements, added corresponding logic.

#### How did you verify/test it?

Verified in physical lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
