### PR TITLE
making change in function to install nanomsg package for cisco devices

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -212,9 +212,13 @@ def _install_nano(dut, creds,  syncd_docker_name):
             dut (SonicHost): The target device.
             creds (dict): Credential information according to the dut inventory
     """
-    output = dut.command(
-        "docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || echo copp'".format(
-            syncd_docker_name))
+
+    if dut.facts["asic_type"] == "cisco-8000":
+        output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] || \
+            echo copp'".format(syncd_docker_name))
+    else:
+        output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || \
+            echo copp'".format(syncd_docker_name))
 
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
@@ -253,6 +257,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
         dut.command(cmd)
+
 
 def _map_port_number_to_interface(dut, nn_target_port):
     """


### PR DESCRIPTION
Description:
For running copp tests in cisco internal runs, we manually replace the syncd-rpc docker and then run the script.
All testcased in test_copp.py error out on 202205 branch during cisco internal runs because the test tries to install package nanomsg on DUT but DUT does not have external connectivity. 

Since nanomsg is already included in syncd-rpc docker Image, script should not try to install it but
it does because of below line in install_nano function in copp_utils.py.

output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || echo copp'".format(syncd_docker_name))

There is no path '/opt/ptf' under syncd-rpc docker.

Changes:
To avoid this issue for cisco devices, we added a condition so that the script does not check '/opt/ptf' path for cisco devices

Verification: 
Verified that copp tests are not throwing the same error after this change.

 



