### PR TITLE
[pre-commit] Fix style issues in test scripts under `tests/decap`, `tests/dhcp_relay`, `tests/disk` folder

### DIFF
--- a/tests/decap/__init__.py
+++ b/tests/decap/__init__.py
@@ -26,10 +26,10 @@ def pytest_addoption(parser):
         default=True,
         help="Specify whether inner layer IPv6 testing will be covered",
     )
-    
+
     decap_group.addoption(
         "--ttl_uniform",
-        action="store_true", 
+        action="store_true",
         default=False,
         help="indicates TTL uniform is supported"
     )

--- a/tests/decap/conftest.py
+++ b/tests/decap/conftest.py
@@ -17,9 +17,12 @@ def build_ttl_dscp_params(uniform_support_info):
         params.append(both_pipe_vxlan)
     return params
 
+
 def pytest_generate_tests(metafunc):
-  ttl = metafunc.config.getoption("ttl_uniform")
-  dscp = metafunc.config.getoption("dscp_uniform")
-  if "supported_ttl_dscp_params" in metafunc.fixturenames:
-      params = build_ttl_dscp_params({'ttl': ttl, 'dscp': dscp})
-      metafunc.parametrize("supported_ttl_dscp_params", params, ids=lambda p: "ttl=%s, dscp=%s, vxlan=%s" % (p['ttl'], p['dscp'], p['vxlan']), scope="module")
+    ttl = metafunc.config.getoption("ttl_uniform")
+    dscp = metafunc.config.getoption("dscp_uniform")
+    if "supported_ttl_dscp_params" in metafunc.fixturenames:
+        params = build_ttl_dscp_params({'ttl': ttl, 'dscp': dscp})
+        metafunc.parametrize("supported_ttl_dscp_params", params,
+                             ids=lambda p: "ttl=%s, dscp=%s, vxlan=%s" % (p['ttl'], p['dscp'], p['vxlan']),
+                             scope="module")

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -2,10 +2,10 @@
 IPinIP Decap configs for different ASICs:
 Table Name in APP_DB: TUNNEL_DECAP_TABLE:IPINIP_TUNNEL
 
-Config          Mellanox <= [201911]        Mellanox >= [202012]        Broadcom <= [201911]        Broadcom >= [202012]     Innovium
-dscp_mode       uniform                     uniform                     pipe                        uniform                  pipe
-ecn_mode        standard                    standard                    copy_from_outer             copy_from_outer          copy_from_outer
-ttl_mode        pipe                        pipe                        pipe                        pipe                     pipe
+Config          Mellanox <= [201911]        Mellanox >= [202012]        Broadcom <= [201911]        Broadcom >= [202012]     Innovium               # noqa E501
+dscp_mode       uniform                     uniform                     pipe                        uniform                  pipe                   # noqa E501
+ecn_mode        standard                    standard                    copy_from_outer             copy_from_outer          copy_from_outer        # noqa E501
+ttl_mode        pipe                        pipe                        pipe                        pipe                     pipe                   # noqa E501
 '''
 import json
 import logging
@@ -18,16 +18,16 @@ from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
-from tests.common.fixtures.fib_utils import fib_info_files
-from tests.common.fixtures.fib_utils import single_fib_for_duts
+from tests.common.fixtures.fib_utils import fib_info_files                  # noqa F401
+from tests.common.fixtures.fib_utils import single_fib_for_duts             # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert as pt_assert
-from tests.common.dualtor.mux_simulator_control import mux_server_url
+from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa F401
 from tests.common.utilities import wait, setup_ferret
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,7 @@ PTFRUNNER_QLEN = 1000
 pytestmark = [
     pytest.mark.topology('any')
 ]
+
 
 def remove_default_decap_cfg(duthosts):
     for duthost in duthosts:
@@ -95,7 +96,7 @@ def loopback_ips(duthosts, duts_running_config_facts):
 
 @pytest.fixture(scope='module')
 def setup_teardown(request, duthosts, duts_running_config_facts, ip_ver, loopback_ips,
-    fib_info_files, single_fib_for_duts, supported_ttl_dscp_params):
+                   fib_info_files, single_fib_for_duts, supported_ttl_dscp_params):     # noqa F811
 
     vxlan = supported_ttl_dscp_params['vxlan']
     is_multi_asic = duthosts[0].sonichost.is_multi_asic
@@ -154,10 +155,10 @@ def apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mod
         duthost.shell('rm /tmp/decap_conf_{}.json'.format(op))
 
 
-def set_mux_side(tbinfo, mux_server_url, side):
+def set_mux_side(tbinfo, mux_server_url, side):     # noqa F811
     if 'dualtor' in tbinfo['topo']['name']:
         res = requests.post(mux_server_url, json={"active_side": side})
-        pt_assert(res.status_code==200, 'Failed to set active side: {}'.format(res.text))
+        pt_assert(res.status_code == 200, 'Failed to set active side: {}'.format(res.text))
         return res.json()   # Response is new mux_status of all mux Y-cables.
     return {}
 
@@ -174,11 +175,12 @@ def simulate_vxlan_teardown(duthosts, ptfhost, tbinfo):
 
 
 @pytest.fixture
-def set_mux_random(tbinfo, mux_server_url):
+def set_mux_random(tbinfo, mux_server_url):         # noqa F811
     return set_mux_side(tbinfo, mux_server_url, 'random')
 
 
-def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mux_random, supported_ttl_dscp_params, ip_ver, loopback_ips,
+def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,           # noqa F811
+               set_mux_random, supported_ttl_dscp_params, ip_ver, loopback_ips,
                duts_running_config_facts, duts_minigraph_facts):
     setup_info = setup_teardown
     asic_type = duthosts[0].facts["asic_type"]
@@ -206,24 +208,25 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mu
         ptf_runner(ptfhost,
                    "ptftests",
                    "IP_decap_test.DecapPacketTest",
-                    platform_dir="ptftests",
-                    params={"outer_ipv4": setup_info["outer_ipv4"],
-                            "outer_ipv6": setup_info["outer_ipv6"],
-                            "inner_ipv4": setup_info["inner_ipv4"],
-                            "inner_ipv6": setup_info["inner_ipv6"],
-                            "lo_ips": setup_info["lo_ips"],
-                            "lo_ipv6s": setup_info["lo_ipv6s"],
-                            "ttl_mode": ttl_mode,
-                            "dscp_mode": dscp_mode,
-                            "asic_type": asic_type,
-                            "ignore_ttl": setup_info["ignore_ttl"],
-                            "max_internal_hops": setup_info["max_internal_hops"],
-                            "fib_info_files": setup_info["fib_info_files"],
-                            "single_fib_for_duts": setup_info["single_fib_for_duts"],
-                            "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts)
-                            },
-                    qlen=PTFRUNNER_QLEN,
-                    log_file=log_file)
+                   platform_dir="ptftests",
+                   params={"outer_ipv4": setup_info["outer_ipv4"],
+                           "outer_ipv6": setup_info["outer_ipv6"],
+                           "inner_ipv4": setup_info["inner_ipv4"],
+                           "inner_ipv6": setup_info["inner_ipv6"],
+                           "lo_ips": setup_info["lo_ips"],
+                           "lo_ipv6s": setup_info["lo_ipv6s"],
+                           "ttl_mode": ttl_mode,
+                           "dscp_mode": dscp_mode,
+                           "asic_type": asic_type,
+                           "ignore_ttl": setup_info["ignore_ttl"],
+                           "max_internal_hops": setup_info["max_internal_hops"],
+                           "fib_info_files": setup_info["fib_info_files"],
+                           "single_fib_for_duts": setup_info["single_fib_for_duts"],
+                           "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                                  duts_running_config_facts, duts_minigraph_facts)
+                           },
+                   qlen=PTFRUNNER_QLEN,
+                   log_file=log_file)
     except Exception as detail:
         raise Exception(detail)
     finally:

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(scope="module", autouse=True)
 def skip_dhcp_relay_tests(tbinfo):
     """

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -2,6 +2,7 @@ import logging
 import random
 import ipaddr
 import pytest
+import ipaddress
 
 import ptf.testutils as testutils
 import ptf.packet as scapy
@@ -14,6 +15,7 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
+
 
 class DhcpPktFwdBase:
     """Base class for DHCP packet forwarding test. The test ensure that DHCP packets are going through T1 device."""
@@ -287,6 +289,7 @@ class DhcpPktFwdBase:
             padding_bytes=0,
             set_broadcast_bit=True
         )
+
 
 class TestDhcpPktFwd(DhcpPktFwdBase):
     """DHCP Packet forward test class"""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
pre-commit is a static analysis tool introduced recently. This tool is not able to do diff-only check. It checks the whole files touched by PR. We can't blame PR author for legacy issues. That's why currently the pre-commit check is only optional.

To ensure that we can make pre-commit a mandatory check for PRs submitted to this repository, we need to fix all the legacy issues complained by pre-commit.
#### How did you do it?
This change fixes the style issues of test scripts under `tests/decap`, `tests/dhcp_relay`, `tests/disk` folder
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
