### PR TITLE
[QoS] headroom test support for Arista-7050CX3-32S-D48C8

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -719,13 +719,13 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
   skip:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32'] and asic_type not in ['mellanox']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   skip:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -716,10 +716,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
       - "asic_type in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
-  xfail:
-    reason: "Image issue on Arista platforms"
-    conditions:
-      - "platform in ['x86_64-arista_7050cx3_32s']"
   skip:
     reason: "Headroom pool size not supported."
     conditions:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -32,6 +32,7 @@ from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file          # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_utils import dualtor_ports, is_tunnel_qos_remap_enabled             # lgtm[py/unused-import]
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.pfcwd.files.pfcwd_helper import set_pfc_timers, start_wd_on_ports
 from qos_sai_base import QosSaiBase
@@ -69,7 +70,8 @@ class TestQosSai(QosSaiBase):
         'Arista-7260CX3-D108C8',
         'Force10-S6100',
         'Arista-7260CX3-Q64',
-        'Arista-7050CX3-32S-C32'
+        'Arista-7050CX3-32S-C32',
+        'Arista-7050CX3-32S-D48C8'
     ]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']
@@ -455,6 +457,56 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.LosslessVoq", testParams=testParams
         )
 
+    def correctPortIds(self, test_port_ids, src_port_ids, dst_port_ids):
+        '''
+        if port id of test_port_ids/dst_port_ids is not existing in test_port_ids
+        correct it, make sure all src/dst id is valid
+        '''
+        sp = src_port_ids
+        slist = True
+        if not isinstance(src_port_ids, list):
+            sp = [src_port_ids]
+            slist = False
+
+        dp = dst_port_ids
+        dlist = True
+        if not isinstance(dst_port_ids, list):
+            dp = [dst_port_ids]
+            dlist = False
+
+        if len(sp) + len(dp) > len(test_port_ids):
+            logger.info('no enough ports for test')
+            return (None, None)
+
+        ports = [pid for pid in test_port_ids]
+
+        si = []
+        for idx, pid in enumerate(sp):
+            if pid not in ports:
+                si.append(idx)
+            else:
+                ports.remove(pid)
+
+        di = []
+        for idx, pid in enumerate(dp):
+            if pid not in ports:
+                di.append(idx)
+            else:
+                ports.remove(pid)
+
+        for idx in si:
+            sp[idx] = ports.pop(0)  # prefer to use port which id is smaller
+
+        for idx in di:
+            dp[idx] = ports.pop(0)  # prefer to use port which id is smaller
+
+        if not slist:
+            sp = sp[0]
+        if not dlist:
+            dp = dp[0]
+
+        return (sp, dp)
+
     def testQosSaiHeadroomPoolSize(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
@@ -487,6 +539,10 @@ class TestQosSai(QosSaiBase):
         if not dutConfig['dualTor']:
             qosConfig['hdrm_pool_size']['pgs'] = qosConfig['hdrm_pool_size']['pgs'][:2]
             qosConfig['hdrm_pool_size']['dscps'] = qosConfig['hdrm_pool_size']['dscps'][:2]
+
+        qosConfig["hdrm_pool_size"]["src_port_ids"], qosConfig["hdrm_pool_size"]["dst_port_id"] = self.correctPortIds(
+            dutConfig["testPortIds"], qosConfig["hdrm_pool_size"]["src_port_ids"], qosConfig["hdrm_pool_size"]["dst_port_id"])
+        pytest_assert(qosConfig["hdrm_pool_size"]["src_port_ids"] and qosConfig["hdrm_pool_size"]["dst_port_id"], "No enough test ports")
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2001,7 +2001,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         if is_dualtor and def_vlan_mac != None:
             self.dst_port_mac = def_vlan_mac
 
-        if self.testbed_type in ['dualtor', 't0', 't0-64', 't0-116']:
+        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116']:
             # populate ARP
             for idx, ptid in enumerate(self.src_port_ids):
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

support headroom test for Arista-7050CX3-32S-D48C8.
- add sku to support list
- fix qos param for this sku: their test port id which defined in qos.yml is out of date, not exist in testPortIds list anymore.
  in this situation, will see below error:
```
        testParams = dict()                                                                                                                                                                                  
        testParams.update(dutTestParams["basicParams"])                                                                                                                                                      
        testParams.update({                                                                                                                                                                                  
            "testbed_type": dutTestParams["topo"],                                                                                                                                                           
            "dscps": qosConfig["hdrm_pool_size"]["dscps"],                                                                                                                                                   
            "ecn": qosConfig["hdrm_pool_size"]["ecn"],                                                                                                                                                       
            "pgs": qosConfig["hdrm_pool_size"]["pgs"],                                                                                                                                                       
            "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],                                                                                                                                     
>           "src_port_ips": [testPortIps[port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],                                                                                        
            "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],                                                                                                                                       
            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],                                                                                                             
            "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],                                                                                                                                               
            "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],                                                                                                                           
            "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],                                                                                                                                             
            "pkts_num_hdrm_full": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_full"],                                                                                                                         
            "pkts_num_hdrm_partial": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_partial"],                                                                                                                   
            "hwsku":dutTestParams['hwsku']                                                                                                                                                                   
        })                                                                                                                                                                                                   
E       KeyError: 1
```

#### How did you do it?

- add sku to support list
- check if test port id is exist in testPortIds list. If not, replace invalid test port id to correct one.


#### How did you verify/test it?

pass local tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
