### PR TITLE
Fixing test_drop_counters.py

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -99,7 +99,7 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
     def _check_drops_on_dut():
         return packets_count in _get_drops_across_all_duthosts()
 
-    if not wait_until(25, 1, 0, _check_drops_on_dut()):
+    if not wait_until(25, 1, 0, _check_drops_on_dut):
         # The actual Drop count should always be equal or 1 or 2 packets more than what is expected
         # due to some other drop may occur over the interface being examined.
         # When that happens if looking onlyu for exact count it will be a false positive failure.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Tests in test_drop_counters.py with "L2" group were failing with the exception in wait_until call. 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Tests in test_drop_counters.py with "L2" group were failing with the exception in wait_until call. 
Below is the backtrace:

```
    def test_not_expected_vlan_tag_drop(do_test, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, setup, pkt_fields, ports_info):
        """
        @summary: Create a VLAN tagged packet which VLAN ID does not match ingress port VLAN ID.
        """
        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
        if "mellanox" == duthost.facts["asic_type"]:
            pytest.SKIP_COUNTERS_FOR_MLNX = True
        start_vlan_id = 2
        log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
        max_vlan_id = 1000
        upper_bound = max(setup["vlans"]) if setup["vlans"] else max_vlan_id
        for interim in range(start_vlan_id, upper_bound):
            if interim not in setup["vlans"]:
                vlan_id = interim
                break
        else:
            pytest.fail("Unable to generate unique not yet existed VLAN ID. Already configured VLANs range {}-{}".format(start_vlan_id,
                upper_bound))

        pkt = testutils.simple_tcp_packet(
            eth_dst=ports_info["dst_mac"],  # DUT port
            eth_src=ports_info["src_mac"],  # PTF port
            ip_src=pkt_fields["ipv4_src"],  # PTF source
            ip_dst=pkt_fields["ipv4_dst"],  # VM source
            tcp_sport=pkt_fields["tcp_sport"],
            tcp_dport=pkt_fields["tcp_dport"],
            dl_vlan_enable=True,
            vlan_vid=vlan_id,
            )

        group = "L2"
>       do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])

do_test    = <function do_counters_test at 0x7f487fed57d0>
duthost    = <MultiAsicSonicHost ixre-egl-board5>
duthosts   = [<MultiAsicSonicHost ixre-egl-board1>, <MultiAsicSonicHost ixre-egl-board5>, <MultiAsicSonicHost ixre-cpm-chassis9>]
enum_rand_one_per_hwsku_frontend_hostname = 'ixre-egl-board5'
group      = 'L2'
interim    = 2
max_vlan_id = 1000
pkt        = <Ether  dst=40:7c:7d:bb:25:97 src=ee:e6:c1:de:1c:2a type=VLAN |<Dot1Q  prio=0 ...rt=4321 flags=S |<Raw  load='tests.drop_packets.test_drop_counters test' |>>>>>
pkt_fields = {'ipv4_dst': u'10.0.0.101', 'ipv6_src': 'ffff::101:101', 'tcp_sport': 1234, 'tcp_dport': 4321, 'ipv4_src': '1.1.1.1', 'ipv6_dst': u'FC00::CA'}
ports_info = {'asic_index': 0, 'dst_mac': u'40:7c:7d:bb:25:97', 'dut_iface': u'Ethernet48', 'ptf_tx_port_id': 42, ...}
ptfadapter = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>
setup      = {'dut_to_ptf_port_map': {'Ethernet-IB0': 36, 'Ethernet-IB1': 37, 'Ethernet-Rec0': 38, 'Ethernet-Rec1': 39, ...}, 'intf...: [u'172.17.0.1', u'152.148.0.0/16', u'135.0.0.0/8'], ...}, 'neighbor_sniff_ports': [37, 59, 71, 67, 49, 66, ...], ...}
start_vlan_id = 2
upper_bound = 1000
vlan_id    = 2

drop_packets/drop_packets.py:611:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ drop_packets/test_drop_counters.py:248: in do_counters_test
    skip_counter_check=skip_counter_check, drop_information=drop_information)
drop_packets/test_drop_counters.py:116: in base_verification
    verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
common/helpers/drop_counters/drop_counters.py:102: in verify_drop_counters
    if not wait_until(25, 1, 0, _check_drops_on_dut()):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

timeout = 25, interval = 1, delay = 0, condition = True, args = (), kwargs = {}

    def wait_until(timeout, interval, delay, condition, *args, **kwargs):
        """
        @summary: Wait until the specified condition is True or timeout.
        @param timeout: Maximum time to wait
        @param interval: Poll interval
        @param delay: Delay time
        @param condition: A function that returns False or True
        @param *args: Extra args required by the 'condition' function.
        @param **kwargs: Extra args required by the 'condition' function.
        @return: If the condition function returns True before timeout, return True. If the condition function raises an
            exception, log the error and keep waiting and polling.
        """
        logger.debug("Wait until %s is True, timeout is %s seconds, checking interval is %s, delay is %s seconds" %
>                    (condition.__name__, timeout, interval, delay))
E       AttributeError: 'bool' object has no attribute '__name__'

args       = ()
condition  = True
delay      = 0
interval   = 1
kwargs     = {}
timeout    = 25
```
#### How did you do it?
The reason for the execption was that in function verify_drop_packets in drop_counters.py at line 102, instead of passing the function name (_check_drops_on_dut) as the argument to wait_until, it was actually calling the function _check_drops_on_dut, and passing the return value (True or False) as 'condition' to wait_until.

Fix was to pass the function name '_check_drops_on_dut', instead of the '_check_drops_on_dut()'
#### How did you verify/test it?
Ran drop_counters suite against VoQ T2 linecard.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
