### PR TITLE
Add a field customize message into tr.xml.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1852,6 +1852,8 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
     cur_only_config = {}
     config_db_check_pass = True
 
+    check_result = {}
+
     if check_flag:
         for duthost in duthosts:
             logger.info("Collecting core dumps before test on {}".format(duthost.hostname))
@@ -2031,6 +2033,12 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
         else:
             logger.info("Core dump and config check passed for {}".format(module_name))
+
+    if check_result:
+        items = request.session.items
+        for item in items:
+            if item.module.__name__ + ".py" == module_name.split("/")[-1]:
+                item.user_properties.append(('dut_check_pass', False))
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -575,7 +575,8 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa F
                     ifs_status = fanout.host.get_interfaces_status()
                     for key, interface_info in ifs_status.items():
                         fanout.fanout_port_alias_to_name[interface_info['alias']] = interface_info['interface']
-                    logging.info("fanout {} fanout_port_alias_to_name {}".format(fanout_host, fanout.fanout_port_alias_to_name))
+                    logging.info("fanout {} fanout_port_alias_to_name {}"
+                                 .format(fanout_host, fanout.fanout_port_alias_to_name))
 
             fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
 
@@ -1212,7 +1213,7 @@ def generate_dut_backend_asics(request, duts_selected):
     for dut in duts_selected:
         mdata = metadata.get(dut)
         if mdata is None:
-            dut_asic_list.append([None]) 
+            dut_asic_list.append([None])
         dut_asic_list.append(mdata.get("backend_asics", [None]))
 
     return dut_asic_list
@@ -1260,7 +1261,7 @@ def pfc_pause_delay_test_params(request):
     try:
         with open(filepath, 'r') as yf:
             info = json.load(yf)
-    except IOError as e:
+    except IOError:
         return empty
 
     if tbname not in info:
@@ -2038,7 +2039,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
         items = request.session.items
         for item in items:
             if item.module.__name__ + ".py" == module_name.split("/")[-1]:
-                item.user_properties.append(('dut_check_pass', False))
+                item.user_properties.append(('CustomMsg', json.dumps({'DutChekResult': False})))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In tests/conftests.py, we use fixture `core_dump_and_config_check` to check if the running config is changed by the running module. And if the running config is changed, there is a warning in log. But it is difficult to find all cases which will change the running config, so in this pr, we add a customize information into tr.xml, and this field will recode some information when the running config is changed. 
**Due to the limitation of pytest, we only add the value in the last case in a module now. In other words, either cases in this module may change running config, not only this case. ** 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In tests/conftests.py, we use fixture `core_dump_and_config_check` to check if the running config is changed by the running module. And if the running config is changed, there is a warning in log. But it is difficult to find all cases which will change the running config, so in this pr, we add a customize information into tr.xml, and this field will recode some information when the running config is changed. 
**Due to the limitation of pytest, we only add the value in the last case in a module now. In other words, either cases in this module may change running config, not only this case. ** 

#### How did you do it?
Add a customize filed into tr.xml. 

#### How did you verify/test it?
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
  <testsuite errors="0" failures="0" hostname="89d3967bee2a" name="pytest" skipped="0" tests="5" time="18.681" timestamp="2023-02-14T08:43:53.295638">
    <properties>
      <property name="topology" value="t0"/>
      <property name="testbed" value="vms-kvm-t0"/>
      <property name="timestamp" value="2023-02-14 08:44:04.478502"/>
      <property name="host" value="vlab-01"/>
      <property name="asic" value="vs"/>
      <property name="platform" value="x86_64-kvm_x86_64-r0"/>
      <property name="hwsku" value="Force10-S6000"/>
      <property name="os_version" value="master.217155-43683d8ce"/>
    </properties>
    <testcase classname="item.test_item2" file="item/test_item2.py" line="0" name="test_item21" time="7.482">
      <properties>
        <property name="start" value="2023-02-14 08:44:00.071734"/>
        <property name="end" value="2023-02-14 08:44:07.554357"/>
      </properties>
    </testcase>
    <testcase classname="item.test_item2" file="item/test_item2.py" line="3" name="test_item22" time="1.126">
      <properties>
        <property name="start" value="2023-02-14 08:44:07.555306"/>
        <property name="CustomMsg" value="{&quot;DutChekResult&quot;: false}"/>
        <property name="end" value="2023-02-14 08:44:08.681835"/>
      </properties>
    </testcase>
    <testcase classname="item.item123.test_item" file="item/item123/test_item.py" line="0" name="test_item1" time="2.097">
      <properties>
        <property name="start" value="2023-02-14 08:44:08.682835"/>
        <property name="end" value="2023-02-14 08:44:10.780698"/>
      </properties>
    </testcase>
    <testcase classname="item.item123.test_item" file="item/item123/test_item.py" line="3" name="test_item2" time="0.002">
      <properties>
        <property name="start" value="2023-02-14 08:44:10.781346"/>
        <property name="end" value="2023-02-14 08:44:10.783781"/>
      </properties>
    </testcase>
    <testcase classname="item.item123.test_item" file="item/item123/test_item.py" line="6" name="test_item3" time="1.190">
      <properties>
        <property name="start" value="2023-02-14 08:44:10.784307"/>
        <property name="CustomMsg" value="{&quot;DutChekResult&quot;: false}"/>
        <property name="end" value="2023-02-14 08:44:11.974242"/>
      </properties>
    </testcase>
  </testsuite>
</testsuites>
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
