### PR TITLE
[test_syslog_rate_limit] Wait rsyslogd restart

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -249,6 +249,7 @@ def wait_rsyslogd_restart(duthost, service_name, old_pid):
     cmd = "docker exec -i {} bash -c 'supervisorctl status rsyslogd'".format(service_name)
     wait_time = 30
     while wait_time > 0:
+        wait_time -= 1
         if get_rsyslogd_pid(duthost, service_name) == old_pid:
             time.sleep(1)
             continue

--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pytest
 import random
+import time
 
 from tests.common.config_reload import config_reload
 from tests.common.utilities import skip_release
@@ -63,6 +64,7 @@ def restore_rate_limit(rand_selected_dut):
     rand_selected_dut.command('config save -y')
 
 
+@pytest.mark.disable_loganalyzer
 def test_syslog_rate_limit(rand_selected_dut):
     """Test case for syslog rate limit
 
@@ -121,8 +123,10 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
             verify_config_rate_limit_fail(rand_selected_dut, service_name)
             continue
 
+        rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, service_name)
         rand_selected_dut.command('config syslog rate-limit-container {} -b {} -i {}'.format(
             service_name, RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL))
+        assert wait_rsyslogd_restart(rand_selected_dut, service_name, rsyslog_pid)
         rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-container {}'.format(service_name))
         pytest_assert(rate_limit_data[0]['interval'] == str(RATE_LIMIT_INTERVAL),
                       'Expect rate limit interval {}, actual {}'.format(RATE_LIMIT_INTERVAL,
@@ -141,7 +145,9 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
                                               LOG_EXPECT_LAST_MESSAGE.format(service_name + '#')],
                                              RATE_LIMIT_BURST + 1)
 
+        rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, service_name)
         rand_selected_dut.command('config syslog rate-limit-container {} -b {} -i {}'.format(service_name, 0, 0))
+        assert wait_rsyslogd_restart(rand_selected_dut, service_name, rsyslog_pid)
         rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-container {}'.format(service_name))
         pytest_assert(rate_limit_data[0]['interval'] == '0',
                       'Expect rate limit interval {}, actual {}'.format(0, rate_limit_data[0]['interval']))
@@ -236,3 +242,28 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
 
     with loganalyzer:
         duthost.command(run_generator_cmd)
+
+
+def wait_rsyslogd_restart(duthost, service_name, old_pid):
+    logger.info('Waiting rsyslogd restart')
+    cmd = "docker exec -i {} bash -c 'supervisorctl status rsyslogd'".format(service_name)
+    wait_time = 30
+    while wait_time > 0:
+        if get_rsyslogd_pid(duthost, service_name) == old_pid:
+            time.sleep(1)
+            continue
+
+        output = duthost.command(cmd, module_ignore_errors=True)['stdout'].strip()
+        if 'RUNNING' in output:
+            logger.info('Rsyslogd restarted')
+            return True
+
+        time.sleep(1)
+
+    logger.error('Rsyslogd failed to restart')
+    return False
+
+
+def get_rsyslogd_pid(duthost, service_name):
+    cmd = "docker exec -i {} bash -c 'pidof rsyslogd'".format(service_name)
+    return duthost.command(cmd, module_ignore_errors=True)['stdout'].strip()


### PR DESCRIPTION
Change-Id: I1a7420ea92e7d0a8bd2df2466a9d7cd6f6335601

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a timed waiting logic to wait for rsyslogd restart after setting rate limiting. Per my test, this is needed for container side only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Wait for rsyslogd restart to make the test more robust.

#### How did you do it?

Add a timed waiting logic to wait for rsyslogd restart after setting rate limiting. Per my test, this is needed for container side only.

#### How did you verify/test it?

Repeatedly running the test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
