### PR TITLE
[chassis][T2] - Fix gen-mg for multi-asic T2 linecards when there is no '-ASIC' in the asic_port_name in port_config.ini

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -257,6 +257,7 @@
   - name: find all interface asic names
     set_fact:
       vm_asic_ifnames: "{{ vm_asic_ifnames | default({}) | combine({item.0.name: vm_asic_ifnames[item.0.name]|default([]) + [ front_panel_asic_ifnames[item.1]] }) }}"
+      vm_asic_ids: "{{ vm_asic_ids | default({}) | combine({item.0.name: vm_asic_ids[item.0.name]|default([]) + [ front_panel_asic_ifs_asic_id[item.1]] }) }}"
     with_subelements:
       - "{{ interface_to_vms }}"
       - "ports"

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -98,15 +98,13 @@ def parse_asic_external_link(link, asic_name, hostname):
     # if chassis internal is false, the interface name will be
     # interface alias which should be converted to asic port name
     if (enddevice.lower() == hostname.lower()):
-        if ((endport in port_alias_to_port_asic_alias_map) and
-                (asic_name.lower() in port_alias_to_port_asic_alias_map[endport].lower())):
+        if endport in port_alias_to_port_asic_alias_map:
             endport = port_alias_to_port_asic_alias_map[endport]
             neighbors[port_alias_asic_map[endport]] = {'name': startdevice, 'port': startport}
             if bandwidth:
                 port_speeds[port_alias_map[endport]] = bandwidth
     elif (startdevice.lower() == hostname.lower()):
-        if ((startport in port_alias_to_port_asic_alias_map) and
-                (asic_name.lower() in port_alias_to_port_asic_alias_map[startport].lower())):
+        if startport in port_alias_to_port_asic_alias_map:
             startport = port_alias_to_port_asic_alias_map[startport]
             neighbors[port_alias_asic_map[startport]] = {'name': enddevice, 'port': endport}
             if bandwidth:

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -103,6 +103,7 @@ class SonicPortAliasMap():
         portspeed = {}
         # Front end interface asic names
         front_panel_asic_ifnames = {}
+        front_panel_asic_id = {}
         # All asic names
         asic_if_names = []
         sysports = []
@@ -172,6 +173,7 @@ class SonicPortAliasMap():
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
                             front_panel_asic_ifnames[alias] = asicifname
+                            front_panel_asic_id[alias] = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):
                         asicifname = mapping[asic_name_index]
                         asic_if_names.append(asicifname)
@@ -206,7 +208,7 @@ class SonicPortAliasMap():
             sysport['hostname'] = hostname
             sysports.insert(0, sysport)
 
-        return (aliases, portmap, aliasmap, portspeed, front_panel_asic_ifnames, asic_if_names,
+        return (aliases, portmap, aliasmap, portspeed, front_panel_asic_ifnames, front_panel_asic_id, asic_if_names,
                 sysports)
 
 def main():
@@ -231,6 +233,7 @@ def main():
         sysports = []
         # Map of ASIC interface names to front panel interfaces
         front_panel_asic_ifnames = {}
+        front_panel_asic_ifs_asic_id = {}
         # { asic_name: [ asic interfaces] }
         asic_if_names = {}
 
@@ -240,6 +243,7 @@ def main():
                                            'port_alias_map': aliasmap,
                                            'port_speed': portspeed,
                                            'front_panel_asic_ifnames': [],
+                                           'front_panel_asic_ids': [],
                                            'asic_if_names': asic_if_names,
                                            'sysports': sysports})
            return
@@ -281,8 +285,8 @@ def main():
                 switchid = switchids[asic_id]
             if num_asic == 1:
                 asic_id = None
-            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic,
-             sysport_asic) = allmap.get_portmap(asic_id, include_internal, hostname, switchid, slotid)
+            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, front_panel_asic_ids,
+             asicifnames_asic, sysport_asic) = allmap.get_portmap(asic_id, include_internal, hostname, switchid, slotid)
             if aliases_asic is not None:
                 aliases.extend(aliases_asic)
             if portmap_asic is not None:
@@ -293,6 +297,8 @@ def main():
                 portspeed.update(portspeed_asic)
             if front_panel_asic is not None:
                 front_panel_asic_ifnames.update(front_panel_asic)
+            if front_panel_asic_ids is not None:
+                front_panel_asic_ifs_asic_id.update(front_panel_asic_ids)
             if asicifnames_asic is not None:
                 asic = 'ASIC' + str(asic_id)
                 asic_if_names[asic] = asicifnames_asic
@@ -303,15 +309,18 @@ def main():
         aliases.sort(key=lambda x: int(x[1]))
         # Get ASIC interface names list based on sorted aliases
         front_panel_asic_ifnames_list = []
+        front_panel_asic_ifs_asic_id_list = []
         for k in aliases:
             if k[0] in front_panel_asic_ifnames:
                 front_panel_asic_ifnames_list.append(front_panel_asic_ifnames[k[0]])
+                front_panel_asic_ifs_asic_id_list.append(front_panel_asic_ifs_asic_id[k[0]])
 
         module.exit_json(ansible_facts={'port_alias': [k[0] for k in aliases],
                                         'port_name_map': portmap,
                                         'port_alias_map': aliasmap,
                                         'port_speed': portspeed,
                                         'front_panel_asic_ifnames': front_panel_asic_ifnames_list,
+                                        'front_panel_asic_ifs_asic_id': front_panel_asic_ifs_asic_id_list,
                                         'asic_if_names': asic_if_names,
                                         'sysports': sysports})
 

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -18,7 +18,7 @@
 {% if vm_asic_ifnames is defined %}
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>{{ vm_asic_ifnames[vm][0].split('-')[1] }}</StartRouter>
+        <StartRouter>{{ vm_asic_ids[vm][0] }}</StartRouter>
         <StartPeer>{{ vm_topo_config['vm'][vm]['bgp_ipv4'][dut_index|int] }}</StartPeer>
         <EndRouter>{{ vm }}</EndRouter>
         <EndPeer>{{ vm_topo_config['vm'][vm]['peer_ipv4'][dut_index|int] }}</EndPeer>
@@ -40,7 +40,7 @@
       </BGPSession>
 {% if vm_asic_ifnames is defined %}
       <BGPSession>
-        <StartRouter>{{ vm_asic_ifnames[vm][0].split('-')[1] }}</StartRouter>
+        <StartRouter>{{ vm_asic_ids[vm][0] }}</StartRouter>
         <StartPeer>{{ vm_topo_config['vm'][vm]['bgp_ipv6'][dut_index|int] }}</StartPeer>
         <EndRouter>{{ vm }}</EndRouter>
         <EndPeer>{{ vm_topo_config['vm'][vm]['peer_ipv6'][dut_index|int] }}</EndPeer>
@@ -207,7 +207,7 @@
         <a:Hostname>{{ asic }}</a:Hostname>
         <a:Peers>
 {% for index in range( vms_number) %}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic %}
           <BGPPeer>
             <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
             <RouteMapIn i:nil="true"/>

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -92,7 +92,7 @@
       <PortChannelInterfaces>
 {% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic_name %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(vm_asic_ifnames[vms[index]])  %}
         <PortChannel>
@@ -138,7 +138,7 @@
       <IPInterfaces>
 {% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic_name %}
 {% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
         <IPInterface>
           <Name i:nil="true"/>
@@ -271,7 +271,7 @@
 {%- set acl_intfs = [] -%}
 {% if card_type is not defined or card_type != 'supervisor' %}
 {%- for index in range(vms_number) %}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic_name %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% set a_intf = 'PortChannel' + '10' + ((index+1)|string) %}
 {{- acl_intfs.append(a_intf) -}}
@@ -284,7 +284,7 @@
 {{- acl_intfs.append(a_intf) -}}
 {% endfor %}
 {%- for index in range(vms_number) -%}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic_name %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
 {% set a_intf = front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
 {{- acl_intfs.append(a_intf) -}}

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -83,7 +83,7 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
-{% for asic_intf in front_panel_asic_ifnames %}
+{% for if_index in range(front_panel_asic_ifnames | length) %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
 {% if port_alias[loop.index - 1] in port_speed %}
@@ -92,8 +92,8 @@
         <Bandwidth>40000</Bandwidth>
 {% endif %}
         <ChassisInternal>true</ChassisInternal>
-        <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
-        <EndPort>{{ asic_intf }}</EndPort>
+        <EndDevice>{{ front_panel_asic_ifs_asic_id[if_index] }}</EndDevice>
+        <EndPort>{{ front_panel_asic_ifnames[if_index] }}</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>{{ inventory_hostname }}</StartDevice>
         <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PR# [13053](https://github.com/sonic-net/sonic-buildimage/pull/13053) broken gen-mg/deploy-mg and minigraph_neigbors in minigraph_facts ansible module.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PR# [13053](https://github.com/sonic-net/sonic-buildimage/pull/13053) removed -ASIC<asic_id> from the asic_port_name for the Nokia linecards in the T2 VoQ chassis. However, this broke:
- gen-mg/deploy-mg utilities
   - The reason for the failure was that the templates used for generating the minigraph were expecting a '-' in the asic_port_name and would split the asic_port_name on '-' to get the asic to which the port belongs. Without the -ASIC<asic_id> in the asic_port_name, we get index out of bound exception.

- the minigraph_neighbors list in the ansible facts return by the minigraph_facts module for a asic would be empty
  - For the minigraph_neighbors being empty, there was check in parse_asic_external_neighbors whether the asic_name.lower() is in the port_alias_to_port_asic_alias_map.
  
#### How did you do it?
Fixes:
- gen-mg/deploy-mg:
   - Modify port_alias to return a list 'front_panel_asic_ifs_asic_id' that is a list of asics to which the front panel port belongs to. Example: ['ASIC0', 'ASIC0', ..... , 'ASIC1', ASIC1, ...]. The length of this array is the same as front_panel_asic_ifnames returned from port_alias - so we have a one-to-one mapping between the front_panel asic ifname and the asic to which it belongs.

     In the templates to generate, we then use this new 'front_panel_asic_ifs_asic_id' instead of the split on '-' to get the asic id to which a port belongs.

- minigraph_neighbors:
   - Ignore the check for asic_name as port_alias_to_port_asic_alias_map is derived for the asic in consideration anyways - so this check is not required.

#### How did you verify/test it?
Ran gen-mg/deploy-mg against chassis with Nokia'a multi-asic linecards and validated minigraph_neighbors is not empty.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
