### PR TITLE
[VM] enhance for wan isis dynamic hostname testcase

### DIFF
--- a/ansible/library/isis_facts.py
+++ b/ansible/library/isis_facts.py
@@ -16,6 +16,8 @@ description:
         * show isis database
         * show isis route
         * show isis hostname
+        * show isis summary
+        * show running-config isisd
     - Retrieved facts will be inserted into the 'isis_facts'
 '''
 
@@ -208,7 +210,7 @@ class IsisModule(object):
         reg = r'(\s{1}\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d+)(\s+\d+\s+)(\S+\s+)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
         regex_v4route = re.compile(reg)
         regex_v6route = re.compile(r'(\s{1}[0-9a-fA-F:]+\/\d+)(\s+\d+\s+)(\S+\s+)([0-9a-fA-F:\-]+)')
-        for line in [item for item in route_items if item.strip()]:
+        for line in [item.strip() for item in route_items if item.strip()]:
             match = regex_v4route.match(line)
             if match:
                 routes['ipv4'][match.group(1).strip()] = {
@@ -227,6 +229,32 @@ class IsisModule(object):
                 continue
         return routes
 
+    def _parse_summary_per_area(self, summary_items):
+
+        def _parse_counter(counter_items):
+            counters = {}
+            regex_counter = re.compile(r'.*: (\d+)$')
+            counters['p2p_iih'] = int(regex_counter.match(counter_items[0]).group(1))
+            counters['l2_lsp'] = int(regex_counter.match(counter_items[1]).group(1))
+            counters['l2_csnp'] = int(regex_counter.match(counter_items[2]).group(1))
+            counters['l2_psnp'] = int(regex_counter.match(counter_items[3]).group(1))
+            return counters
+
+        summary_items = [item.strip() for item in summary_items if item.strip()]
+        summary = {'tx_cnt': {}, 'rx_cnt': {}, 'level_2': {}}
+        regex_p2p_iih = re.compile(r'P2P IIH: (\d+)')
+        while len(summary_items) > 0:
+            line = summary_items.pop(0).strip()
+            if 'TX counters per PDU type:' in line:
+                if regex_p2p_iih.match(summary_items[0]):
+                    summary['tx_cnt'] = _parse_counter(summary_items[0:5])
+                    summary_items = summary_items[5:-1]
+            elif 'RX counters per PDU type:' in line:
+                if regex_p2p_iih.match(summary_items[0]):
+                    summary['rx_cnt'] = _parse_counter(summary_items[0:4])
+                    summary_items = summary_items[4:-1]
+        return summary
+
     def parse_neighbors(self):
         self.facts['neighbors'] = self._parse_areas(self.out.split('\n'), self._parse_neighbors_per_area)
         return
@@ -239,6 +267,9 @@ class IsisModule(object):
         self.facts['route'] = self._parse_areas(self.out.split('\n'), self._parse_route_per_area)
         return
 
+    def parse_summary(self):
+        self.facts['summary'] = self._parse_areas(self.out.split('\n'), self._parse_summary_per_area)
+
     def parse_hostname(self):
         regex_hostname = re.compile(r'(\s*[2\*]\s+)(\d{4}.\d{4}.\d{4}\s+)(\S+)')
         split_output = self.out.split('\n')
@@ -248,6 +279,20 @@ class IsisModule(object):
             if match:
                 hostnames[match.group(2).rstrip()] = match.group(3)
         self.facts['hostname'] = hostnames
+        return
+
+    def collect_isis_config(self, command_str):
+        docker_cmd = '{} "show {} isisd" '.format(self.vty_cmd, command_str)
+        try:
+            rc, self.out, err = self.module.run_command(docker_cmd, executable='/bin/bash', use_unsafe_shell=True)
+        except Exception as e:
+            self.module.fail_json(msg=str(e))
+
+        if rc != 0:
+            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
+                                      (rc, self.out, err))
+        else:
+            self.facts['running-config'] = self.out
         return
 
     def run(self):
@@ -262,6 +307,11 @@ class IsisModule(object):
 
         self.collect_data("hostname")
         self.parse_hostname()
+
+        self.collect_data("summary")
+        self.parse_summary()
+
+        self.collect_isis_config("running-config")
 
         self.module.exit_json(ansible_facts={'isis_facts': self.facts})
 

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -52,10 +52,11 @@ def adapt_interface_name(func):
         new_list = []
         for item in args_list:
             new_item = item
-            if 'Ethernet' in new_item:
-                new_item = re.sub(r'(^|\s)Ethernet', 'GigabitEthernet0/0/0/', new_item)
-            if 'Port-Channel' in item:
-                new_item = re.sub(r'(^|\s)Port-Channel', 'Bundle-Ether', new_item)
+            if isinstance(new_item, str):
+                if 'Ethernet' in new_item:
+                    new_item = re.sub(r'(^|\s)Ethernet', 'GigabitEthernet0/0/0/', new_item)
+                elif 'Port-Channel' in new_item:
+                    new_item = re.sub(r'(^|\s)Port-Channel', 'Bundle-Ether', new_item)
             new_list.append(new_item)
         new_args = tuple(new_list)
         return func(self, *new_args)

--- a/tests/wan/isis/conftest.py
+++ b/tests/wan/isis/conftest.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import functools
 
@@ -14,23 +15,70 @@ def get_target_dut_port(mg_facts, dut_intf):
     return dut_port
 
 
-def get_dut_isis_dpg_topo(dut_host, nbrhosts, tbinfo):
+def parse_vm_vlan_port(vlan):
+    if isinstance(vlan, int):
+        dut_index = 0
+        vlan_index = vlan
+        ptf_index = vlan
+    else:
+        m = re.match(r"(\d+)\.(\d+)@(\d+)", vlan)
+        (dut_index, vlan_index, ptf_index) = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    return (dut_index, vlan_index, ptf_index)
+
+
+def port_indice_to_name(dut_host, tbinfo, port_indice):
+    mg_facts = dut_host.get_extended_minigraph_facts(tbinfo)
+    indice_port_map = dict(zip(mg_facts['minigraph_port_indices'].values(), mg_facts['minigraph_port_indices'].keys()))
+    return indice_port_map[port_indice]
+
+
+def get_dut_isis_dpg_topo(dut_host, nbrhosts, duts_interconnects, tbinfo):
     connections = []
     mg_facts = dut_host.get_extended_minigraph_facts(tbinfo)
     for k, v in mg_facts['minigraph_neighbors'].items():
-        if v['name'] in nbrhosts.keys():
+        if v['name'] in nbrhosts:
             dut_port = get_target_dut_port(mg_facts, k)
             nbr_port = nbrhosts[v['name']]['host'].get_portchannel_by_member(v['port'])
             if nbr_port and dut_port:
                 connections.append((dut_host, dut_port, nbrhosts[v['name']]['host'], nbr_port))
+
+    for (dut1_host, dut1_port_index, dut2_host, dut2_port_index) in duts_interconnects:
+        if dut1_host == dut_host:
+            dut1_port = get_target_dut_port(
+                mg_facts,
+                port_indice_to_name(dut1_host, tbinfo, dut1_port_index))
+            dut2_port = get_target_dut_port(
+                dut2_host.get_extended_minigraph_facts(tbinfo),
+                port_indice_to_name(dut2_host, tbinfo, dut2_port_index))
+            connections.append((dut1_host, dut1_port, dut2_host, dut2_port))
+
     return connections
 
 
 @pytest.fixture(scope="session")
-def isis_dpg_topo(duthosts, nbrhosts, tbinfo):
+def duts_interconnects(duthosts, tbinfo):
+    connections = []
+    dut_names = [dut.hostname for dut in duthosts]
+    dut_index_map = dict(zip(tbinfo['duts_map'].values(), tbinfo['duts_map'].keys()))
+    if 'devices_interconnect_interfaces' in tbinfo['topo']['properties']['topology']:
+        for _, items in tbinfo['topo']['properties']['topology']['devices_interconnect_interfaces'].items():
+            assert(len(items) == 2)
+            connect = []
+            for item in items:
+                (dut_index, vlan_index, _) = parse_vm_vlan_port(item)
+                if dut_index not in dut_index_map or dut_index_map[dut_index] not in dut_names:
+                    break
+                connect.extend([duthosts[dut_index_map[dut_index]], vlan_index])
+            else:
+                connections.append(tuple(connect))
+    return connections
+
+
+@pytest.fixture(scope="session")
+def isis_dpg_topo(duthosts, nbrhosts, duts_interconnects, tbinfo):
     dpg_topo_list = []
     for dut_host in duthosts:
-        dpg_topo_list.extend(get_dut_isis_dpg_topo(dut_host, nbrhosts, tbinfo))
+        dpg_topo_list.extend(get_dut_isis_dpg_topo(dut_host, nbrhosts, duts_interconnects, tbinfo))
     return list(dict.fromkeys(dpg_topo_list))
 
 

--- a/tests/wan/isis/isis_helpers.py
+++ b/tests/wan/isis/isis_helpers.py
@@ -174,12 +174,12 @@ def get_dev_ports(selected_connections):
     """
     dev_ports = {}
     for item in selected_connections:
-        if item[0] not in dev_ports.keys():
+        if item[0] not in dev_ports:
             dev_ports[item[0]] = [item[1]]
         else:
             dev_ports[item[0]].append(item[1])
 
-        if item[2] not in dev_ports.keys():
+        if item[2] not in dev_ports:
             dev_ports[item[2]] = [item[3]]
         else:
             dev_ports[item[2]].append(item[3])
@@ -211,7 +211,7 @@ def teardown_isis(selected_connections):
         connected_ports: include a list of items such as (dut_host, dut_port, nbr_host, nbr_port)
         which describes the connection between port_channels in different devices.
     """
-    for device in get_dev_ports(selected_connections).keys():
+    for device in get_dev_ports(selected_connections):
         if isinstance(device, EosHost):
             remove_nbr_isis_config(device)
         else:

--- a/tests/wan/isis/test_isis_dynamic_hostname.py
+++ b/tests/wan/isis/test_isis_dynamic_hostname.py
@@ -18,7 +18,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def isis_setup_teardown(isis_common_setup_teardown, request):
     target_devices = []
     selected_connections = isis_common_setup_teardown
@@ -38,21 +38,50 @@ def isis_setup_teardown(isis_common_setup_teardown, request):
     request.addfinalizer(functools.partial(revert_isis_config, target_devices))
 
 
-def test_isis_dynamic_hostname(isis_common_setup_teardown, isis_setup_teardown, nbrhosts):
+def test_isis_dynamic_hostname(isis_common_setup_teardown, nbrhosts):
     selected_connections = isis_common_setup_teardown
     (dut_host, dut_port, nbr_host, nbr_port) = selected_connections[0]
 
-    nbr_net = get_device_systemid(nbr_host)
+    # 1. Check nbr_net and nbr_hostname mapping exist in "show isis hostname"
+    nbr_net = get_device_systemid(dut_host)
     isis_facts = dut_host.isis_facts()["ansible_facts"]['isis_facts']
 
-    # The maximum length of hostname in lspid is 14, larger part will be dropped.
-    if nbr_net not in isis_facts['hostname'].keys():
+    if nbr_net not in isis_facts['hostname']:
         pytest_assert(False, "Failed to find net {} hostname.".format(nbr_net))
 
+    # 2. Check "no hostname dynamic" not exist in running-config isisd
+    pytest_assert('no hostname dynamic' not in isis_facts['running-config'],
+                  "Dynamic Hostname is not configured")
+
+    # 3. Check hostname should exist in show isis database
+    # The maximum length of hostname in lspid is 14, larger part will be dropped.
     nbr_hostname = isis_facts['hostname'][nbr_net][:14]
     regex_lspid = re.compile(r'{}.\d{{2}}-\d{{2}}'.format(nbr_hostname))
-    for item in isis_facts['database'][isis_instance].keys():
+    for item in isis_facts['database'][isis_instance]:
         if regex_lspid.match(item) is not None:
             break
     else:
-        pytest_assert(False, "Failed to find hostname {} in LSPID.".format(nbr_hostname))
+        pytest_assert(False, "Failed to find hostname {} in IS-IS database.".format(nbr_hostname))
+
+
+def test_isis_no_dynamic_hostname(isis_common_setup_teardown, isis_setup_teardown, nbrhosts):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, nbr_host, nbr_port) = selected_connections[0]
+
+    # 1. Check nbr_net and nbr_hostname mapping exist in "show isis hostname"
+    nbr_net = get_device_systemid(dut_host)
+    isis_facts = dut_host.isis_facts()["ansible_facts"]['isis_facts']
+    if nbr_net not in isis_facts['hostname']:
+        pytest_assert(False, "Failed to find net {} hostname.".format(nbr_net))
+
+    # 2. Check "no hostname dynamic" exist in "show running-config isisd"
+    pytest_assert('no hostname dynamic' in isis_facts['running-config'],
+                  "Dynamic Hostname should not be configured")
+
+    # 3. Check net address exists in "show isis database"
+    regex_lspid = re.compile(r'{}.\d{{2}}-\d{{2}}'.format(nbr_net))
+    for item in isis_facts['database'][isis_instance]:
+        if regex_lspid.match(item) is not None:
+            break
+    else:
+        pytest_assert(False, "Failed to find net address {} in IS-IS database.".format(nbr_net))

--- a/tests/wan/isis/test_isis_level_capacity.py
+++ b/tests/wan/isis/test_isis_level_capacity.py
@@ -17,7 +17,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def isis_setup_teardown_l12(isis_common_setup_teardown, request):
     target_devices = []
     selected_connections = isis_common_setup_teardown
@@ -37,7 +37,7 @@ def isis_setup_teardown_l12(isis_common_setup_teardown, request):
     request.addfinalizer(functools.partial(revert_isis_config, target_devices))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def isis_setup_teardown_l1(isis_common_setup_teardown, request):
     target_devices = []
     selected_connections = isis_common_setup_teardown

--- a/tests/wan/isis/test_isis_neighbor.py
+++ b/tests/wan/isis/test_isis_neighbor.py
@@ -17,17 +17,17 @@ pytestmark = [
 
 def check_isis_neighbor(duthost, nbr_name, state):
     isis_facts = duthost.isis_facts()["ansible_facts"]['isis_facts']
-    if isis_instance not in isis_facts['neighbors'].keys():
+    if isis_instance not in isis_facts['neighbors']:
         logger.info("Failed to isis instance {} in dut {}.".format(isis_instance, duthost.hostname))
         return False
 
-    if state == 'Up' and nbr_name not in isis_facts['neighbors'][isis_instance].keys():
+    if state == 'Up' and nbr_name not in isis_facts['neighbors'][isis_instance]:
         return False
 
     if state == 'Up' and isis_facts['neighbors'][isis_instance][nbr_name]['state'] == 'Up':
         return True
 
-    if state == 'Down' and nbr_name not in isis_facts['neighbors'][isis_instance].keys():
+    if state == 'Down' and nbr_name not in isis_facts['neighbors'][isis_instance]:
         return True
 
     logger.info("Failed to nbr {} in dut {}.".format(nbr_name, duthost.hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enhance is-is dynamic hostname case, add test case to check when no dynamic hostname is configured. And also add duts inter-connect topo auto-discovery. 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enhance is-is dynamic hostname case. Add wan topology for inter-connect duts auto-discovery.
#### How did you do it?
1. Add a new testcase to check no dynamic hostname.
2. Add wan topology for inter-connect duts auto-discovery, find inter-connect interface and add them to topo binding list.
#### How did you verify/test it?
1. Run is-is dynamic hostname case, case would pass.
2. Run wan-2dut topo, all devices would setup is-is.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
`wan-pub`, `wan-2dut`
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
