### PR TITLE
Make traffic shift tests work on devices with different route-maps

### DIFF
--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -105,6 +105,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} allowas-in
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -330,7 +330,7 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
         duthost.shell("TSB")
 
 
-def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts_to_dut, bgpmon_setup_teardown, tbinfo):
+def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
     """
     Test TSB.
     Establish BGP session between PTF and DUT, and verify all routes are announced to bgp monitor,
@@ -341,8 +341,8 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
     # Get all routes on neighbors before doing TSA
-    orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
-    orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
+    orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
+    orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
 
     # Shift traffic away using TSA
     duthost.shell("TSA")
@@ -360,17 +360,17 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     cur_v4_routes = {}
     cur_v6_routes = {}
     # Verify that all routes advertised to neighbor at the start of the test
-    if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, cur_v4_routes, 4):
+    if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
         log_missing_routes(orig_v4_routes, cur_v4_routes)
         pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-    if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, cur_v6_routes, 6):
+    if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
         log_missing_routes(orig_v6_routes, cur_v6_routes)
         pytest.fail("Not all ipv6 routes are announced to neighbors")
 
 
 def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                   bgpmon_setup_teardown, nbrhosts_to_dut):
+                                   bgpmon_setup_teardown, nbrhosts):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
@@ -382,8 +382,8 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
                   "DUT is not in normal state")
     try:
         # Get all routes on neighbors before doing TSA
-        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
-        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
         # Remove the Neighbors for the particular BGP instance
         bgp_neighbors = remove_bgp_neighbors(duthost, asic_index)
 
@@ -410,18 +410,18 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, cur_v4_routes, 4):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
             log_missing_routes(orig_v4_routes, cur_v4_routes)
             pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, cur_v6_routes, 6):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             log_missing_routes(orig_v6_routes, cur_v6_routes)
             pytest.fail("Not all ipv6 routes are announced to neighbors")
 
 
 
 @pytest.mark.disable_loganalyzer
-def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, 
                                     nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA after config save and config reload
@@ -438,8 +438,8 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         #cur_nbrhosts = get_bgp_neighbor_hosts(duthost, nbrhosts)
 
         # Get all routes on neighbors before doing TSA
-        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
-        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
         # Issue TSA on DUT
         duthost.shell("TSA")
         duthost.shell('sudo config save -y')
@@ -474,11 +474,11 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, cur_v4_routes, 4):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
             log_missing_routes(orig_v4_routes, cur_v4_routes)
             pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, cur_v6_routes, 6):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             log_missing_routes(orig_v6_routes, cur_v6_routes)
             pytest.fail("Not all ipv6 routes are announced to neighbors")
 
@@ -486,7 +486,7 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
 
 @pytest.mark.disable_loganalyzer
 def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                ptfhost, nbrhosts_to_dut, bgpmon_setup_teardown,
+                                                ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown,
                                                 traffic_shift_community, tbinfo):
     """
     Test load_minigraph --traffic-shift-away
@@ -501,8 +501,8 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
 
     try:
         # Get all routes on neighbors before doing TSA
-        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
-        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
         config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True,
                       traffic_shift_away=True)
 
@@ -532,11 +532,11 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, cur_v4_routes, 4):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
             log_missing_routes(orig_v4_routes, cur_v4_routes)
             pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, cur_v6_routes, 6):
+        if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             log_missing_routes(orig_v6_routes, cur_v6_routes)
             pytest.fail("Not all ipv6 routes are announced to neighbors")
 

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -224,6 +224,17 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
     return True
 
 
+def verify_current_routes_announced_to_neighs(dut_host, neigh_hosts, orig_routes_on_all_nbrs, ip_ver):
+    """
+    Verify all the original routes are announced to neighbors after TSB
+    """
+    logger.info("Verifying all the original routes(ipv{}) are announced to bgp neighbors".format(ip_ver))
+    routes_on_all_nbrs = parse_routes_on_neighbors(dut_host, neigh_hosts, ip_ver)
+    # Compare current routes after TSB with original routes advertised to neighbors
+    if routes_on_all_nbrs.items() != orig_routes_on_all_nbrs.items():
+        return False           
+    return True
+
 def verify_loopback_route_with_community(dut_host, neigh_hosts, ip_ver, community):
     logger.info("Verifying only loopback routes are announced to bgp neighbors")
     mg_facts = dut_host.minigraph_facts(host=dut_host.hostname)['ansible_facts']
@@ -273,7 +284,7 @@ def check_tsa_persistence_support(duthost):
     return True
 
 
-def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts,
+def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
              nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA
@@ -303,14 +314,28 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
         duthost.shell("TSB")
 
 
-def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
+def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts_to_dut, bgpmon_setup_teardown, tbinfo):
     """
     Test TSB.
     Establish BGP session between PTF and DUT, and verify all routes are announced to bgp monitor,
     and all routes are announced to neighbors
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Issue TSB on DUT
+    # Ensure that the DUT is not in maintenance already before start of the test
+    pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
+                  "DUT is not in normal state")
+
+    #cur_nbrhosts = get_bgp_neighbor_hosts(duthost, nbrhosts)
+
+    # Get all routes on neighbors before doing TSA
+    orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
+    orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
+
+    # Shift traffic away using TSA
+    duthost.shell("TSA")
+    pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
+                      "DUT is not in maintenance state")
+    # Issue TSB on DUT to bring traffic back
     duthost.shell("TSB")
     # Verify DUT is in normal state.
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
@@ -319,25 +344,30 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
         pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost, bgpmon_setup_teardown['namespace']) == [],
                       "Not all routes are announced to bgpmon")
 
-    pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 4), 4),
+    # Verify that all routes advertised to neighbor at the start of the test
+    pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, 4),
                   "Not all ipv4 routes are announced to neighbors")
-    pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
+    pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, 6),
                   "Not all ipv6 routes are announced to neighbors")
 
 
 def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                   bgpmon_setup_teardown, nbrhosts):
+                                   bgpmon_setup_teardown, nbrhosts_to_dut):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bgp_neighbors = {}
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
-
+    # Ensure that the DUT is not in maintenance already before start of the test
+    pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
+                  "DUT is not in normal state")
     try:
+        #cur_nbrhosts = get_bgp_neighbor_hosts(duthost, nbrhosts)
 
-        routes_4 = parse_rib(duthost, 4)
-        routes_6 = parse_rib(duthost, 6)
+        # Get all routes on neighbors before doing TSA
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
         # Remove the Neighbors for the particular BGP instance
         bgp_neighbors = remove_bgp_neighbors(duthost, asic_index)
 
@@ -361,28 +391,36 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
                       "Not all BGP sessions are established on DUT")
 
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_4, 4),
-                      "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs, duthost, nbrhosts, routes_6, 6),
-                      "Not all ipv6 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v4_routes, 4),
+                  "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts_to_dut, orig_v6_routes, 6),
+                  "Not all ipv6 routes are announced to neighbors")
 
 
 @pytest.mark.disable_loganalyzer
-def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts,
+def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
                                     nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA after config save and config reload
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    # Ensure that the DUT is not in maintenance already before start of the test
+    pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
+                  "DUT is not in normal state")
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
 
     try:
+        #cur_nbrhosts = get_bgp_neighbor_hosts(duthost, nbrhosts)
+
+        # Get all routes on neighbors before doing TSA
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
         # Issue TSA on DUT
         duthost.shell("TSA")
         duthost.shell('sudo config save -y')
-        config_reload(duthost, check_intf_up_ports=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),
@@ -404,33 +442,39 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         # Recover to Normal state
         duthost.shell("TSB")
         duthost.shell('sudo config save -y')
-        config_reload(duthost, check_intf_up_ports=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,
-                                 duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                      "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,
-                                 duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                      "Not all ipv6 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, 
+                                duthost, nbrhosts_to_dut, orig_v4_routes, 4),
+                                "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, 
+                                duthost, nbrhosts_to_dut, orig_v6_routes, 6),
+                                "Not all ipv6 routes are announced to neighbors")
 
 
 @pytest.mark.disable_loganalyzer
 def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown,
+                                                ptfhost, nbrhosts_to_dut, bgpmon_setup_teardown,
                                                 traffic_shift_community, tbinfo):
     """
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    # Ensure that the DUT is not in maintenance already before start of the test
+    pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
+                  "DUT is not in normal state")
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
 
     try:
+        # Get all routes on neighbors before doing TSA
+        orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 4)
+        orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts_to_dut, 6)
         config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True,
                       traffic_shift_away=True)
 
@@ -457,9 +501,9 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
         # Wait until all routes are announced to neighbors
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,
-                                 duthost, nbrhosts, parse_rib(duthost, 4), 4),
-                      "Not all ipv4 routes are announced to neighbors")
-        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,
-                                 duthost, nbrhosts, parse_rib(duthost, 6), 6),
-                      "Not all ipv6 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, 
+                                duthost, nbrhosts_to_dut, orig_v4_routes, 4),
+                                "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, 
+                                duthost, nbrhosts_to_dut, orig_v6_routes, 6),
+                                "Not all ipv6 routes are announced to neighbors")

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -231,7 +231,7 @@ def verify_current_routes_announced_to_neighs(dut_host, neigh_hosts, orig_routes
     logger.info("Verifying all the original routes(ipv{}) are announced to bgp neighbors".format(ip_ver))
     cur_routes_on_all_nbrs.update(parse_routes_on_neighbors(dut_host, neigh_hosts, ip_ver))
     # Compare current routes after TSB with original routes advertised to neighbors
-    if cur_routes_on_all_nbrs.items() != orig_routes_on_all_nbrs.items():        
+    if cur_routes_on_all_nbrs != orig_routes_on_all_nbrs:        
         return False           
     return True
 

--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -185,10 +185,14 @@ def chk_for_pfc_wd(duthost):
     log_debug("pfc_status={}".format(pfc_status))
 
     if pfc_status == "enable":
-        res = duthost.shell('redis-dump -d 4 --pretty -k \"PFC_WD*\"')
-        pfc_wd_data = json.loads(res["stdout"])
-        if len(pfc_wd_data):
-            ret = True
+        for namespace in duthost.get_frontend_asic_namespace_list():
+            cmd_prefix = ''
+            if duthost.is_multi_asic:
+                cmd_prefix = 'sudo ip netns exec {} '.format(namespace)            
+            res = duthost.shell(cmd_prefix + 'redis-dump -d 4 --pretty -k \"PFC_WD*\"')
+            pfc_wd_data = json.loads(res["stdout"])
+            if len(pfc_wd_data):
+                ret = True                
     else:
         # pfc is not enabled; return True, as there will not be any pfc to check
         ret = True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Changes to make TSA/B test cases generic and allow validation with different route-maps where not all routes are advertised

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently TSB validation is done by checking if all routes are advertised to all neighbors. On devices which have route-maps preventing advertisement of all routes to neighbors, this test fails, even though the TSA/B functionality works. 

#### How did you do it?
Change TSA/B validation logic to compare the routes on the neighbors before and after the test. Also fixed PFC_WD config validation after config reload to be multi-asic aware

#### How did you verify/test it?
Run bgp/test_traffic_shift.py on T1 & T2 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
