### PR TITLE
[Python3 migrate] Fix some type upgrade issue

### DIFF
--- a/ansible/plugins/action/apswitch.py
+++ b/ansible/plugins/action/apswitch.py
@@ -6,6 +6,12 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils._text import to_text
 
 import ast
+import sys
+
+# If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
+if sys.version_info[0] >= 3:
+    unicode = str
+
 
 class ActionModule(ActionBase):
 

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -2,6 +2,8 @@ import pytest
 import os
 import six
 import yaml
+import sys
+import copy
 
 
 @pytest.fixture(scope="module")
@@ -86,4 +88,22 @@ def get_graph_facts(duthost, localhost, hostnames):
         kargs["hosts"] = hostnames
     conn_graph_facts = localhost.conn_graph_facts(
         **kargs)["ansible_facts"]
-    return conn_graph_facts
+    return key_convert2str(conn_graph_facts)
+
+
+def key_convert2str(conn_graph_facts):
+    """
+        In Python2, some key type are unicode, but In Python3, are AnsibleUnsafeText. Convert them to str.
+        Currently, convert the key in conn_graph_facts['device_conn'].
+    """
+    # If Python2, do not change
+    if sys.version_info[0] < 3:
+        return conn_graph_facts
+
+    # Else, convert
+    result = copy.deepcopy(conn_graph_facts)
+    result['device_conn']={}
+    for key, value in conn_graph_facts['device_conn'].items():
+        result['device_conn'][str(key)] = value
+
+    return result

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -78,7 +78,7 @@ def get_graph_facts(duthost, localhost, hostnames):
                     kargs["hosts"] = hostnames
                 conn_graph_facts = localhost.conn_graph_facts(
                     **kargs)["ansible_facts"]
-                return conn_graph_facts
+                return key_convert2str(conn_graph_facts)
     # END OF DEPRECATE WARNING: deprecate ends here.
 
     kargs = {"filepath": lab_conn_graph_path}

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -71,7 +71,7 @@ class LagTest:
     def __get_lag_intf_info(self, lag_facts, lag_name):
         # Figure out interface informations
         po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
-        intf          = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
+        intf          = list(lag_facts['lags'][lag_name]['po_config']['ports'].keys())[0]
         return intf, po_interfaces
 
     def __get_lag_intf_namespace_id(self, lag_facts, lag_name):

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -71,6 +71,8 @@ class LagTest:
     def __get_lag_intf_info(self, lag_facts, lag_name):
         # Figure out interface informations
         po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
+        # In Python2, dict.keys() returns list object, but in Python3 returns an iterable but not indexable object.
+        # So that convert to list explicitly.
         intf          = list(lag_facts['lags'][lag_name]['po_config']['ports'].keys())[0]
         return intf, po_interfaces
 

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -2,6 +2,11 @@ import datetime
 import ipaddress
 
 from tests.common import constants
+import sys
+
+# If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
+if sys.version_info[0] >= 3:
+    unicode = str
 
 
 class TrafficPorts(object):
@@ -188,7 +193,9 @@ class TrafficPorts(object):
             temp_ports (dict): port info constructed from the vlan interfaces
         """
         temp_ports = dict()
-        vlan_details = self.vlan_info.values()[0]
+        # In Python2, dict.values() returns list object, but in Python3 returns an iterable but not indexable object.
+        # So that convert to list explicitly.
+        vlan_details = list(self.vlan_info.values())[0]
         # Filter(remove) PortChannel interfaces from VLAN members list
         vlan_members = [port for port in vlan_details['members'] if 'PortChannel' not in port]
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -66,7 +66,7 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
     test_ports = setup_info['test_ports']
     timers = setup_info['pfc_timers']
     eth0_ip = setup_info['eth0_ip']
-    pfc_wd_test_port = test_ports.keys()[0]
+    pfc_wd_test_port = list(test_ports.keys())[0]
     neighbors = setup_info['neighbors']
     fanout_info = enum_fanout_graph_facts
     dut = duthost

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -66,6 +66,8 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
     test_ports = setup_info['test_ports']
     timers = setup_info['pfc_timers']
     eth0_ip = setup_info['eth0_ip']
+    # In Python2, dict.keys() returns list object, but in Python3 returns an iterable but not indexable object.
+    # So that convert to list explicitly.
     pfc_wd_test_port = list(test_ports.keys())[0]
     neighbors = setup_info['neighbors']
     fanout_info = enum_fanout_graph_facts


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Some test cases like `pc/test_lag_2.py` failed in Python3 environment, caused by key error like the below:
```
KeyError('str2-7260cx3-acs-fan-15')
Traceback (most recent call last):
  File "/azp/_work/25/s/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/azp/_work/25/s/tests/pfcwd/test_pfcwd_timer_accuracy.py", line 75, in pfcwd_timer_setup_restore
    storm_handle = set_storm_params(dut, fanout_info, fanout, peer_params)
  File "/azp/_work/25/s/tests/pfcwd/test_pfcwd_timer_accuracy.py", line 133, in set_storm_params
    storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
  File "/azp/_work/25/s/tests/common/helpers/pfc_storm.py", line 51, in __init__
    self.peer_device = self.fanout_hosts[self.peer_info['peerdevice']]
KeyError: 'str2-7260cx3-acs-fan-15'
```

Actually, it is caused by these codes (When parsing conn_graph_facts):
```
@pytest.fixture(scope="module")
def fanouthosts(ansible_adhoc, conn_graph_facts, creds, ditheists):      # noqa F811
    """
    Shortcut fixture for getting Fanout hosts
    """

    dev_conn = conn_graph_facts.get('device_conn', {})
    fanout_hosts = {}
    # WA for virtual testbed which has no fanout
    try:
        for dut_host, value in dev_conn.items():
            duthost = duthosts[dut_host]
```
In Python2 env, the `dut_host`(the key in dev_conn.items()) is `unicode` object, but in Python3 is `AnsileUnsafeText` object, because [Ansible marks all strings inside returned data as Unsafe.](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#module-return-values-unsafe-strings)
![image](https://user-images.githubusercontent.com/39114813/216935047-43b06844-3d01-41f5-852a-344f24f4e3c0.png)

So, we convert the `AnsileUnsafeText` to `str` in Py3 after got ansible return value.

Other fixes:

In Python2, dict.keys()/dict.values() returns list object, but in Python3 returns an iterable but not indexable object. So that need to convert to list.

The Python "NameError name 'unicode' is not defined" occurs when using the unicode object in Python 3. To solve the error, replace all calls to unicode() with str() because unicode was renamed to str in Python 3.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Python3 migrate fix key error.

#### How did you do it?

Add explicit convert.

#### How did you verify/test it?

Run TC and no key error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
