### PR TITLE
Free more space if necessary during sonic image upgrade

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -73,7 +73,7 @@ def setup_swap_if_necessary(module):
                      msg="Create a temporary swap file")
 
 
-def reduce_installed_sonic_images(module, disk_used_pcent):
+def reduce_installed_sonic_images(module):
     _, out, _  = exec_command(module, cmd="sonic_installer list", ignore_error=True)
     lines = out.split('\n')
 
@@ -188,7 +188,7 @@ def main():
     try:
         results["current_stage"] = "start"
         work_around_for_slow_disks(module)
-        reduce_installed_sonic_images(module, disk_used_pcent)
+        reduce_installed_sonic_images(module)
         results["current_stage"] = "prepare"
         if new_image_url or save_as:
             free_up_disk_space(module, disk_used_pcent)

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -89,10 +89,6 @@ def reduce_installed_sonic_images(module, disk_used_pcent):
 
     exec_command(module, cmd="sonic_installer cleanup -y", ignore_error=True)
 
-    if get_disk_used_percent(module) > disk_used_pcent:
-        cmd = "rm -rf /host/{}/rw/home/admin/*".format(curr_image.replace('SONiC-OS', 'image'))
-        exec_command(module, cmd, ignore_error=True)
-
 
 def download_new_sonic_image(module, new_image_url, save_as):
     global results
@@ -162,18 +158,18 @@ def work_around_for_slow_disks(module):
     exec_command(module, cmd="sysctl -w kernel.hung_task_timeout_secs=600", ignore_error=True)
 
 
-def get_disk_used_percent(module):
-    output = exec_command(module, cmd="df -BM --output=pcent /host")[1]
-    return int(output.splitlines()[-1][:-1])
-
-
 def free_up_disk_space(module, disk_used_pcent):
     """Remove old log, core and dump files."""
+    def get_disk_used_percent(module):
+        output = exec_command(module, cmd="df -BM --output=pcent /host")[1]
+        return int(output.splitlines()[-1][:-1])
+
     if get_disk_used_percent(module) > disk_used_pcent:
         # free up spaces at best effort
         exec_command(module, "rm -f /var/log/*.gz", ignore_error=True)
         exec_command(module, "rm -f /var/core/*", ignore_error=True)
         exec_command(module, "rm -rf /var/dump/*", ignore_error=True)
+        exec_command(module, "rm -rf /home/admin/*", ignore_error=True)
 
 
 def main():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Sometimes nightly test failed during upgrade image due to no enough space to upgrade the target image.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Sometimes nightly test failed during upgrade image due to no enough space to upgrade the target image.

#### How did you do it?
1: If current image is not same with next boot image, set the current image as next boot image and remove the original next boot image.
2: If dick usage percent larger than input percent threshold, then remove the current image's home directory.

#### How did you verify/test it?
Run pipeline, pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
