### PR TITLE
[VM]add swan option for isis

### DIFF
--- a/tests/wan/isis/conftest.py
+++ b/tests/wan/isis/conftest.py
@@ -6,6 +6,14 @@ from isis_helpers import setup_isis
 from isis_helpers import teardown_isis
 
 
+def pytest_addoption(parser):
+    """
+    Adds pytest options that are used by swan agent tests
+    """
+    parser.addoption("--swan_agent", action="store_true", default=False,
+                     help="Enable swan agent test on wan testbed")
+
+
 def get_target_dut_port(mg_facts, dut_intf):
     for k, v in mg_facts['minigraph_portchannels'].items():
         if dut_intf in v['members']:
@@ -86,10 +94,13 @@ def isis_dpg_topo(duthosts, nbrhosts, duts_interconnects, tbinfo):
 def isis_common_setup_teardown(isis_dpg_topo, request, rand_selected_dut):
     dut_host = rand_selected_dut
     selected_connections = []
-    for item in isis_dpg_topo:
-        if dut_host == item[0]:
-            selected_connections.append(item)
-            break
+    if request.config.getoption("--swan_agent"):
+        selected_connections = isis_dpg_topo
+    else:
+        for item in isis_dpg_topo:
+            if dut_host == item[0]:
+                selected_connections.append(item)
+                break
 
     if not selected_connections:
         pytest.skip('No target device found in isis testcase {}.'.format(request.node.name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add swan agent option for IS-IS test and once this option is enabled, all detected links will be enabled IS-IS protocol.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add one option for IS-IS test and once this option is enabled, all detected links will be enabled IS-IS protocol.
#### How did you do it?
If this option is enabled, all the detected links will be selected. If this option is not enabled, selected the first link of DUT.
#### How did you verify/test it?
Run IS-IS testcases, and check IS-IS neighbors.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
