### PR TITLE
Skip test_buffer.py for cisco-8000 platforms.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -652,6 +652,12 @@ qos:
     conditions:
       - "topo_name in ['m0', 'mx']"
 
+qos/test_buffer.py:
+  skip:
+    reason: "These tests don't apply to cisco 8000 platforms, since they support only traditional model."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 qos/test_buffer_traditional.py:
   skip:
     reason: "Buffer traditional test is only supported 201911 branch and not yet supported on multi-ASIC platform."


### PR DESCRIPTION
All tests in qos/test_buffer.py check for dynamic buffer model and then procede. Since cisco-8000 platform supports only traditional model, this does nothing, and spends a lot of time unnecessarily. This PR is to skip them at the entry level itself for cisco-8000 platforms.


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
To save time running on cisco-8000 platforms.

#### How did you do it?
Added skip condition in common skip condition yaml file.

#### How did you verify/test it?
Ran it with cisco platform:
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
20:17:06 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
SKIPPED [1] qos/test_buffer.py:1991: These tests don't apply to cisco 8000 platforms, since they support only traditional model.
SKIPPED [16] qos/test_buffer.py: These tests don't apply to cisco 8000 platforms, since they support only traditional model.
================================================================================================= 17 skipped in 2.34 seconds =================================================================================================
vxr@02b4831febde:/data/tests$ 

Without this fix, we get 3 minutes to skip all:
`<testsuite errors="0" failures="0" name="pytest" skipped="17" tests="17" time="164.315">`

#### Any platform specific information?
Specific to cisco-8000 platforms only.