### PR TITLE
Fix stress acl failure in brcm dut

### DIFF
--- a/tests/acl/templates/acltb_test_stress_acl.sh
+++ b/tests/acl/templates/acltb_test_stress_acl.sh
@@ -4,6 +4,7 @@ finished_times=0
 while [[ ${loop_times} > 0 ]]; do
         echo "Load acl rules"
         sonic-cfggen -j /tmp/acltb_test_stress_acl_rules.json -w
+        sleep(1)
         echo "Delete acl rules"
         acl-loader delete STRESS_ACL
         let finished_times+=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Frequent add/delete acl action will cause brcm dut will fail in stress_acl test will error msg: "ERR syncd#syncd: [none] SAI_API_ACL:brcm_sai_get_acl_counter_attribute:5682 Invalid acl table."
#### How did you do it?
The purpose of this testcase is to test stability when add/delete acl rules, not to test responding speed. 
Add 1 second sleep time when add/delete acl rules will fix this error.
#### How did you verify/test it?
Run tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
