### PR TITLE
[Testbed] Update ansible playbook for deploying SONiC 202205 fanout switches

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -21,7 +21,7 @@
   become: yes
 
 - name: SONiC update config db
-  shell: config reload -y
+  shell: config reload -y -f
   become: true
 
 - name: wait for SONiC update config db finish
@@ -31,15 +31,3 @@
 - name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
   shell: docker exec -i swss supervisorctl stop arp_update
   become: yes
-
-- name: Setup broadcom based fanouts
-  block:
-    - name: configure TPID of access ports
-      set_port_tpid:
-        fanout_port_vlans: "{{ device_port_vlans[inventory_hostname] }}"
-        fanout_port_config: "{{ fanout_port_config }}"
-
-    - name: reinit fp entries
-      shell: "bcmcmd 'fp detach' && bcmcmd 'fp init'"
-      become: yes
-  when: "'broadcom' in fanout_sonic_version.asic_type"

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -31,3 +31,10 @@
 - name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
   shell: docker exec -i swss supervisorctl stop arp_update
   become: yes
+
+- name: Setup broadcom based fanouts
+  block:
+    - name: reinit fp entries
+      shell: "bcmcmd 'fp detach' && bcmcmd 'fp init'"
+      become: yes
+  when: "'broadcom' in fanout_sonic_version.asic_type"

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -18,7 +18,7 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] and device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
             "tpid": "0x9100",
     {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -18,6 +18,9 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
+    {% if device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
+            "tpid": "0x9100",
+    {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"
     {% else %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update ansible playbook for deploying SONiC 202205 fanout switches:
1. Add a `-f` param to `config reload` command to force config reload without system checks. This will be helpful if `swss` container cannot start after system boot.
2. Add `tpid` configuration to SONiC `config_db.json` template. This is a better way to config tpid persistently on SONiC 202205.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Update ansible playbook for deploying SONiC 202205 fanout switches.


#### How did you do it?
1. Add a `-f` param to `config reload` command to force config reload without system checks. This will be helpful if `swss` container cannot start after system boot.
2. Add `tpid` configuration to SONiC `config_db.json` template. This is a better way to config tpid persistently on SONiC 202205.

#### How did you verify/test it?
Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
