### PR TITLE
XFail any test that uses pfc_gen.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -611,6 +611,18 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions:
         - "asic_type in ['cisco-8000']"
 
+pfcwd/test_pfcwd_warm_reboot.py:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+pfcwd/test_pfcwd_timer_accuracy.py:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+pfcwd/test_pfcwd_function.py:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
 #######################################
 #####         platform_tests      #####
 #######################################
@@ -763,6 +775,26 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     reason: "Shared reservation size test is not supported."
     conditions:
       - "asic_type not in ['cisco-8000']"
+
+qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+qos/test_pfc_counters.py:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+qos/test_pfc_pause.py::test_pfc_pause_lossless:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_active:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
+qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_standby:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
 
 #######################################
 #####         restapi             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -614,18 +614,26 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
 pfcwd/test_pfcwd_warm_reboot.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_timer_accuracy.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_function.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_all_port_storm.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 #######################################
 #####         platform_tests      #####
@@ -783,14 +791,20 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_active:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_standby:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
+    conditions:
+        - "asic_type in ['cisco-8000']"
 
 #######################################
 #####         restapi             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -784,10 +784,6 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
 
-qos/test_pfc_pause.py::test_pfc_pause_lossless:
-  xfail:
-    reason: "The fanout script(pfc_gen.py) is not reliable."
-
 qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_active:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -623,6 +623,10 @@ pfcwd/test_pfcwd_function.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
 
+pfcwd/test_pfcwd_all_port_storm.py:
+  xfail:
+    reason: "The fanout script(pfc_gen.py) is not reliable."
+
 #######################################
 #####         platform_tests      #####
 #######################################
@@ -777,10 +781,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
       - "asic_type not in ['cisco-8000']"
 
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
-  xfail:
-    reason: "The fanout script(pfc_gen.py) is not reliable."
-
-qos/test_pfc_counters.py:
   xfail:
     reason: "The fanout script(pfc_gen.py) is not reliable."
 


### PR DESCRIPTION
### Description of PR
The script pfc_gen.py that is used to produce pfc xoff from fanout host is not as reliable as we hope it to be. There are many instances where the xoff is sent with a larger gap than needed, and the DUT ends up leaking out the packets in that interval. This causes many pfc tests to fail. All these tests have to be re-written with ixia or spirent.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Until we have a set of new tests that can replace the current set of pfcwd tests, we have to xfail them.

#### How did you do it?
I have set the tests as xfail in the mark file.

#### How did you verify/test it?
I ran one of the tests, and it came out xpass when it passed:
----------------------------------------------------------------------------------------------------- live log teardown ------------------------------------------------------------------------------------------------------
18:45:54 conftest.core_dump_and_config_check      L1757 WARNING| Core dump or config check failed for test_pfcwd_timer_accuracy.py, results: {"core_dump_check": {"new_core_dumps": {"mth64-m5-2": []}, "pass": true}, "config_db_check": {"cur_only_config": {"mth64-m5-2": {"PFC_WD": {"Ethernet180": {"action": "drop", "detection_time": "400", "restoration_time": "400"}, "GLOBAL": {"POLL_INTERVAL": "400"}}}}, "inconsistent_config": {"mth64-m5-2": {}}, "pre_only_config": {"mth64-m5-2": {}}, "pass": false}}


-------------------------------------------------------------- generated xml file: /home/vxr/vxlan/logs/pfcwd/test_pfcwd_timer_accuracy_2023-02-09-18-35-51.xml --------------------------------------------------------------
================================================================================================== short test summary info ===================================================================================================
XPASS pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[None] The fanout script(pfc_gen.py) is not reliable.
================================================================================================ 1 xpassed in 893.49 seconds =================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
vxr@02b4831febde:/data/tests$ 
