### PR TITLE
[Framework] Add ACL counter related methods to `SonicHost`

### DIFF
--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -135,6 +135,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 
 - [facts](sonichost_methods/facts.md) - Returns platform information facts about the sonic device.
 
+- [get_acl_counter](sonichost_methods/get_acl_counter.md) - Read ACL counter of specific ACL table and ACL rule.
+
 - [get_asic_name](sonichost_methods/get_asic_name.md) - Returns name of current ASIC. For use in multi-ASIC environments.
 
 - [get_auto_negotiation_mode](sonichost_methods/get_auto_negotiation_mode.md) - Gets the auto negotiation status for a provided interface

--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -123,6 +123,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 
 - [check_default_route](sonichost_methods/check_default_route.md) - Provides the status of the default route
 
+- [clear_acl_counters](sonichost_methods/clear_acl_counters.md) - Clear ACL counters statistics.
+
 - [critical_process_status](sonichost_methods/critical_process_status.md) - Gets status of service and provides list of exited and running member processes.
 
 - [critical_services](sonichost_methods/critical_services.md) - Provides a list of critical services running on the SONiC host.

--- a/docs/api_wiki/sonichost_methods/clear_acl_counters.md
+++ b/docs/api_wiki/sonichost_methods/clear_acl_counters.md
@@ -1,0 +1,26 @@
+# clear_acl_counters
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+
+## Overview
+
+Clear ACL counters statistics.
+
+## Examples
+
+```python
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    duthost.clear_acl_counters()
+```
+
+## Arguments
+
+Takes no arguments.
+
+## Expected Output
+
+Provides no output.

--- a/docs/api_wiki/sonichost_methods/get_acl_counter.md
+++ b/docs/api_wiki/sonichost_methods/get_acl_counter.md
@@ -29,7 +29,7 @@ def test_fun(duthosts, rand_one_dut_hostname):
 - `timeout` - maximum time (in second) to wait until ACL counter available.
     - Required: `False`
     - Type: `Integer`
-    - Default: `tests.common.devices.constants.ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 3`
+    - Default: `tests.common.devices.constants.ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 2`
 - `interval` - retry interval (in second) between read ACL counter.
     - Required: `False`
     - Type: `Integer`

--- a/docs/api_wiki/sonichost_methods/get_acl_counter.md
+++ b/docs/api_wiki/sonichost_methods/get_acl_counter.md
@@ -1,0 +1,52 @@
+# get_acl_counter
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+- [Potential Exception](#potential-exception)
+
+## Overview
+
+Read ACL counter of specific ACL table and ACL rule.
+
+## Examples
+
+```python
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    packets_count = duthost.get_acl_counter('YOUR_ACL_TABLE', 'YOUR_ACL_RULE')
+```
+
+## Arguments
+
+- `acl_table_name` - name of ACL table
+    - Required: `True`
+    - Type: `String`
+- `acl_rule_name` - name of ACL rule
+    - Required: `True`
+    - Type: `String`
+- `timeout` - maximum time (in second) to wait until ACL counter available.
+    - Required: `False`
+    - Type: `Integer`
+    - Default: `tests.common.devices.constants.ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 3`
+- `interval` - retry interval (in second) between read ACL counter.
+    - Required: `False`
+    - Type: `Integer`
+    - Default: `tests.common.devices.constants.ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC`
+
+## Expected Output
+
+Returns an `Integer` indicates the count of packets hit the specific ACL rule.
+
+Example output:
+
+```json
+1
+```
+
+## Potential Exception
+
+- `AssertionError` - If argument `timeout < 0` or `interval <= 0`.
+- `ValueError` - If `aclshow -a` returns an invalid string on DUT.
+- `Exception` - If `aclshow -a` still returns `N/A` after `timeout` seconds.

--- a/tests/common/devices/constants.py
+++ b/tests/common/devices/constants.py
@@ -1,0 +1,3 @@
+
+# default interval of orchagent to update the ACL counters
+ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC = 10

--- a/tests/common/devices/constants.py
+++ b/tests/common/devices/constants.py
@@ -1,3 +1,2 @@
-
 # default interval of orchagent to update the ACL counters
 ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC = 10

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2069,8 +2069,14 @@ Totals               6450                 6449
         """
         return self.show_and_parse('show syslog')
 
+    def clear_acl_counters(self):
+        """
+        Clear ACL counters statistics.
+        """
+        self.command('aclshow -c')
+
     def get_acl_counter(self, acl_table_name, acl_rule_name,
-                        timeout=ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 3,
+                        timeout=ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 2,
                         interval=ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC):
         """
         Read ACL counter of specific ACL table and ACL rule.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -14,6 +14,7 @@ from ansible import constants as ansible_constants
 from ansible.plugins.loader import connection_loader
 
 from tests.common.devices.base import AnsibleHostBase
+from tests.common.devices.constants import ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC
 from tests.common.helpers.dut_utils import is_supervisor_node
 from tests.common.utilities import get_host_visible_vars
 from tests.common.cache import cached
@@ -2067,6 +2068,40 @@ Totals               6450                 6449
             ]
         """
         return self.show_and_parse('show syslog')
+
+    def get_acl_counter(self, acl_table_name, acl_rule_name,
+                        timeout=ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC * 3,
+                        interval=ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC):
+        """
+        Read ACL counter of specific ACL table and ACL rule.
+
+        Args:
+            acl_table_name (str): Name of ACL table.
+            acl_rule_name (str): Name of ACL rule.
+            timeout (int): Maximum time (in second) wait for ACL counter available.
+            interval (int): Retry interval (in second) between read ACL counter.
+
+        Return:
+            packets_count (int): count of packets hit the specific ACL rule.
+        """
+        assert timeout >= 0 and interval > 0  # Validate arguments to avoid infinite loop
+        while timeout >= 0:
+            time.sleep(interval)  # Wait for orchagent to update the ACL counters
+            timeout -= interval
+            result = self.show_and_parse('aclshow -a')
+            for rule in result:
+                if acl_table_name == rule['table name'] and acl_rule_name == rule['rule name']:
+                    try:
+                        packets_count = int(rule['packets count'])
+                        return packets_count
+                    except ValueError:
+                        if rule['packets count'] == 'N/A':
+                            logging.warning("ACL counters are not ready yet, will retry after {} seconds"
+                                            .format(interval))
+                        else:
+                            raise ValueError('Got invalid packets count "{}" for {}|{}'
+                                             .format(acl_table_name, acl_rule_name, rule['packets count']))
+        raise Exception("Failed to read acl counter for {}|{}".format(acl_table_name, acl_rule_name))
 
     def remove_acl_table(self, acl_table):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added two ACL counter related methods to `SonicHost`. Test cases can use these methods to clear and read ACL counter.

**`get_acl_counter`**

```python
# sample code
def test_fun(duthosts, rand_one_dut_hostname):
    duthost = duthosts[rand_one_dut_hostname]
    packets_count = duthost.get_acl_counter('YOUR_ACL_TABLE', 'YOUR_ACL_RULE')
```

**`clear_acl_counters`**

```python
def test_fun(duthosts, rand_one_dut_hostname):
    duthost = duthosts[rand_one_dut_hostname]
    duthost.clear_acl_counters()
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Added two ACL counter related methods to `SonicHost`. Test cases can use these methods to clear and read ACL counter.

#### How did you do it?

Add `get_acl_counter` and `clear_acl_counters` method to `SonicHost`.

#### How did you verify/test it?

Verified in some ACL testcases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
