### PR TITLE
[cisco-8000] avoid the insufficient resource on NHOP members when validating NHOP group counts up to 92%

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -17,6 +17,8 @@ from tests.common.mellanox_data import is_mellanox_device
 from tests.common.innovium_data import is_innovium_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
+CISCO_NHOP_GROUP_FILL_PERCENTAGE = 0.92
+
 pytestmark = [
     pytest.mark.topology('t1', 't2')
 ]
@@ -320,7 +322,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     """
     # Set of parameters for Cisco-8000 devices
     if is_cisco_device(duthost):
-        default_max_nhop_paths = 10
+        default_max_nhop_paths = 2
         polling_interval = 1
         sleep_time = 380
     elif is_innovium_device(duthost):
@@ -348,6 +350,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     if is_cisco_device(duthost) or is_innovium_device(duthost):
         crm_stat = get_crm_info(duthost, asic)
         nhop_group_count = crm_stat["available"]
+        nhop_group_count = int(nhop_group_count * CISCO_NHOP_GROUP_FILL_PERCENTAGE)
     else:
         nhop_group_count = min(max_nhop, nhop_group_limit) + extra_nhops
 
@@ -357,7 +360,10 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     eth_if = ip_ifaces[0]
 
     # Generate ARP entries
-    arp_count = 40
+    if is_cisco_device(duthost):
+        arp_count = 257
+    else:
+        arp_count = 40
     arplist = Arp(duthost, asic, arp_count, eth_if)
     arplist.arps_add()
 
@@ -414,10 +420,19 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
 
     # verify the test used up all the NHOP group resources
     # skip this check on Mellanox as ASIC resources are shared
-    if not is_mellanox_device(duthost):
+    if is_cisco_device(duthost):
+        pytest_assert(
+            crm_after["available"] + nhop_group_count == crm_before["available"],
+            "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(
+                crm_after["available"], crm_after["used"], nhop_group_count, crm_before["available"]
+            )
+        )
+    elif is_mellanox_device(duthost):
+        logging.info("skip this check on Mellanox as ASIC resources are shared")
+    else:
         pytest_assert(
             crm_after["available"] == 0,
-            "Unused NHOP group resource: {}, used:{}".format(
+            "Unused NHOP group resource:{}, used:{}".format(
                 crm_after["available"], crm_after["used"]
             )
         )


### PR DESCRIPTION
**Description:**
In our lab environment, cisco sonic router will to hit insufficient resource issue on NHOP members when validating NHOP group counts.

Steps to reproduce the issue:
run the testcase " ipfwd/test_nhop_count.py " on T1 testbed.

ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_ROUTE, status: SAI_STATUS_INSUFFICIENT_RESOURCES\n']},

**Describe the results you expected:**
testcase Pass with enough sample NHOP group (92%)

**Additional information you deem important:**

modified default_max_nhop_paths = 2
means each NHOP group will have 2 NHOP members with diff ip addresses

modified arp_count = 257
testscript's arp value is an amount(a pool) of diff IP addresses.
if default_max_nhop_paths is 2 , it means to select 2 diff ip addresses over these 257 ip diff IP address.

the generated /tmp/static_ip.sh will have
257 C 2 > 32K samples nhopg (each nhopg has 2 nhopg members) 
zip(257 C 2, nhop_group_count * 0.92) = MIN(257 C 2, nhop_group_count(16K) * 0.92)=
which is (nhop_group_count * 0.92)*2 = 15K nhog members

if arp is equal to 40
40 C 2 = 780 samples nhopg (each nhopg has 2 nhopg members) which is so less since we plan to change
default_max_nhop_paths from 10 to 2
//calculator: https://www.mathway.com/popular-problems/Finite%20Math/601854

**solution:**
adjust the format of each NHOP group and achieve the testscript's purpose with enough amount.
will skip to check on the full use available crm nexthopg counts.