### PR TITLE
[Mellanox] Added ignore for test case "test_sai_sdk_dump" on non Nvidia devices

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -806,6 +806,12 @@ show_techsupport/test_techsupport.py::test_techsupport:
       - "branch in ['internal-202012']"
       - "build_version <= '20201231.33'"
 
+show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sai_sdk_dump:
+  skip:
+    reason: "Test supported only on Nvidia(Mellanox) devices"
+    conditions:
+      - "asic_type not in ['mellanox']"
+
 #######################################
 #####            snmp             #####
 #######################################


### PR DESCRIPTION
### Description of PR
New test has been introduced in PR: https://github.com/sonic-net/sonic-mgmt/pull/7365 but test supported on Nvidia(Mellanox) devices only. So added ignore for this test case for all non Nvidia(Mellanox) devices

Summary: Added ignore for test case "test_sai_sdk_dump" on non Nvidia(Mellanox) devices
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
New test has been introduced in PR: https://github.com/sonic-net/sonic-mgmt/pull/7365 but test supported on Nvidia(Mellanox) devices only. So added ignore for this test case for all non Nvidia(Mellanox) devices

#### How did you do it?
Added ignore for test case "test_sai_sdk_dump" on non Nvidia(Mellanox) devices

#### How did you verify/test it?
Executed test and checked that it skipped in case of non Nvidia(Mellanox) device

#### Any platform specific information?
Nvidia(Mellanox)

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
