### PR TITLE
fix output parsing for some EOS commands

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -315,12 +315,12 @@ class EosHost(AnsibleHostBase):
 
     def get_speed(self, interface_name):
         output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
-        found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
+        found_txt = re.search(r'Operational [Ss]peed: (\d+)G', output['stdout'][0])
         if found_txt is None:
             _raise_err('Not able to extract interface %s speed from output: %s' % (interface_name, output['stdout']))
 
         v = found_txt.groups()[0]
-        return v[:-1] + '000'
+        return v + '000'
 
     def _has_cli_cmd_failed(self, cmd_output_obj):
         err_out = False
@@ -366,7 +366,7 @@ class EosHost(AnsibleHostBase):
                     'show interface {} hardware'.format(interface_name)]
         for command in commands:
             output = self.eos_command(commands=[command])
-            found_txt = re.search("Speed/Duplex: (.+)", output['stdout'][0])
+            found_txt = re.search("Speed/[Dd]uplex: (.+)", output['stdout'][0])
             if found_txt is not None:
                 break
 
@@ -379,7 +379,10 @@ class EosHost(AnsibleHostBase):
 
         def extract_speed_only(v):
             return re.match(r'\d+', v.strip()).group() + '000'
-        return list(map(extract_speed_only, speed_list))
+
+        speed_list = map(extract_speed_only, speed_list)
+        uniq_speeds = set(speed_list)
+        return list(uniq_speeds)
 
     def get_dut_iface_mac(self, interface_name):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix output parsing for some EOS commands
Fixes # (issue)

Noticed there's some small diff in command outputs of different EOS versions that may cause output parsing to fail. Fixed
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
