### PR TITLE
Updated QoS SAI tests PTF timeout from 600 to 1200 sec

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -111,7 +111,7 @@ class QosBase:
             qlen=10000,
             is_python3=True,
             relax=False,
-            timeout=600,
+            timeout=1200,
             custom_options=custom_options
         )
 


### PR DESCRIPTION
### Description of PR
Summary: Updated QoS SAI tests PTF timeout from 600 to 1200 sec
Fixes # (issue)  600 sec not enough for test case "testQosSaiHeadroomPoolSize" - sometimes it failed with error: ptf.ptfutils.Timeout.TimeoutError after 10 min runtime

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Seems like 600 sec not enough for test case "testQosSaiHeadroomPoolSize" - sometimes it failed with error: ptf.ptfutils.Timeout.TimeoutError after 10 min runtime

#### How did you do it?
increased timeout

#### How did you verify/test it?
Executed tests which using code in which timeout increased

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
