### PR TITLE
Enlarge waiting time in test_pfcwd_timer_accuracy case

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -153,7 +153,7 @@ class TestPfcwdAllTimer(object):
         storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
         storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         logger.info("Wait for PFC storm end marker to appear in logs")
-        time.sleep(1)
+        time.sleep(8)
         storm_end_ms = self.retrieve_timestamp("[P]FC_STORM_END")
         storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
         real_detect_time = storm_detect_ms - storm_start_ms


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PFC watchdog time issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enlarge the PFC package count from 300000 to 1000000, it takes more time to restore.
Need enlarge the waiting time in case script.

#### How did you do it?
Increase the waiting time from 1s to 8s.

#### How did you verify/test it?
Run the PFC cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
