### PR TITLE
[TACACS] Improve tacacs per-command authorization test case

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -267,6 +267,9 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
     """
         Verify user can't run script with sh/python with following command.
             python ./testscript.py
+
+        NOTE: TACACS UT using tac_plus as server side, there is a bug that tac_plus can't handle a authorization messagecontains more than 10 attributes.
+              Because every command parameter will convert to a TACACS attribute, please don't using more than 5 command parameters in test case.
     """
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, 'echo "" >> ./testscript.py')
     pytest_assert(exit_code == 0)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -268,7 +268,7 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
         Verify user can't run script with sh/python with following command.
             python ./testscript.py
 
-        NOTE: TACACS UT using tac_plus as server side, there is a bug that tac_plus can't handle an authorization messagecontains more than 10 attributes.
+        NOTE: TACACS UT using tac_plus as server side, there is a bug that tac_plus can't handle an authorization message contains more than 10 attributes.
               Because every command parameter will convert to a TACACS attribute, please don't using more than 5 command parameters in test case.
     """
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, 'echo "" >> ./testscript.py')

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -275,7 +275,7 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
     check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 
     # Verify user can't run 'find' command with '-exec' parameter.
-    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "find . -type f -exec /bin/sh ;")
+    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "find . -exec")
     pytest_assert(exit_code == 1)
     check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -268,7 +268,7 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
         Verify user can't run script with sh/python with following command.
             python ./testscript.py
 
-        NOTE: TACACS UT using tac_plus as server side, there is a bug that tac_plus can't handle a authorization messagecontains more than 10 attributes.
+        NOTE: TACACS UT using tac_plus as server side, there is a bug that tac_plus can't handle an authorization messagecontains more than 10 attributes.
               Because every command parameter will convert to a TACACS attribute, please don't using more than 5 command parameters in test case.
     """
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, 'echo "" >> ./testscript.py')


### PR DESCRIPTION
**What I did**
Improve tacacs per-command authorization test case.

**Why I did it**
Currently  per-command authorization test case using tac_plus as AAA server, there is a limitation in current version of tac_plus: can' handle more than 10 attributes in TACACS package.

Currently test code in 'test_bypass_authorization' will send 10 attributes to to tac_plus, then SONiC tacacs been config to send additional attributets in per-command authorization request, the test case will failed.

To fix the issue, remove unnecessary parameters from test case code.

**How I verified it**
Pass all UT.

**Details if related**
