### PR TITLE
[dualtor] fix hard coded subnet mask length in `remove_static_routes`

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1355,7 +1355,7 @@ def remove_static_routes(standby_tor, route_dst):
     """
     route_dst = ipaddress.ip_address(route_dst.decode())
     subnet_mask_len = 32 if route_dst.version == 4 else 128
-    
+
     logger.info("Removing dual ToR peer switch static route:  {}/{}".format(str(route_dst), subnet_mask_len))
     standby_tor.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1354,7 +1354,10 @@ def remove_static_routes(standby_tor, active_tor_loopback_ip):
     Remove static routes for active tor
     """
     logger.info("Removing dual ToR peer switch static route")
-    standby_tor.shell('ip route del {}/32'.format(active_tor_loopback_ip), module_ignore_errors=True)
+
+    active_tor_loopback_ip = ipaddress.ip_address(active_tor_loopback_ip.decode())
+    subnet_mask_len = 32 if active_tor_loopback_ip.version == 4 else 128
+    standby_tor.shell('ip route del {}/{}'.format(str(active_tor_loopback_ip), subnet_mask_len), module_ignore_errors=True)
 
 
 def increase_linkmgrd_probe_interval(duthosts, tbinfo):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1356,7 +1356,7 @@ def remove_static_routes(standby_tor, route_dst):
     route_dst = ipaddress.ip_address(route_dst.decode())
     subnet_mask_len = 32 if route_dst.version == 4 else 128
     
-    logger.info("Removing dual ToR peer switch static route: ip route del {}/{}".format(str(route_dst), subnet_mask_len))
+    logger.info("Removing dual ToR peer switch static route:  {}/{}".format(str(route_dst), subnet_mask_len))
     standby_tor.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
 
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1349,15 +1349,15 @@ def add_nexthop_routes(standby_tor, route_dst, nexthops=None):
     logging.info("Route added to {}: {}".format(standby_tor.hostname, route_cmd))
 
 
-def remove_static_routes(standby_tor, active_tor_loopback_ip):
+def remove_static_routes(standby_tor, route_dst):
     """
     Remove static routes for active tor
     """
-    logger.info("Removing dual ToR peer switch static route")
-
-    active_tor_loopback_ip = ipaddress.ip_address(active_tor_loopback_ip.decode())
-    subnet_mask_len = 32 if active_tor_loopback_ip.version == 4 else 128
-    standby_tor.shell('ip route del {}/{}'.format(str(active_tor_loopback_ip), subnet_mask_len), module_ignore_errors=True)
+    route_dst = ipaddress.ip_address(route_dst.decode())
+    subnet_mask_len = 32 if route_dst.version == 4 else 128
+    
+    logger.info("Removing dual ToR peer switch static route: ip route del {}/{}".format(str(route_dst), subnet_mask_len))
+    standby_tor.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
 
 
 def increase_linkmgrd_probe_interval(duthosts, tbinfo):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1349,15 +1349,15 @@ def add_nexthop_routes(standby_tor, route_dst, nexthops=None):
     logging.info("Route added to {}: {}".format(standby_tor.hostname, route_cmd))
 
 
-def remove_static_routes(standby_tor, route_dst):
+def remove_static_routes(duthost, route_dst):
     """
-    Remove static routes for active tor
+    Remove static routes for duthost
     """
     route_dst = ipaddress.ip_address(route_dst.decode())
     subnet_mask_len = 32 if route_dst.version == 4 else 128
 
     logger.info("Removing dual ToR peer switch static route:  {}/{}".format(str(route_dst), subnet_mask_len))
-    standby_tor.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
+    duthost.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
 
 
 def increase_linkmgrd_probe_interval(duthosts, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Below is the test log for `[dualtor.test_orchagent_active_tor_downstream][test_downstream_ecmp_nexthops[ipv6]]`, the hard coded prefix length in  `remove_static_routes` is failing the test. 

> 29/01/2023 16:46:47 dual_tor_utils.add_nexthop_routes        L1292 INFO   | Route added to **************: ip route replace **fc10:2020::f/128** nexthop via fc02:1000::6d nexthop via fc02:1000::6c nexthop via fc02:1000::1a nexthop via fc02:1000::6e 

> 29/01/2023 17:05:54 dual_tor_utils.**remove_static_routes**      L1299 INFO   | Removing dual ToR peer switch static route
> 29/01/2023 17:05:54 base._run                                L0063 DEBUG  | /azp/_work/11/s/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#100: [**************] AnsibleModule::shell, args=[**"ip route del fc10:2020::f/32"**], kwargs={"module_ignore_errors": true}
> 29/01/2023 17:05:55 base._run                                L0082 DEBUG  | /azp/_work/11/s/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#100: [**************] AnsibleModule::shell Result => {"stderr_lines": ["RTNETLINK answers: No such process"], "changed": true, "end": "2023-01-29 17:05:55.856325", "_ansible_no_log": false, "stdout": "", **"cmd": "ip route del fc10:2020::f/32", "rc": 2, "failed": true, "stderr": "RTNETLINK answers: No such process", "delta": "0:00:00.003365",** "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "ip route del fc10:2020::f/32", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": [], "start": "2023-01-29 17:05:55.852960", "msg": "non-zero return code"}
> 29/01/2023 17:05:55 __init__._log_sep_line                   L0160 INFO   | ==================== dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops[ipv6] teardown ====================


sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
