### PR TITLE
Ignore IP flags in generate_hashed_packet_to_server in tests/common/dualtor/dual_tor_utils.py

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -872,6 +872,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "id")       # since src and dst changed, ID would change too
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "ttl")      # ttl in outer packet is set to 255
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "chksum")   # checksum would differ as the IP header is not the same
+	exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")  # "Don't fragment" flag may be set in the outer header
 
         return send_pkt, exp_pkt, exp_tunnel_pkt
 
@@ -913,6 +914,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "id")
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "ttl")
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "chksum")
+	exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")
 
         return send_pkt, exp_pkt, exp_tunnel_pkt
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -872,7 +872,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "id")       # since src and dst changed, ID would change too
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "ttl")      # ttl in outer packet is set to 255
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "chksum")   # checksum would differ as the IP header is not the same
-	exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")  # "Don't fragment" flag may be set in the outer header
+        exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")    # "Don't fragment" flag may be set in the outer header
 
         return send_pkt, exp_pkt, exp_tunnel_pkt
 
@@ -914,7 +914,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "id")
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "ttl")
         exp_tunnel_pkt.set_do_not_care_scapy(IP, "chksum")
-	exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")
+        exp_tunnel_pkt.set_do_not_care_scapy(IP, "flags")
 
         return send_pkt, exp_pkt, exp_tunnel_pkt
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently the method generate_hashed_packet_to_server in tests/common/dualtor/dual_tor_utils.py is only used by test case tests/dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops. 
The IP flags should be ignored when verifying encapsulated packets, because the "Don't fragment" flag may be set on some platforms, for example the Mellanox platforms, when the packet is encapsulated.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Ignore IP flags in generate_hashed_packet_to_server to make test test_downstream_ecmp_nexthops pass on Mellanox platforms.
#### How did you do it?
Ignore IP flags in the mask for verifying the encapsulated packets.
#### How did you verify/test it?
Verified by automation, test case test_downstream_ecmp_nexthops passed on Mellanox 4600C dualtor testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
