### PR TITLE
Add shutdown_multiple and no_shutdown_multiple functions for Onyx fanouts

### DIFF
--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -41,11 +41,21 @@ class OnyxHost(AnsibleHostBase):
         logging.info('Shut interface [%s]' % interface_name)
         return out
 
+    def shutdown_multiple(self, interfaces):
+        for interface in interfaces:
+            out = self.shutdown(interface)
+        return out
+
     def no_shutdown(self, interface_name):
         out = self.host.onyx_config(
             lines=['no shutdown'],
             parents='interface %s' % interface_name)
         logging.info('No shut interface [%s]' % interface_name)
+        return out
+
+    def no_shutdown_multiple(self, interfaces):
+        for interface in interfaces:
+            out = self.no_shutdown(interface)
         return out
 
     def check_intf_link_state(self, interface_name):


### PR DESCRIPTION
Change-Id: I0122eb3351358e7abf54afcf1329e742f211e260

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some tests use the multiple shutdown/no shutdown methods on fanout switch, but Onyx fanout doesn't support such methods. Add two functions to simulate the multiple shutdown methods by operating the interfaces one by one in iterations. 
To align with the multiple shutdown methods of other NOS, the return value is an ansible adhoc object of the last shutdown/ no shutdown cli result, for it's impossible to combine all the cli results together.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add shutdown_multiple and no_shutdown_multiple functions for Onyx fanouts.
#### How did you do it?
Add two functions in tests/common/devices/onyx.py. 
#### How did you verify/test it?
Verfied by automation, the test case uses shutdown_multiple/no_shutdown_multiple passed on testbeds with Onyx fanouts.
#### Any platform specific information?
Only for Onyx fanouts.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
