### PR TITLE
Fix issue: wrong PFC packet form in PFC storm docker

### DIFF
--- a/tests/common/helpers/pfc_gen.py
+++ b/tests/common/helpers/pfc_gen.py
@@ -144,7 +144,7 @@ def main():
         class_enable_field = binascii.unhexlify(format(class_enable, '04x'))
 
         packet = packet + class_enable_field
-        for p in range(0, 7):
+        for p in range(0, 8):
             if (class_enable & (1 << p)):
                 packet = packet + binascii.unhexlify(format(options.time, '04x'))
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes: wrong PFC packet form in PFC storm docker

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

The PFC storm is generated using a script but only block times of priority 0~6 are sent in the packet.
It won't affect function but the PFC frames are identified as malformatted, which is confusing.

#### How did you do it?

Extend the range (0, 7) => (0, 8)

#### How did you verify/test it?

Manually test

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
