### PR TITLE
acl test support for new topo t1-56-lag

### DIFF
--- a/ansible/veos
+++ b/ansible/veos
@@ -15,6 +15,7 @@ all:
         topologies:
           - t1
           - t1-lag
+          - t1-56-lag
           - t1-64-lag
           - t1-64-lag-clet
           - t1-backend

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -11,6 +11,7 @@ all:
         topologies:
           - t1
           - t1-lag
+          - t1-56-lag
           - t1-64-lag
           - t1-8-lag
           - t1-64-lag-clet

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -288,7 +288,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
             if namespace:
                 acl_table_ports[''] += port
 
-    if topo in ["t0", "m0"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet"):
+    if topo in ["t0", "m0"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet", "t1-56-lag"):
         for k, v in port_channels.iteritems():
             acl_table_ports[v['namespace']].append(k)
             # In multi-asic we need config both in host and namespace.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Failed to run "config acl add table" command for t1-56-lag testbed.
RCA: miss relevant "t1-56-lag" definition, caused choose wrong test port. 

#### How did you do it?
add "t1-56-lag' definition.

#### How did you verify/test it?
pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
