### PR TITLE
[dualtor] Fix `test_bgp_update_timer`

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -86,7 +86,7 @@ def common_setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         if k == duthost.hostname:
             dut_type = v['type']
 
-    if  dut_type in ['ToRRouter', 'SpineRouter']:
+    if dut_type in ['ToRRouter', 'SpineRouter']:
         neigh_type = 'LeafRouter'
     else:
         neigh_type = 'ToRRouter'
@@ -216,7 +216,8 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
         # handle both multi-sic and single-asic
         bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]
         for neighbor in neighbors:
-            is_established &= neighbor.ip in bgp_facts["bgp_neighbors"] and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
+            is_established &= neighbor.ip in bgp_facts["bgp_neighbors"] and \
+                bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
 
         return is_established
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -12,8 +12,8 @@ from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.mux_simulator_control import mux_server_url   # noqa F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dualtor.mux_simulator_control import mux_server_url                                                           # noqa F811
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m    # noqa F811
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 pytestmark = [
@@ -157,7 +157,7 @@ def constants(is_quagga, setup_interfaces):
 
 
 def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                          toggle_all_simulator_ports_to_rand_selected_tor_m):   # noqa F811
+                          toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m):   # noqa F811
 
     def bgp_update_packets(pcap_file):
         """Get bgp update packets from pcap file."""

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -400,10 +400,12 @@ def _probe_mux_ports(duthosts, ports):
 def _get_mux_ports(duthost, target_status=None, exclude_status=None):
     """Get mux ports that has expected mux status."""
     def _check_status(mux_status):
-        return ((target_status is None or target_status == mux_status) and (exclude_status is None or exclude_status != mux_status))
+        return ((target_status is None or target_status == mux_status) and
+                (exclude_status is None or exclude_status != mux_status))
 
     muxcables = json.loads(duthost.shell("show muxcable status --json")['stdout'])
-    return {port:mux_status for port, mux_status in muxcables['MUX_CABLE'].items() if _check_status(mux_status["STATUS"])}
+    return {port: mux_status for port, mux_status in muxcables['MUX_CABLE'].items()
+            if _check_status(mux_status["STATUS"])}
 
 
 def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux_server_url, tbinfo):
@@ -421,7 +423,8 @@ def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux
         if probe:
             _probe_mux_ports(duthosts, list(inactive_ports.keys()))
 
-        logger.info('Found muxcables not active on {}: {}'.format(duthost.hostname, json.dumps(list(inactive_ports.keys()))))
+        logger.info('Found muxcables not active on {}: {}'.format(
+            duthost.hostname, json.dumps(list(inactive_ports.keys()))))
         return False
 
     logging.info("Toggling mux cable to {}".format(target_dut_hostname))
@@ -444,7 +447,8 @@ def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux
             is_toggle_done = True
             break
 
-    if not is_toggle_done and not utilities.wait_until(120, 10, 0, _check_toggle_done, duthosts, target_dut_hostname, probe=True):
+    if (not is_toggle_done and
+            not utilities.wait_until(120, 10, 0, _check_toggle_done, duthosts, target_dut_hostname, probe=True)):
         pytest_assert(False, "Failed to toggle all ports to {} from mux simulator".format(target_dut_hostname))
 
 
@@ -541,9 +545,8 @@ def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(duthos
     duthosts.shell('config muxcable mode auto all')
 
 
-
 @pytest.fixture
-def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):
+def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):    # noqa F811
     """
     A function level fixture to toggle all ports to a random side.
     """

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -516,7 +516,34 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):    # noqa F811
+def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(duthosts, enum_rand_one_per_hwsku_frontend_hostname, mux_server_url, tbinfo): # noqa F811
+    """
+    A function level fixture to toggle all ports to enum_rand_one_per_hwsku_frontend_hostname.
+
+    Before toggling, this fixture firstly sets all muxcables to 'manual' mode on all ToRs.
+    After test is done, restore all mux cables to 'auto' mode on all ToRs in teardown phase.
+    """
+    # Skip on non dualtor testbed
+    if 'dualtor' not in tbinfo['topo']['name']:
+        yield
+        return
+
+    logger.info('Set all muxcable to manual mode on all ToRs')
+    duthosts.shell('config muxcable mode manual all')
+
+    _toggle_all_simulator_ports_to_target_dut(
+        enum_rand_one_per_hwsku_frontend_hostname, duthosts, mux_server_url, tbinfo
+    )
+
+    yield
+
+    logger.info('Set all muxcable to auto mode on all ToRs')
+    duthosts.shell('config muxcable mode auto all')
+
+
+
+@pytest.fixture
+def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):
     """
     A function level fixture to toggle all ports to a random side.
     """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
`test_bgp_update_timer` uses `toggle_all_simulator_ports_to_rand_selected_tor_m` to toggle device `rand_one_dut_hostname` mux ports to active, but in the test, it uses `enum_rand_one_per_hwsku_frontend_hostname` to select DUT.
But `rand_one_dut_hostname` might differ from `enum_rand_one_per_hwsku_frontend_hostname` sometimes.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Let's add a new fixture `toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m` that will be used by `test_bgp_update_timer` so all operations will be performed on the same DUT.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
