### PR TITLE
[chassis] Everflow enhancement

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -744,7 +744,7 @@ def find_duthost_on_role(duthosts, role, tbinfo):
             if role in neighbor["name"]:
                 role_host = duthost
                 role_set = True
-    pytest_assert(role_host, "Could not find duthost")
+    pytest_assert(role_host, "Could not find {} duthost".format(role))
     return role_host
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -730,8 +730,9 @@ def get_image_type(duthost):
 
 
 def find_duthost_on_role(duthosts, role, tbinfo):
+    pytest_assert(role_host, "Could not find duthost")
     role_set = False
-
+    role_host = None
     for duthost in duthosts:
         if role_set:
             break
@@ -743,6 +744,7 @@ def find_duthost_on_role(duthosts, role, tbinfo):
             if role in neighbor["name"]:
                 role_host = duthost
                 role_set = True
+    pytest_assert(role_host, "Could not find duthost")
     return role_host
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -26,6 +26,7 @@ from tests.common import constants
 from tests.common.cache import cached
 from tests.common.cache import FactsCache
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -730,7 +731,6 @@ def get_image_type(duthost):
 
 
 def find_duthost_on_role(duthosts, role, tbinfo):
-    pytest_assert(role_host, "Could not find duthost")
     role_set = False
     role_host = None
     for duthost in duthosts:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -312,6 +312,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
     if 't1' in topo or 't0' in topo or 'm0' in topo or 'mx' in topo or 'dualtor' in topo:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
     elif 't2' in topo:
+        pytest_assert(len(duthosts) > 1, "Test must run on whole chassis")
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
         
     setup_information = gen_setup_information(downstream_duthost, upstream_duthost, tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For T2 scenario, Everflow tests need to run for whole chassis.
if any linecard is specified to run test, `def find_duthost_on_role` will fail to search all duthosts that has `role` neighbor.
before:
```
  File "/data/sonic-mgmt-int/tests/everflow/everflow_test_utilities.py", line 315, in setup_info
    downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
  File "/data/sonic-mgmt-int/tests/everflow/everflow_test_utilities.py", line 294, in get_t2_duthost
    t1_duthost = find_duthost_on_role(duthosts, "T1", tbinfo)
  File "/data/sonic-mgmt-int/tests/common/utilities.py", line 735, in find_duthost_on_role
    return role_host
UnboundLocalError: local variable 'role_host' referenced before assignment
```
After:
```
        topo = tbinfo['topo']['name']
        if 't1' in topo or 't0' in topo or 'm0' in topo or 'mx' in topo or 'dualtor' in topo:
            downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
        elif 't2' in topo:
>           pytest_assert(len(duthosts) > 1, "Test must run on whole chassis")
E           Failed: Test must run on whole chassis

duthosts   = [<MultiAsicSonicHost str2-7804-lc5-1>]
rand_one_dut_hostname = 'str2-7804-lc5-1'
request    = <SubRequest 'setup_info' for <Function test_everflow_per_interface[ipv4]>>
tbinfo     = {'auto_recover': 'True', 'comment': 'v-saidia', 'conf-name': 'vms26-t2-7800-1', 'duts': ['str2-7804-lc5-1', 'str2-7804-lc6-1', 'str2-7804-lc7-1', 'str2-7804-sup-1'], ...}
topo       = 't2'

everflow/everflow_test_utilities.py:315: Failed
-------------------------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
ERROR everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4] - Failed: Test must run on whole chassis
ERROR everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6] - Failed: Test must run on whole chassis
```
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
