### PR TITLE
[chassis] increase timeout for fixture shutdown_ebgp

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -125,7 +125,7 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
-            ".*ERR lldp[0-9]*#lldp-syncd [lldp_syncd].*Could not infer system information from.*",
+            ".*ERR lldp[0-9]*#lldp-syncd \[lldp_syncd\] ERROR: Could not infer system information from.*",
             ".*ERR syncd[0-9]*#syncd.*threadFunction: time span WD exceeded.*create:SAI_OBJECT_TYPE_SWITCH.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_SWITCH_ATTR.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_OBJECT_TYPE_SWITCH.*",

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -125,7 +125,7 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
-            ".*ERR lldp[0-9]*#lldp-syncd \[lldp_syncd\] ERROR: Could not infer system information from.*",
+            ".*ERR lldp[0-9]*#lldp-syncd [lldp_syncd] ERROR: Could not infer system information from.*",
             ".*ERR syncd[0-9]*#syncd.*threadFunction: time span WD exceeded.*create:SAI_OBJECT_TYPE_SWITCH.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_SWITCH_ATTR.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_OBJECT_TYPE_SWITCH.*",

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -125,7 +125,7 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
             ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_WRITE is not handled.*",
             ".*ERR swss[0-9]*#orchagent: :- updateNotifications: pointer for SAI_SWITCH_ATTR_REGISTER_READ is not handled.*",
-            ".*ERR lldp[0-9]*#lldp-syncd [lldp_syncd] ERROR: Could not infer system information from.*",
+            ".*ERR lldp[0-9]*#lldp-syncd [lldp_syncd].*Could not infer system information from.*",
             ".*ERR syncd[0-9]*#syncd.*threadFunction: time span WD exceeded.*create:SAI_OBJECT_TYPE_SWITCH.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_SWITCH_ATTR.*",
             ".*ERR syncd[0-9]*#syncd.*logEventData:.*SAI_OBJECT_TYPE_SWITCH.*",

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -244,7 +244,7 @@ def shutdown_ebgp(duthosts):
         pytest_assert(wait_until(120, 10, 10, check_ebgp_routes, orig_v4_ebgp, orig_v6_ebgp, duthost),
                       "eBGP v4 routes are {}, and v6 route are {}, and not what they were originally after enabling "
                       "all neighbors on {}".format(orig_v4_ebgp, orig_v6_ebgp, duthost))
-        pytest_assert(wait_until(60, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+        pytest_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                       "Orch CPU utilization {} > orch cpu threshold {} after startup all eBGP"
                       .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
                               orch_cpu_threshold))

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -215,6 +215,7 @@ def shutdown_ebgp(duthosts):
     orch_cpu_threshold = 10
     # increase timeout for check_orch_cpu_utilization to 120sec for chassis
     # especially uplink cards need >60sec for orchagent cpu usage to come down to 10%
+    duthost = duthosts[rand_one_dut_hostname]
     is_chassis = duthost.get_facts().get("modular_chassis")
     orch_cpu_timeout = 120 if is_chassis else 60
     for duthost in duthosts.frontend_nodes:

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -216,7 +216,7 @@ def shutdown_ebgp(duthosts):
     # increase timeout for check_orch_cpu_utilization to 120sec for chassis
     # especially uplink cards need >60sec for orchagent cpu usage to come down to 10%
     is_chassis = duthost.get_facts().get("modular_chassis")
-    orch_cpu_timeout = 60 if is_chassis else 120
+    orch_cpu_timeout = 120 if is_chassis else 60
     for duthost in duthosts.frontend_nodes:
         # Get the original number of eBGP v4 and v6 routes on the DUT.
         sumv4, sumv6 = duthost.get_ip_route_summary()

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -280,7 +280,7 @@ def utils_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tb
             if 'tagging_mode' not in vlan_members[k][port]:
                 continue
             mode = vlan_members[k][port]['tagging_mode']
-            config_ports_vlan[port].append({'vlanid':int(vlanid), 'ip': ip, 'tagging_mode': mode})
+            config_ports_vlan[port].append({'vlanid': int(vlanid), 'ip': ip, 'tagging_mode': mode})
 
     if config_portchannels:
         for po in config_portchannels:
@@ -379,7 +379,7 @@ def utils_vlan_intfs_dict_add(vlan_intfs_dict, add_cnt):
         }
     '''
     vlan_cnt = 0
-    for i in xrange(0, 255):
+    for i in range(0, 255):
         vid = 100 + i
         if vid in vlan_intfs_dict:
             continue
@@ -410,7 +410,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     cmds = []
     logger.info("Add vlans, assign IPs")
     for k, v in vlan_intfs_dict.items():
-        if v['orig'] == True:
+        if v['orig']:
             continue
         cmds.append('config vlan add {}'.format(k))
         cmds.append("config interface ip add Vlan{} {}".format(k, v['ip'].upper()))
@@ -431,7 +431,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     logger.info("Add members to Vlans")
     for vlan_port in vlan_ports_list:
         for permit_vlanid in vlan_port['permit_vlanid']:
-            if vlan_intfs_dict[int(permit_vlanid)]['orig'] == True:
+            if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -208,7 +208,7 @@ def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
 
 
 @pytest.fixture(scope="module")
-def shutdown_ebgp(duthosts):
+def shutdown_ebgp(duthosts, rand_one_dut_hostname):
     # To store the original number of eBGP v4 and v6 routes.
     v4ebgps = {}
     v6ebgps = {}

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -215,7 +215,8 @@ def shutdown_ebgp(duthosts):
     orch_cpu_threshold = 10
     # increase timeout for check_orch_cpu_utilization to 120sec for chassis
     # especially uplink cards need >60sec for orchagent cpu usage to come down to 10%
-    orch_cpu_timeout = 60 if len(duthosts) == 1 else 120
+    is_chassis = duthost.get_facts().get("modular_chassis")
+    orch_cpu_timeout = 60 if is_chassis else 120
     for duthost in duthosts.frontend_nodes:
         # Get the original number of eBGP v4 and v6 routes on the DUT.
         sumv4, sumv6 = duthost.get_ip_route_summary()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
test_sfp.py is erroring because of shutdown_bgp failed to check_orch_cpu_utilization within 60sec timeout, the check makes sure OA cpu utilization go below 10% within a timeout, currently is 60sec.
Chassis orchagent CPU usage need >60sec to come down to below 10% on uplink linecards.
This PR increases timeout to 120 only for chassis duts

1. arista chassis uplink card takes ~87sec with (51150+51140) routes(masic card)
2. nokia svc chassis uplink card with (51158+51154) routes takes ~60sec at the boundary and testcase could be flaky
3. other topo are fine as they have fewer routes on uplink card

datapoints:
arista:
```
admin@arista_chassis_uplink_card:~$ date
Mon 13 Feb 2023 11:24:53 PM UTC
admin@arista_chassis_uplink_card:~$ show process cpu | grep orch
 552409 root      20   0  953596 571620  15116 R  82.4   3.5   1:42.55 orchagent
 552401 root      20   0  927300 545388  15424 S  17.6   3.3   1:21.79 orchagent
...
admin@arista_chassis_uplink_card:~$ show process cpu | grep orch
 552409 root      20   0  953596 571620  15116 R  87.5   3.5   2:17.72 orchagent
 552401 root      20   0  927300 545388  15424 S   0.0   3.3   1:51.05 orchagent
admin@arista_chassis_uplink_card:~$ show process cpu | grep orch
 552401 root      20   0  927300 545388  15424 S   0.0   3.3   1:51.05 orchagent
 552409 root      20   0  953596 571620  15116 S   0.0   3.5   2:25.22 orchagent
admin@arista_chassis_uplink_card~$ date
Mon 13 Feb 2023 11:26:19 PM UTC
```
nokia:
```
admin@nokia_svc_uplink_card:~$ date
Mon 13 Feb 2023 11:21:21 PM UTC
admin@nokia_svc_uplink_card:~$ show process cpu | grep orch
2951989 root      20   0  821664 439764  15444 R 100.0   1.3   1:09.54 orchagent
2951987 root      20   0  906192 524368  15576 S  64.7   1.6   1:21.59 orchagent
...
admin@nokia_svc_uplink_card:~$ show process cpu | grep orch
2951987 root      20   0  903700 522224  15576 S   0.0   1.6   1:49.54 orchagent
2951989 root      20   0  821664 439764  15444 S   0.0   1.3   1:34.79 orchagent
admin@nokia_svc_uplink_card:~$ date
Mon 13 Feb 2023 11:22:23 PM UTC
```

Summary:
Fixes # (issue)
https://github.com/aristanetworks/sonic/issues/70
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
```
2023-02-06T12:04:12.1632429Z ==================================== ERRORS ====================================
2023-02-06T12:04:12.1637850Z _________ ERROR at setup of TestSfpApi.test_get_name[str2-7804-lc5-1] __________
2023-02-06T12:04:12.1639491Z 
2023-02-06T12:04:12.1644475Z duthosts = [<MultiAsicSonicHost str2-7804-lc5-1>, <MultiAsicSonicHost str2-7804-lc6-1>, <MultiAsicSonicHost str2-7804-lc7-1>, <MultiAsicSonicHost str2-7804-sup-1>]
2023-02-06T12:04:12.1647514Z 
2023-02-06T12:04:12.1650097Z     @pytest.fixture(scope="module")
2023-02-06T12:04:12.1652167Z     def shutdown_ebgp(duthosts):
2023-02-06T12:04:12.1654273Z         # To store the original number of eBGP v4 and v6 routes.
2023-02-06T12:04:12.1656585Z         v4ebgps = {}
2023-02-06T12:04:12.1658433Z         v6ebgps = {}
2023-02-06T12:04:12.1660553Z         orch_cpu_threshold = 10
2023-02-06T12:04:12.1662783Z         for duthost in duthosts.frontend_nodes:
2023-02-06T12:04:12.1665306Z             # Get the original number of eBGP v4 and v6 routes on the DUT.
2023-02-06T12:04:12.1668139Z             sumv4, sumv6 = duthost.get_ip_route_summary()
2023-02-06T12:04:12.1672595Z             v4ebgps[duthost.hostname] = sumv4.get('ebgp', {'routes': 0})['routes']
2023-02-06T12:04:12.1676829Z             v6ebgps[duthost.hostname] = sumv6.get('ebgp', {'routes': 0})['routes']
2023-02-06T12:04:12.1679328Z             # Shutdown all eBGP neighbors
2023-02-06T12:04:12.1681307Z             duthost.command("sudo config bgp shutdown all")
2023-02-06T12:04:12.1683102Z             # Verify that the total eBGP routes are 0.
2023-02-06T12:04:12.1685074Z             pytest_assert(wait_until(30, 2, 0, check_ebgp_routes, 0, 0, duthost),
2023-02-06T12:04:12.1687278Z                           "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
2023-02-06T12:04:12.1690470Z             pytest_assert(wait_until(60, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
2023-02-06T12:04:12.1692967Z                           "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"
2023-02-06T12:04:12.1696041Z                           .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
2023-02-06T12:04:12.1698217Z >                                 orch_cpu_threshold))
2023-02-06T12:04:12.1700130Z E           Failed: Orch CPU utilization  > orch cpu threshold 10 after shutdown all eBGP
2023-02-06T12:04:12.1701191Z 
```

After:
```
platform_tests/api/test_sfp.py::TestSfpApi::test_get_name[str2-7804-lc5-1] PASSED                                                                                                                                                                        [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
================================================================================================================== 1 passed in 286.27 seconds ==================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
