### PR TITLE
Parse the customize message in tr.xml. 

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -85,6 +85,7 @@ TESTCASE_PROPERTY_TAG = "property"
 REQUIRED_TESTCASE_PROPERTIES = [
     "start",
     "end",
+    "CustomMsg"
 ]
 
 REQUIRED_TESTCASE_JSON_FIELDS = ["result", "error", "summary"]
@@ -289,6 +290,7 @@ def _validate_test_metadata(root):
     if set(seen_properties) < set(REQUIRED_METADATA_PROPERTIES):
         raise JUnitXMLValidationError("missing metadata element(s)")
 
+
 def _validate_test_case_properties(root):
     testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
 
@@ -322,6 +324,7 @@ def _validate_test_case_properties(root):
     missing_testcase_property = set(REQUIRED_TESTCASE_PROPERTIES) - set(seen_testcase_properties)
     if missing_testcase_property:
         print("missing testcase property: {}".format(list(missing_testcase_property)))
+
 
 def _validate_test_cases(root):
     def _validate_test_case(test_case):
@@ -379,7 +382,7 @@ def _extract_test_summary(test_cases):
     test_result_summary = defaultdict(int)
     for _, cases in test_cases.items():
         for case in cases:
-            # Error may occur along with other test results, to count error separately. 
+            # Error may occur along with other test results, to count error separately.
             # The result field is unique per test case, either error or failure.
             # xfails is the counter for all kinds of xfail results (include success/failure/error/skipped)
             test_result_summary["tests"] += 1
@@ -387,10 +390,9 @@ def _extract_test_summary(test_cases):
             test_result_summary["skipped"] += case["result"] == "skipped"
             test_result_summary["errors"] += case["error"]
             test_result_summary["time"] += float(case["time"])
-            test_result_summary["xfails"] += case["result"] == "xfail_failure" or \
-                                             case["result"] == "xfail_error" or \
-                                             case["result"] == "xfail_skipped" or \
-                                             case["result"] == "xfail_success"
+            test_result_summary["xfails"] += \
+                case["result"] == "xfail_failure" or case["result"] == \
+                "xfail_error" or case["result"] == "xfail_skipped" or case["result"] == "xfail_success"
 
     test_result_summary = {k: str(v) for k, v in test_result_summary.items()}
     return test_result_summary
@@ -409,6 +411,7 @@ def _parse_test_metadata(root):
 
     return test_result_metadata
 
+
 def _parse_testcase_properties(root):
     testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
 
@@ -421,6 +424,7 @@ def _parse_testcase_properties(root):
             testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
 
     return testcase_properties
+
 
 def _parse_test_cases(root):
     test_case_results = defaultdict(list)
@@ -492,10 +496,12 @@ def _update_test_summary(current, update):
 
     new_summary = {}
     for attribute, attr_type in REQUIRED_TESTSUITE_ATTRIBUTES:
-        new_summary[attribute] = str(round(attr_type(current.get(attribute, 0)) + attr_type(update.get(attribute, 0)), 3))
+        new_summary[attribute] = str(round(attr_type(current.get(attribute, 0))
+                                           + attr_type(update.get(attribute, 0)), 3))
 
     for attribute, attr_type in EXTRA_XML_SUMMARY_ATTRIBUTES:
-        new_summary[attribute] = str(round(attr_type(current.get(attribute, 0)) + attr_type(update.get(attribute, 0)), 3))
+        new_summary[attribute] = str(round(attr_type(current.get(attribute, 0))
+                                           + attr_type(update.get(attribute, 0)), 3))
 
     return new_summary
 
@@ -659,7 +665,8 @@ python3 junit_xml_parser.py tests/files/sample_tr.xml
         "--json",
         "-j",
         action="store_true",
-        help="Load an existing test result JSON file from path_name. Will perform validation only regardless of --validate-only option.",
+        help="Load an existing test result JSON file from path_name. "
+             "Will perform validation only regardless of --validate-only option.",
     )
 
     args = parser.parse_args()

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -421,7 +421,14 @@ def _parse_testcase_properties(root):
     testcase_properties = {}
     for testcase_prop in testcase_properties_element.iterfind(TESTCASE_PROPERTY_TAG):
         if testcase_prop.get("value"):
-            testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
+            if testcase_prop.get("name") == "CustomMsg":
+                if not testcase_properties.get(testcase_prop.get("name")):
+                    testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
+                else:
+                    testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value") + ", " + \
+                                                                     testcase_properties[testcase_prop.get("name")]
+            else:
+                testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
 
     return testcase_properties
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr [#7459](https://github.com/sonic-net/sonic-mgmt/pull/7459), I add a field called `CustomMsg` to record customize information in tr.xml. And in this pr, I parse this new field. The `CustomMsg` field supports duplicate key with different value like
```
<property name="CustomMsg" value="{&quot;CustomMsg1&quot;: &quot;CustomMsg1&quot;}"/>
<property name="CustomMsg" value="{&quot;CustomMsg2&quot;: &quot;CustomMsg2&quot;}"/>
<property name="CustomMsg" value="{&quot;CustomMsg3&quot;: &quot;CustomMsg3&quot;}"/>
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In pr [#7459](https://github.com/sonic-net/sonic-mgmt/pull/7459), I add a field called `CustomMsg` to record customize information in tr.xml. And in this pr, I parse this new field. The `CustomMsg` field supports duplicate key with different value like
```
<property name="CustomMsg" value="{&quot;CustomMsg1&quot;: &quot;CustomMsg1&quot;}"/>
<property name="CustomMsg" value="{&quot;CustomMsg2&quot;: &quot;CustomMsg2&quot;}"/>
<property name="CustomMsg" value="{&quot;CustomMsg3&quot;: &quot;CustomMsg3&quot;}"/>
```

#### How did you do it?
Parse the new field `CustomMsg` and handle duplicate key with different value.

#### How did you verify/test it?
```
{
    "test_cases": {
        "item": [
            {
                "classname": "item.test_item2",
                "end": "2023-02-15 01:59:45.618933",
                "error": false,
                "file": "item/test_item2.py",
                "line": "0",
                "name": "test_item21",
                "result": "success",
                "start": "2023-02-15 01:59:38.284803",
                "summary": "",
                "time": "7.333"
            },
            {
                "CustomMsg": "{\"CustomMsg3\": \"CustomMsg3\"}, {\"CustomMsg2\": \"CustomMsg2\"}, {\"CustomMsg1\": \"CustomMsg1\"}",
                "classname": "item.test_item2",
                "end": "2023-02-15 01:59:46.748990",
                "error": false,
                "file": "item/test_item2.py",
                "line": "3",
                "name": "test_item22",
                "result": "success",
                "start": "2023-02-15 01:59:45.619753",
                "summary": "",
                "time": "1.129"
            },
            {
                "classname": "item.item123.test_item",
                "end": "2023-02-15 01:59:48.788236",
                "error": false,
                "file": "item/item123/test_item.py",
                "line": "0",
                "name": "test_item1",
                "result": "success",
                "start": "2023-02-15 01:59:46.749967",
                "summary": "",
                "time": "2.038"
            },
            {
                "classname": "item.item123.test_item",
                "end": "2023-02-15 01:59:48.791589",
                "error": false,
                "file": "item/item123/test_item.py",
                "line": "3",
                "name": "test_item2",
                "result": "success",
                "start": "2023-02-15 01:59:48.788888",
                "summary": "",
                "time": "0.002"
            },
            {
                "CustomMsg": "{\"CustomMsg3\": \"CustomMsg3\"}, {\"CustomMsg2\": \"CustomMsg2\"}, {\"CustomMsg1\": \"CustomMsg1\"}",
                "classname": "item.item123.test_item",
                "end": "2023-02-15 01:59:49.999651",
                "error": false,
                "file": "item/item123/test_item.py",
                "line": "6",
                "name": "test_item3",
                "result": "success",
                "start": "2023-02-15 01:59:48.792122",
                "summary": "",
                "time": "1.207"
            }
        ]
    },
    "test_metadata": {
        "asic": "vs",
        "host": "vlab-01",
        "hwsku": "Force10-S6000",
        "os_version": "master.217155-43683d8ce",
        "platform": "x86_64-kvm_x86_64-r0",
        "testbed": "vms-kvm-t0",
        "timestamp": "2023-02-15 01:59:42.460404",
        "topology": "t0"
    },
    "test_summary": {
        "errors": "0",
        "failures": "0",
        "skipped": "0",
        "tests": "5",
        "time": "11.709000000000001",
        "xfails": "0"
    }
}
```


in kusto, it displays like this 
```
CustomMsg
{"CustomMsg3": "CustomMsg3"}, {"CustomMsg2": "CustomMsg2"}, {"CustomMsg1": "CustomMsg1"}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
