### PR TITLE
support input alias to shutdown interface in Sonic

### DIFF
--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -23,6 +23,7 @@ class FanoutHost(object):
         self.fanout_to_host_port_map = {}
         if os == 'sonic':
             self.os = os
+            self.fanout_port_alias_to_name = {}
             self.host = SonicHost(ansible_adhoc, hostname,
                                   shell_user=shell_user,
                                   shell_passwd=shell_passwd)
@@ -66,6 +67,9 @@ class FanoutHost(object):
                 raise AttributeError("Host of type {} does not contain a"
                                      "'shutdown_multiple' method"
                                      .format(type(self.host)))
+        if self.os == 'sonic':
+            if interface_name in self.fanout_port_alias_to_name.keys():
+                return self.host.shutdown(self.fanout_port_alias_to_name[interface_name])
 
         return self.host.shutdown(interface_name)
 
@@ -85,6 +89,10 @@ class FanoutHost(object):
                 raise AttributeError("Host of type {} does not contain a"
                                      "'no_shutdown_multiple' method"
                                      .format(type(self.host)))
+
+        if self.os == 'sonic':
+            if interface_name in self.fanout_port_alias_to_name.keys():
+                return self.host.no_shutdown(self.fanout_port_alias_to_name[interface_name])
 
         return self.host.no_shutdown(interface_name)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1007,7 +1007,15 @@ class SonicHost(AnsibleHostBase):
                 ifname: the interface to shutdown
         """
         logging.info("Shutting down {}".format(ifname))
-        return self.command("sudo config interface shutdown {}".format(ifname))
+
+        # if input ifname is alias, not interface name, need find out the interface name
+        ifs_status = self.get_interfaces_status()
+        logging.info("##### Shutting down ifs_status {}".format(ifs_status))
+
+        for key, interface_info in ifs_status.items():
+            if ifname == interface_info['alias'] or ifname == interface_info['interface']:
+                logging.debug('Shutting down %s (%s)' % (ifname, interface_info['interface']))
+                return self.command("sudo config interface shutdown {}".format(interface_info['interface']))
 
     def shutdown_multiple(self, ifnames):
         """
@@ -1035,7 +1043,12 @@ class SonicHost(AnsibleHostBase):
                 ifname: the interface to bring up
         """
         logging.info("Starting up {}".format(ifname))
-        return self.command("sudo config interface startup {}".format(ifname))
+
+        ifs_status = self.get_interfaces_status()
+        for key, interface_info in ifs_status.items():
+            if ifname == interface_info['alias'] or ifname == interface_info['interface']:
+                logging.debug('Starting up %s (%s)' % (ifname, interface_info['interface']))
+                return self.command("sudo config interface startup {}".format(interface_info['interface']))
 
     def no_shutdown_multiple(self, ifnames):
         """

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1007,15 +1007,7 @@ class SonicHost(AnsibleHostBase):
                 ifname: the interface to shutdown
         """
         logging.info("Shutting down {}".format(ifname))
-
-        # if input ifname is alias, not interface name, need find out the interface name
-        ifs_status = self.get_interfaces_status()
-        logging.info("##### Shutting down ifs_status {}".format(ifs_status))
-
-        for key, interface_info in ifs_status.items():
-            if ifname == interface_info['alias'] or ifname == interface_info['interface']:
-                logging.debug('Shutting down %s (%s)' % (ifname, interface_info['interface']))
-                return self.command("sudo config interface shutdown {}".format(interface_info['interface']))
+        return self.command("sudo config interface shutdown {}".format(ifname))
 
     def shutdown_multiple(self, ifnames):
         """
@@ -1043,12 +1035,7 @@ class SonicHost(AnsibleHostBase):
                 ifname: the interface to bring up
         """
         logging.info("Starting up {}".format(ifname))
-
-        ifs_status = self.get_interfaces_status()
-        for key, interface_info in ifs_status.items():
-            if ifname == interface_info['alias'] or ifname == interface_info['interface']:
-                logging.debug('Starting up %s (%s)' % (ifname, interface_info['interface']))
-                return self.command("sudo config interface startup {}".format(interface_info['interface']))
+        return self.command("sudo config interface startup {}".format(ifname))
 
     def no_shutdown_multiple(self, ifnames):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -569,6 +569,13 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa F
                                         shell_passwd=shell_password)
                     fanout.dut_hostnames = [dut_host]
                     fanout_hosts[fanout_host] = fanout
+
+                    if fanout.os == 'sonic':
+                        ifs_status = fanout.host.get_interfaces_status()
+                        for key, interface_info in ifs_status.items():
+                            fanout.fanout_port_alias_to_name[interface_info['alias']] = interface_info['interface']
+                        logging.info("fanout {} fanout_port_alias_to_name {}".format(fanout_host, fanout.fanout_port_alias_to_name))
+
                 fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
 
                 # Add port name to fanout port mapping port if dut_port is alias.


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Sonic CLI does not support using interface alias as param to shutdown the interface.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Sonic CLI does not support using interface alias to shutdown the interface.

#### How did you do it?
Before doing "sudo config interface shutdown xxx", do "show interface status" CMD first.
Then get the alias and interface name.
If the input param is same as alias or interface name, then use interface name to do the shutdown CMD.
If not match, do nothing

#### How did you verify/test it?
Shutdown the fanout's interface and run the sanity check.
Sanity check could find the down interface and recover it.

collected 1 item                                                                                                                                                                                                

bgp/test_bgp_fact.py::test_bgp_facts[str2-8101-32fh-02-None] 
------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------
05:47:08 recover.recover                          L0155 WARNING| Try to recover str2-8101-32fh-02 using method adaptive
05:47:08 recover._recover_interfaces              L0032 WARNING| Restoring port: PortChannel102
05:47:08 recover._recover_interfaces              L0032 WARNING| Restoring port: Ethernet8
05:47:47 recover.adaptive_recover                 L0141 WARNING| Restoring {'check_item': 'interfaces', 'failed': True, 'host': 'str2-8101-32fh-02', 'down_ports': [u'PortChannel102', u'Ethernet8']} with proposed action: config_reload, final action: config_reload
05:48:29 recover.adaptive_recover                 L0141 WARNING| Restoring {'check_item': 'bgp', 'failed': True, 'host': 'str2-8101-32fh-02', 'bgp': {'down_neighbors': [u'fc00::2', u'10.0.0.1']}} with proposed action: config_reload, final action: config_reload
PASSED             


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
