### PR TITLE
[acl] Remove typo in shell of test_stress_acl

### DIFF
--- a/tests/acl/templates/acltb_test_stress_acl.sh
+++ b/tests/acl/templates/acltb_test_stress_acl.sh
@@ -4,7 +4,6 @@ finished_times=0
 while [[ ${loop_times} > 0 ]]; do
         echo "Load acl rules"
         sonic-cfggen -j /tmp/acltb_test_stress_acl_rules.json -w
-        sleep(1)
         echo "Delete acl rules"
         acl-loader delete STRESS_ACL
         let finished_times+=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Typo in here will cause shell run failed.

#### How did you do it?
After checking with @xwjiang-ms, remove this line.

#### How did you verify/test it?
Run test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
