### PR TITLE
Script must use the correct function to get the dutmac for different ASICs.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -731,7 +731,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(
+                 self.ptf,
+                 duthost.get_dut_iface_mac(port),
+                 self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
@@ -805,14 +808,20 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         try:
             for idx, mmu_action in enumerate(MMU_ACTIONS):
-                self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
+                self.traffic_inst = SendVerifyTraffic(
+                    self.ptf,
+                    duthost.get_dut_iface_mac(port),
+                    self.pfc_wd)
                 pfc_wd_restore_time_large = request.config.getoption("--restore-time")
                 # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
                 self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
                 if idx:
                     self.update_queue(port)
                     self.storm_setup()
-                self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
+                self.traffic_inst = SendVerifyTraffic(
+                    self.ptf,
+                    duthost.get_dut_iface_mac(port),
+                    self.pfc_wd)
                 self.run_test(self.dut, port, "drop", mmu_action=mmu_action)
                 self.dut.command("pfcwd stop")
 
@@ -873,7 +882,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing port toggling with PFCWD enabled on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(
+                 self.ptf,
+                 duthost.get_dut_iface_mac(port),
+                 self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -731,7 +731,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
@@ -805,14 +805,14 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         try:
             for idx, mmu_action in enumerate(MMU_ACTIONS):
-                self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd)
+                self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
                 pfc_wd_restore_time_large = request.config.getoption("--restore-time")
                 # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
                 self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
                 if idx:
                     self.update_queue(port)
                     self.storm_setup()
-                self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd)
+                self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
                 self.run_test(self.dut, port, "drop", mmu_action=mmu_action)
                 self.dut.command("pfcwd stop")
 
@@ -873,7 +873,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing port toggling with PFCWD enabled on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(self.ptf, duthost.get_dut_iface_mac(port), self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)


### PR DESCRIPTION
The file: tests/tests_pfcwd_function.py is using get_dut_mac() to get the Mac address of the DUT. This works only in single ASIC devices. For multiASIC devices, the function: get_dut_iface_mac() must be used.