### PR TITLE
support t1-56-lag

### DIFF
--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -47,7 +47,7 @@ EXAMPLES = '''
         testcases:
             acl:
                 filename: acl.yml
-                topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+                topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
                 execvar:
                   ptf_host:
                   testbed_type:
@@ -58,7 +58,7 @@ EXAMPLES = '''
                   ptf_host:
             bgp_fact:
                 filename: bgp_fact.yml
-                topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+                topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
             ...
 
     To use it:
@@ -95,6 +95,7 @@ RETURN = '''
                 t1-lag:    [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
                 t1-64-lag: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
                 t1-64-lag-clet: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
+                t1-56-lag: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
             }
 '''
 

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is unsupported."
-  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
+  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']
 
 - name: Get VM info.
   include_tasks: "roles/test/tasks/bgp_gr_helper/get_vm_info.yml"

--- a/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
@@ -16,7 +16,7 @@
       vm_name: "{{ item.value.name }}"
       vm_intf: "{{ item.key }}"
   with_dict: "{{ minigraph_neighbors }}"
-  when: "testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet'] and 'T0' in item.value.name and not vm_name"
+  when: "testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag'] and 'T0' in item.value.name and not vm_name"
 
 - name: Get neighbor IPv4 address.
   set_fact:

--- a/ansible/roles/test/tasks/bgp_multipath_relax.yml
+++ b/ansible/roles/test/tasks/bgp_multipath_relax.yml
@@ -9,8 +9,8 @@
 - fail: msg="please provide testbed_type for bgp_multipath_relax test"
   when: testbed_type is not defined 
 
-- fail: mgs="This test only works for leaf routers as DUT in topology, t1, t1-lag, t1-64-lag, t1-64-lag-clet"
-  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
+- fail: mgs="This test only works for leaf routers as DUT in topology, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag"
+  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/everflow_testbed/get_general_port_info.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/get_general_port_info.yml
@@ -35,5 +35,5 @@
 
 - name: Get the list of ports to be combined to Everflow ACL tables
   set_fact:
-    everflow_table_ports: "{{ (testbed_type in ['t1-lag', 't1-64-lag', 't1-64-lag-clet']) | ternary(portchannel_ports + tor_ports, spine_ports + tor_ports) }}"
+    everflow_table_ports: "{{ (testbed_type in ['t1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']) | ternary(portchannel_ports + tor_ports, spine_ports + tor_ports) }}"
 

--- a/ansible/roles/test/tasks/everflow_testbed/run_test.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/run_test.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't1-64-lag-clet']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -14,7 +14,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['spine']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
@@ -22,7 +22,7 @@
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -13,7 +13,7 @@
 ::/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
+{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') or (testbed_type == 't1-56-lag') %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
 ::/0 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0-116' %}
@@ -39,7 +39,7 @@
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
+{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') or (testbed_type == 't1-56-lag') %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 [0 1] [4 5] [16 17] [20 21]
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0' or testbed_type == 't0-52' or testbed_type == 't0-64' or testbed_type == 't0-64-32' %}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -1,14 +1,14 @@
 testcases:
     acl:
       filename: acltb.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     arp:
       filename: arpall.yml
-      topologies: [ptf32, ptf64, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [ptf32, ptf64, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
 
@@ -22,15 +22,15 @@ testcases:
 
     bgp_gr_helper:
       filename: bgp_gr_helper.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -44,12 +44,12 @@ testcases:
 
     config:
         filename: config.yml
-        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t0, t0-64, t0-116, t0-120]
+        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-120]
 
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     copp:
       filename: copp.yml
@@ -59,7 +59,7 @@ testcases:
 
     decap:
       filename: decap.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
@@ -77,7 +77,7 @@ testcases:
 
     everflow_testbed:
       filename: everflow_testbed.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -155,14 +155,14 @@ testcases:
 
     fib:
       filename: simple-fib.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     hash:
       filename: hash.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -170,7 +170,7 @@ testcases:
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -199,28 +199,28 @@ testcases:
 
     lag_2:
       filename: lag_2.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     lldp:
       filename: lldp.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     link_flap:
       filename: link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     mtu:
       filename: mtu.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -233,16 +233,16 @@ testcases:
 
     neighbour_mac_noptf:
       filename: neighbour-mac-noptf.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     ntp:
       filename: ntp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     pfc_wd:
       filename: pfc_wd.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     portstat:
       filename: portstat.yml
@@ -251,7 +251,7 @@ testcases:
     port_toggle:
       filename: port_toggle.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     qos_sai:
       filename: qos_sai.yml
@@ -259,40 +259,40 @@ testcases:
 
     reboot:
       filename: reboot.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss:
       filename: run_config_cleanup.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss_service:
       filename: restart_swss.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_syncd:
       filename: restart_syncd.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     sensors:
       filename: sensors_check.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     service_acl:
       filename: service_acl.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     snmp:
       filename: snmp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     syslog:
       filename: syslog.yml
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     vlan:
       filename: vlantb.yml
@@ -307,7 +307,7 @@ testcases:
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -227,7 +227,7 @@ veos_groups:
     servers:
         children: [server_1, server_2]                      # source: sonic-mgmt/veos
         vars: 
-            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
+            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
     server_1:
         children: [vm_host_1, vms_1]                        # source: sonic-mgmt/veos
         vars:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -145,7 +145,7 @@ copp/test_copp.py:
   skip:
     reason: "Topology not supported by COPP tests"
     conditions:
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-backend', 'm0', 'mx'] and 't2' not in topo)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'mx'] and 't2' not in topo)"
 
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
@@ -676,9 +676,9 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
 
 qos/test_qos_masic.py:
   skip:
-    reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-backend."
+    reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-56-lag, t1-backend."
     conditions:
-      - "is_multi_asic==False or topo_name not in ['t1-lag', 't1-64-lag', 't1-backend']"
+      - "is_multi_asic==False or topo_name not in ['t1-lag', 't1-64-lag', 't1-56-lag', 't1-backend']"
 
 qos/test_qos_sai.py:
   skip:
@@ -690,7 +690,7 @@ qos/test_qos_sai.py::TestQosSai:
   skip:
     reason: "Unsupported testbed type."
     conditions:
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
   skip:

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -103,7 +103,7 @@ def setup_pfc_test(
     Yields:
         setup_info: dictionary containing pfc timers, generated test ports and selected test ports
     """
-    SUPPORTED_T1_TOPOS = {"t1-lag", "t1-64-lag"}
+    SUPPORTED_T1_TOPOS = {"t1-lag", "t1-64-lag", "t1-56-lag"}
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_list = mg_facts['minigraph_ports'].keys()

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -28,7 +28,7 @@ class QosBase:
     Common APIs
     """
     SUPPORTED_T0_TOPOS = ["t0", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-120", "dualtor", "t0-80", "t0-backend"]
-    SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-backend"]
+    SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3", "j2c+", "jr2"]
 

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -76,8 +76,8 @@ DESTINATION_PREFIX = 150
 NEXTHOP_PREFIX = 100
 
 pytestmark = [
-    # This script supports any T1 topology: t1, t1-64-lag, t1-lag.
-    pytest.mark.topology("t1", "t1-64-lag", "t1-lag")
+    # This script supports any T1 topology: t1, t1-64-lag, t1-56-lag, t1-lag.
+    pytest.mark.topology("t1", "t1-64-lag", "t1-56-lag", "t1-lag")
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

need to add support for t1-56-lag, 


#### How did you do it?
since t1-56-lag is similar to t1-64-lag, all support for t1-64-lag is copied to t1-56-lag.

#### How did you verify/test it?
pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
