### PR TITLE
[sonichost]: Remove teamd from default services for DPU

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -73,7 +73,7 @@ class MultiAsicSonicHost(object):
             # Update the asic service based on feature table state and asic flag
             config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
             for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
-                if service == "teamd" and config_facts['DEVICE_METADATA']['localhost']['switch_type'] == 'dpu':
+                if service == 'teamd' and config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu':
                     logger.warning("Removing teamd from default services for switch_type DPU")
                     self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                     continue

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -73,6 +73,10 @@ class MultiAsicSonicHost(object):
             # Update the asic service based on feature table state and asic flag
             config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
             for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
+                if service == "teamd" and config_facts['DEVICE_METADATA']['localhost']['switch_type'] == 'dpu':
+                    logger.warning("Removing teamd from default services for switch_type DPU")
+                    self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
+                    continue
                 if config_facts['FEATURE'][service]['has_per_asic_scope'] == "False":
                     self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 if config_facts['FEATURE'][service]['state'] == "disabled":


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, the teamd service is not included in images built for DPU devices.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
