### PR TITLE
[Snappi] Modifications to pfcwd a2a test design for mlnx 4600c

### DIFF
--- a/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
@@ -125,9 +125,8 @@ def run_pfcwd_multi_node_test(api,
     speed_str = testbed_config.layer1[0].speed
     speed_gbps = int(speed_str.split('_')[1])
 
-    """Check for whether DUT is a Mellanox 4600c device"""
+    """ Retrieve platform information for DUT """
     platform = duthost.facts['platform']
-    is_mlnx_4600c = True if "mlnx" and "4600c" in platform.lower() else False
 
     __verify_results(rows=flow_stats,
                      speed_gbps=speed_gbps,
@@ -141,7 +140,7 @@ def run_pfcwd_multi_node_test(api,
                      trigger_pfcwd=trigger_pfcwd,
                      pause_port_id=port_id,
                      tolerance=TOLERANCE_THRESHOLD,
-                     is_mlnx_4600c=is_mlnx_4600c)
+                     platform=platform)
 
 
 def __data_flow_name(name_prefix, src_id, dst_id, prio):
@@ -523,7 +522,7 @@ def __verify_results(rows,
                      trigger_pfcwd,
                      pause_port_id,
                      tolerance,
-                     is_mlnx_4600c):
+                     platform):
     """
     Verify if we get expected experiment results
 
@@ -540,11 +539,15 @@ def __verify_results(rows,
         trigger_pfcwd (bool): if PFC watchdog is expected to be triggered
         pause_port_id (int): ID of the port to send PFC pause frames
         tolerance (float): maximum allowable deviation
-        is_mlnx_4600c (bool): is DUT a Mellanox 4600c device
+        platform (str): platform information for DUT
 
     Returns:
         N/A
     """
+
+    """ Check for whether DUT is a Mellanox 4600c device """
+    is_mlnx_4600c = True if "mlnx" and "4600c" in platform.lower() else False
+
     for row in rows:
         flow_name = row.name
         tx_frames = row.frames_tx

--- a/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
@@ -125,8 +125,8 @@ def run_pfcwd_multi_node_test(api,
     speed_str = testbed_config.layer1[0].speed
     speed_gbps = int(speed_str.split('_')[1])
 
-    """ Retrieve platform information for DUT """
-    platform = duthost.facts['platform']
+    """ Retrieve ASIC information for DUT """
+    asic_type = duthost.facts['asic_type']
 
     __verify_results(rows=flow_stats,
                      speed_gbps=speed_gbps,
@@ -140,7 +140,7 @@ def run_pfcwd_multi_node_test(api,
                      trigger_pfcwd=trigger_pfcwd,
                      pause_port_id=port_id,
                      tolerance=TOLERANCE_THRESHOLD,
-                     platform=platform)
+                     asic_type=asic_type)
 
 
 def __data_flow_name(name_prefix, src_id, dst_id, prio):
@@ -522,7 +522,7 @@ def __verify_results(rows,
                      trigger_pfcwd,
                      pause_port_id,
                      tolerance,
-                     platform):
+                     asic_type):
     """
     Verify if we get expected experiment results
 
@@ -539,14 +539,14 @@ def __verify_results(rows,
         trigger_pfcwd (bool): if PFC watchdog is expected to be triggered
         pause_port_id (int): ID of the port to send PFC pause frames
         tolerance (float): maximum allowable deviation
-        platform (str): platform information for DUT
+        asic_type (str): asic_type information for DUT
 
     Returns:
         N/A
     """
 
-    """ Check for whether DUT is a Mellanox 4600c device """
-    is_mlnx_4600c = True if "mlnx" and "4600c" in platform.lower() else False
+    """ Check for whether DUT is a Mellanox device """
+    is_mlnx_device = True if "mellanox" in asic_type.lower() else False
 
     for row in rows:
         flow_name = row.name
@@ -584,10 +584,10 @@ def __verify_results(rows,
                               '{} should have dropped packets'.format(flow_name))
             
             elif trigger_pfcwd and src_port_id == pause_port_id:
-                if is_mlnx_4600c:
-                    """ During a pfc storm with pfcwd triggered, Mellanox 4600c does not drop Rx packets """
+                if is_mlnx_device:
+                    """ During a pfc storm with pfcwd triggered, Mellanox devices do not drop Rx packets """
                     pytest_assert(tx_frames == rx_frames,
-                                  '{} should not have dropped packets for Mlnx 4600c'.format(flow_name))
+                                  '{} should not have dropped packets for Mellanox device'.format(flow_name))
 
             elif not trigger_pfcwd and dst_port_id == pause_port_id:
                 """ This test flow is delayed by PFC storm """

--- a/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
@@ -140,7 +140,7 @@ def run_pfcwd_multi_node_test(api,
                      data_pkt_size=DATA_PKT_SIZE,
                      trigger_pfcwd=trigger_pfcwd,
                      pause_port_id=port_id,
-                     tolerance=TOLERANCE_THRESHOLD
+                     tolerance=TOLERANCE_THRESHOLD,
                      is_mlnx_4600c=is_mlnx_4600c)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The Mellanox 4600c switch does not drop packets on the Rx port when a PFC storm is generated on a port, thereby triggering the PFC watch dog. The existing pfcwd a2a (all-to-all) test assumed that packets would be dropped on the Rx port, regardless of switch HwSKU. This change modifies how the test will verify the flow of packets for the Mellanox 4600c during a PFCWD all-to-all test. 

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Pfcwd a2a test failure on mellanox 4600c switch. 

#### How did you do it?
Added a condition that checks for whether the switch is a mellanox 4600c switch, and have a check to ensure that no packets are dropped on the Rx port. 

#### How did you verify/test it?
Ran the test on the mellanox 4600c - it passed. 

#### Any platform specific information?
Platform - x86_64-mlnx_msn4600c-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
