### PR TITLE
Fix failures in everflow tests for T2 topology

### DIFF
--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -10,11 +10,11 @@ def setup_recycle_port(duthosts, tbinfo):
         for duthost in duthosts.frontend_nodes:
             rec_intf[duthost.hostname] = {}
             for asic in duthost.asics:
-                output = duthost.command("show ip interfaces -n {} -d all".format(asic.namespace))['stdout_lines']
+                output = duthost.command("show ip interfaces {} -d all".format(asic.cli_ns_option))['stdout_lines']
                 if 'Ethernet-Rec' not in output:
                     rec_intf[duthost.hostname][asic.namespace] = 1
-                    cmd = "sudo config interface -n {ns} ip add Ethernet-Rec{rec} 1.1.1.{an}/32".format(
-                        ns=asic.namespace,
+                    cmd = "sudo config interface {ns} ip add Ethernet-Rec{rec} 1.1.1.{an}/32".format(
+                        ns=asic.cli_ns_option,
                         rec=asic.asic_index,
                         an=asic.asic_index + 1)
                     logging.info(cmd)
@@ -25,8 +25,8 @@ def setup_recycle_port(duthosts, tbinfo):
         for duthost in duthosts.frontend_nodes:
             for asic in duthost.asics:
                 if rec_intf[duthost.hostname][asic.namespace]:
-                    cmd = "sudo config interface -n {ns} ip remove Ethernet-Rec{rec} 1.1.1.{an}/32".format(
-                        ns=asic.namespace,
+                    cmd = "sudo config interface {ns} ip remove Ethernet-Rec{rec} 1.1.1.{an}/32".format(
+                        ns=asic.cli_ns_option,
                         rec=asic.asic_index,
                         an=asic.asic_index + 1)
                     logging.info(cmd)

--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+import logging
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_recycle_port(duthosts, tbinfo):
+    """Setup recycle port ip address on t2 topo"""
+    rec_intf = {}
+    if "t2" in tbinfo['topo']['name']:
+        for duthost in duthosts.frontend_nodes:
+            rec_intf[duthost.hostname] = {}
+            for asic in duthost.asics:
+                output = duthost.command("show ip interfaces -n {} -d all".format(asic.namespace))['stdout_lines']
+                if 'Ethernet-Rec' not in output:
+                    rec_intf[duthost.hostname][asic.namespace] = 1
+                    cmd = "sudo config interface -n {ns} ip add Ethernet-Rec{rec} 1.1.1.{an}/32".format(
+                        ns=asic.namespace,
+                        rec=asic.asic_index,
+                        an=asic.asic_index + 1)
+                    logging.info(cmd)
+                    duthost.command(cmd)
+            duthost.command("sudo config save -y")
+    yield
+    if "t2" in tbinfo['topo']['name']:
+        for duthost in duthosts.frontend_nodes:
+            for asic in duthost.asics:
+                if rec_intf[duthost.hostname][asic.namespace]:
+                    cmd = "sudo config interface -n {ns} ip remove Ethernet-Rec{rec} 1.1.1.{an}/32".format(
+                        ns=asic.namespace,
+                        rec=asic.asic_index,
+                        an=asic.asic_index + 1)
+                    logging.info(cmd)
+                    duthost.command(cmd)
+            duthost.command("sudo config save -y")
+

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -839,7 +839,7 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
         if duthost.facts["asic_type"] == 'marvell':
             expected_packet.set_do_not_care_scapy(packet.IP, "id")
-        if duthost.facts["asic_type"] in ["cisco-8000", "innovium", "broadcom"]:
+        if duthost.facts["asic_type"] in ["cisco-8000", "innovium"] or duthost.facts.get("platform_asic") in ["broadcom-dnx"]:
             expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
 
         # The fanout switch may modify this value en route to the PTF so we should ignore it, even

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -725,31 +725,14 @@ class BaseEverflowTest(object):
         if 't2' in setup['topo']:
             if valid_across_namespace is True:
                 src_port_set.add(src_port)
+                src_port_metadata_map[src_port] = (None, 1)
                 if duthost.facts['switch_type'] == "voq":
-                    src_port_metadata_map[src_port] = (None, 1)
                     if self.mirror_type() != "egress":  # no egress route on the other node/namespace
                         src_port_set.add(dest_ports[0])
                         src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 1)
                 else:
-                    src_port_metadata_map[src_port] = (None, 0)
                     src_port_set.add(dest_ports[0])
                     src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 0)
-
-        if 't2' in setup['topo']:
-            if valid_across_namespace is True:
-                src_port_set.add(src_port)
-                if duthost.facts['switch_type'] == "voq":
-                        src_port_metadata_map[src_port] = (None, 1)
-                else:
-                    src_port_metadata_map[src_port] = (None, 0)
-
-            if duthost.facts['switch_type'] == "voq":
-                if self.mirror_type() != "egress":  # no egress route on the other node/namespace
-                    src_port_set.add(dest_ports[0])
-                    src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 1)
-            else:
-                src_port_set.add(dest_ports[0])
-                src_port_metadata_map[dest_ports[0]] = (setup[direction]["egress_router_mac"], 0)
 
         else:
             src_port_namespace = setup[direction]["everflow_namespace"]
@@ -821,10 +804,6 @@ class BaseEverflowTest(object):
                     inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
 
                 logging.info("Expected inner packet: %s", mirror_packet_sent.summary())
-                if not inner_packet.pkt_match(mirror_packet_sent):
-                    logging.info("going to fail")
-                    mirror_packet_sent.show()
-                    inner_packet.exp_pkt.show()
                 pytest_assert(inner_packet.pkt_match(mirror_packet_sent), "Mirror payload does not match received packet")
             else:
                 testutils.verify_no_packet_any(ptfadapter, expected_mirror_packet, dest_ports)

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -816,7 +816,8 @@ class BaseEverflowTest(object):
         if duthost.facts["asic_type"] in ["mellanox"]:
             payload = binascii.unhexlify("0" * 44) + str(payload)
 
-        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get("platform_asic") in ["broadcom-dnx"]:
+        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get(
+                "platform_asic") in ["broadcom-dnx"]:
             payload = binascii.unhexlify("0" * 24) + str(payload)
 
         expected_packet = testutils.simple_gre_packet(

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -74,7 +74,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3", "j2c+"]
+    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3", "j2c+", "jr2"]
 
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request):

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -257,8 +257,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
         finally:
             # Clean up the test
-            remote_dut.shell(remote_dut.get_linux_ip_cmd_for_namespace("ip neigh del {} dev {}".format(peer_ip, tx_port), setup_info[dest_port_type]["remote_namespace"]))
-            remote_dut.get_asic_or_sonic_host_from_namespace(setup_info[dest_port_type]["remote_namespace"]).command("ping {} -c3".format(peer_ip))
+            remote_dut.shell(
+                remote_dut.get_linux_ip_cmd_for_namespace("ip neigh del {} dev {}".format(peer_ip, tx_port),
+                                                          setup_info[dest_port_type]["remote_namespace"]))
+            remote_dut.get_asic_or_sonic_host_from_namespace(setup_info[dest_port_type]["remote_namespace"]).command(
+                "ping {} -c3".format(peer_ip))
 
         # Verify that everything still works
         time.sleep(10)  # for redis to get update to other lc

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -74,7 +74,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3"]
+    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3", "j2c+"]
 
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request):
@@ -261,6 +261,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             remote_dut.get_asic_or_sonic_host_from_namespace(setup_info[dest_port_type]["remote_namespace"]).command("ping {} -c3".format(peer_ip))
 
         # Verify that everything still works
+        time.sleep(10)  # for redis to get update to other lc
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
@@ -362,7 +363,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
       
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
         remote_dut = setup_info[dest_port_type]['remote_dut']
- 
+
+        if tbinfo['topo']['type'] == "t2":
+            if everflow_dut.facts['switch_type'] == "voq":
+                pytest.skip("Skip test as is not supported on a VoQ chassis.")
+
         # Remaining Scenario not applicable for this topology
         if len(setup_info[dest_port_type]["dest_port"]) <= 2:
             pytest.skip("Skip test as not enough neighbors/ports.")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixing failures seen in everflow suite when run against a T2 VoQ chassis.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Everflow broke on T2 topology with reworked everflow tests after PR #6945 was merged. 
With this PR, everflow tests started failing on T2 VoQ chassis
Some modifications are needed for testcases to pass

#### How did you do it?
- J2C+ to the unsupported ....
- some tescases need to be handled differently on a T2 chassis when switch_type is VoQ
- Check for asic_type boradcom and/or broadcom_dnx in 
- skip test_everflow_remove_used_ecmp_next_hop test case as it is not supported on a VoQ chassis

#### How did you verify/test it?
Ran all everflow test cases on a multi duts multi asics VoQ chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
