### PR TITLE
[chassis] [link down test] [test refine] error out unexpected link status, save runtime

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -121,11 +121,12 @@ class EosHost(AnsibleHostBase):
             if output_port in ports:
                 if port_status == 'notconnect':
                     logging.info("Interface {} is down on {}".format(output_port, self.hostname))
-                else if port_status == 'connected':
-                    logging.info("Interface {} is up on {}".format(output_port, self.hostname))
-                    return False
                 else:
-                    logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
+                    if port_status == 'connected':
+                        logging.info("Interface {} is up on {}".format(output_port, self.hostname))
+                    else:
+                        logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
+                    return False               
         return True
 
     def links_status_up(self, ports):
@@ -142,11 +143,12 @@ class EosHost(AnsibleHostBase):
             if output_port in ports:
                 if port_status == 'connected':
                     logging.info("Interface {} is up on {}".format(output_port, self.hostname))
-                else if port_status == 'notconnect':
-                    logging.info("Interface {} is down on {}".format(output_port, self.hostname))
-                    return False
                 else:
-                    logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
+                    if port_status == 'notconnect':
+                        logging.info("Interface {} is down on {}".format(output_port, self.hostname))
+                    else:
+                        logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
+                    return False
         return True
 
     def set_interface_lacp_rate_mode(self, interface_name, mode):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -133,7 +133,7 @@ class EosHost(AnsibleHostBase):
         for output_line in show_int_result['stdout_lines'][0]:
             """
             (Pdb) output_line
-            u'Et33/1     str2-7804-lc6-1-Ethernet0            notconnect   1134     full   100G   100GBASE-CR4
+            u'Et37/1     str2-7804-lc6-1-Ethernet16           connected    1138     full   100G   100GBASE-CR4
             """
             items = re.split("\s+", output_line)
             output_port = items[0].replace('Et', 'Ethernet')

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -123,13 +123,11 @@ class EosHost(AnsibleHostBase):
             if output_port in ports:
                 if 'notconnect' in output_line:
                     logging.info("Interface {} is down on {}".format(output_port, self.hostname))
-                    continue
-                if 'connected' in output_line:
+                else if 'connected' in output_line:
                     logging.info("Interface {} is up on {}".format(output_port, self.hostname))
                     return False
                 else:
-                    logging.info("Please check status for interface {} on {}".format(output_port, self.hostname))
-                    return False
+                    logger.error("Interface {} on {} is unexpected, please check link status".format(output_port, self.hostname))
         return True
 
     def links_status_up(self, ports):
@@ -148,13 +146,11 @@ class EosHost(AnsibleHostBase):
             if output_port in ports:
                 if 'connected' in output_line:
                     logging.info("Interface {} is up on {}".format(output_port, self.hostname))
-                    continue
-                if 'notconnect' in output_line:
+                else if 'notconnect' in output_line:
                     logging.info("Interface {} is down on {}".format(output_port, self.hostname))
                     return False
                 else:
-                    logging.info("Please check status for interface {} on {}".format(output_port, self.hostname))
-                    return False
+                    logger.error("Interface {} on {} is unexpected, please check link status".format(output_port, self.hostname))
         return True
 
     def set_interface_lacp_rate_mode(self, interface_name, mode):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -111,46 +111,42 @@ class EosHost(AnsibleHostBase):
         show_int_result = self.eos_command(commands=['show interface status'])
         for output_line in show_int_result['stdout_lines'][0]:
             """
-            Note:
             (Pdb) output_line
             u'Et33/1     str2-7804-lc6-1-Ethernet0            notconnect   1134     full   100G   100GBASE-CR4
-            e.g.
-            (Pdb) output_line.split(' ')[0]
-            u'Et1/1'
             """
-            output_port = output_line.split(' ')[0].replace('Et', 'Ethernet')
+            items = re.split("\s+", output_line)
+            output_port = items[0].replace('Et', 'Ethernet')
+            port_status = items[2]
             # Only care about port that connect to current DUT
             if output_port in ports:
-                if 'notconnect' in output_line:
+                if port_status == 'notconnect':
                     logging.info("Interface {} is down on {}".format(output_port, self.hostname))
-                else if 'connected' in output_line:
+                else if port_status == 'connected':
                     logging.info("Interface {} is up on {}".format(output_port, self.hostname))
                     return False
                 else:
-                    logger.error("Interface {} on {} is unexpected, please check link status".format(output_port, self.hostname))
+                    logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
         return True
 
     def links_status_up(self, ports):
         show_int_result = self.eos_command(commands=['show interface status'])
         for output_line in show_int_result['stdout_lines'][0]:
             """
-            Note:
             (Pdb) output_line
             u'Et33/1     str2-7804-lc6-1-Ethernet0            notconnect   1134     full   100G   100GBASE-CR4
-            e.g.
-            (Pdb) output_line.split(' ')[0]
-            u'Et1/1'
             """
-            output_port = output_line.split(' ')[0].replace('Et', 'Ethernet')
+            items = re.split("\s+", output_line)
+            output_port = items[0].replace('Et', 'Ethernet')
+            port_status = items[2]
             # Only care about port that connect to current DUT
             if output_port in ports:
-                if 'connected' in output_line:
+                if port_status == 'connected':
                     logging.info("Interface {} is up on {}".format(output_port, self.hostname))
-                else if 'notconnect' in output_line:
+                else if port_status == 'notconnect':
                     logging.info("Interface {} is down on {}".format(output_port, self.hostname))
                     return False
                 else:
-                    logger.error("Interface {} on {} is unexpected, please check link status".format(output_port, self.hostname))
+                    logger.error("Interface {} status is {} on {}".format(output_port, port_status, self.hostname))
         return True
 
     def set_interface_lacp_rate_mode(self, interface_name, mode):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

no functionality change
1. Error out unexpected link status on fanout:
There are cases where eos fanout has link disabled by CLI manually:
```Et57/1     str2-7804-lc6-1-Ethernet96           disabled     1158     full   100G   100GBASE-CR4   ```
This PR help to identify this kind of root cause and error out in log

2. save runtime
`if 'connected' in output_line` does a string search inside for loop, new change will save runtime by string comparison
3. change sequence of 2 tests, test on host first, then on sup
reason: if sup test failed, it takes longer time for all fanout links to come up, then later when testing on linecards, it'll need to wait for some time in `links_up` check.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
