### PR TITLE
Use same device hostname fixture in cont-reboot and advanced_reboot

### DIFF
--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -326,7 +326,7 @@ class ContinuousReboot:
 
 
 @pytest.mark.device_type('vs')
-def test_continuous_reboot(request, duthosts, rand_one_dut_hostname, ptfhost, localhost, conn_graph_facts, tbinfo, creds):
+def test_continuous_reboot(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, localhost, conn_graph_facts, tbinfo, creds):
     """
     @summary: This test performs continuous reboot cycles on images that are provided as an input.
     Supported parameters for this test can be modified at runtime:
@@ -347,7 +347,7 @@ def test_continuous_reboot(request, duthosts, rand_one_dut_hostname, ptfhost, lo
         Status of transceivers - ports in lab_connection_graph should be present
         Status of BGP neighbors - should be established
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     continuous_reboot = ContinuousReboot(request, duthost, ptfhost, localhost, conn_graph_facts)
     continuous_reboot.start_continuous_reboot(request, duthosts, duthost, ptfhost, localhost, tbinfo, creds)
     continuous_reboot.test_teardown()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use same device selection fixture between `test_cont_warm_reboot` and fixture `advanced_reboot`.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Test cont warm reboot uses fixture `rand_one_dut_hostname` which is other than the device selection fixture used in `advanced_reboot` fixture- `enum_rand_one_per_hwsku_frontend_hostname`

https://github.com/sonic-net/sonic-mgmt/blob/83a72c8f6cb16115c2c91a66644e791891933a3f/tests/common/fixtures/advanced_reboot.py#L824

This can cause inconsistencies between the DUT selected for test by the test script, and DUT selected by the fixture.

To make sure same device is picked, use fixture for both.



#### How did you do it?

#### How did you verify/test it?

Tested on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
