### PR TITLE
[chassis][T2] Ignore 'Invalid port id' error messages in syslog related to pfc and mc counters

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -170,3 +170,4 @@ r, ".* ERR CCmisApi:.*system_service.*Broken pipe.*"
 r, ".*ERR kernel: \[.*\] AMD-Vi: Event logged \[IO_PAGE_FAULT device=00:13.1 domain=0x0009 address=0x0 flags=0x0000\].*"
 
 r, ".*WARNING kernel: .*linux_knet_cb.*linux_bcm_knet.*linux_user_bde.*linux_kernel_bde.*xt_TCPMSS.*8021q.*garp.*mrp.*dummy.*"
+r, ".* ERR .*CounterCheck: Invalid port oid.*"


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
After PR# [2602](https://github.com/sonic-net/sonic-swss/pull/2606) was added, we started periodically seeing error messages like below in the syslot
```
   ERR swss1#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x15d00000000007b
   ERR swss0#orchagent: :- mcCounterCheck: Invalid port oid 0x5d000000000026
```
#### How did you do it?
Issue is going to be raised for this against sonic-buildimage. 
But, until the issue is resolved, we are ignoring such error messages

#### How did you verify/test it?
Ran tests against T2 chassis and made sure that the tests don't error out

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
