### PR TITLE
Fixes - Platform API tests for test_module & test_watchdog - Changes for PR #4909

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -646,8 +646,10 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_set_low_threshold:
 platform_tests/api/test_watchdog.py:
   skip:
     reason: "Unsupported platform API"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku)"
+      - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0']"
 
 #######################################
 #####           broadcom          #####

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -461,7 +461,7 @@ class TestModuleApi(PlatformApiTestBase):
                 logger.info("skipping reboot for module {} ".format(mod_name))
             else:
                 module_reboot = module.reboot(platform_api_conn, mod_idx, reboot_type)
-                pytest_assert(module_reboot == "True", "module {} reboot failed".format(mod_idx))
+                pytest_assert(module_reboot == bool(True), "module {} reboot failed".format(mod_idx))
                 sleep(reboot_timeout)
                 mod_status = module.get_oper_status(platform_api_conn, mod_idx)
                 pytest_assert(mod_status == "Online", "module {} boot up successful".format(mod_idx))

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -91,6 +91,17 @@ class TestModuleApi(PlatformApiTestBase):
             return True
         return False
 
+    def skip_module_other_than_myself(self, module_num, platform_api_conn):
+        if chassis.is_modular_chassis(platform_api_conn):
+            name = module.get_name(platform_api_conn, module_num)
+            module_slot = module.get_slot(platform_api_conn, module_num)
+            chassis_slot = chassis.get_my_slot(platform_api_conn)
+            if module_slot != chassis_slot:
+                logger.info("Skipping module {} since it is not the same module as myself".format(name))
+                return True
+            return False
+        return False
+
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
@@ -119,6 +130,8 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
                 continue
+            if self.skip_module_other_than_myself(i,platform_api_conn):
+                continue
             model = module.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve module {} model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "Module {} model appears incorrect".format(i))
@@ -128,6 +141,8 @@ class TestModuleApi(PlatformApiTestBase):
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
+                continue
+            if self.skip_module_other_than_myself(i,platform_api_conn):
                 continue
             serial = module.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Module {}: Failed to retrieve serial number".format(i)):
@@ -173,6 +188,8 @@ class TestModuleApi(PlatformApiTestBase):
         # TODO: Add expected base MAC address for each module to inventory file and compare against it
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
+                continue
+            if self.skip_module_other_than_myself(i,platform_api_conn):
                 continue
             # Need to skip FABRIC-CARDx as they do not have base_mac assigned
             mod_name = module.get_name(platform_api_conn, i)
@@ -220,7 +237,8 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
                 continue
-
+            if self.skip_module_other_than_myself(i,platform_api_conn):
+                continue
             # Need to skip FABRIC-CARDx as they do not have system_eeprom info
             mod_name = module.get_name(platform_api_conn, i)
             if "FABRIC-CARD" in mod_name:
@@ -437,6 +455,8 @@ class TestModuleApi(PlatformApiTestBase):
         reboot_timeout = 300
         for mod_idx in range(self.num_modules):
             mod_name = module.get_name(platform_api_conn, mod_idx)
+            if self.skip_module_other_than_myself(mod_idx,platform_api_conn):
+                continue
             if mod_name in self.skip_mod_list:
                 logger.info("skipping reboot for module {} ".format(mod_name))
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- These changes SKIP other modules and verify _model_, _serial_, _base_mac_ and _syseprom_ only for the modules myself. For example, LC in case of line card and SUP in case of supervisor card.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- These changes help to SKIP for other modules than myself. For example, SKIP supervisor card in case if the module is line card and SKIP line card in case if the module is supervisor card and verify the parameters.

#### How did you do it?
- Get the chassis-slot and module-slot and verify if both are same. If not, SKIP the current module and proceed with the next one.

#### How did you verify/test it?
- Ran the platform test_module API test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="1657" alt="test_module_result" src="https://user-images.githubusercontent.com/114024719/213511387-af029f27-1f60-481e-bf9a-e99fc3efbe60.PNG">
