### PR TITLE
[dualtor] Fix test_standby_tor_downstream_loopback_route_readded

### DIFF
--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -200,21 +200,32 @@ def route_matches_expected_state(duthost, route_ip, expect_route):
 
 
 @pytest.fixture
-def remove_peer_loopback_route(rand_unselected_dut, shutdown_bgp_sessions):  # noqa: F811
+def remove_peer_loopback_route(rand_selected_dut, rand_unselected_dut, shutdown_bgp_sessions, get_testbed_params):  # noqa: F811
     """
     Remove routes to peer ToR loopback IP by shutting down BGP sessions on the peer
     """
 
     def _remove_peer_loopback_route():
-        shutdown_bgp_sessions(rand_unselected_dut)
-        # We need to maintain the expected active/standby state for the test
-        rand_unselected_dut.shell("config mux mode active all")
+        if rand_unselected_dut is None:
+            # mocked testbed, remove the static route installed by
+            # apply_dual_tor_peer_switch_route from kernel
+            remove_static_routes(rand_selected_dut, active_tor_loopback0)
+        else:
+            shutdown_bgp_sessions(rand_unselected_dut)
+            # We need to maintain the expected active/standby state for the test
+            rand_unselected_dut.shell("config mux mode active all")
+
+    active_tor_loopback0 = get_testbed_params()['active_tor_ip']
 
     yield _remove_peer_loopback_route
 
-    # The `shutdown_bgp_sessions` fixture already restores BGP sessions during teardown so we
-    # don't need to do it here
-    rand_unselected_dut.shell("config mux mode auto all")
+    if rand_unselected_dut is None:
+        # mocked testbed, need to add back the static route to kernel
+        add_nexthop_routes(rand_selected_dut, active_tor_loopback0)
+    else:
+        # The `shutdown_bgp_sessions` fixture already restores BGP sessions during teardown so we
+        # don't need to do it here
+        rand_unselected_dut.shell("config mux mode auto all")
 
 
 def test_standby_tor_downstream_loopback_route_readded(
@@ -238,7 +249,11 @@ def test_standby_tor_downstream_loopback_route_readded(
     check_tunnel_balance(**params)
 
     # Readd loopback routes and verify traffic is equally distributed
-    rand_unselected_dut.shell("config bgp start all")
+    if rand_unselected_dut is None:
+        # mocked testbed, need to add back the static route to kernel
+        add_nexthop_routes(rand_selected_dut, active_tor_loopback0)
+    else:
+        rand_unselected_dut.shell("config bgp start all")
     pt_assert(
         wait_until(
             10, 1, 0,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In testcase test_standby_tor_downstream_loopback_route_readded:

Current route to peer deletion/restore is assuming it is a real dualtor testbed.
It will fail on a mocked dualtor testbed.

Add back the static route delete/restore logic if the testbed is a mocked dualtor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As in the motivation

#### How did you verify/test it?
```
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv4] PASSED [ 50%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv6] PASSED [100%]

========================== 2 passed in 947.60 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
