### PR TITLE
[macsec]: Recover neighbor devices by sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -133,7 +133,6 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     recover_method = "adaptive"
     pre_check_items = copy.deepcopy(SUPPORTED_CHECKS)  # Default check items
     post_check = False
-    enable_macsec = False
 
     customized_sanity_check = None
     for m in request.node.iter_markers():
@@ -175,10 +174,8 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     if request.config.option.post_check:
         post_check = True
 
-    if request.config.option.enable_macsec:
-        enable_macsec = True
-        startup_macsec = request.getfixturevalue("startup_macsec")
-        start_macsec_service = request.getfixturevalue("start_macsec_service")
+    if not request.config.option.enable_macsec:
+        pre_check_items.remove("check_neighbor_macsec_empty")
 
     cli_check_items = request.config.getoption("--check_items")
     cli_post_check_items = request.config.getoption("--post_check_items")
@@ -260,9 +257,6 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                     for action in infra_recovery_actions:
                         action()
 
-                    if enable_macsec:
-                        start_macsec_service()
-                        startup_macsec()
                 except Exception as e:
                     request.config.cache.set("pre_sanity_check_failed", True)
                     logger.error("Recovery of sanity check failed with exception: ")

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -26,7 +26,8 @@ CHECK_ITEMS = [
     'check_dbmemory',
     'check_monit',
     'check_mux_simulator',
-    'check_secureboot']
+    'check_secureboot',
+    'check_neighbor_macsec_empty']
 
 __all__ = CHECK_ITEMS
 
@@ -851,4 +852,40 @@ def check_secureboot(duthosts, request):
             check_results.append(check_result)
 
         return check_results
+    return _check
+
+
+@pytest.fixture(scope="module")
+def check_neighbor_macsec_empty(ctrl_links):
+    nodes = []
+    nodes_name = set()
+    dut_nbr_mapping = {}
+    for _, nbr in ctrl_links.items():
+        if nbr["name"] in nodes_name:
+            continue
+        nodes_name.add(nbr["name"])
+        nodes.append({
+            "nbr_host": nbr["host"],
+            "nbr_name": nbr["name"]})
+        dut_nbr_mapping[nbr["name"]] = nbr["dut_name"]
+
+    def _check_macsec_empty(*args, **kwargs):
+        node = kwargs['node']
+        results = kwargs['results']
+        check_result = len(node["nbr_host"].command("ip macsec show")["stdout_lines"]) > 0
+        results[node["nbr_name"]] = check_result
+
+    def _check(*args, **kwargs):
+        init_check_result = {"failed": False, "check_item": "neighbor_macsec_empty", "unhealthy_nbrs": []}
+        check_results = parallel_run(_check_macsec_empty, args, kwargs, nodes, timeout=300)
+        unhealthy_dut = set()
+        for nbr_name, check_result in check_results.items():
+            if check_result:
+                init_check_result["failed"] = True
+                init_check_result["unhealthy_nbrs"].append(nbr_name)
+                unhealthy_dut.add(dut_nbr_mapping[nbr_name])
+        if len(unhealthy_dut) > 0:
+            init_check_result["hosts"] = list(unhealthy_dut)
+        return init_check_result
+
     return _check

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -9,6 +9,8 @@ from tests.common.config_reload import config_force_option_supported
 from tests.common.reboot import reboot
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_FAST, REBOOT_TYPE_COLD
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+from tests.common import config_reload
+from tests.common.devices.sonic import SonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -103,13 +105,27 @@ def _neighbor_vm_recover_bgpd(node=None, results=None):
     results[nbr_host.hostname] = result
 
 
-def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
+def _neighbor_vm_recover_config(node=None, results=None):
+    if isinstance(node["host"], SonicHost):
+        config_reload(node["host"])
+    return results
+
+
+def neighbor_vm_restore(duthost, nbrhosts, tbinfo, result):
     logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
     if vm_neighbors:
-        results = parallel_run(_neighbor_vm_recover_bgpd, (), {}, nbrhosts.values(), timeout=300)
-        logger.debug('Results of restoring neighbor VMs: {}'.format(json.dumps(dict(results))))
+        if result["check_item"] == "neighbor_macsec_empty":
+            unhealthy_nbrs = []
+            for name, host in nbrhosts.items():
+                if name in result["unhealthy_nbrs"]:
+                    unhealthy_nbrs.append(host)
+            parallel_run(_neighbor_vm_recover_config, (), {}, unhealthy_nbrs, timeout=300)
+            logger.debug('Results of restoring neighbor VMs: {}'.format(unhealthy_nbrs))
+        else:
+            results = parallel_run(_neighbor_vm_recover_bgpd, (), {}, nbrhosts.values(), timeout=300)
+            logger.debug('Results of restoring neighbor VMs: {}'.format(json.dumps(dict(results))))
     return 'config_reload'  # May still need to do a config reload
 
 
@@ -126,8 +142,8 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
                 action = _recover_interfaces(dut, fanouthosts, result, wait_time)
             elif result['check_item'] == 'services':
                 action = _recover_services(dut, result)
-            elif result['check_item'] == 'bgp':
-                action = neighbor_vm_restore(dut, nbrhosts, tbinfo)
+            elif result['check_item'] == 'bgp' or result['check_item'] == "neighbor_macsec_empty":
+                action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)
             elif result['check_item'] in [ 'processes', 'mux_simulator' ]:
                 action = 'config_reload'
             else:

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -16,8 +16,11 @@ from macsec_config_helper import enable_macsec_feature
 from macsec_config_helper import disable_macsec_feature
 from macsec_config_helper import setup_macsec_configuration
 from macsec_config_helper import cleanup_macsec_configuration
+# flake8: noqa: F401
+from tests.common.plugins.sanity_check import sanity_check
 
 logger = logging.getLogger(__name__)
+
 
 class MacsecPlugin(object):
     """
@@ -46,27 +49,27 @@ class MacsecPlugin(object):
             metafunc.parametrize('macsec_profile',
                                  [self.macsec_profiles[x] for x in profiles],
                                  ids=profiles,
-                                 scope="session")
+                                 scope="module")
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def start_macsec_service(self, duthost, macsec_nbrhosts):
         def __start_macsec_service():
             enable_macsec_feature(duthost, macsec_nbrhosts)
         return __start_macsec_service
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def stop_macsec_service(self, duthost, macsec_nbrhosts):
         def __stop_macsec_service():
             disable_macsec_feature(duthost, macsec_nbrhosts)
         return __stop_macsec_service
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def macsec_feature(self, start_macsec_service, stop_macsec_service):
         start_macsec_service()
         yield
         stop_macsec_service()
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def startup_macsec(self, request, duthost, ctrl_links, macsec_profile):
         def __startup_macsec():
             profile = macsec_profile
@@ -83,21 +86,21 @@ class MacsecPlugin(object):
 
             cleanup_macsec_configuration(duthost, ctrl_links, profile['name'])
             setup_macsec_configuration(duthost, ctrl_links,
-                                        profile['name'], profile['priority'], profile['cipher_suite'],
-                                        profile['primary_cak'], profile['primary_ckn'], profile['policy'],
-                                        profile['send_sci'], profile['rekey_period'])
+                                       profile['name'], profile['priority'], profile['cipher_suite'],
+                                       profile['primary_cak'], profile['primary_ckn'], profile['policy'],
+                                       profile['send_sci'], profile['rekey_period'])
             logger.info(
                 "Setup MACsec configuration with arguments:\n{}".format(locals()))
         return __startup_macsec
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def shutdown_macsec(self, duthost, ctrl_links, macsec_profile):
         def __shutdown_macsec():
             profile = macsec_profile
             cleanup_macsec_configuration(duthost, ctrl_links, profile['name'])
         return __shutdown_macsec
 
-    @pytest.fixture(scope="session", autouse=True)
+    @pytest.fixture(scope="module", autouse=True)
     def macsec_setup(self, startup_macsec, shutdown_macsec, macsec_feature):
         '''
             setup macsec links
@@ -106,11 +109,11 @@ class MacsecPlugin(object):
         yield
         shutdown_macsec()
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def macsec_nbrhosts(self, ctrl_links):
         return {nbr["name"]: nbr for nbr in ctrl_links.values()}
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def ctrl_links(self, duthost, tbinfo, nbrhosts):
         if not nbrhosts:
             topo_name = tbinfo['topo']['name']
@@ -120,7 +123,7 @@ class MacsecPlugin(object):
         nbrhosts = {name: nbrhosts[name] for name in ctrl_nbr_names}
         return self.find_links_from_nbr(duthost, tbinfo, nbrhosts)
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def unctrl_links(self, duthost, tbinfo, nbrhosts, ctrl_links):
         unctrl_nbr_names = set(nbrhosts.keys())
         for _, nbr in ctrl_links.items():
@@ -130,12 +133,13 @@ class MacsecPlugin(object):
         nbrhosts = {name: nbrhosts[name] for name in unctrl_nbr_names}
         return self.find_links_from_nbr(duthost, tbinfo, nbrhosts)
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def downstream_links(self, duthost, tbinfo, nbrhosts):
         links = collections.defaultdict(dict)
 
         def filter(interface, neighbor, mg_facts, tbinfo):
-            if ((tbinfo["topo"]["type"] == "t0" and "Server" in neighbor["name"]) or (tbinfo["topo"]["type"] == "t2" and "T1" in neighbor["name"])) :
+            if ((tbinfo["topo"]["type"] == "t0" and "Server" in neighbor["name"])
+                    or (tbinfo["topo"]["type"] == "t2" and "T1" in neighbor["name"])):
                 port = mg_facts["minigraph_neighbors"][interface]["port"]
                 links[interface] = {
                     "name": neighbor["name"],
@@ -145,12 +149,13 @@ class MacsecPlugin(object):
         self.find_links(duthost, tbinfo, filter)
         return links
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="module")
     def upstream_links(self, duthost, tbinfo, nbrhosts):
         links = collections.defaultdict(dict)
 
         def filter(interface, neighbor, mg_facts, tbinfo):
-            if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"]) or (tbinfo["topo"]["type"] == "t2" and "T3" in neighbor["name"])):
+            if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"])
+                    or (tbinfo["topo"]["type"] == "t2" and "T3" in neighbor["name"])):
                 for item in mg_facts["minigraph_bgp"]:
                     if item["name"] == neighbor["name"]:
                         if isinstance(ip_address(item["addr"]), IPv4Address):
@@ -193,7 +198,8 @@ class MacsecPlugin(object):
             links[interface] = {
                 "name": neighbor["name"],
                 "host": nbrhosts[neighbor["name"]]["host"],
-                "port": port
+                "port": port,
+                "dut_name": duthost.hostname
             }
         self.find_links(duthost, tbinfo, filter)
         return links


### PR DESCRIPTION
What is the motivation for this PR?
The neighbor devices may fail to initialize MACsec due to an abnormal condition that the MACsec interfaces weren't cleanupped in the last test.

How did you do it?
If "MACsec" is enabled to check whether the MACsec interface isn't in neighbor device. If not, recover the neighbor devices by config reload.

How did you verify/test it?
Check Azp

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/7449

Signed-off-by: Ze Gan <ganze718@gmail.com>