### PR TITLE
Add wait time to verify mux status in sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -25,8 +25,8 @@ CHECK_ITEMS = [
     'check_bgp',
     'check_dbmemory',
     'check_monit',
-    'check_mux_simulator',
-    'check_secureboot']
+    'check_secureboot',
+    'check_mux_simulator',]
 
 __all__ = CHECK_ITEMS
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -539,7 +539,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
     duts_parsed_mux_status = {}
     err_msg_from_mux_status = []
     if (has_active_active_ports and not wait_until(30, 5, 0, _verify_show_mux_status)) \
-            or (not _verify_show_mux_status()):
+            or (not wait_until(30, 5, 0, _verify_show_mux_status)):
         if err_msg_from_mux_status:
             err_msg = err_msg_from_mux_status[-1]
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
After config reload, mux simulator needs some time to switch to correct status
#### How did you do it?
Add wait time in sanity check to verify mux status
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
