### PR TITLE
Fix wait_until condition argument issue in drop_counters.py

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -97,9 +97,10 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         return drop_list
 
     def _check_drops_on_dut():
+        import pdb;pdb.set_trace()
         return packets_count in _get_drops_across_all_duthosts()
 
-    if not wait_until(25, 1, 0, _check_drops_on_dut()):
+    if not wait_until(25, 1, 0, _check_drops_on_dut):
         # The actual Drop count should always be equal or 1 or 2 packets more than what is expected
         # due to some other drop may occur over the interface being examined.
         # When that happens if looking onlyu for exact count it will be a false positive failure.

--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -97,7 +97,6 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         return drop_list
 
     def _check_drops_on_dut():
-        import pdb;pdb.set_trace()
         return packets_count in _get_drops_across_all_duthosts()
 
     if not wait_until(25, 1, 0, _check_drops_on_dut):


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In https://github.com/sonic-net/sonic-mgmt/pull/7274, it enhanced some code in `tests/common/helpers/drop_counters/drop_counters.py`, but introduced an issue which caused the following error when running `test_drop_counters.py`:

```
  File "/azp/_work/30/s/tests/drop_packets/test_drop_counters.py", line 334, in test_src_ip_link_local
    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
  File "/azp/_work/30/s/tests/drop_packets/test_drop_counters.py", line 248, in do_counters_test
    skip_counter_check=skip_counter_check, drop_information=drop_information)
  File "/azp/_work/30/s/tests/drop_packets/test_drop_counters.py", line 128, in base_verification
    verify_drop_counters(duthosts, asic_index, tx_dut_ports[ports_info["dut_iface"]], GET_L3_COUNTERS, L3_COL_KEY, packets_count=PKT_NUMBER)
  File "/azp/_work/30/s/tests/common/helpers/drop_counters/drop_counters.py", line 102, in verify_drop_counters
    if not wait_until(25, 1, 0, _check_drops_on_dut()):
  File "/azp/_work/30/s/tests/common/utilities.py", line 100, in wait_until
    (condition.__name__, timeout, interval, delay))
AttributeError: 'bool' object has no attribute '__name__'
```
#### How did you do it?
The condition parameter of wait_until should be function name only, it should not add (), otherwise it will put the return value into condition argument.

#### How did you verify/test it?
```
drop_packets/test_drop_counters.py::test_src_ip_link_local[port_channel_members-str-msn2700-03]PASSED                                                           [ 33%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[vlan_members-str-msn2700-03]PASSED                                                                   [ 66%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[rif_members-str-msn2700-03] SKIPPED                                                                  [100%]
=========================== short test summary info ============================
SKIPPED [1] /data/sonic-mgmt-int/tests/drop_packets/drop_packets.py:338: No rif_members available
============= 2 passed, 1 skipped, 99 deselected in 152.59 seconds =============
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
