### PR TITLE
[T2][chassis] Fixing test_link_down.py in platform tests

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -701,7 +701,10 @@ def get_plt_reboot_ctrl(duthost, tc_name, reboot_type):
     """
 
     reboot_dict = dict()
-    dut_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    im = duthost.sonichost.host.options['inventory_manager']
+    inv_files = im._sources
+    dut_vars = get_host_visible_vars(inv_files, duthost.hostname)
+
     if 'plt_reboot_dict' in dut_vars:
         for key in dut_vars['plt_reboot_dict'].keys():
             if key in tc_name:

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -32,6 +32,7 @@ def set_max_to_reboot(duthost):
     if plt_reboot_ctrl:
         MAX_TIME_TO_REBOOT = plt_reboot_ctrl['wait']
 
+
 def multi_duts_and_ports(duthosts):
     """
     For multi-host
@@ -136,6 +137,7 @@ def link_status_on_all_LC(duthosts, localhost, fanouts_and_ports, up=True):
 def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list):
     for LC in duthosts.frontend_nodes:
         check_interfaces_and_services(LC, conn_graph_facts["device_conn"][LC.hostname], xcvr_skip_list)
+
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname, 
                                  conn_graph_facts, duts_running_config_facts, 

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -7,7 +7,6 @@ This test supports different platforms including:
     Note that for now we only run this on t2(chassis)
     
 """
-import time
 import logging
 import pytest
 
@@ -150,7 +149,8 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     # and SUP may not have enough time to recover all dockers and the wait for process wait for 300 secs in
     # pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
     # would not be enough. _all_critical_processes_healthy only validates processes are started
-    time.sleep(MAX_TIME_TO_REBOOT)
+    # Wait for ssh port to open up on the DUT
+    wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
 
     hostname = duthost.hostname
     # Before test, check all interfaces and services are up on all linecards


### PR DESCRIPTION


  


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_link_down.py in platform_tests would fail on Nokia T2 chassis, and subsequent set of the tests in platform_tests to fail as well with HostUnreachable.and not wait long enough for linecards/supervisor cards in T2 chassis to come up - causing s

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There were 2 issues with the tests in this suite:
- sleep time after reboot was hard-coded to 120 seconds. However, some of cards might take longer to reboot. On some of the Nokia cards we have seen take about 3 mins for card to be up after reboot is issues (via SUP or through CLI) In such scenario, test_link_down call the dut.get_up_time() could fail with AnsibleHostUnreachable. Subsequent set of the tests in platform_tests to fail as well with HostUnreachable in the pipeline run - until the cards are back up.
- - After the cards are rebooted, there is no check to make sure that the cards are in healthy state - services and ports are up. 
#### How did you do it?
For the first issue, 
 - include logic to get wait time from plt_reboot_ctrl dictionary from the inventory file. Below is the example that of plt_reboot_ctrl that was added to the inventory file for Nokia cards:
      ```
    plt_reboot_dict:
        cold:
          timeout: 240
          wait: 180
      ```
 - Instead of sleep, added a call to wait_for_startup utilitiy in reboot.py to make sure that card is ready for ssh connection

For the second issue
  - Added checks for critical services and interfaces are up on the LCs and also the ports are up on the fanouts after the cards have been rebooted.
 
#### How did you verify/test it?
Ran tests against T2 Nokia chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
