### PR TITLE
Added try/except block in case when we do get for routes from EOS hosts in parallel

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -182,8 +182,11 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
         if entry:
             routes[entry] = community
         results[hostname] = routes
-
-    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
+    try:
+        all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
+    except BaseException as err:
+        logger.error('Failed to get routes info from VMs. Got error: {}\n\nTrying one more time.'.format(err))
+        all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
     return all_routes
 
 


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Added try/except block in case when we do get for routes from EOS hosts in parallel
It seems like some bug in Ansible parallel execution.

Sometimes parallel call to EOS hosts may fail(~5%-10% of runs) Added try/except block which solved this issue, example of failure and retry:
```
17:35:44 test_traffic_shift.parse_routes_on_eos   L0188 ERROR  | Failed to get routes info from VMs. Got error: Processes "['parse_routes_process--<EosHost VM1914>']" failed with exit code ""
Exception:

Traceback:

Trying one more time.
17:35:44 parallel.parallel_run                    L0152 DEBUG  | Started process 62251 running target "parse_routes_process--<EosHost VM1903>"
```

Summary: Added try/except block in case when we do get for routes from EOS hosts in parallel
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fixed failure which happen time to time when  we do get for routes from EOS hosts in parallel

#### How did you do it?
Added try/except block and retry after failure

#### How did you verify/test it?
Executed test case which has been modified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
