### PR TITLE
[tacacs] Fix tacacs test remove default server in teardown

### DIFF
--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -25,7 +25,7 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_cre
 
     yield
 
-    cleanup_tacacs(ptfhost, tacacs_creds, duthost, default_tacacs_servers)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
     restore_tacacs_servers(duthost, default_tacacs_servers, tacacs_server_ip)
 
 @pytest.fixture(scope="module")
@@ -35,9 +35,9 @@ def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_
     if 'ansible_hostv6' not in ptfhost_vars:
         pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")
     tacacs_server_ip = ptfhost_vars['ansible_hostv6']
-    default_tacacs_servers = setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
-    cleanup_tacacs(ptfhost, tacacs_creds, duthost, default_tacacs_servers)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost)

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -25,7 +25,7 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_cre
 
     yield
 
-    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost, default_tacacs_servers)
     restore_tacacs_servers(duthost, default_tacacs_servers, tacacs_server_ip)
 
 @pytest.fixture(scope="module")
@@ -35,9 +35,9 @@ def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_
     if 'ansible_hostv6' not in ptfhost_vars:
         pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")
     tacacs_server_ip = ptfhost_vars['ansible_hostv6']
-    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    default_tacacs_servers = setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
-    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost, default_tacacs_servers)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -138,12 +138,12 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     check_all_services_status(ptfhost)
 
 
-def cleanup_tacacs(ptfhost, tacacs_creds, duthost, tacacs_server_not_delete=[]):
+def cleanup_tacacs(ptfhost, tacacs_creds, duthost):
     # stop tacacs server
     stop_tacacs_server(ptfhost)
 
     # reset tacacs client configuration
-    remove_all_tacacs_server(duthost, tacacs_server_not_delete)
+    remove_all_tacacs_server(duthost)
     duthost.shell("sudo config tacacs default passkey")
     duthost.shell("sudo config aaa authentication login default")
     duthost.shell("sudo config aaa authentication failthrough default")
@@ -160,11 +160,11 @@ def cleanup_tacacs(ptfhost, tacacs_creds, duthost, tacacs_server_not_delete=[]):
     duthost.copy(src="./tacacs/templates/del_tacacs_keys.json", dest='/tmp/del_tacacs_keys.json')
     duthost.shell("configlet -d -j {}".format("/tmp/del_tacacs_keys.json"))
 
-def remove_all_tacacs_server(duthost, tacacs_server_not_delete=[]):
+def remove_all_tacacs_server(duthost):
     # use grep command to extract tacacs server address from tacacs config
     find_server_command = 'show tacacs | grep -Po "TACPLUS_SERVER address \K.*"'
     server_list = duthost.shell(find_server_command, module_ignore_errors=True)['stdout']
     for tacacs_server in server_list:
         tacacs_server = tacacs_server.rstrip()
-        if tacacs_server and tacacs_server not in tacacs_server_not_delete:
+        if tacacs_server:
             duthost.shell("sudo config tacacs delete %s" % tacacs_server)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -138,12 +138,12 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     check_all_services_status(ptfhost)
 
 
-def cleanup_tacacs(ptfhost, tacacs_creds, duthost):
+def cleanup_tacacs(ptfhost, tacacs_creds, duthost, tacacs_server_not_delete=[]):
     # stop tacacs server
     stop_tacacs_server(ptfhost)
 
     # reset tacacs client configuration
-    remove_all_tacacs_server(duthost)
+    remove_all_tacacs_server(duthost, tacacs_server_not_delete)
     duthost.shell("sudo config tacacs default passkey")
     duthost.shell("sudo config aaa authentication login default")
     duthost.shell("sudo config aaa authentication failthrough default")
@@ -160,11 +160,11 @@ def cleanup_tacacs(ptfhost, tacacs_creds, duthost):
     duthost.copy(src="./tacacs/templates/del_tacacs_keys.json", dest='/tmp/del_tacacs_keys.json')
     duthost.shell("configlet -d -j {}".format("/tmp/del_tacacs_keys.json"))
 
-def remove_all_tacacs_server(duthost):
+def remove_all_tacacs_server(duthost, tacacs_server_not_delete=[]):
     # use grep command to extract tacacs server address from tacacs config
     find_server_command = 'show tacacs | grep -Po "TACPLUS_SERVER address \K.*"'
-    server_list = duthost.shell(find_server_command)['stdout']
+    server_list = duthost.shell(find_server_command, module_ignore_errors=True)['stdout']
     for tacacs_server in server_list:
         tacacs_server = tacacs_server.rstrip()
-        if tacacs_server:
+        if tacacs_server and tacacs_server not in tacacs_server_not_delete:
             duthost.shell("sudo config tacacs delete %s" % tacacs_server)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
According to the current logic of remove_all_tacacs_server, if the dut is not configured with default tacacs_server, it will cause an error in the find_server_command. If the dut is configured with default tacacs_server, the default tacacs_server will be deleted by mistake.

#### How did you do it?
1. Add module_ignore_errors for cmd finding tacacs server.
2. Make sure tacacs server to be deleted is not default tacacs server.

#### How did you verify/test it?
Run tacacs test on mx, m0, t0, t1 testbed. All passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
