### PR TITLE
[Mellanox] Fixed nhop_group test failing on SPC1 due to HW limitation

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -13,7 +13,7 @@ import ptf.packet as scapy
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.cisco_data import is_cisco_device
-from tests.common.mellanox_data import is_mellanox_device
+from tests.common.mellanox_data import is_mellanox_device, get_chip_type
 from tests.common.innovium_data import is_innovium_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
@@ -330,6 +330,10 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
         sleep_time = 380
     elif is_innovium_device(duthost):
         default_max_nhop_paths = 3
+        polling_interval = 10
+        sleep_time = 120
+    elif is_mellanox_device(duthost) and get_chip_type(duthost) == 'spectrum1':
+        default_max_nhop_paths = 8
         polling_interval = 10
         sleep_time = 120
     else:

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -24,6 +24,8 @@ pytestmark = [
     pytest.mark.topology('t1', 't2')
 ]
 
+logger = logging.getLogger(__name__)
+
 
 class IPRoutes:
     """
@@ -81,10 +83,7 @@ class IPRoutes:
         """
         with open(self.filename, "w") as fn:
             for ip_nhop in self.ip_nhops:
-
-                ip_route = "sudo {} ip route del {}".format(
-                    self.asic.ns_arg, ip_nhop.prefix
-                )
+                ip_route = "sudo {} ip route del {}".format(self.asic.ns_arg, ip_nhop.prefix)
                 fn.write(ip_route + "\n")
 
         fn.close()
@@ -102,22 +101,19 @@ class Arp:
     Create IP interface and create a list of ARPs with given IP,
     MAC parameters
     """
-    def __init__(
-        self, duthost, asic, count, iface, ip=ipaddr.IPAddress("172.16.0.0"),
-        mac="C0:FF:EE:00"
-    ):
+    def __init__(self, duthost, asic, count, iface, ip=ipaddr.IPAddress("172.16.0.0"), mac="C0:FF:EE:00"):
         IP_MAC = namedtuple("IP_MAC", "ip mac")
         self.iface = iface
         self.ip_mac_list = []
         self.duthost = duthost
         self.asic = asic
-        self.if_addr = "{}/16".format(ip+3)
+        self.if_addr = "{}/16".format(ip + 3)
 
         fileloc = os.path.join(os.path.sep, "tmp")
         self.filename = os.path.join(fileloc, "static_arp.sh")
 
         # create a list of IP-MAC bindings
-        for i in range(11, count+11):
+        for i in range(11, count + 11):
             moff1 = "{0:x}".format(i / 255)
             moff2 = "{0:x}".format(i % 255)
 
@@ -134,7 +130,7 @@ class Arp:
 
         # add IP address to the eth interface
         ip_iface = "ip address add {} dev {}".format(self.if_addr, self.iface)
-        logging.info("IF ADDR ADD {}".format(ip_iface))
+        logger.info("IF ADDR ADD {}".format(ip_iface))
         result = self.asic.command(ip_iface)
         pytest_assert(result["rc"] == 0, ip_iface)
 
@@ -178,7 +174,7 @@ class Arp:
 
         # del IP address from the eth interface
         ip_iface = "ip address del {} dev {}".format(self.if_addr, self.iface)
-        logging.info("IF ADDR DEL {}".format(ip_iface))
+        logger.info("IF ADDR DEL {}".format(ip_iface))
         try:
             self.asic.command(ip_iface)
         except:  # noqa: E722
@@ -234,8 +230,8 @@ def combinations(iterable, r):
         else:
             return
         indices[i] += 1
-        for j in range(i+1, r):
-            indices[j] = indices[j-1] + 1
+        for j in range(i + 1, r):
+            indices[j] = indices[j - 1] + 1
         yield tuple(pool[i] for i in indices)
 
 
@@ -312,7 +308,7 @@ def build_pkt(dest_mac, ip_addr, ttl):
     return pkt, exp_packet
 
 
-def test_nhop_group_member_count(request, duthost, tbinfo):
+def test_nhop_group_member_count(duthost, tbinfo):
     """
     Test next hop group resource count. Steps:
     - Add test IP address to an active IP interface
@@ -347,9 +343,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     asic = duthost.asic_instance()
 
     # find out MAX NHOP group count supported on the platform
-    result = asic.run_redis_cmd(
-        argv=["redis-cli", "-n", 6, "HGETALL", "SWITCH_CAPABILITY|switch"]
-    )
+    result = asic.run_redis_cmd(argv=["redis-cli", "-n", 6, "HGETALL", "SWITCH_CAPABILITY|switch"])
     it = iter(result)
     switch_capability = dict(zip(it, it))
     max_nhop = switch_capability.get("MAX_NEXTHOP_GROUP_COUNT")
@@ -378,7 +372,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     indices = range(arp_count)
     ip_indices = combinations(indices, default_max_nhop_paths)
 
-    # intitialize log analyzer
+    # initialize log analyzer
     marker = "NHOP TEST PATH COUNT {} {}".format(nhop_group_count, eth_if)
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker)
     marker = loganalyzer.init()
@@ -393,7 +387,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
     # increase CRM polling time
     asic.command("crm config polling interval {}".format(polling_interval))
 
-    logging.info("Adding {} next hops on {}".format(nhop_group_count, eth_if))
+    logger.info("Adding {} next hops on {}".format(nhop_group_count, eth_if))
 
     # create nexthop group
     nhop = IPRoutes(duthost, asic)
@@ -432,7 +426,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
             )
         )
     elif is_mellanox_device(duthost):
-        logging.info("skip this check on Mellanox as ASIC resources are shared")
+        logger.info("skip this check on Mellanox as ASIC resources are shared")
     else:
         pytest_assert(
             crm_after["available"] == 0,
@@ -442,7 +436,7 @@ def test_nhop_group_member_count(request, duthost, tbinfo):
         )
 
 
-def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter, gather_facts,
+def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_facts,
                                             enum_rand_one_frontend_asic_index):
     """
     Test SONiC and SAI Vendor capability are same for ordered ecmp feature
@@ -454,15 +448,11 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
 
     asic = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
-    result = asic.run_redis_cmd(
-        argv=["redis-cli", "-n", 6, "HGETALL", "SWITCH_CAPABILITY|switch"]
-    )
+    result = asic.run_redis_cmd(argv=["redis-cli", "-n", 6, "HGETALL", "SWITCH_CAPABILITY|switch"])
     it = iter(result)
     switch_capability = dict(zip(it, it))
 
-    result = asic.run_redis_cmd(
-        argv=["redis-cli", "-n", 0, "HGETALL", "SWITCH_TABLE:switch"]
-    )
+    result = asic.run_redis_cmd(argv=["redis-cli", "-n", 0, "HGETALL", "SWITCH_TABLE:switch"])
 
     it = iter(result)
     switch_table = dict(zip(it, it))
@@ -500,7 +490,7 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
 
     for x in range(2):
         try:
-            # create neighibor entry in different order list
+            # create neighbor entry in different order list
             random.seed(x)
             random.shuffle(arplist.ip_mac_list)
             arplist.arps_add()
@@ -516,8 +506,8 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
 
             ptfadapter.dataplane.flush()
             testutils.send(ptfadapter, gather_facts['dst_port_ids'][0], pkt, 10)
-            (_, recv_pkt) = testutils.verify_packet_any_port(test=ptfadapter,
-                                                             pkt=exp_pkt, ports=gather_facts['src_port_ids'])
+            (_, recv_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
+                                                             ports=gather_facts['src_port_ids'])
 
             assert recv_pkt
 
@@ -526,14 +516,14 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
             pytest_assert(scapy.Ether(recv_pkt).src == rtr_mac, "Routed Packet Source Mac is not router MAC")
             pytest_assert(scapy.Ether(recv_pkt).dst.lower() in neighbor_mac,
                           "Routed Packet Destination Mac not valid neighbor entry")
-            # Add the receive port index and reviced dest mac (Nexthop identify property) to the dictionary
+            # Add the received port index and received dest mac (Nexthop identify property) to the dictionary
             recvd_pkt_result[scapy.Ether(recv_pkt).dst] += 1
         finally:
             nhop.delete_routes()
             arplist.clean_up()
 
     # make sure we should have only one element in dict.
-    pytest_assert(len(recvd_pkt_result.keys()) == 1, "Error Same flow recevied on different nexthop")
+    pytest_assert(len(recvd_pkt_result.keys()) == 1, "Error Same flow received on different nexthop")
     neighbor_ip_selected = original_ip_mac_list[neighbor_mac.index(scapy.Ether(recv_pkt).dst.lower())][0]
 
     # Make sure a given flow always hash to same nexthop/neighbor. This is done to try to find issue
@@ -554,9 +544,9 @@ def test_nhop_group_member_order_capability(request, duthost, tbinfo, ptfadapter
             break
 
     if not dutAsic:
-        # Vendor need to update SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP.
-        # To do this we need to run the test case 1st time and see the neighbor picked by flow (pkt) sent above.
-        # Once that is determine update the map SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP
+        # Vendor need to update SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP . To do this we need to run the test case 1st
+        # time and see the neighbor picked by flow (pkt) sent above. Once that is determined update the map
+        # SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP
         pytest.xfail("ASIC to flow mapping is not define. "
                      "Please read above comment to update map with the given ASIC to flow map")
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Due to limited HW resources on older Spectrum1, need to use a lower value for default_max_nhop_paths.

Summary:
- Fixed failing test on SPC1 due to HW limitation.
- Fixed typos and code quality errors.
- Removed redundant variables
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix failing test and improve code quality

#### How did you do it?
Added condition for Mellanox Spectrum1 to run default_max_nhop_paths = 3

#### How did you verify/test it?
By running the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
