### PR TITLE
[dualtor] Fix ignore bgpmon error regex

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -58,7 +58,7 @@ def temp_enable_bgp_autorestart(duthosts):
 def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
-        ".* ERR bgp#bgpmon: *ERROR* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'"
+        ".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'"
     ]
 
     if loganalyzer:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
dualtor bgp failure testcases suffer from loganalyzer error when syslog has the following entry:
```
Jan 15 10:24:20.577110 demo-hello-2 ERR bgp#bgpmon: *ERROR* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'

```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Fix the regex pattern to match this line

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
