### PR TITLE
made possible to skip one of 2 similar warmboot test cases

### DIFF
--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -143,3 +143,15 @@ def add_advanced_reboot_args(parser):
             "which helps to keep total runtime within desired limits. Avg time per case: " +\
             "sad(3h45m), multi_sad(5h), sad_bgp(1h5m), sad_lag_member(1h15m), sad_lag(1h15m), sad_vlan_port(1h10m), sad_inboot(1h20m)",
     )
+
+    parser.addoption(
+        "--single_sad_only",
+        action="store_true",
+        default=False
+    )
+
+    parser.addoption(
+        "--multi_sad_only",
+        action="store_true",
+        default=False
+    )

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -20,17 +20,23 @@ pytestmark = [
 logger = logging.getLogger()
 
 def pytest_generate_tests(metafunc):
-    input_sad_cases = metafunc.config.getoption("sad_case_list")
-    input_sad_list = list()
-    for input_case in input_sad_cases.split(","):
-        input_case = input_case.strip()
+    if "sad_case_type" not in metafunc.fixturenames:
+        return
+    
+    input_sad_cases_str = metafunc.config.getoption("sad_case_list")
+    input_sad_cases = [suitename.strip() for suitename in input_sad_cases_str.split(",")]
+    if metafunc.config.option.single_sad_only:
+        input_sad_cases.remove("multi_sad")
+    if metafunc.config.option.multi_sad_only:
+        input_sad_cases.remove("sad")
+
+    selected_sad_list = []
+    for input_case in input_sad_cases:
         if input_case.lower() not in SAD_CASE_LIST:
             logging.warn("Unknown SAD case ({}) - skipping it.".format(input_case))
             continue
-        input_sad_list.append(input_case.lower())
-    if "sad_case_type" in metafunc.fixturenames:
-        sad_cases = input_sad_list
-        metafunc.parametrize("sad_case_type", sad_cases, scope="module")
+        selected_sad_list.append(input_case.lower())
+    metafunc.parametrize("sad_case_type", selected_sad_list, scope="module")
 
 
 ### Tetcases to verify normal reboot procedure ###


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: made possible to skip one of 2 similar warmboot test cases
Fixes # (issue)

There are 2 warm-reboot TC sets for `test_warm_reboot_sad` among others: sad and multi-sad.
Such a suite sets port/lag oper/admin state down before reboot and verifies its still down after reboot. The only difference between sad and multi_sad suites is the number of ports selected for the scenario - "sad" selects 1 port only while "multi_sad" selects 2-3.

To reduce test exec time we can skip just "sad" suite and run "multi_sad" suite only as it covers same scenario with more ports checked. Introduced corresponding flags that allow skipping sad/multi_sad test suite - "single_sad_only" and "multi_sad_only".

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Allow one to reduce advanced tests exec time by skipping one of similar test suites
#### How did you do it?
Introduced flags for skipping a desired test
#### How did you verify/test it?
```
pytest platform_tests/test_advanced_reboot.py -k test_warm_reboot_sad --multi_sad_only
pytest platform_tests/test_advanced_reboot.py -k test_warm_reboot_sad --single_sad_only
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
