### PR TITLE
[cisco gb asic]: fill up the first expected nexthop ip addr after ecmp order scheme performs

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -531,7 +531,7 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
     # as there is always probability even after change of Hash Function same nexthop/neighbor is selected.
 
     # Fill this array after first run of test case which will give neighbor selected
-    SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP = {"th": "172.16.0.16", "tl7": "172.16.0.13"}
+    SUPPORTED_ASIC_TO_NEIGHBOR_SELECTED_MAP = {"th": "172.16.0.16", "tl7": "172.16.0.13", "gb": "172.16.0.18"}
 
     vendor = duthost.facts["asic_type"]
     hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]


### PR DESCRIPTION
**Description**
In our lab environment, testcase requests to fill up the first expected nexthop ip addr after ecmp order scheme based on asic type.

**Steps to reproduce the issue:**
run the testcase with "ipfwd/test_nhop_group.py::test_nhop_group_member_order_capability" on T1 testbed.

Describe the results you received:
Traceback (most recent call last):
File "ipfwd/test_nhop_group.py", line 550, in runTest

pytest.xfail("ASIC to flow mapping is not define. " "Please read above comment to update map with the given ASIC to flow map")

**Describe the results you expected:**
testcase Pass

**Additional information you deem important:**
none

**solution:**
as PR listed

