### PR TITLE
Restore linkmgrd prober interval in dualtor after test

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1357,21 +1357,18 @@ def remove_static_routes(standby_tor, active_tor_loopback_ip):
     standby_tor.shell('ip route del {}/32'.format(active_tor_loopback_ip), module_ignore_errors=True)
 
 
-def increase_linkmgrd_probe_interval(duthosts, tbinfo):
+def recover_linkmgrd_probe_interval(duthosts, tbinfo):
     '''
     Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
     '''
     if 'dualtor' not in tbinfo['topo']['name']:
         return
 
-    probe_interval_ms = 1000
-
-    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
-
+    default_probe_interval_ms = 100
+    logger.info("Recover linkmgrd probe interval on {} to {}ms".format(duthosts, default_probe_interval_ms))
     cmds = []
     cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                .format(probe_interval_ms))
-    cmds.append("config save -y")
+                .format(default_probe_interval_ms))
     duthosts.shell_cmds(cmds=cmds)
 
 
@@ -1382,9 +1379,10 @@ def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
     if 'dualtor' not in tbinfo['topo']['name']:
         return
 
-    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
+    logger.info("Update linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
     cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'.format(probe_interval_ms))
+    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                .format(probe_interval_ms))
     duthosts.shell_cmds(cmds=cmds)
 
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1365,11 +1365,7 @@ def recover_linkmgrd_probe_interval(duthosts, tbinfo):
         return
 
     default_probe_interval_ms = 100
-    logger.info("Recover linkmgrd probe interval on {} to {}ms".format(duthosts, default_probe_interval_ms))
-    cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                .format(default_probe_interval_ms))
-    duthosts.shell_cmds(cmds=cmds)
+    update_linkmgrd_probe_interval(duthosts, tbinfo, default_probe_interval_ms)
 
 
 def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
@@ -1383,7 +1379,7 @@ def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
     cmds = []
     cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
                 .format(probe_interval_ms))
-    duthosts.shell_cmds(cmds=cmds)
+    duthosts.shell(cmds=cmds)
 
 
 @pytest.fixture(scope='module')

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1359,27 +1359,22 @@ def remove_static_routes(standby_tor, active_tor_loopback_ip):
 
 def recover_linkmgrd_probe_interval(duthosts, tbinfo):
     '''
-    Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
+    Recover the linkmgrd probe interval to default value
     '''
-    if 'dualtor' not in tbinfo['topo']['name']:
-        return
-
     default_probe_interval_ms = 100
     update_linkmgrd_probe_interval(duthosts, tbinfo, default_probe_interval_ms)
 
 
 def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
     '''
-    Temporarily modify linkmgrd probe interval
+    Update the linkmgrd probe interval
     '''
     if 'dualtor' not in tbinfo['topo']['name']:
         return
 
     logger.info("Update linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
-    cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                .format(probe_interval_ms))
-    duthosts.shell(cmds=cmds)
+    duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                   .format(probe_interval_ms))
 
 
 @pytest.fixture(scope='module')

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -232,7 +232,7 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
     global icmp_responder_session_started
 
     update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
-    duthosts.shell_cmds("config save -y")
+    duthosts.shell("config save -y")
 
     duthost = duthosts[0]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -280,7 +280,7 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
         return
 
     update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
-    duthosts.shell_cmds("config save -y")
+    duthosts.shell("config save -y")
 
     duthost = duthosts[rand_one_dut_hostname]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -308,7 +308,7 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
     ptfhost.shell("supervisorctl stop icmp_responder")
     logging.info("Recover linkmgrd probe interval")
     recover_linkmgrd_probe_interval(duthosts, tbinfo)
-    duthosts.shell_cmds("config save -y")
+    duthosts.shell("config save -y")
 
 
 @pytest.fixture

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 
 from tests.common import constants
 from tests.common.helpers.assertions import pytest_assert as pt_assert
-from tests.common.dualtor.dual_tor_utils import increase_linkmgrd_probe_interval
+from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval, recover_linkmgrd_probe_interval
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ ICMP_RESPONDER_CONF_TEMPL = "icmp_responder.conf.j2"
 GARP_SERVICE_PY = 'garp_service.py'
 GARP_SERVICE_CONF_TEMPL = 'garp_service.conf.j2'
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
+PROBER_INTERVAL_MS = 1000
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -230,7 +231,8 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     global icmp_responder_session_started
 
-    increase_linkmgrd_probe_interval(duthosts, tbinfo)
+    update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
+    duthosts.shell_cmds("config save -y")
 
     duthost = duthosts[0]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -277,7 +279,8 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
         yield
         return
 
-    increase_linkmgrd_probe_interval(duthosts, tbinfo)
+    update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
+    duthosts.shell_cmds("config save -y")
 
     duthost = duthosts[rand_one_dut_hostname]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -303,6 +306,9 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
 
     logging.info("Stop running icmp_responder")
     ptfhost.shell("supervisorctl stop icmp_responder")
+    logging.info("Recover linkmgrd probe interval")
+    recover_linkmgrd_probe_interval(duthosts, tbinfo)
+    duthosts.shell_cmds("config save -y")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1828,7 +1828,7 @@ def __dut_reload(duts_data, node=None, results=None):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def core_dump_and_config_check(duthosts, request):
+def core_dump_and_config_check(duthosts, tbinfo, request):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.
     If so, we will reload the running config after test case running.
@@ -1920,14 +1920,14 @@ def core_dump_and_config_check(duthosts, request):
             EXCLUDE_CONFIG_TABLE_NAMES = set([])
             # The keys that we don't care
             # Current skipped keys:
-            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder` fixture
+            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder_session` fixture in dualtor-mixed
             # to account for the lower performance of the ICMP responder/mux simulator,
             # compared to real servers and mux cables. It's appropriate to persist this change
-            # since the testbed will always be using the ICMP responder and mux simulator.
-            # Linkmgrd is the only service to consume this table so it should not affect other test cases.
-            EXCLUDE_CONFIG_KEY_NAMES = [
-                'MUX_LINKMGR|LINK_PROBER'
-            ]
+            # since the testbed will always be using the ICMP responder and mux simulator in dualtor-mixed.
+            if "mixed" in tbinfo["topo"]["name"]:
+                EXCLUDE_CONFIG_KEY_NAMES = [
+                    'MUX_LINKMGR|LINK_PROBER'
+                ]
 
             def _remove_entry(table_name, key_name, config):
                 if table_name in config and key_name in config[table_name]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1919,15 +1919,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             # The tables that we don't care
             EXCLUDE_CONFIG_TABLE_NAMES = set([])
             # The keys that we don't care
-            # Current skipped keys:
-            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder_session` fixture in dualtor-mixed
-            # to account for the lower performance of the ICMP responder/mux simulator,
-            # compared to real servers and mux cables. It's appropriate to persist this change
-            # since the testbed will always be using the ICMP responder and mux simulator in dualtor-mixed.
-            if "mixed" in tbinfo["topo"]["name"]:
-                EXCLUDE_CONFIG_KEY_NAMES = [
-                    'MUX_LINKMGR|LINK_PROBER'
-                ]
+            EXCLUDE_CONFIG_KEY_NAMES = []
 
             def _remove_entry(table_name, key_name, config):
                 if table_name in config and key_name in config[table_name]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1928,6 +1928,8 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
                 EXCLUDE_CONFIG_KEY_NAMES = [
                     'MUX_LINKMGR|LINK_PROBER'
                 ]
+            else:
+                EXCLUDE_CONFIG_KEY_NAMES = []
 
             def _remove_entry(table_name, key_name, config):
                 if table_name in config and key_name in config[table_name]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1919,7 +1919,15 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             # The tables that we don't care
             EXCLUDE_CONFIG_TABLE_NAMES = set([])
             # The keys that we don't care
-            EXCLUDE_CONFIG_KEY_NAMES = []
+            # Current skipped keys:
+            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder_session` fixture in dualtor-mixed
+            # to account for the lower performance of the ICMP responder/mux simulator,
+            # compared to real servers and mux cables. It's appropriate to persist this change
+            # since the testbed will always be using the ICMP responder and mux simulator in dualtor-mixed.
+            if "mixed" in tbinfo["topo"]["name"]:
+                EXCLUDE_CONFIG_KEY_NAMES = [
+                    'MUX_LINKMGR|LINK_PROBER'
+                ]
 
             def _remove_entry(table_name, key_name, config):
                 if table_name in config and key_name in config[table_name]:

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
-from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval
+from tests.common.dualtor.dual_tor_utils import recover_linkmgrd_probe_interval, update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until
 
 
@@ -13,8 +13,6 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
-
-DEFAUL_INTERVAL_V4 = 100
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -49,7 +47,7 @@ def test_toggle_mux_from_simulator(duthosts, tbinfo, active_side, toggle_all_sim
 
     cur_interval_v4 = get_interval_v4
     if cur_interval_v4 is not None:
-        update_linkmgrd_probe_interval(duthosts, tbinfo, DEFAUL_INTERVAL_V4)
+        recover_linkmgrd_probe_interval(duthosts, tbinfo)
 
     logger.info('Toggle mux active side from mux simulator')
     toggle_all_simulator_ports(active_side)
@@ -69,7 +67,7 @@ def test_toggle_mux_from_cli(duthosts, tbinfo, active_side, get_mux_status, get_
 
     cur_interval_v4 = get_interval_v4
     if cur_interval_v4 is not None:
-        update_linkmgrd_probe_interval(duthosts, tbinfo, DEFAUL_INTERVAL_V4)
+        recover_linkmgrd_probe_interval(duthosts, tbinfo)
 
     # Use cli to toggle muxcable active side
     if active_side == UPPER_TOR:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixture run_icmp_responder(scope="module") will increase linkmgrd_probe_interval to 1s to reduce performance expectations and improve consistency, but won't restore after test.
When we reload config during sanity check(will use golden config) in one side of dualtor, that will cause different configurations between two tors.
#### How did you do it?
Restore linkmgrd_probe_interval after teardown, remove ignore linkmgrd_probe_interval check.
Dualtor-mixed will always run icmp responder, so don't need to restore at present, also need to keep ignore linkmgrd_probe_interval check in dualtor-mixed, since increase linkmgrd_probe_interval will run before sanity check, if sanity check fail, linkmgrd_probe_interval will recover to default value
#### How did you verify/test it?
Check running config and configdb during/after test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
