### PR TITLE
Update test_iface_namingmode.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -425,7 +425,7 @@ iface_namingmode/test_iface_namingmode.py::TestShowQueue:
 
 iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
   skip:
-    reason: "Dynamic breakout for 40G is not supported for cisco 8101 platform"
+    reason: "40G is not supported for cisco 8101 platform"
     conditions:
       - "platform in ['x86_64-8101_32fh_o-r0']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -423,6 +423,12 @@ iface_namingmode/test_iface_namingmode.py::TestShowQueue:
     conditions:
       - "topo_name in ['m0', 'mx']"
 
+iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
+  skip:
+    reason: "Dynamic breakout for 40G is not supported for cisco 8000 platform"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####            ip               #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -425,9 +425,9 @@ iface_namingmode/test_iface_namingmode.py::TestShowQueue:
 
 iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
   skip:
-    reason: "Dynamic breakout for 40G is not supported for cisco 8000 platform"
+    reason: "Dynamic breakout for 40G is not supported for cisco 8101 platform"
     conditions:
-      - "asic_type in ['cisco-8000']"
+      - "platform in ['x86_64-8101_32fh_o-r0']"
 
 #######################################
 #####            ip               #####

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -714,7 +714,7 @@ class TestConfigInterface():
         pytest_assert(wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, _port_status, 'up'),
                         "Interface {} should be admin up".format(test_intf))
 
-
+    @pytest.mark.skip(reason="Cisco 8000 Platform doesnt support 40G breakout")
     def test_config_interface_speed(self, setup_config_mode, sample_intf, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Checks whether 'config interface speed <intf> <speed>' sets

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -714,7 +714,6 @@ class TestConfigInterface():
         pytest_assert(wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, _port_status, 'up'),
                         "Interface {} should be admin up".format(test_intf))
 
-    @pytest.mark.skip(reason="Cisco 8000 Platform doesnt support 40G breakout")
     def test_config_interface_speed(self, setup_config_mode, sample_intf, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Checks whether 'config interface speed <intf> <speed>' sets

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -714,6 +714,7 @@ class TestConfigInterface():
         pytest_assert(wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, _port_status, 'up'),
                         "Interface {} should be admin up".format(test_intf))
 
+        
     def test_config_interface_speed(self, setup_config_mode, sample_intf, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """
         Checks whether 'config interface speed <intf> <speed>' sets


### PR DESCRIPTION
Cisco 8101 Platform doesnt support 40G breakout

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Cisco 8101 Platform doesnt support 40G breakout. Raising this PR to skip the test case test_config_interface_speed as per discussion with MSFT

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
To add a skip condition for unsupported feature on cisco8000 platform
#### How did you do it?
Added skip condition in [plugins/conditional_mark](https://github.com/sonic-net/sonic-mgmt/tree/master/tests/common/plugins/conditional_mark)
#### How did you verify/test it?
Yes, This has been verified internally.
#### Any platform specific information?
Cisco 8000
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
