### PR TITLE
Fix generate_dut_backend_asics when multiple DUTs are selected

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1207,7 +1207,7 @@ def generate_dut_backend_asics(request, duts_selected):
     metadata = get_testbed_metadata(request)
 
     if metadata is None:
-        return [[None]]
+        return [[None]]*len(duts_selected)
 
     for dut in duts_selected:
         mdata = metadata.get(dut)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1212,7 +1212,7 @@ def generate_dut_backend_asics(request, duts_selected):
     for dut in duts_selected:
         mdata = metadata.get(dut)
         if mdata is None:
-            continue
+            dut_asic_list.append([None]) 
         dut_asic_list.append(mdata.get("backend_asics", [None]))
 
     return dut_asic_list


### PR DESCRIPTION
to run test

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Error seen at the test collection stage when running all tests on a testbed which consists of multiple frontend HwSKUs.
Error log:
```
_________________ ERROR collecting tests/qos/test_qos_masic.py _________________
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:234: in pytest_pycollect_makeitem
    res = list(collector._genfunctions(name, obj))
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:410: in _genfunctions
    self.ihook.pytest_generate_tests(metafunc=metafunc)
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
conftest.py:1279: in pytest_generate_tests
    for a_asic in asics_selected[a_dut_index]:
E   IndexError: list index out of range
```
This is because test_qos_masic_dscp_queue_mapping() uses fixtures: enum_rand_one_per_hwsku_frontend_hostname, enum_backend_asic_index
The collection will fail to parametrize using enum_backend_asic_index if number of duts selected is more than 1 for fixture enum_rand_one_per_hwsku_frontend_hostname and if metadata is empty.

#### How did you do it?
If metadata is empty then currently a list is returned assuming that number of DUT selected is 1.
Fix is to make sure that:
1. If metadata is empty, we return None asic_index for each dut selected.
2. If metadata is not empty, append None asic_index for dut that is not available in metadata.
#### How did you verify/test it?
py test collection succeeds after this fix.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
