### PR TITLE
[dualtor] Restart icmp_responder only if it is running

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -13,6 +13,7 @@ from tests.common import constants
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.dualtor.dual_tor_utils import increase_linkmgrd_probe_interval
 
+
 logger = logging.getLogger(__name__)
 
 ROOT_DIR = "/root"
@@ -121,9 +122,11 @@ def change_mac_addresses(ptfhost):
     logger.info("Change interface MAC addresses on ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.change_mac_addresses()
     # NOTE: up/down ptf interfaces in change_mac_address will interrupt icmp_responder
-    # socket read/write operations, so let's restart icmp_responder
-    logging.debug("restart icmp_responder after change ptf port mac addresses")
-    ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
+    # socket read/write operations, so let's restart icmp_responder if it is running
+    icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)
+    if icmp_responder_status["rc"] == 0 and "RUNNING" in icmp_responder_status["stdout"]:
+        logging.debug("restart icmp_responder after change ptf port mac addresses")
+        ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Only restart `icmp_responder` only if it is running.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
