### PR TITLE
Skip test_trap_config_save_after_reboot for 202012 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -153,7 +153,7 @@ copp/test_copp.py:
       - "topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-backend', 't2', 'm0', 'mx']"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
-  xfail:
+  skip:
     reason: "'Add always_enabled field to coppmgr' is not merged into 202012 yet"
     conditions:
       - "release in ['202012']"


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_trap_config_save_after_reboot case should skipped in 202012 branch, since always_enable feature is not merged into 202012 image.
 [[CoPP] Add always_enabled field to coppmgr logic by noaOrMlnx · Pull Request #2034 · sonic-net/sonic-swss (github.com)](https://github.com/sonic-net/sonic-swss/pull/2034)

Test case was added in this PR:
https://github.com/sonic-net/sonic-mgmt/pull/4891

xfail in this PR
[[test] skip/xfail unmerged copp feature temporarily by yejianquan · Pull Request #5148 · sonic-net/sonic-mgmt (github.com)](https://github.com/sonic-net/sonic-mgmt/pull/5148)

#### How did you do it?
Xfail is not correct, it needs to be skipped for now.
Change xfail to skip.

#### How did you verify/test it?
Run test_trap_config_save_after_reboot against 202012 branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
