### PR TITLE
[202205][multi-asic][vs]: Skip test_snmp_queue on multi-asic vs checks

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -816,7 +816,7 @@ snmp/test_snmp_queue.py:
       - https://github.com/sonic-net/sonic-buildimage/issues/13289
       - "asic_type in ['vs']"
       - "hwsku in ['msft_four_asic_vs', 'msft_multi_asic_vs']"
-      - "branch in ['202205']"
+      - "'202205' in branch"
 
 #######################################
 #####            span             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [#7204](https://github.com/sonic-net/sonic-mgmt/pull/7204), it skips test_snmp_queue on multi-asic vs checks. And the condition `branch in ['202205']` seems to be false, because in the test log, the branch name is `202205-12722`. So in this pr, it changes this condition. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In pr [#7204](https://github.com/sonic-net/sonic-mgmt/pull/7204), it skips test_snmp_queue on multi-asic vs checks. And the condition `branch in ['202205']` seems to be false, because in the test log, the branch name is `202205-12722`. So in this pr, it changes this condition. 

#### How did you do it?
Change the condition here. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
