### PR TITLE
[Testbed] Fix bugs in startup-config template of SONiC fanouts

### DIFF
--- a/ansible/roles/fanout/library/port_config_gen.py
+++ b/ansible/roles/fanout/library/port_config_gen.py
@@ -24,7 +24,41 @@ description:
     - If the hwsku_type is dynamic, generate the hwsku based on the port breakout with script sonic_sku_create.py then return the port config
 options:
     N/A
+
+Ansible_facts:
+    fanout_platform: A string, device platform info.
+    fanout_hwsku: A string, device hwsku info.
+    fanout_port_config: A dict, device port configuration generated from connection graph and port_config.ini.
+                        The key is a string, represents the port name.
+                        The value is a dict, contains the port configuration.
 """
+
+EXAMPLES = '''
+return:
+    "fanout_platform": "x86_64-cel_seastone-r0",
+    "fanout_hwsku": "Celestica-DX010-C32",
+    "fanout_port_config": {
+        "Ethernet0": {
+            "alias": "etp1",
+            "index": "1",
+            "lanes": "65,66,67,68",
+            "name": "Ethernet0",
+            "peerdevice": "7050qx-2",
+            "peerport": "Ethernet4",
+            "speed": "40000"
+        },
+        "Ethernet100": {
+            "alias": "etp26",
+            "index": "26",
+            "lanes": "21,22,23,24",
+            "name": "Ethernet100",
+            "peerdevice": "7050qx-2",
+            "peerport": "Ethernet104",
+            "speed": "40000"
+        },
+        ...
+    }
+'''
 
 
 class PortConfigGenerator(object):
@@ -186,7 +220,7 @@ class PortConfigGenerator(object):
         for port_alias, port_config in hwsku_port_config.items():
             port_name = port_config['name']
             if port_name not in self.fanout_port_config:
-                self.fanout_port_config[port_alias] = port_config
+                self.fanout_port_config[port_name] = port_config
 
 
 def main():

--- a/ansible/roles/fanout/templates/sonic_deploy_202012.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202012.j2
@@ -7,18 +7,18 @@
     },
 
     "PORT": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}": {
-            "alias": "{{ alias }}",
-            "speed" : "{{ fanout_port_config[alias]['speed'] | default('100000') }}",
-            "index": "{{ fanout_port_config[alias]['index'] }}",
-            "lanes": "{{ fanout_port_config[alias]['lanes'] }}",
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": {
+            "alias": "{{ fanout_port_config[port_name]['alias'] }}",
+            "speed" : "{{ fanout_port_config[port_name]['speed'] | default('100000') }}",
+            "index": "{{ fanout_port_config[port_name]['index'] }}",
+            "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
-    {% if fanout_port_config[alias]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if 'peerdevice' in fanout_port_config[alias] %}
+    {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"
     {% else %}
             "admin_status": "down"
@@ -37,17 +37,17 @@
 
     {% set ns = {'firstPrinted': False} %}
     "VLAN_MEMBER": {
-    {% for alias in device_port_vlans[inventory_hostname] %}
-    {% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
+    {% for port_name in device_port_vlans[inventory_hostname] %}
+    {% if device_port_vlans[inventory_hostname][port_name]['mode'] == 'Access' %}
     {% if ns.firstPrinted %},{% endif %}
-        "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ fanout_port_config[alias]['name'] }}": {
+        "Vlan{{ device_port_vlans[inventory_hostname][port_name]['vlanids'] }}|{{ fanout_port_config[port_name]['name'] }}": {
             "tagging_mode" : "untagged"
         }
     {% if ns.update({'firstPrinted': True}) %} {% endif %}
-    {% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
-    {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
+    {% elif device_port_vlans[inventory_hostname][port_name]['mode'] == 'Trunk' %}
+    {% for vlanid in device_port_vlans[inventory_hostname][port_name]['vlanlist'] %}
     {% if ns.firstPrinted %},{% endif %}
-        "Vlan{{ vlanid }}|{{ fanout_port_config[alias]['name'] }}": {
+        "Vlan{{ vlanid }}|{{ fanout_port_config[port_name]['name'] }}": {
             "tagging_mode" : "tagged"
         }
     {% if ns.update({'firstPrinted': True}) %} {% endif %}
@@ -75,28 +75,28 @@
     },
 
     "QUEUE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}|0": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|1": {
+        "{{ port_name }}|1": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|2": {
+        "{{ port_name }}|2": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|3": {
+        "{{ port_name }}|3": {
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
             "scheduler": "[SCHEDULER|scheduler.1]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|4": {
+        "{{ port_name }}|4": {
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
             "scheduler": "[SCHEDULER|scheduler.1]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|5": {
+        "{{ port_name }}|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|6": {
+        "{{ port_name }}|6": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
@@ -104,8 +104,8 @@
 
     "CABLE_LENGTH": {
         "AZURE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}": "300m"{% if not loop.last %},{% endif %}
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": "300m"{% if not loop.last %},{% endif %}
     {% endfor %}
         }
     },

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -7,18 +7,18 @@
     },
 
     "PORT": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}": {
-            "alias": "{{ alias }}",
-            "speed" : "{{ fanout_port_config[alias]['speed'] | default('100000') }}",
-            "index": "{{ fanout_port_config[alias]['index'] }}",
-            "lanes": "{{ fanout_port_config[alias]['lanes'] }}",
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": {
+            "alias": "{{ fanout_port_config[port_name]['alias'] }}",
+            "speed" : "{{ fanout_port_config[port_name]['speed'] | default('100000') }}",
+            "index": "{{ fanout_port_config[port_name]['index'] }}",
+            "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
-    {% if fanout_port_config[alias]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if 'peerdevice' in fanout_port_config[alias] %}
+    {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"
     {% else %}
             "admin_status": "down"
@@ -37,17 +37,17 @@
 
     {% set ns = {'firstPrinted': False} %}
     "VLAN_MEMBER": {
-    {% for alias in device_port_vlans[inventory_hostname] %}
-    {% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
+    {% for port_name in device_port_vlans[inventory_hostname] %}
+    {% if device_port_vlans[inventory_hostname][port_name]['mode'] == 'Access' %}
     {% if ns.firstPrinted %},{% endif %}
-        "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ fanout_port_config[alias]['name'] }}": {
+        "Vlan{{ device_port_vlans[inventory_hostname][port_name]['vlanids'] }}|{{ fanout_port_config[port_name]['name'] }}": {
             "tagging_mode" : "untagged"
         }
     {% if ns.update({'firstPrinted': True}) %} {% endif %}
-    {% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
-    {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
+    {% elif device_port_vlans[inventory_hostname][port_name]['mode'] == 'Trunk' %}
+    {% for vlanid in device_port_vlans[inventory_hostname][port_name]['vlanlist'] %}
     {% if ns.firstPrinted %},{% endif %}
-        "Vlan{{ vlanid }}|{{ fanout_port_config[alias]['name'] }}": {
+        "Vlan{{ vlanid }}|{{ fanout_port_config[port_name]['name'] }}": {
             "tagging_mode" : "tagged"
         }
     {% if ns.update({'firstPrinted': True}) %} {% endif %}
@@ -75,28 +75,28 @@
     },
 
     "QUEUE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}|0": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}|0": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|1": {
+        "{{ port_name }}|1": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|2": {
+        "{{ port_name }}|2": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|3": {
+        "{{ port_name }}|3": {
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
             "scheduler": "[SCHEDULER|scheduler.1]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|4": {
+        "{{ port_name }}|4": {
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
             "scheduler": "[SCHEDULER|scheduler.1]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|5": {
+        "{{ port_name }}|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
-        "{{ fanout_port_config[alias]['name'] }}|6": {
+        "{{ port_name }}|6": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
@@ -104,8 +104,8 @@
 
     "CABLE_LENGTH": {
         "AZURE": {
-    {% for alias in fanout_port_config %}
-        "{{ fanout_port_config[alias]['name'] }}": "300m"{% if not loop.last %},{% endif %}
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": "300m"{% if not loop.last %},{% endif %}
     {% endfor %}
         }
     },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix bugs about incorrectly using port name as port alias in startup-config templates of SONiC fanouts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

In ansible module `port_config_gen`, variable `fanout_port_config` is generated from `fanout_connections`, and `fanout_connections` is generated from connection graph. Connection graph uses port name, so dict `fanout_port_config` uses port name as key. However, the startup-config templates of SONiC fanout incorrectly use the key as port alias. This will cause the port alias is set to the same as port name on SONiC fanouts. In this PR, I'm fixing this bug.

#### How did you do it?

1. Update startup-config templates of SONiC fanouts, fix all the incorrect usage.
2. Update the comments of ansible module `port_config_gen` to describe the structure of return values.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
