### PR TITLE
Skip checking LineCard that are already on Inventory file Skip module…

### DIFF
--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -71,13 +71,18 @@ def test_show_chassis_module_midplane_status(duthosts, enum_rand_one_per_hwsku_h
 
     for mod_idx in res_mid_status:
         mod_mid_status = res_mid_status[mod_idx]['Reachability']
-        if mod_idx in skip_mod_list:
-            pytest_assert(res_mid_status[mod_idx]['Reachability'] == "False",
-                          "reachability of line card {} expected false but is {}".format(mod_idx, mod_mid_status))
-        else:
+        if mod_idx not in skip_mod_list:
             pytest_assert(mod_mid_status == "True",
                           "midplane reachability of line card {} expected true but is {}".format(mod_idx,
                                                                                                  mod_mid_status))
+        else:
+            # There are cases where the chassis is logically divided where some LCs belongs to another chassis and needs to be skipped
+            # and for those cases we should not assume if skipped means it must be offline.
+            if "LINE-CARD" in mod_idx:
+                logger.info("skip checking midplane status for {} since it is on skip_mod_list".format(mod_idx))
+            else:
+                pytest_assert(mod_mid_status == "False",
+                          "reachability of {} expected false but is {}".format(mod_idx, mod_mid_status))
 
 
 


### PR DESCRIPTION
### Description of PR
In our testbed where we share a physical chassis that uses the same Supervisor card but group different LCs for different "logical chassis" so for some "logical chassis" some LCs are added to "skip_mod_list" as they are not meant to be tested for that logical chassis. Our expectation is that if it is marked as skipped, it is not meant for testing and no state of those skipped modules should be used for any validation logic. We should always trust what the inventory marked as skipped and not try to look at whatever state the "skipped module" should be.
In this particular testcase it is not handling the "logical chassis" scenario correctly and treating the linecards on the skip list must always have "Reachability" being "False".  This logic causes logical testbed to always fail the test.

Summary:
No issue was filed for this yet. This problem was found during internal nightly test runs which we observed this failure on our logical chassis scenario.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
