### PR TITLE
Skip test case test_show_platform_syseeprom for arista 7060

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -100,7 +100,7 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
     @summary: Verify output of `show platform syseeprom`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050", "arista_7260"])
+    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050", "arista_7260", "arista_7060"])
     cmd = " ".join([CMD_SHOW_PLATFORM, "syseeprom"])
 
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In https://github.com/sonic-net/sonic-mgmt/pull/4614, skip arista_7260 for `test_show_platform_syseeprom`, but actually, arista_7060 has some issue.


The output of 7060 for show platform syseeprom:
```
admin@str-a7060cx-acs-1:~$ show platform syseeprom
ASY: ASY0171710B0
HwApi: 03.00
HwRev: 12.00
KVN: 111
MAC: 28:99:3a:17:1c:08
MfgTime: 20170207215037
PCA: PCA0061510A2
SID: Upperlake
SKU: DCS-7060CX-32S
SerialNumber: JPE17051884
(checksum valid)
```
The output on other platform:
```
admin@str-s6100-acs-5:~$ show platform syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 170
TLV Name             Code      Len  Value
-------------------  ------  -----  ----------------------------------
Product Name         0x21        8  S6100-ON
Part Number          0x22        6  0F6N2R
Serial Number        0x23       20  TH0F6N2RCET009CE001X
Base MAC Address     0x24        6  8C:04:BA:D2:19:40
Manufacture Date     0x25       19  11/15/2022 21:18:54
Device Version       0x26        1  1
Label Revision       0x27        3  A11
Platform Name        0x28       26  x86_64-dell_s6100_c2538-r0
ONIE Version         0x29        8  3.15.1.0
MAC Addresses        0x2A        2  384
Manufacturer         0x2B        5  CET00
Manufacture Country  0x2C        2  TH
Vendor Name          0x2D        4  DELL
Diag Version         0x2E        8  3.25.4.1
Service Tag          0x2F        7  4NKD9Z2
Vendor Extension     0xFD        7  0x00 0x00 0x02 0xA2 0x2D 0x46 0x46
CRC-32               0xFE        4  0x5D973705

(checksum valid)
```
#### How did you do it?
Skip the test platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom since for this Arista does not abide by the ONIE output format because our eeprom uses a different format and stores other information.

#### How did you verify/test it?
`platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom` on 7060 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
