### PR TITLE
[chassis] ensure test_thermal_state_db to run on sup only

### DIFF
--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -83,6 +83,8 @@ def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo)
     duthost = duthosts[enum_supervisor_dut_hostname]
     if duthost.facts['modular_chassis'] == "False":
         pytest.skip("Test skipped applicable to modular chassis only")
+    if not duthost.is_supervisor_node():
+        pytest.skip("Test skipped applicable to supervisor only")
     chassis_db_ip = get_chassis_db_ip(duthost)
     expected_num_thermals = get_expected_num_thermals(duthosts)
     thermal_out = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"TEMP*\"".format(chassis_db_ip))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ensure test_thermal_global_state_db is running for sup only.
if we use ./run_tests script and specifies '-d' with any linecard, `def get_specified_duts` will return linecard for `def generate_params_supervisor_hostname` and return linecard for fixture `enum_supervisor_dut_hostname`

Fixes # (issue)
Before:
```
   def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo):
        """
         This test case will verify global state db data on supervisor
         Verify data for all sensors from line cards and fabric cards present in global state db
        """
        duthost = duthosts[enum_supervisor_dut_hostname]
        if duthost.facts['modular_chassis'] == "False":
            pytest.skip("Test skipped applicable to modular chassis only")
>       chassis_db_ip = get_chassis_db_ip(duthost)

duthost    = <MultiAsicSonicHost str2-7804-lc5-1>
duthosts   = [<MultiAsicSonicHost str2-7804-lc5-1>]
enum_supervisor_dut_hostname = 'str2-7804-lc5-1'
tbinfo     = {'auto_recover': 'True', 'comment': 'v-saidia', 'conf-name': 'vms26-t2-7800-1', 'duts': ['str2-7804-lc5-1', 'str2-7804-lc6-1', 'str2-7804-lc7-1', 'str2-7804-sup-1'], ...}

platform_tests/test_thermal_state_db.py:86: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
platform_tests/test_thermal_state_db.py:12: in get_chassis_db_ip
    out = duthost.command("cat /etc/sonic/chassisdb.conf")['stdout_lines']
```

After:
```
platform_tests/test_thermal_state_db.py::test_thermal_state_db[str2-x-lc6-1] PASSED                                                                                                                                                                   [ 50%]
platform_tests/test_thermal_state_db.py::test_thermal_global_state_db[str2-x-lc6-1] SKIPPED                                                                                                                                                           [100%]

-------------------------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [1] /data/sonic-mgmt-int/tests/platform_tests/test_thermal_state_db.py:88: Test skipped applicable to supervisor only
============================================================================================================ 1 passed, 1 skipped in 108.82 seconds =============================================================================================================
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
