### PR TITLE
[loganalyzer] Fix loganalyzer connection refused error

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -222,7 +222,7 @@ def parallel_run(
         )
     )
 
-    return results
+    return dict(results)
 
 
 def reset_ansible_local_tmp(target):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The error:
```
E               Exception:
E               [Errno 111] Connection refused
E               Traceback:
E               Traceback (most recent call last):
E                 File "/home/lolv/workspace/repo/libra/sonic-mgmt/tests/common/helpers/parallel.py", line 31, in run
E                   Process.run(self)
E                 File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/home/lolv/workspace/repo/libra/sonic-mgmt/tests/common/helpers/parallel.py", line 243, in wrapper
E                   target(*args, **kwargs)
E                 File "/home/lolv/workspace/repo/libra/sonic-mgmt/tests/common/plugins/loganalyzer/__init__.py", line 39, in analyze_logs
E                   dut_analyzer.analyze(markers[node.hostname])
E                 File "<string>", line 2, in __getitem__
E                 File "/usr/lib/python2.7/multiprocessing/managers.py", line 755, in _callmethod
E                   self._connect()
E                 File "/usr/lib/python2.7/multiprocessing/managers.py", line 742, in _connect
E                   conn = self._Client(self._token.address, authkey=self._authkey)
E                 File "/usr/lib/python2.7/multiprocessing/connection.py", line 169, in Client
E                   c = SocketClient(address)
E                 File "/usr/lib/python2.7/multiprocessing/connection.py", line 308, in SocketClient
E                   s.connect(address)
E                 File "/usr/lib/python2.7/socket.py", line 228, in meth
E                   return getattr(self._sock,name)(*args)
E               error: [Errno 111] Connection refused
```

In loganalyzer fixture, the markers in the fixture setup is returned by parallel_run is a proxy dict object. It has problem connecting to the proxy manager server sometimes as the proxy manager is already deleted as last call of parallel_run is returned.

So let's use built-in dict object as return for parallel_run.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
As in the motivation.


#### How did you verify/test it?
```
dualtor_io/test_link_drop.py::test_active_link_drop_upstream[active-active] PASSED                                                                                                                                                                                     [100%]
================================================================================================================== 1 passed, 1 deselected in 479.30 seconds ==================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
