### PR TITLE
Remove xfail for test_chassis.py::TestChassisApi in 202012 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -47,12 +47,6 @@ dualtor_io/test_normal_op.py:
       - "'dualtor' in topo_name"
       - "'7260' in platform"
 
-platform_tests/api/test_chassis.py::TestChassisApi:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202012']"
-
 platform_tests/test_advanced_reboot.py:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Remove xfail for test_chassis.py::TestChassisApi in 202012 branch, since most of test_chassis.py cases can pass in 202012 branch.

#### How did you do it?
Remove test_chassis.py::TestChassisApi from tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml

#### How did you verify/test it?
Run test_chassis.py against 202012 branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
