### PR TITLE
[service_warm_restart] Fixed missing import, enhanced reboot tests flow 

### DIFF
--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -4,12 +4,14 @@ import logging
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import skip_release
-from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]
+from tests.platform_tests.verify_dut_health import verify_dut_health  # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
+
 
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
@@ -23,29 +25,33 @@ def check_image_version(duthost):
     """
     skip_release(duthost, ["201811", "201911", "202012", "202106"])
 
+
 def get_builtin_services(duthost):
     spm_data = duthost.show_and_parse('spm list')
     return {item['name'] for item in spm_data if item['status'] == 'Built-In'}
-    
+
+
 def get_running_services(duthost):
     services = duthost.shell('docker ps --format \{\{.Names\}\}')['stdout_lines']
     return services
 
+
 def get_ignored_services(request):
     ignored_services = request.config.getoption("--ignore_service")
     return ignored_services.split(',') if ignored_services else []
+
 
 class ServiceMatchRules:
     services_warmboot_unsupported = ['database', 'syncd']
 
     def __init__(self, duthost, request):
         feature_info = duthost.show_and_parse('show feature status')
-        self.feature_data = {info['feature']:info for info in feature_info}
+        self.feature_data = {info['feature']: info for info in feature_info}
 
         self.ignored_services = get_ignored_services(request)
         self.builtin_services = get_builtin_services(duthost)
         self.running_services = get_running_services(duthost)
-    
+
     def is_running(self, s):
         return s in self.running_services
 
@@ -57,13 +63,12 @@ class ServiceMatchRules:
 
     def is_feature_enabled(self, s):
         return self.feature_data[s]['state'] not in ['disabled', 'always_disabled']
-    
+
     def is_warmboot_supported(self, s):
         return s not in ServiceMatchRules.services_warmboot_unsupported
 
-    
-def select_services_to_warmrestart(duthost, request):
 
+def select_services_to_warmrestart(duthost, request):
     all_services = [feature_data['feature'] for feature_data in duthost.show_and_parse('show feature status')]
 
     rules = ServiceMatchRules(duthost, request)
@@ -81,13 +86,13 @@ def select_services_to_warmrestart(duthost, request):
     ]
 
     def passes_all_checks(service):
-        return all(rule(service) for rule in all_checks )
-    
+        return all(rule(service) for rule in all_checks)
+
     return [service for service in all_services if passes_all_checks(service)]
-    
+
 
 def test_service_warm_restart(request, duthosts, rand_one_dut_hostname, verify_dut_health, get_advanced_reboot,
-    advanceboot_loganalyzer, capture_interface_counters):
+                              advanceboot_loganalyzer, capture_interface_counters):
     duthost = duthosts[rand_one_dut_hostname]
 
     candidate_service_list = select_services_to_warmrestart(duthost, request)

--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 import time
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 from tests.common.platform.transceiver_utils import parse_transceiver_info
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD
 
@@ -34,13 +35,10 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
-    # Wait until 300 seconds after boot up since a part of the services has delayed start (e.g., snmp)
-    wait_until_uptime(duthost, 300)
+    pytest_assert(wait_until(330, 30, 0, duthost.critical_services_fully_started),
+                  "dut.critical_services_fully_started is False")
 
     logging.info("Check critical service status")
-    if not duthost.critical_services_fully_started():
-        raise RebootHealthError("dut.critical_services_fully_started is False")
-
     for service in duthost.critical_services:
         status = duthost.get_service_props(service)
         if status["ActiveState"] != "active":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixed missing import in test_service_warm_restart.py: copy_ptftests_directory. the test was failing because of that.
Enhanced wait_until logic in check_services function to decrease reboot tests runtime. Before we used just 300-sec sleep, now we can check the status of services and if they are up we can go ahead, saving time in the regression.
Summary: Fixed missing import, enhanced test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To fix test service_warm_restart failing. 
And enhance reboot tests flow to save time.

#### How did you do it?
Added missing import.
Used wait_until function

#### How did you verify/test it?
Run the test manually and as part of the nightly regression.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
