### PR TITLE
[cherry-pick 202205 ] sonic port alias2name

### DIFF
--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -23,6 +23,7 @@ class FanoutHost(object):
         self.fanout_to_host_port_map = {}
         if os == 'sonic':
             self.os = os
+            self.fanout_port_alias_to_name = {}
             self.host = SonicHost(ansible_adhoc, hostname,
                                   shell_user=shell_user,
                                   shell_passwd=shell_passwd)
@@ -66,6 +67,9 @@ class FanoutHost(object):
                 raise AttributeError("Host of type {} does not contain a"
                                      "'shutdown_multiple' method"
                                      .format(type(self.host)))
+        if self.os == 'sonic':
+            if interface_name in self.fanout_port_alias_to_name.keys():
+                return self.host.shutdown(self.fanout_port_alias_to_name[interface_name])
 
         return self.host.shutdown(interface_name)
 
@@ -85,6 +89,10 @@ class FanoutHost(object):
                 raise AttributeError("Host of type {} does not contain a"
                                      "'no_shutdown_multiple' method"
                                      .format(type(self.host)))
+
+        if self.os == 'sonic':
+            if interface_name in self.fanout_port_alias_to_name.keys():
+                return self.host.no_shutdown(self.fanout_port_alias_to_name[interface_name])
 
         return self.host.no_shutdown(interface_name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,6 +535,13 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
                                         shell_passwd=shell_password)
                     fanout.dut_hostnames = [dut_host]
                     fanout_hosts[fanout_host] = fanout
+
+                    if fanout.os == 'sonic':
+                        ifs_status = fanout.host.get_interfaces_status()
+                        for key, interface_info in ifs_status.items():
+                            fanout.fanout_port_alias_to_name[interface_info['alias']] = interface_info['interface']
+                        logging.info("fanout {} fanout_port_alias_to_name {}".format(fanout_host, fanout.fanout_port_alias_to_name))
+
                 fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
 
                 # Add port name to fanout port mapping port if dut_port is alias.


### PR DESCRIPTION
add fanout_port_alias_to_name for sonic fanout device support input alias name to shutdown interface for sonic fanout device

Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Cherry pick support input alias to shutdown interface in Sonic #7233

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Sonic CLI does not support using interface alias to shutdown the interface.

#### How did you do it?
Cherry pick support input alias to shutdown interface in Sonic #7233

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
