### PR TITLE
skip tun kernel route for test_cont_link_flap case

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -218,7 +218,7 @@ def check_bgp_routes(dut, start_time_ipv4_route_counts, start_time_ipv6_route_co
     """
     MAX_DIFF = 5
 
-    sumv4, sumv6 = dut.get_ip_route_summary(True)
+    sumv4, sumv6 = dut.get_ip_route_summary(skip_kernel_tunnel=True)
     totalsv4 = sumv4.get('Totals', {})
     totalsv6 = sumv6.get('Totals', {})
     routesv4 = totalsv4.get('routes', 0)

--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -218,7 +218,7 @@ def check_bgp_routes(dut, start_time_ipv4_route_counts, start_time_ipv6_route_co
     """
     MAX_DIFF = 5
 
-    sumv4, sumv6 = dut.get_ip_route_summary()
+    sumv4, sumv6 = dut.get_ip_route_summary(True)
     totalsv4 = sumv4.get('Totals', {})
     totalsv6 = sumv6.get('Totals', {})
     routesv4 = totalsv4.get('routes', 0)

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -55,7 +55,10 @@ class TestContLinkFlap(object):
         logging.info("Redis Memory: %s M", start_time_redis_memory)
 
         # Record ipv4 route counts at start
-        sumv4, sumv6 = duthost.get_ip_route_summary()
+        sumv4, sumv6 = duthost.get_ip_route_summary(True)
+        logging.debug("sumv4  {} ".format(sumv4))
+        logging.debug("sumv6  {} ".format(sumv6))
+
         totalsv4 = sumv4.get('Totals', {})
         totalsv6 = sumv6.get('Totals', {})
         start_time_ipv4_route_counts = totalsv4.get('routes', 0)

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -55,7 +55,7 @@ class TestContLinkFlap(object):
         logging.info("Redis Memory: %s M", start_time_redis_memory)
 
         # Record ipv4 route counts at start
-        sumv4, sumv6 = duthost.get_ip_route_summary(True)
+        sumv4, sumv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True)
         logging.debug("sumv4  {} ".format(sumv4))
         logging.debug("sumv6  {} ".format(sumv6))
 
@@ -89,7 +89,7 @@ class TestContLinkFlap(object):
 
         # Make Sure all ipv4/ipv6 routes are relearned with jitter of ~5
         if not wait_until(120, 2, 0, check_bgp_routes, duthost, start_time_ipv4_route_counts, start_time_ipv6_route_counts):
-            endv4, endv6 = duthost.get_ip_route_summary()
+            endv4, endv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True)
             failmsg = []
             failmsg.append(
                 "IP routes are not equal after link flap: before ipv4 {} ipv6 {}, after ipv4 {} ipv6 {}".format(sumv4,


### PR DESCRIPTION
Signed-off-by: xuliping <xuliping@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_cont_link_flap case failure for dualtor if interface status changed (active <-> standby)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Dualtor's standby interface has a kernel tunnel route if the interface status changes during the test_cont_link_flap case test.
the kernel tunnel route count would be changed.

#### How did you do it?
Skip the kernel tunnel route count in case test_cont_link_flap for this time.
And enhancement to check interfaces' status next time.

#### How did you verify/test it?
Run the test_cont_link_flap case .

#### Any platform specific information?
Dualtor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
