### PR TITLE
[packet-chassis]: Fixes required to run test_snmp_lldp test on packet chassis

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -419,7 +419,7 @@ def parse_dpg(dpg, hname):
             if vintftype is not None:
                 vlan_attributes['type'] = vintftype.text
             vlans[vintfname] = vlan_attributes
-            ports.pop(vintfname)
+            ports.pop(vintfname, None)
 
         aclintfs = child.find(str(QName(ns, "AclInterfaces")))
         acls = {}

--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -378,6 +378,7 @@ def main():
         snmp_auth,
         cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
         cmdgen.MibVariable(p.sysDescr,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -554,6 +555,7 @@ def main():
         cmdgen.MibVariable(p.entPhysMfgName,),
         cmdgen.MibVariable(p.entPhysModelName,),
         cmdgen.MibVariable(p.entPhysIsFRU, ),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -609,6 +611,7 @@ def main():
         cmdgen.MibVariable(p.entPhySensorPrecision,),
         cmdgen.MibVariable(p.entPhySensorValue,),
         cmdgen.MibVariable(p.entPhySensorOperStatus,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -676,6 +679,7 @@ def main():
         cmdgen.MibVariable(p.lldpLocChassisId,),
         cmdgen.MibVariable(p.lldpLocSysName,),
         cmdgen.MibVariable(p.lldpLocSysDesc,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -699,6 +703,7 @@ def main():
         cmdgen.MibVariable(p.lldpLocPortIdSubtype,),
         cmdgen.MibVariable(p.lldpLocPortId,),
         cmdgen.MibVariable(p.lldpLocPortDesc,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -725,6 +730,7 @@ def main():
         cmdgen.MibVariable(p.lldpLocManAddrIfSubtype,),
         cmdgen.MibVariable(p.lldpLocManAddrIfId,),
         cmdgen.MibVariable(p.lldpLocManAddrOID,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -759,6 +765,7 @@ def main():
         cmdgen.MibVariable(p.lldpRemSysDesc,),
         cmdgen.MibVariable(p.lldpRemSysCapSupported,),
         cmdgen.MibVariable(p.lldpRemSysCapEnabled,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -802,6 +809,7 @@ def main():
         cmdgen.MibVariable(p.lldpRemManAddrIfSubtype,),
         cmdgen.MibVariable(p.lldpRemManAddrIfId,),
         cmdgen.MibVariable(p.lldpRemManAddrOID,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -831,6 +839,7 @@ def main():
         cmdgen.MibVariable(p.cpfcIfIndications,),
         cmdgen.MibVariable(p.requestsPerPriority,),
         cmdgen.MibVariable(p.indicationsPerPriority,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -859,6 +868,7 @@ def main():
         snmp_auth,
         cmdgen.UdpTransportTarget((m_args['host'], 161)),
         cmdgen.MibVariable(p.csqIfQosGroupStats,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -879,6 +889,7 @@ def main():
         snmp_auth,
         cmdgen.UdpTransportTarget((m_args['host'], 161)),
         cmdgen.MibVariable(p.cefcFRUPowerOperStatus,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -897,6 +908,7 @@ def main():
         cmdgen.UdpTransportTarget((m_args['host'], 161)),
         cmdgen.MibVariable(p.ipCidrRouteEntry,),
         cmdgen.MibVariable(p.ipCidrRouteStatus,),
+        lookupMib=False,
     )
 
     if errorIndication:
@@ -965,6 +977,7 @@ def main():
             snmp_auth,
             cmdgen.UdpTransportTarget((m_args['host'], 161)),
             cmdgen.MibVariable(p.dot1qTpFdbEntry,),
+            lookupMib=False,
         )
 
         if errorIndication:

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -266,10 +266,10 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
+{% if card_type is not defined or card_type != 'supervisor' %}
         <AclInterface>
           <AttachTo>
 {%- set acl_intfs = [] -%}
-{% if card_type is not defined or card_type != 'supervisor' %}
 {%- for index in range(vms_number) %}
 {% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
@@ -297,12 +297,12 @@
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}
-{% endif %}
 {{- acl_intfs|join(';') -}}
           </AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
+{% endif %}
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>


### PR DESCRIPTION

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_snmp_lldp test case fails on packet chassis supervisor.
Error1:
```
run module minigraph_facts failed, Ansible Results => {"changed": false, "failed": true, "msg": "'Vlan2'\nTraceback (most recent call last):\n  File "/tmp/ansible_minigraph_facts_payload_pc8w9us9/main.py", line 841, in main\n    results = parse_xml(filename, m_args['host'], namespace)\n  File "/tmp/ansible_minigraph_facts_payload_pc8w9us9/main.py", line 671, in parse_xml\n    (intfs, lo_intfs, mgmt_intf, vlans, pcs, acls, dhcp_servers, dhcpv6_servers) = parse_dpg(child, asic_name)\n  File "/tmp/ansible_minigraph_facts_payload_pc8w9us9/main.py", line 422, in parse_dpg\n    ports.pop(vintfname)\nKeyError: 'Vlan2'\n"}
```
Error2 :
Generated minigraph has no data in "AttachTo" in DataAcl of dpg section causing minigraph_facts to fail

Error3:
snmp_facts.py - when getting snmp_facts for Supervisor, the MIB request and response is being resolved because lookupMIB is set to true in cmdgen. This is causing the OID to match with the expected string.
Current scenario:
```
>>> from pysnmp.entity.rfc3413.oneliner import cmdgen
>>> cmdGen = cmdgen.CommandGenerator()
>>> cmdgen.CommunityData('..')
CommunityData(communityIndex='..', communityName=.., mpModel=1, contextEngineId=None, contextName='', tag='', securityName='..')
>>> host='..'
>>> mib_str='1.0.8802.1.1.2.1.3.1'
>>> auth = cmdgen.CommunityData('..')
>>> errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
...     auth,
...     cmdgen.UdpTransportTarget((host, 161)),
...     cmdgen.MibVariable(mib_str))
>>> for oid, val in varBinds:
...    current_oid = oid.prettyPrint()
...    current_val = val.prettyPrint()
...    print(current_oid)
...    print(current_val)
... 
SNMPv2-SMI::iso.0.8802.1.1.2.1.3.1    -- this does not match with the expected OID
```
Expected scenario:
```
>>> errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
...     auth,
...     cmdgen.UdpTransportTarget((host, 161)),
...     cmdgen.MibVariable(mib_str), lookupMib=False,)
>>> for oid, val in varBinds:
...    current_oid = oid.prettyPrint()
...    current_val = val.prettyPrint()
...    print(current_oid)
...    print(current_val)
... 
1.0.8802.1.1.2.1.3.1
```

#### How did you do it?
1. Fix minigraph_facts.py to return None if key is not found, in this case vlan is being searched in ports dictionary, but ports contain only Ethernet interface.
2. Fix minigraph_dpg_asic.j2 template to ensure that empty DataAcl entry is not generated.
3. Fix snmp_facts.py with lookupMib set to false to avoid resolving request and response.

#### How did you verify/test it?
test_snmp_lldp.py passes on packet-chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
