### PR TITLE
Fix 0xffff checksum packet behavior in Arista-7280CR3-C40 hwsku

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -429,13 +429,13 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_dr
   skip:
     reason: "Broadcom, Cisco and Marvell Asic will tolorate IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000', 'marvell']"
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell'] and hwsku not in ['Arista-7280CR3-C40']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:
     reason: "Mellanox Asic will drop IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or hwsku in ['Arista-7280CR3-C40']"
 
 #######################################
 #####            ipfwd            #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Arista-7280CR3-C40 uses th3 broadcom asic, behavior is different from other broadcom asics when forwarding 0xffff checksum packet
#### How did you do it?
Don't have enought th3 asic to test, so add Arista-7280CR3-C40 hwsku in conditional mark to expect 7280 drop 0xffff checksum packet
#### How did you verify/test it?
Run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
