### PR TITLE
testcase for IS-IS overload bit and wide metric

### DIFF
--- a/tests/wan/isis/template/sonic_isis_config.j2
+++ b/tests/wan/isis/template/sonic_isis_config.j2
@@ -6,7 +6,8 @@
             "level-capability": "{{ level_capability | default('level-2') }}",
             "dynamic-hostname": "{{ dynamic_hostname | default('true') }}",
             "lsp-mtu-size": "{{ lsp_mtu_size | default('1497') }}",
-            "log-adjacency-changes": "{{ log_adjacency_changes | default('false') }}"
+            "log-adjacency-changes": "{{ log_adjacency_changes | default('false') }}",
+            "set-overload-bit": "{{ isis_overload_bit | default('false') }}"
         }
 {%- endif %}
     },

--- a/tests/wan/isis/test_isis_metric_wide.py
+++ b/tests/wan/isis/test_isis_metric_wide.py
@@ -1,0 +1,53 @@
+import pytest
+import logging
+import functools
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+from isis_helpers import config_device_isis
+from isis_helpers import add_dev_isis_attr, del_dev_isis_attr
+
+logger = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.topology('wan-com'),
+]
+
+
+@pytest.fixture(scope="function")
+def isis_setup_teardown_wide_metric(isis_common_setup_teardown, request):
+    target_devices = []
+    selected_connections = isis_common_setup_teardown
+
+    config_key = "wide_metric"
+    config_dict = {config_key: '16777215'}
+    for (dut_host, _, _, _) in selected_connections:
+        add_dev_isis_attr(dut_host, config_dict)
+        target_devices.append(dut_host)
+        config_device_isis(dut_host)
+
+    def revert_isis_config(devices):
+        for device in devices:
+            del_dev_isis_attr(dut_host, [config_key])
+            config_device_isis(device)
+
+    request.addfinalizer(functools.partial(revert_isis_config, target_devices))
+
+
+def check_isis_wide_metric(duthost):
+    isis_facts = duthost.isis_facts()["ansible_facts"]['isis_facts']
+    for lsp, metric in isis_facts['database_detail']['test'].items():
+        if duthost.hostname in lsp:
+            for _, value in metric.items():
+                if int(value) == 16777215:
+                    return True
+    return False
+
+
+def test_isis_wide_metric(isis_common_setup_teardown, isis_setup_teardown_wide_metric):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, _, _) = selected_connections[0]
+
+    pytest_assert(wait_until(90, 2, 0, check_isis_wide_metric, dut_host),
+                  "Max wide metric doesn't set!")

--- a/tests/wan/isis/test_isis_overload_bit.py
+++ b/tests/wan/isis/test_isis_overload_bit.py
@@ -1,0 +1,83 @@
+import pytest
+import logging
+import functools
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+from isis_helpers import config_device_isis
+from isis_helpers import add_dev_isis_attr, del_dev_isis_attr
+
+logger = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.topology('wan-com'),
+]
+
+
+@pytest.fixture(scope="function")
+def isis_setup_teardown_set_overload_bit(isis_common_setup_teardown, request):
+    target_devices = []
+    selected_connections = isis_common_setup_teardown
+
+    config_key = "isis_overload_bit"
+    config_dict = {config_key: 'true'}
+    for (dut_host, _, _, _) in selected_connections:
+        add_dev_isis_attr(dut_host, config_dict)
+        target_devices.append(dut_host)
+        config_device_isis(dut_host)
+
+    def revert_isis_config(devices):
+        for device in devices:
+            del_dev_isis_attr(dut_host, [config_key])
+            config_device_isis(device)
+
+    request.addfinalizer(functools.partial(revert_isis_config, target_devices))
+
+
+@pytest.fixture(scope="function")
+def isis_setup_teardown_unset_overload_bit(isis_common_setup_teardown, request):
+    target_devices = []
+    selected_connections = isis_common_setup_teardown
+
+    config_key = "isis_overload_bit"
+    config_dict = {config_key: 'false'}
+    for (dut_host, _, _, _) in selected_connections:
+        add_dev_isis_attr(dut_host, config_dict)
+        target_devices.append(dut_host)
+        config_device_isis(dut_host)
+
+    def revert_isis_config(devices):
+        for device in devices:
+            del_dev_isis_attr(dut_host, [config_key])
+            config_device_isis(device)
+
+    request.addfinalizer(functools.partial(revert_isis_config, target_devices))
+
+
+def check_isis_overload_bit(duthost, enabled):
+    isis_facts = duthost.isis_facts()["ansible_facts"]['isis_facts']
+
+    for lsp, _ in isis_facts['database']['test'].items():
+        if duthost.hostname in lsp:
+            overload = isis_facts['database']['test'][lsp]['overload']
+            if int(overload) == enabled:
+                return True
+
+    return False
+
+
+def test_isis_set_overload_bit(isis_common_setup_teardown, isis_setup_teardown_set_overload_bit):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, _, _) = selected_connections[0]
+
+    pytest_assert(wait_until(30, 2, 0, check_isis_overload_bit, dut_host, 1),
+                  "Overload bit doesn't set!")
+
+
+def test_isis_unset_overload_bit(isis_common_setup_teardown, isis_setup_teardown_unset_overload_bit):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, _, _) = selected_connections[0]
+
+    pytest_assert(wait_until(30, 2, 0, check_isis_overload_bit, dut_host, 0),
+                  "Overload bit doesn't unset!")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
To verify IS-IS set overload bit and wide metric funciton
Summary:
Fixes # (issue)
N/A
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
For function verification of IS-IS set-overload-bit and wide metric.
#### How did you do it?
Add new testcases.
#### How did you verify/test it?
Based on WAN topo verify these testcases.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
WAN topo.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
