### PR TITLE
[Barefoot] Update sku sensor data for platforms

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -3717,20 +3717,20 @@ sensors_checks:
       fan: []
       power: []
       temp:
-      - - tmp75-i2c-3-48/Outlet Middle Temp/temp1_input
-        - tmp75-i2c-3-48/Outlet Middle Temp/temp1_max
-      - - tmp75-i2c-3-49/Inlet Middle Temp/temp1_input
-        - tmp75-i2c-3-49/Inlet Middle Temp/temp1_max
-      - - tmp75-i2c-3-4a/Inlet Left Temp/temp1_input
-        - tmp75-i2c-3-4a/Inlet Left Temp/temp1_max
-      - - tmp75-i2c-3-4b/Switch Temp/temp1_input
-        - tmp75-i2c-3-4b/Switch Temp/temp1_max
-      - - tmp75-i2c-3-4c/Inlet Right Temp/temp1_input
-        - tmp75-i2c-3-4c/Inlet Right Temp/temp1_max
-      - - tmp75-i2c-8-48/Outlet Right Temp/temp1_input
-        - tmp75-i2c-8-48/Outlet Right Temp/temp1_max
-      - - tmp75-i2c-8-49/Outlet Left Temp/temp1_input
-        - tmp75-i2c-8-49/Outlet Left Temp/temp1_max
+      - - tmp75-i2c-3-48/Chip Temp/temp1_input
+        - tmp75-i2c-3-48/Chip Temp/temp1_max
+      - - tmp75-i2c-3-49/Exhaust2 Temp/temp1_input
+        - tmp75-i2c-3-49/Exhaust2 Temp/temp1_max
+      - - tmp75-i2c-3-4a/Exhaust Temp/temp1_input
+        - tmp75-i2c-3-4a/Exhaust Temp/temp1_max
+      - - tmp75-i2c-3-4b/Intake Temp/temp1_input
+        - tmp75-i2c-3-4b/Intake Temp/temp1_max
+      - - tmp75-i2c-3-4c/Intake2 Temp/temp1_input
+        - tmp75-i2c-3-4c/Intake2 Temp/temp1_max
+      - - tmp75-i2c-8-48/Fan Board Outlet Right Temp/temp1_input
+        - tmp75-i2c-8-48/Fan Board Outlet Right Temp/temp1_max
+      - - tmp75-i2c-8-49/Fan Board Outlet Left Temp/temp1_input
+        - tmp75-i2c-8-49/Fan Board Outlet Left Temp/temp1_max
 
     non_zero:
       fan:
@@ -3761,16 +3761,16 @@ sensors_checks:
       fan: []
       power: []
       temp:
-      - - tmp75-i2c-3-48/Outlet Middle Temp/temp1_input
-        - tmp75-i2c-3-48/Outlet Middle Temp/temp1_max
-      - - tmp75-i2c-3-49/Inlet Middle Temp/temp1_input
-        - tmp75-i2c-3-49/Inlet Middle Temp/temp1_max
-      - - tmp75-i2c-3-4a/Inlet Left Temp/temp1_input
-        - tmp75-i2c-3-4a/Inlet Left Temp/temp1_max
-      - - tmp75-i2c-3-4b/Switch Temp/temp1_input
-        - tmp75-i2c-3-4b/Switch Temp/temp1_max
-      - - tmp75-i2c-3-4c/Inlet Right Temp/temp1_input
-        - tmp75-i2c-3-4c/Inlet Right Temp/temp1_max
+      - - tmp75-i2c-3-48/Chip Temp/temp1_input
+        - tmp75-i2c-3-48/Chip Temp/temp1_max
+      - - tmp75-i2c-3-49/Exhaust2 Temp/temp1_input
+        - tmp75-i2c-3-49/Exhaust2 Temp/temp1_max
+      - - tmp75-i2c-3-4a/Exhaust Temp/temp1_input
+        - tmp75-i2c-3-4a/Exhaust Temp/temp1_max
+      - - tmp75-i2c-3-4b/Intake Temp/temp1_input
+        - tmp75-i2c-3-4b/Intake Temp/temp1_max
+      - - tmp75-i2c-3-4c/Tofino Temp/temp1_input
+        - tmp75-i2c-3-4c/Tofino Temp/temp1_max
       - - tmp75-i2c-8-48/Outlet Right Temp/temp1_input
         - tmp75-i2c-8-48/Outlet Right Temp/temp1_max
       - - tmp75-i2c-8-49/Outlet Left Temp/temp1_input
@@ -7207,4 +7207,3 @@ sensors_checks:
     psu_skips: {}
 
     sensor_skip_per_version: {}
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR 

Update sku sensor data for  accton  platforms

What is the motivation for this PR?
Make sensors case working for x86_64-accton_wedge100bf_65x-r0,  x86_64-accton_wedge100bf_32x-r0 platforms

How did you do it?
Update sensors data


How did you verify/test it?
It is a part of fix, therefore without Pr in SDK test should not pass. Run sensors TC case and get PASS result
Test:
platform_tests/test_sensors.py::test_sensors
Any platform specific information?


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Paths for sensors were changed
#### How did you do it?
Update path for sensors
#### How did you verify/test it?
Run sensors TC case and get PASS result
#### Any platform specific information?
admin@cab18-1-dut:~$ show version

SONiC Software Version: SONiC.202012.205404-dirty-20230119.130022
Distribution: Debian 10.13
Kernel: 4.19.0-12-2-amd64
Build commit: 21ad9876a
Build date: Thu Jan 19 13:05:49 UTC 2023
Built by: AzDevOps@vmss-soni000C2Z

Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
ASIC Count: 1
Serial Number: AI01016184
Uptime: 10:19:52 up 12:36,  1 user,  load average: 0.53, 0.71, 0.62
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
