### PR TITLE
[testbed] Convert port alias to name when generating connection graph

### DIFF
--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -6,6 +6,13 @@ import os
 import argparse
 from lxml import etree
 
+try:
+    from ansible.module_utils.port_utils import get_port_alias_to_name_map
+except ImportError:
+    # Add parent dir for using outside Ansible
+    sys.path.append('..')
+    from module_utils.port_utils import get_port_alias_to_name_map
+
 DEFAULT_DEVICECSV = 'sonic_lab_devices.csv'
 DEFAULT_LINKCSV = 'sonic_lab_links.csv'
 DEFAULT_CONSOLECSV = 'sonic_lab_console_links.csv'
@@ -17,18 +24,17 @@ LAB_CONNECTION_GRAPH_DPGL2_NAME = 'DevicesL2Info'
 
 class LabGraph(object):
 
-    """ 
+    """
     This is used to create "graph" file of lab for all connections and vlan info from csv file
     We(both engineer and lab technician) maintian and modify the csv file to keep track of the lab
-    infrastucture for Sonic development and testing environment. 
+    infrastucture for Sonic development and testing environment.
     """
 
     def __init__(self, dev_csvfile=None, link_csvfile=None, cons_csvfile=None, pdu_csvfile=None, graph_xmlfile=None):
-        #TODO:make generated xml file name as parameters in the future to make it more flexible
-        self.devices = []
-        self.links =  []
-        self.consoles =  []
-        self.pdus =  []
+        self.devices = {}
+        self.links = []
+        self.consoles = []
+        self.pdus = []
         self.devcsv = dev_csvfile
         self.linkcsv = link_csvfile
         self.conscsv = cons_csvfile
@@ -41,42 +47,56 @@ class LabGraph(object):
         self.csgroot = etree.Element('ConsoleGraphDeclaration')
         self.pcgroot = etree.Element('PowerControlGraphDeclaration')
 
+    def translate_port_alias(self, device_hostname, device_port):
+        """
+        If device_port is port alias, return the corresponding port name.
+        Otherwise, return as is.
+        """
+        devtype = self.devices[device_hostname]['Type'].lower()
+        if devtype == 'devsonic' or 'fanout' in devtype:
+            hwsku = self.devices[device_hostname]['HwSku']
+            port_alias_to_name, _, _ = get_port_alias_to_name_map(hwsku)
+            return port_alias_to_name.get(device_port, device_port)
+        return device_port
+
     def read_devices(self):
         with open(self.devcsv) as csv_dev:
-            csv_devices = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_dev))
+            csv_devices = csv.DictReader(filter(lambda row: row[0] != '#' and len(row.strip()) != 0, csv_dev))
             devices_root = etree.SubElement(self.pngroot, 'Devices')
             pdus_root = etree.SubElement(self.pcgroot, 'DevicesPowerControlInfo')
             cons_root = etree.SubElement(self.csgroot, 'DevicesConsoleInfo')
             for row in csv_devices:
                 attrs = {}
-                self.devices.append(row)
-                devtype=row['Type'].lower()
+                self.devices[row['Hostname']] = row
+                devtype = row['Type'].lower()
                 if 'pdu' in devtype:
-                    for  key in row:
-                        attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(pdus_root, 'DevicePowerControlInfo', attrs)
                 elif 'consoleserver' in devtype:
-                    for  key in row:
-                        attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
                 else:
-                    for  key in row:
-                        if key.lower() != 'managementip' and key.lower() !='protocol':
-                            attrs[key]=row[key].decode('utf-8')
+                    for key in row:
+                        if key.lower() != 'managementip' and key.lower() != 'protocol':
+                            attrs[key] = row[key].decode('utf-8')
                     etree.SubElement(devices_root, 'Device', attrs)
- 
+
     def read_links(self):
         with open(self.linkcsv) as csv_file:
-            csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
+            csv_links = csv.DictReader(filter(lambda row: row[0] != '#' and len(row.strip()) != 0, csv_file))
             links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
             for link in csv_links:
+                link['StartPort'] = self.translate_port_alias(link['StartDevice'], link['StartPort'])
+                link['EndPort'] = self.translate_port_alias(link['EndDevice'], link['EndPort'])
                 attrs = {}
                 for key in link:
                     if key.lower() != 'vlanid' and key.lower() != 'vlanmode':
-                        attrs[key]=link[key].decode('utf-8')
+                        attrs[key] = link[key].decode('utf-8')
                 etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
                 self.links.append(link)
- 
+
     def read_consolelinks(self):
         if not os.path.exists(self.conscsv):
             return
@@ -86,7 +106,7 @@ class LabGraph(object):
             for cons in csv_cons:
                 attrs = {}
                 for key in cons:
-                    attrs[key]=cons[key].decode('utf-8')
+                    attrs[key] = cons[key].decode('utf-8')
                 etree.SubElement(conslinks_root, 'ConsoleLinkInfo', attrs)
                 self.consoles.append(cons)
 
@@ -99,15 +119,14 @@ class LabGraph(object):
             for pdu_link in csv_pdus:
                 attrs = {}
                 for key in pdu_link:
-                    attrs[key]=pdu_link[key].decode('utf-8')
+                    attrs[key] = pdu_link[key].decode('utf-8')
                 etree.SubElement(pduslinks_root, 'PowerControlLinkInfo', attrs)
                 self.pdus.append(pdu_link)
 
     def generate_dpg(self):
-        for dev in self.devices:
-            hostname = dev.get('Hostname', '')
-            managementip = dev.get('ManagementIp', '')
-            devtype = dev['Type'].lower()
+        for hostname in self.devices:
+            managementip = self.devices[hostname].get('ManagementIp', '')
+            devtype = self.devices[hostname]['Type'].lower()
             if not hostname:
                 continue
             if devtype in ('server', 'devsonic'):
@@ -154,6 +173,7 @@ class LabGraph(object):
         result = etree.tostring(root, pretty_print=True)
         onexml.write(result)
 
+
 def get_file_names(args):
     if not args.inventory:
         device, links, console, pdu = args.device, args.links, args.console, args.pdu
@@ -164,6 +184,7 @@ def get_file_names(args):
         pdu = 'sonic_{}_pdu_links.csv'.format(args.inventory)
 
     return device, links, console, pdu
+
 
 def main():
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Using port alias instead of name in `sonic_lab_links.csv` will make connecting cables more convenient. But `connection_graph.xml` requires using port name. So, I improved the `creategraph.py` to support converting port alias to port name when generating `connection_graph.xml`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

For SONiC devices (both DUT and fanout switches), support converting port alias to port name when generating `connection_graph.xml`.

#### How did you do it?

For each SONiC device, collect all the ports appear in `link.csv` and check:

1. If any port in the list is neither port name nor port alias, skip conversion for this device. (To keep the script behavior same as before)
2. If all the ports are valid port alias, convert them to port name.
3. If some ports use port name and others use port alias, raise an Exception to ask user to ensure all ports use port name, or ensure all ports use port alias.

#### How did you verify/test it?

Verified in physical lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
