### PR TITLE
[202205][show_techsupport] Fix duplate adding of docker list in test_auto_techsupport #7428

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -60,6 +60,7 @@ class TestAutoTechSupport:
     test_docker = None
 
     def set_test_dockers_list(self):
+        self.dockers_list = []
         auto_tech_support_features_list = self.dut_cli.auto_techsupport.parse_show_auto_techsupport_feature().keys()
         system_features_status = self.duthost.get_feature_status()
         for feature in auto_tech_support_features_list:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick of this PR: https://github.com/sonic-net/sonic-mgmt/pull/7428
Setup code will add duplicate docker list by fixture whose scope is 'function' by default
<pre>
2023-02-10T03:43:57.2182820Z show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity
2023-02-10T03:43:57.2186917Z -------------------------------- live log setup --------------------------------
2023-02-10T03:43:57.2191765Z 03:43:57 test_auto_techsupport.set_test_dockers_l L0064 WARNING| yaqiangzhu auto_tech_support_features_list: [u'lldp', u'bgp', u'pmon', u'database', u'radv', u'macsec', u'telemetry', u'snmp', u'mux', u'acms', u'dhcp_relay', u'teamd', u'syncd', u'swss']
2023-02-10T03:43:58.3812529Z 03:43:58 test_auto_techsupport.set_test_dockers_l L0066 WARNING| yaqiangzhu system_features_status: ({'lldp': 'enabled', 'bgp': 'enabled', 'pmon': 'enabled', 'database': 'always_enabled', 'radv': 'enabled', 'macsec': 'disabled', 'telemetry': 'enabled', 'snmp': 'enabled', 'mux': 'always_disabled', 'acms': 'enabled', 'dhcp_relay': 'enabled', 'teamd': 'enabled', 'gbsyncd': 'enabled', 'syncd': 'enabled', 'swss': 'enabled'}, True)
<b><em>2023-02-10T03:43:58.3819461Z 03:43:58 test_auto_techsupport.set_test_dockers_l L0073 WARNING| yaqiangzhu number_of_test_dockers: 12</em></b>
2023-02-10T03:43:58.3822132Z 03:43:58 test_auto_techsupport.set_test_dockers_l L0074 WARNING| yaqiangzhu test_docker: snmp
<b><em>2023-02-10T03:43:58.3826802Z 03:43:58 test_auto_techsupport.set_test_dockers_l L0075 WARNING| yaqiangzhu dockers_list: [u'lldp', u'bgp', u'pmon', u'database', u'radv', u'telemetry', u'snmp', u'acms', u'dhcp_relay', u'teamd', u'syncd', u'swss']</em></b>
2023-02-10T03:47:11.8075888Z PASSED                                                                   [ 25%]
2023-02-10T03:47:29.0949889Z show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval 
2023-02-10T03:47:29.0953073Z -------------------------------- live log setup --------------------------------
2023-02-10T03:47:29.0955031Z 03:47:29 test_auto_techsupport.set_test_dockers_l L0064 WARNING| yaqiangzhu auto_tech_support_features_list: [u'lldp', u'bgp', u'pmon', u'database', u'radv', u'macsec', u'telemetry', u'snmp', u'mux', u'acms', u'dhcp_relay', u'teamd', u'syncd', u'swss']
2023-02-10T03:47:30.3083315Z 03:47:30 test_auto_techsupport.set_test_dockers_l L0066 WARNING| yaqiangzhu system_features_status: ({'lldp': 'enabled', 'bgp': 'enabled', 'pmon': 'enabled', 'database': 'always_enabled', 'radv': 'enabled', 'macsec': 'disabled', 'telemetry': 'enabled', 'snmp': 'enabled', 'mux': 'always_disabled', 'acms': 'enabled', 'dhcp_relay': 'enabled', 'teamd': 'enabled', 'gbsyncd': 'enabled', 'syncd': 'enabled', 'swss': 'enabled'}, True)
<b><em>2023-02-10T03:47:30.3089460Z 03:47:30 test_auto_techsupport.set_test_dockers_l L0073 WARNING| yaqiangzhu number_of_test_dockers: 24</em></b>
2023-02-10T03:47:30.3092352Z 03:47:30 test_auto_techsupport.set_test_dockers_l L0074 WARNING| yaqiangzhu test_docker: bgp
<b><em>2023-02-10T03:47:30.3099215Z 03:47:30 test_auto_techsupport.set_test_dockers_l L0075 WARNING| yaqiangzhu dockers_list: [u'lldp', u'bgp', u'pmon', u'database', u'radv', u'telemetry', u'snmp', u'acms', u'dhcp_relay', u'teamd', u'syncd', u'swss', u'lldp', u'bgp', u'pmon', u'database', u'radv', u'telemetry', u'snmp', u'acms', u'dhcp_relay', u'teamd', u'syncd', u'swss']</em></b>
</pre>

#### How did you do it?
Add clear docker list in teardown period

#### How did you verify/test it?
run test
```
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity PASSED                                                                                                           [ 25%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval PASSED                                                                                              [ 50%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[techsupport] PASSED                                                                                           [ 75%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[core] PASSED                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
