### PR TITLE
[chassis]: Fix dropcounter tests for T2 testbed with single and multi asic linecards

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -92,8 +92,12 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
     def _get_drops_across_all_duthosts():
         drop_list = []
         for duthost in duthosts.frontend_nodes:
-            drop_list.append(int(get_pkt_drops(duthost, get_cnt_cli_cmd, asic_index)[dut_iface][column_key]
-                                 .replace(",", "")))
+            pkt_drops = get_pkt_drops(duthost, get_cnt_cli_cmd, asic_index)
+            # we cannot assume the iface name will be same on all the devices for SONiC chassis
+            # if the dut_iface is not found ignore this device
+            if dut_iface not in pkt_drops:
+                continue
+            drop_list.append(int(pkt_drops[dut_iface][column_key].replace(",", "")))L3 counters may not be supported on this platform
         return drop_list
 
     def _check_drops_on_dut():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7424 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
In the current drop counter tests, for multi dut topologies it is assumed the port names will be same on all the duts.
This is not true on the device having a mix of single and multi asic linecards or linecard with different asics. 
The PR fixes this.
#### How did you do it?
we drop counters are retrived for linecard then check if the  port the tests is checking for existing on the dut before updating the drop counter list.

#### How did you verify/test it?
Run on the chassis with mix of single and multi asic linecards

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
