### PR TITLE
[Chassis] Modify sleep_time from 60s to 90s for ZR interfaces in platform and voq tests

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -143,6 +143,8 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False, check_statu
         fanout_port: Port of fanout
         watch: Logging system state
     """
+
+    sleep_time = 90
     logger.info("Testing link flap on %s", dut_port)
     if check_status:
         pytest_assert(__check_if_status(dut, dut_port, 'up', verbose=True), "Fail: dut port {}: link operational down".format(dut_port))
@@ -153,7 +155,7 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False, check_statu
     try:
         fanout.shutdown(fanout_port)
         if check_status:
-            pytest_assert(wait_until(30, 1, 0, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
+            pytest_assert(wait_until(sleep_time, 1, 0, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
 
         if watch:
             time.sleep(1)
@@ -162,13 +164,14 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False, check_statu
         logger.info("Bring up fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
         fanout.no_shutdown(fanout_port)
         need_recovery = False
+
         if check_status:
-            pytest_assert(wait_until(30, 1, 0, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
+            pytest_assert(wait_until(sleep_time, 1, 0, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
     finally:
         if need_recovery:
             fanout.no_shutdown(fanout_port)
             if check_status:
-                wait_until(30, 1, 0, __check_if_status, dut, dut_port, 'up', True)
+                wait_until(sleep_time, 1, 0, __check_if_status, dut, dut_port, 'up', True)
 
 
 def watch_system_status(dut):

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -4,7 +4,6 @@ Check SFP status and configure SFP using sfputil.
 This script covers test case 'Check SFP status and configure SFP' in the SONiC platform test plan:
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
-
 import logging
 import time
 import copy
@@ -109,7 +108,7 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
             assert reset_result["rc"] == 0, "'{} {}' failed".format(cmd_sfp_reset, intf)
             time.sleep(5)
     logging.info("Wait some time for SFP to fully recover after reset")
-    time.sleep(60)
+    time.sleep(sleep_time)
 
     logging.info("Check sfp presence again after reset")
     sfp_presence = duthost.command(cmd_sfp_presence)
@@ -229,6 +228,11 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
+    cmd = "show interfaces transceiver eeprom {} | grep 400ZR".format(asichost.cli_ns_option)
+    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+        logging.info("sleeping for 60 seconds for ZR optics to come up")
+        time.sleep(60)
+
     namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     # TODO Remove this logic when minigraph facts supports namespace in multi_asic

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -107,6 +107,10 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
             reset_result = duthost.command("{} {}".format(cmd_sfp_reset, intf))
             assert reset_result["rc"] == 0, "'{} {}' failed".format(cmd_sfp_reset, intf)
             time.sleep(5)
+    sleep_time = 60
+    if duthost.shell("show interfaces transceiver eeprom | grep 400ZR", module_ignore_errors=True)['rc'] == 0:
+        sleep_time = 90
+
     logging.info("Wait some time for SFP to fully recover after reset")
     time.sleep(sleep_time)
 

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -863,8 +863,13 @@ class LinkFlap(object):
 
         """
         logger.info("Bring up link: %s/%s <-> %s/%s", fanout.hostname, fanport, dut.hostname, dut_intf)
+        sleep_time = 60
         fanout.no_shutdown(fanport)
-        pytest_assert(wait_until(60, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
+        cmd = "show interfaces transceiver eeprom | grep 400ZR"
+        if dut.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+            logging.info("sleeping for 90 seconds for ZR optics to come up")
+            sleep_time = 90
+        pytest_assert(wait_until(sleep_time, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
 
     def localport_admindown(self, dut, asic, dut_intf):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Modified sleep_time form 60 to 90.  It takes more than 60 seconds for  ZR optics to come up

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To sleep enough for ZR optics to come up.  It takes around 90 seconds for the optics to come up. 

#### How did you do it?
Changed sleep to 90 from 60 in test_sfputill.py since it takes more than 60 seconds for ZR optics to come up 
Changed sleep to 90 from 30 in link_flap_utils for the same reason.

#### How did you verify/test it?
Tested test_port_toggle and reboot test cases on a multi cards multi ASICs chassis that has ZR optics installed.
  
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
