### PR TITLE
ADD_TOPO: Enhancements to support large number of CEOS VMs required for scaled T2 Topology

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -218,7 +218,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, type='str'),
-            state=dict(required=True, choices=['started', 'restarted', 'stopped', 'present', 'absent', 'status'], type='str'),
+            state=dict(required=True, choices=['started', 'restarted', 'stopped', 'present', 'absent', 'status', 'configure'], type='str'),
             router_id=dict(required=False, type='str'),
             local_ip=dict(required=False, type='str'),
             peer_ip=dict(required=False, type='str'),
@@ -259,6 +259,9 @@ def main():
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, dump_script=dump_script, passive=passive)
             setup_exabgp_supervisord_conf(name)
             refresh_supervisord(module)
+        elif state == 'configure':
+            setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, dump_script=dump_script, passive=passive)
+            setup_exabgp_supervisord_conf(name)
         elif state == 'stopped':
             stop_exabgp(module, name)
         elif state == 'absent':

--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -28,7 +28,7 @@
       - net_admin
     privileged: yes
     memory: 2G
-    memory_swap: 2G
+    memory_swap: 4G
     env:
       CEOS=1
       container=docker

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -164,8 +164,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 8G
-      memory_swap: 8G
+      memory: 16G
+      memory_swap: 32G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -29,38 +29,72 @@
       ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
       ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
 
-  - name: (Re)start exabgp processes for IPv4 on PTF
+  - name: Configure exabgp processes for IPv4 on PTF
     exabgp:
       name: "{{ vm_item.key }}"
-      state: "restarted"
+      state: "configure"
       router_id: "{{ ptf_local_ipv4 }}"
       local_ip: "{{ ptf_local_ipv4 }}"
       peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv4.split('/')[0] }}"
       local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
       peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
       port: "{{ 5000 + vm_item.value.vm_offset|int }}"
-    async: 300
-    poll: 0
     loop: "{{ topology['VMs']|dict2items }}"
     loop_control:
       loop_var: vm_item
     delegate_to: "{{ ptf_host }}"
 
-  - name: (Re)start exabgp processes for IPv6 on PTF
+  - name: Gather exabgp v4 programs
+    set_fact:
+      program_group_name: "exabgpv4"
+      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '(.*)', 'exabgp-\\1') | join(',')}}"
+
+  - name: Configure exabgpv4 group
+    template:
+      src: "roles/vm_set/templates/exabgp.conf.j2"
+      dest: "/etc/supervisor/conf.d/exabgpv4.conf"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: configure exabgp processes for IPv6 on PTF
     exabgp:
       name: "{{ vm_item.key }}-v6"
-      state: "restarted"
+      state: "configure"
       router_id: "{{ ptf_local_ipv4 }}"
       local_ip: "{{ ptf_local_ipv6 }}"
       peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv6.split('/')[0] }}"
       local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
       peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
       port: "{{ 6000 + vm_item.value.vm_offset|int }}"
-    async: 300
-    poll: 0
     loop: "{{ topology['VMs']|dict2items }}"
     loop_control:
       loop_var: vm_item
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Gather exabgp v6 programs
+    set_fact:
+      program_group_name: "exabgpv6"
+      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '(.*)', 'exabgp-\\1-v6') | join(',')}}"
+
+  - name: Configure exabgpv6 group
+    template:
+      src: "roles/vm_set/templates/exabgp.conf.j2"
+      dest: "/etc/supervisor/conf.d/exabgpv6.conf"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Reread supervisor
+    shell: supervisorctl reread
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Update supervisor
+    shell: supervisorctl update
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Restart v4 Exabgp 
+    shell: supervisorctl restart exabgpv4:*
+    delegate_to: "{{ ptf_host }}"
+  
+  - name: Restart v6 Exabgp 
+    shell: supervisorctl restart exabgpv6:*
     delegate_to: "{{ ptf_host }}"
 
   - name: Wait for exabgp to (re)start

--- a/ansible/roles/vm_set/templates/exabgp.conf.j2
+++ b/ansible/roles/vm_set/templates/exabgp.conf.j2
@@ -1,0 +1,2 @@
+[group:{{ program_group_name }}]
+programs={{ program_group_programs }}


### PR DESCRIPTION
### Description of PR
ADD_TOPO: Enhancements to support large number of CEOS VMs required for scaled T2 Topology

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
So Far, with T0, and T1 topologies, we had limited requirements of the number of CEOS neighbors and the exabgp route scale per neighbor was low. Now with Different T2 topologies being Introduced, the requirement on both no of CEOS neighbors(T1 neighbors, + T3 neighbors), as well as route scale(On T3 neighbors, route scale requirement is higher) is pretty high. 

We are coming up with newer T2 topology for fully loaded Testbed. The requirement is that 2 linecards are used as Uplink linecards, and 4 as Downlink linecards.. And the Number of T3 neighbors required are 40+, and no of T1 neighbors required are 120+.

While deploying this new topology, observed following issues during add-topo.

1. ptf-docker runs out of memory.
2. Some of the exabgp proccesses are getting exited randomly. Supervisord is not able to restart them. The rest of the exabgp processes are very flaky..They are getting exited and restarted in a loop.
3. TestServer hangs with high CPU and runs out of memory.

#### How did you do it?
Following are the root causes and fixes.
1. For PTF-docker, Now since Routes are scaled (32k per T3 neighbor), with more number of T3 neighbors, the ptf memory usage has increased. Earlier PTF docker was instantiated with 8G memory (no swap). Made the change to run with 16G memory(+16 G Swap).
2. With 160+ CEOS containers, we need to start 320+ Exabgp processes(1 v4, 1 v6 for each neighbor), our current mechanism of starting processes by Supervisord is not working(random processes are exiting and restarting in a loop). Some of the processes are never started after a while.
With some experimentation, found that instead of starting them one by one, creating a group and start all of them belonging to a group is much faster and stable. So the change is made to create 2 Process Groups(one for v4 and another for v6). And exabgp processes are controlled by starting these 2 groups.
3. On current testbed, the observation is that each T1 CEOS container takes 1G+ memory, and each T3 CEOS container takes 1.3G+ memory(more routes here). With high number of containers along with PTF container(16G +) is easily crossing total memory available on test server(on my server 187G). To Fix this, enabled --memory-swap for each CEOS container.. Earlier it was 2G memory (no swap), now its changed to 2G memory (+2G Swap). 
With this change, the system doesnt go out of memory, but of course the CPU gets busy once it hits the memory limit(starts using SWAP Space).



#### How did you verify/test it?
Tried the changes with 144 Neighbors(40 T3 + 104 T1 Neighbors).
![image](https://user-images.githubusercontent.com/115033986/217674269-4f6681f3-975d-4cff-a47d-1564fdd0563c.png)



![image](https://user-images.githubusercontent.com/115033986/217674625-96235696-eb4b-4d52-87fe-a2ccc0d93e93.png)







#### Any platform specific information?
None

