### PR TITLE
[202205] Fix overlap of mark condition for test_snmp_queue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -805,18 +805,12 @@ snmp/test_snmp_phy_entity.py::test_psu_info:
 
 snmp/test_snmp_queue.py:
   skip:
-    reason: "Interfaces not present on supervisor node or M0 topo does not support test_snmp_queue"
+    reason: "Unsupported for supervisor node / mx or m0 topo / multi-asic vs"
+    conditions_logical_operator: 'OR'
     conditions:
-      - "is_supervisor or topo_name in ['m0']"
-
-snmp/test_snmp_queue.py:
-  skip:
-    reason: "Test is flaky on multi-asic vs"
-    conditions:
-      - https://github.com/sonic-net/sonic-buildimage/issues/13289
-      - "asic_type in ['vs']"
-      - "hwsku in ['msft_four_asic_vs', 'msft_multi_asic_vs']"
-      - "branch in ['202205']"
+      - "is_supervisor"
+      - "topo_name in ['m0', 'mx']"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/13289 and asic_type in ['vs'] and hwsku in ['msft_four_asic_vs', 'msft_multi_asic_vs'] and branch in ['202205']"
 
 #######################################
 #####            span             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Repeated key (test case) in the condition mark will cause the previous rule to be overwritten

#### How did you do it?
User conditions_logical_operator to modify logical to OR

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
