### PR TITLE
Fixed "TypeError: __init__() takes exactly 8 arguments (7 given)"

### DIFF
--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -273,7 +273,7 @@ class ContinuousReboot:
             format(self.test_failures, self.reboot_count))
 
 
-    def start_continuous_reboot(self, request, duthost, ptfhost, localhost, tbinfo, creds):
+    def start_continuous_reboot(self, request, duthosts, duthost, ptfhost, localhost, tbinfo, creds):
         self.test_set_up()
         # Start continuous warm/fast reboot on the DUT
         for count in range(self.continuous_reboot_count):
@@ -284,7 +284,7 @@ class ContinuousReboot:
                 .format(self.reboot_count, self.continuous_reboot_count, self.reboot_type))
             reboot_type = self.reboot_type + "-reboot"
             try:
-                self.advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, tbinfo, creds,\
+                self.advancedReboot = AdvancedReboot(request, duthosts, duthost, ptfhost, localhost, tbinfo, creds,\
                     rebootType=reboot_type, moduleIgnoreErrors=True)
             except Exception:
                 self.sub_test_result = False
@@ -349,5 +349,5 @@ def test_continuous_reboot(request, duthosts, rand_one_dut_hostname, ptfhost, lo
     """
     duthost = duthosts[rand_one_dut_hostname]
     continuous_reboot = ContinuousReboot(request, duthost, ptfhost, localhost, conn_graph_facts)
-    continuous_reboot.start_continuous_reboot(request, duthost, ptfhost, localhost, tbinfo, creds)
+    continuous_reboot.start_continuous_reboot(request, duthosts, duthost, ptfhost, localhost, tbinfo, creds)
     continuous_reboot.test_teardown()


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed "TypeError: __init__() takes exactly 8 arguments (7 given)" in test platform_tests/test_cont_warm_reboot.py which happen after merge community code. Issue introduced in PR: https://github.com/sonic-net/sonic-mgmt/pull/6968 - [advanced-reboot] IO path verification fixes for dualtor


Summary: Fixed "TypeError: __init__() takes exactly 8 arguments (7 given)"
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix issue "TypeError: __init__() takes exactly 8 arguments (7 given)"

#### How did you do it?
Added argument in method call

#### How did you verify/test it?
Executed test which has been modified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
