### PR TITLE
Skip mvrf tests for T2 profile

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -502,9 +502,9 @@ mpls/test_mpls.py:
 #######################################
 mvrf:
   skip:
-    reason: "M0/MX topo does not support mvrf"
+    reason: "M0/MX/T2 topo does not support mvrf"
     conditions:
-      - "topo_name in ['m0', 'mx']"
+      - "topo_name in ['m0', 'mx', 't2']"
 
 #######################################
 #####           nat               #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -502,9 +502,9 @@ mpls/test_mpls.py:
 #######################################
 mvrf:
   skip:
-    reason: "M0/MX/T2 topo does not support mvrf"
+    reason: "M0/MX topo does not support mvrf"
     conditions:
-      - "topo_name in ['m0', 'mx', 't2']"
+      - "topo_name in ['m0', 'mx']"
 
 #######################################
 #####           nat               #####


### PR DESCRIPTION
### Description of PR

Skip mvrf tests for T2 profile.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip mvrf tests for T2 profile.

#### How did you do it?
Updated tests_mark_conditions.yaml for skipping T2 profile

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
