### PR TITLE
[chassis][t2] swap_syncd on all asics when dealing with multi-asic duthost

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -114,7 +114,11 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
         creds (dict): Credentials used to access the docker registry.
     """
 
-    asic = duthost.asic_instance_from_namespace(namespace)
+    if namespace == DEFAULT_NAMESPACE and duthost.is_multi_asic:
+        asics_list = duthost.asics
+    else:
+        asics_list = [duthost.asic_instance_from_namespace(namespace)]
+
     vendor_id = _get_vendor_id(duthost)
 
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
@@ -127,8 +131,9 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     # Force image download to go through mgmt network
     duthost.command("config bgp shutdown all")
 
-    asic.stop_service("swss")
-    asic.delete_container("syncd")
+    for asic in asics_list:
+        asic.stop_service("swss")
+        asic.delete_container("syncd")
 
     # Set sysctl RCVBUF parameter for tests
     duthost.command("sysctl -w net.core.rmem_max=609430500")
@@ -136,7 +141,8 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     # Set sysctl SENDBUF parameter for tests
     duthost.command("sysctl -w net.core.wmem_max=609430500")
 
-    _perform_swap_syncd_shutdown_check(asic)
+    for asic in asics_list:
+        _perform_swap_syncd_shutdown_check(asic)
 
     is_syncdrpc_present_locally = duthost.command('docker image inspect ' + docker_rpc_image,
                                                   module_ignore_errors=True)['rc'] == 0
@@ -161,8 +167,8 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
 
     logger.info("Reloading config and restarting swss...")
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
-
-    _perform_syncd_liveness_check(asic)
+    for asic in asics_list:
+        _perform_syncd_liveness_check(asic)
 
 
 def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
@@ -174,7 +180,10 @@ def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
         duthost (SonicHost): The target device.
         creds (dict): Credentials used to access the docker registry.
     """
-    asic = duthost.asic_instance_from_namespace(namespace)
+    if namespace == DEFAULT_NAMESPACE and duthost.is_multi_asic:
+        asics_list = duthost.asics
+    else:
+        asics_list = [duthost.asic_instance_from_namespace(namespace)]
     vendor_id = _get_vendor_id(duthost)
 
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
@@ -182,8 +191,9 @@ def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
     if duthost.facts.get("platform_asic") == 'broadcom-dnx':
         docker_syncd_name = docker_syncd_name + "-dnx"
 
-    asic.stop_service("swss")
-    asic.delete_container("syncd")
+    for asic in asics_list:
+        asic.stop_service("swss")
+        asic.delete_container("syncd")
 
     tag_image(
         duthost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
QoS multi-asic tests are failing when run against a multi-asic DUT.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
QoS multi-asic tests are failing when run against a multi-asic DUT.

Reason:
PR #[5097 ](https://github.com/sonic-net/sonic-mgmt/pull/5097) introduced namespace with default value of  DEFAULT_NAMESPACE in swap_syncd in tests/common/system_utils/docker.py For multi-asic DUT, if namespace is not specified, then syncd is only swapped on the first asic of DUT. Since, the PR did not update swapSyncd in tests/conftest.py to pass any value to namespace, syncd is swapped only on asic0.

#### How did you do it?
For backward compatability, modified swap_syncd that if DUT is multi asic and namespace is DEFAULT_NAMESPACE, then swap syncd on all the asics in the DUT
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
