### PR TITLE
changing routes added from 10 to 64 in test_crm.py script

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -476,9 +476,9 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
 
     # Add IPv[4/6] routes 
-    # Cisco platforms need an upward of 10 routes for crm_stats_ipv4_route_available to decrement
+    # Cisco platforms need an upward of 64 routes for crm_stats_ipv4_route_available to decrement
     if is_cisco_device(duthost) and ip_ver == '4':
-        total_routes = 10
+        total_routes = 64 
     else:
         total_routes = 1
     for i in range(total_routes):


### PR DESCRIPTION
Description: 
Cisco platforms need an upward of 10 routes for 'crm_stats_ipv4_route_available' to decrement . It was observed that even with 10 routes, test_crm_route[str2-8102-02-None-ipv4] tescase was failing because "crm_stats_ipv4_route_available" counter was not getting decremented.

Changes: 
It was decided that its better to increase the ipv4 routes added from 10 to 64 to make sure that the crm_stats_ipv4_route_available counter is decremented consistently.

Verification: 
The test was run multiple times after changing the routes from 10 to 64. No failures were seen.