### PR TITLE
DscpToPgMapping qos test fails intermittently due to tcp/lacp messages received

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -600,6 +600,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
         dscp_to_pg_map = self.test_params.get('dscp_to_pg_map', None)
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
 
         print("dst_port_id: %d, src_port_id: %d" %
               (dst_port_id, src_port_id), file=sys.stderr)
@@ -631,6 +632,9 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     pg_dscp_map[int(pg)] = [int(dscp)]
 
         print(pg_dscp_map, file=sys.stderr)
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip)
+        print("actual dst_port_id: %d" % (dst_port_id), file=sys.stderr)
 
         try:
             for pg, dscps in list(pg_dscp_map.items()):
@@ -641,7 +645,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 for dscp in dscps:
                     tos = (dscp << 2)
                     tos |= 1
-                    pkt = simple_tcp_packet(pktlen=64,
+                    pkt = simple_ip_packet(pktlen=64,
                                             eth_dst=router_mac if router_mac != '' else dst_port_mac,
                                             eth_src=src_port_mac,
                                             ip_src=src_port_ip,

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -646,7 +646,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     tos = (dscp << 2)
                     tos |= 1
                     pkt = simple_ip_packet(pktlen=64,
-                                            eth_dst=router_mac if router_mac != '' else dst_port_mac,
+                                            eth_dst=pkt_dst_mac,
                                             eth_src=src_port_mac,
                                             ip_src=src_port_ip,
                                             ip_dst=dst_port_ip,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

DscpToPgMapping qos tests in test_qos_sai.py fails intermittently when being run against T2 topology. The failure would be seen against any topology that has eBGP peers and/or LAGs.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

There were 3 issues with the corresponding class DscpToPgMapping in saitests/py3/sai_qos_tests.py:

- The test was not checking If the dst port is in a LAG and could be wrong dst port being used.
- LACP/LLDP packets coming from the remote peer during the test would get mapped to queue 0 and thus the count of that queue could increment.
-  QoS tests in test_qos_sai.py disable bgp services on the DUT side. However, the test doesn't disable BGP on the remote eBGP peers (ceos dockers/veos or vsonic VMs). Thus, the remote eBGP peers will continue to send TCP SYN packets to try to re-establish the BGP peership. The packets map to queue 4. Thus, if we receive any TCP SYN packet during the test run, queue 4 stats would increment.
  
#### How did you do it?

Below are the changes for DscpToPgMapping Qos_test that fix the above issues:
- dst port in a LAG:
   - Use existing get_rx_port method to figure out the actual port that packets would be received on.
   - Since get_rx_port uses, simple_ip_packet, we had to change the test to use simple_ip_packet instead of simple_tcp_packet
- Allow for more than expected packets for queue0 and queue4 when checking the counters for each queue.

#### How did you verify/test it?

Ran the tests against a  single_asic, single_dut_multi_asic and multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
