### PR TITLE
Changed the bidirectional traffic-flow check to unidirection in ixia pfcwd script for cisco-8000

### DIFF
--- a/tests/ixia/pfcwd/conftest.py
+++ b/tests/ixia/pfcwd/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from tests.common.cisco_data import is_cisco_device
+@pytest.fixture
+def setup_cgm_alpha_cisco(duthost):
+    if not is_cisco_device(duthost):
+        return
+    duthost.shell("mmuconfig -p pg_lossless_100000_300m_profile -a -6")
+    yield
+    duthost.shell("mmuconfig -p pg_lossless_100000_300m_profile -a -2")
+
+

--- a/tests/ixia/pfcwd/test_pfcwd_a2a.py
+++ b/tests/ixia/pfcwd/test_pfcwd_a2a.py
@@ -7,11 +7,13 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
+from tests.common.cisco_data import is_cisco_device
 
 from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from files.helper import skip_pfcwd_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
+
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
 def test_pfcwd_all_to_all(ixia_api,
@@ -21,6 +23,7 @@ def test_pfcwd_all_to_all(ixia_api,
                           duthosts,
                           rand_one_dut_hostname,
                           rand_one_dut_portname_oper_up,
+                          setup_cgm_alpha_cisco,
                           rand_one_dut_lossless_prio,
                           lossy_prio_list,
                           prio_dscp_map,

--- a/tests/ixia/pfcwd/test_pfcwd_a2a.py
+++ b/tests/ixia/pfcwd/test_pfcwd_a2a.py
@@ -7,7 +7,6 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
-from tests.common.cisco_data import is_cisco_device
 
 from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from files.helper import skip_pfcwd_test

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -7,7 +7,6 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
-from tests.common.cisco_data import is_cisco_device
 
 from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from files.helper import skip_pfcwd_test

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -7,11 +7,13 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
+from tests.common.cisco_data import is_cisco_device
 
 from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from files.helper import skip_pfcwd_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
+
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
 def test_pfcwd_many_to_one(ixia_api,
@@ -20,6 +22,7 @@ def test_pfcwd_many_to_one(ixia_api,
                            fanout_graph_facts,
                            duthosts,
                            rand_one_dut_hostname,
+                           setup_cgm_alpha_cisco,
                            rand_one_dut_portname_oper_up,
                            rand_one_dut_lossless_prio,
                            lossy_prio_list,


### PR DESCRIPTION
Resubmitting instead of #6511.

Cisco-8000 platform forwards the rx traffic in a port that is also receiving Xoff. This was recently done. The ixia/pfcwd scripts assume that the bi-directional traffic will drop. This will fail. This PR fixes this.

What is the motivation for this PR?

When a port is receiving xoff, these a2a and m2o test cases assume that the receiving traffic will be dropped. But this asusmption is not valid for Cisco-8000. Due to this, the tests are failing. The check needs to be adjusted for cisco 8000 platform.
Also since the traffic is directly connected routes, we need to lower the CGM alpha value, so that the pfc response kicks in due to lower amount of memory available for queue.
How did you do it?
Added a check for cisco-8000 platform to verify only in the forwarding direction, not the reverse direction.
Also added a code to reduce the CGM value for cisco-8000 platform and revert it at the end of the script.

How did you verify/test it?
Ran it on my testbed, and verified that the failing cases are passing now.

@kevinskwang , pls check. I have kept only the required changes, and removed the other pre-submit related changes.