### PR TITLE
[202012] Cherry-pick dut_ports.py for 202012

### DIFF
--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def encode_dut_port_name(dutname, portname):
     return dutname + '|' + portname
 
@@ -15,3 +20,10 @@ def decode_dut_port_name(dut_portname):
         portname = None
     return dutname, portname
 
+
+def get_duthost_with_name(duthosts, dut_name):
+    for duthost in duthosts:
+        if dut_name in ['unknown', duthost.hostname]:
+            return duthost
+    logger.error("Can't find duthost with name {}.".format(dut_name))
+    return


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
My PR #6074 was not merged to 202012, but most of its code have been merged into 202012 within #6055.
But the function `get_duthost_with_name` in dut_ports.py is missed and test case failed with below error:
```
___________________ ERROR collecting tests/pc/test_lag_2.py ____________________
ImportError while importing test module '/azp/_work/37/s/sonic-mgmt-int/tests/pc/test_lag_2.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
pc/test_lag_2.py:14: in <module>
    from tests.common.helpers.dut_ports import get_duthost_with_name
E   ImportError: cannot import name get_duthost_with_name
```

#### How did you do it?
Add this function for 202012 in this PR.

#### How did you verify/test it?
Run `pc/test_lag_2.py` against 202012 branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
