### PR TITLE
[Chassis] Remove skip to allow the  test_reboot_supervisor to run on chassis

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -154,7 +154,6 @@ def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo):
                              dev=vm_host_to_A, size=size, ttl=ttl)
 
 
-@pytest.mark.skip(reason="Not yet implemented - reboot of supervisor does not reset line cards.")
 def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs, tbinfo):
     """
     Tests the system after supervisor reset, all cards should reboot and interfaces/neighbors should be in sync across


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Remove skip to allow the test test_reboot_supervisor to run
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Remove skip to allow the test test_reboot_supervisor to run

#### How did you do it?
Remove skip to allow the test test_reboot_supervisor 

#### How did you verify/test it?
Ran test case test_reboot_supervisor on multi cards multi ASICs chassis.
 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
