### PR TITLE
[chassis] [autorestart] add ignore some syslog errors

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -123,8 +123,22 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR gbsyncd#syncd: :- updateNotificationsPointers: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not "
             "handled.*",
             ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
-            ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
-            ".*ERR swss#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
+            ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
+            ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
+            ".*ERR lldp[0-9]*#lldp-syncd [lldp_syncd].*Could not infer system information from.*",
+            ".*ERR syncd[0-9]*#syncd.*threadFunction: time span WD exceeded.*create:SAI_OBJECT_TYPE_SWITCH.*",
+            ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_SWITCH_ATTR.*",
+            ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_OBJECT_TYPE_SWITCH.*",
+            ".*ERR syncd[0-9]*#syncd.*setEndTime:.*SAI_OBJECT_TYPE_SWITCH.*",
+            ".*ERR syncd[0-9]*#syncd:.*SAI_API_PORT:brcm_sai_get_port_stats:.*Multi stats get failed with error Invalid parameter.*",
+            ".*ERR syncd[0-9]*#syncd:.*SAI_API_PORT:_brcm_sai_port_wred_stats_get:.*port gport get failed with error Feature unavailable.*",
+            ".*ERR swss[0-9]*#orchagent: :- doLagMemberTask: Failed to locate port.*",
+            ".*ERR swss[0-9]*#orchagent:.*update: Failed to get port by bridge port ID.*",
+            ".*ERR swss[0-9]*#orchagent:.*handlePortStatusChangeNotification: Failed to get port object for port id.*",
+            ".*ERR swss[0-9]*#orchagent:.*pfcFrameCounterCheck: Invalid port oid.*",
+            ".*ERR swss[0-9]*#orchagent: :- mcCounterCheck: Invalid port oid.*",
+            ".*ERR swss[0-9]*#orchagent: :- getResAvailability: Failed to get availability counter.*",
+            ".*ERR swss[0-9]*#supervisor-proc-exit-listener: Process 'orchagent' is not running in namespace.*",
     ]
     ignore_regex_dict = {
         'common': [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ignore following syslog errors for either chassis or single-asic/multi-asic dut, this should work for all platforms:
1.
```
ERR lldp0#lldp-syncd [lldp_syncd] ERROR: Could not infer system information from: {'id': {'type': '', 'value': ''}, 'capability': [{'type': 'Other', 'enabled': True}, {'type': 'Wlan', 'enabled': True}]}#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/lldp_syncd/daemon.py", line 302, in parse_chassis#012    chassis_id_subtype = str(self.ChassisIdSubtypeMap[id_attributes['type']].value)#012  File "/usr/lib/python3.9/enum.py", line 408, in __getitem__#012    return cls._member_map_[name]#012KeyError: ''
```
2. These following syslog errors are due to syncd/swss/OA got rebooted during test, and it could be down for sometime and thus caused these errors
```
ERR syncd0#syncd: :- threadFunction: time span WD exceeded 30082 ms for create:SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000
```
```
ERR swss0#orchagent: :- handlePortStatusChangeNotification: Failed to get port object for port id 0x10000000000ec
```
```
ERR swss#supervisor-proc-exit-listener: Process 'orchagent' is not running in namespace 'host' (3.0 minutes).
ERR swss#supervisor-proc-exit-listener: Process 'orchagent' is not running in namespace 'host' (4.0 minutes).
...
```
```
ERR swss#orchagent: :- handlePortStatusChangeNotification: Failed to get port object for port id 0x10000000000eb
ERR swss#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x5d0000000000d5
ERR swss#orchagent: :- mcCounterCheck: Invalid port oid 0x5d0000000000d4
```
```  
ERR swss1#orchagent: :- getResAvailability: Failed to get availability counter for MPLS_INSEG CRM resourse
```
3. This error is due to OA tries to find ports that belong to a linecard that's not connected in Chassis, and not shutdown for testing purpose as we want to connect this card later:
```
ERR swss0#orchagent: :- doLagMemberTask: Failed to locate port str2-7804-lc3-1|ASIC0|Ethernet0
```


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
After:
```
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-lldp] PASSED                                                                                                                                                 [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-acms] SKIPPED                                                                                                                                                [ 15%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-pmon] PASSED                                                                                                                                                 [ 23%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-snmp] PASSED                                                                                                                                                 [ 30%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-macsec] SKIPPED                                                                                                                                              [ 38%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-telemetry] PASSED                                                                                                                                            [ 46%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-mux] SKIPPED                                                                                                                                                 [ 53%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-bgp] PASSED                                                                                                                                                  [ 61%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-radv] SKIPPED                                                                                                                                                [ 69%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-teamd] PASSED                                                                                                                                                [ 76%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-dhcp_relay] SKIPPED                                                                                                                                          [ 84%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-swss] PASSED                                                                                                                                                 [ 92%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7804-lc7-1-None-syncd] PASSED                                                                                                                                                [100%]
---------------------------------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------------------------------
20:28:02 conftest.core_dump_and_config_check      L1902 WARNING| Core dump or config check failed for autorestart/test_container_autorestart.py, results: {"core_dump_check": {"new_core_dumps": {"str2-7804-lc7-1": []}, "pass": true}, "config_db_check": {"cur_only_config": {"str2-7804-lc7-1": {"null": {}}}, "inconsistent_config": {"str2-7804-lc7-1": {"null": {"SNMP_COMMUNITY": {"pre_value": {"msft": {"TYPE": "RO"}}, "cur_value": {"public": {"TYPE": "RO"}, "msft": {"TYPE": "RO"}}}}}}, "pre_only_config": {"str2-7804-lc7-1": {"null": {}}}, "pass": false}}


------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container acms
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container radv
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container mux
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container macsec
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container dhcp_relay
============================================================================================================ 8 passed, 5 skipped in 2357.35 seconds ===================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
