### PR TITLE
fix the get_auto_negotiation_mode

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -285,9 +285,10 @@ class EosHost(AnsibleHostBase):
         output = self.eos_command(commands=[{
             'command': 'show interfaces %s status' % interface_name,
             'output': 'json'
-        }])
+        }], module_ignore_errors=True)
         if self._has_cli_cmd_failed(output):
-            _raise_err('Failed to get auto neg state for {}: {}'.format(interface_name, output['msg']))
+            logger.info('Failed to get auto neg state for {}: {}'.format(interface_name, output['msg']))
+            return None
         autoneg_enabled = output['stdout'][0]['interfaceStatuses'][interface_name]['autoNegotiateActive']
         return autoneg_enabled
 


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7266 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
In some eos fanout switches the `show interface status <portname> json` is not supported. This causes error in `test_update_testbed_metadata`

#### How did you do it?
in `get_auto_negotiation_mode` return None instead of raising a error

#### How did you verify/test it?
Run pretest in t2 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
