### PR TITLE
Check dualtor in setup_uplink fixture

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -181,6 +181,7 @@ def setup_uplink(rand_selected_dut, tbinfo):
     1. Only keep 1 uplink up. Shutdown others to force the bounced back traffic is egressed from monitor port of mirror session
     2. If there are more than 1 member in the LAG, update the LAG to have only one member
     """
+    pytest_require("dualtor" in tbinfo['topo']['name'], "Only run on dualtor testbed")
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     portchannels = mg_facts['minigraph_portchannels'].keys()
     up_portchannel = random.choice(portchannels)
@@ -245,7 +246,6 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, p
     The issue can happen if the bounced back packets egressed from the monitor port of mirror session
     Find more details in CSP CS00012263713. 
     """
-    pytest_require("dualtor" in tbinfo['topo']['name'], "Only run on dualtor testbed")
     # Since we have only 1 uplink, the source port is also the dest port
     src_port_id = setup_mirror_session
     _, server_ip = rand_selected_interface


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to improve test case `test_encap_with_mirror_session`.
Before the change, the testbed name is checked in the test case, that is after the fixture running.
This PR moves the checking of testbed name from the test body to the fixture `setup_uplink`. The setup procedure will be skipped if the testbed is not dualtor.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to move the checking of testbed name from the test body to the fixture `setup_uplink`.

#### How did you do it?

#### How did you verify/test it?
Verified on a single tor testbed, confirm the setup fixture is skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
