### PR TITLE
[QoS] remove platform dependent code in qos_sai_base.py

### DIFF
--- a/tests/qos/files/brcm/qos_param_generator.py
+++ b/tests/qos/files/brcm/qos_param_generator.py
@@ -18,7 +18,7 @@ class QosParamBroadcom(object):
                  dualTor,
                  dutTopo,
                  bufferConfig,
-                 asicConfig,
+                 dutHost,
                  testbedTopologyName,
                  verbose=True):
         self.qos_params = qos_params

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -935,35 +935,6 @@ class QosSaiBase(QosBase):
             logger.info(err)
         return bufferConfig
 
-    def dutAsicConfig(self, asic, duthost):
-        asicConfig = {}
-        # Only support to get brcm asic info, so far
-        if 'broadcom' in asic.lower():
-            try:
-                output = duthost.shell('bcmcmd "g THDI_BUFFER_CELL_LIMIT_SP"', module_ignore_errors=True)
-                logger.info('Read ASIC THDI_BUFFER_CELL_LIMIT_SP register, output {}'.format(output))
-                for line in output['stdout'].replace('\r', '\n').split('\n'):
-                    if line:
-                        m = re.match('THDI_BUFFER_CELL_LIMIT_SP\(0\).*\<LIMIT=(\S+)\>', line)
-                        if m:
-                            asicConfig['ingress_shared_limit_sp0'] = int(m.group(1), 0)
-                            break
-
-                output = duthost.shell('bcmcmd "g MMU_THDM_DB_POOL_SHARED_LIMIT"', module_ignore_errors=True)
-                logger.info('Read ASIC MMU_THDM_DB_POOL_SHARED_LIMIT register, output {}'.format(output))
-                count = 0
-                for line in output['stdout'].replace('\r', '\n').split('\n'):
-                    if line:
-                        m = re.match('MMU_THDM_DB_POOL_SHARED_LIMIT\(([01])\).*\]\=(\S+)', line)
-                        if m:
-                            asicConfig['egress_shared_limit_sp{}'.format(m.group(1))] = int(m.group(2), 0)
-                            count += 1
-                            if count == 2:
-                                break
-            except:
-                logger.info('Failed to read and parse ASIC THDI_BUFFER_CELL_LIMIT_SP/MMU_THDM_DB_POOL_SHARED_LIMIT register')
-        return asicConfig
-
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
             self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
@@ -1034,7 +1005,6 @@ class QosSaiBase(QosBase):
             pytest_assert('BUFFER_PROFILE' in bufferConfig, 'BUFFER_PROFILE is not exist in bufferConfig')
             pytest_assert('BUFFER_QUEUE' in bufferConfig, 'BUFFER_QUEUE is not exist in bufferConfig')
             pytest_assert('BUFFER_PG' in bufferConfig, 'BUFFER_PG is not exist in bufferConfig')
-            asicConfig = self.dutAsicConfig(duthost.facts['asic_type'], duthost)
 
             current_file_dir = os.path.dirname(os.path.realpath(__file__))
             sub_folder_dir = os.path.join(current_file_dir, "files/brcm/")
@@ -1053,7 +1023,7 @@ class QosSaiBase(QosBase):
                                                        dutConfig["dualTor"],
                                                        dutTopo,
                                                        bufferConfig,
-                                                       asicConfig,
+                                                       duthost,
                                                        tbinfo["topo"]["name"])
             qosParams = qpm.run()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Implementation of qos_sai_base.py should be platform independent.
So remove brcm command which used to collect register value.

#### How did you do it?
remove platform dependency code.
and pass duthost to qos parameter calculation function, and run private command in specific platform. 

#### How did you verify/test it?
pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
