### PR TITLE
Modified copp test case to run it on marvell asic

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -354,6 +354,9 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
     logging.info("Set up the PTF for COPP tests")
     copp_utils.configure_ptf(ptf, test_params, is_backend_topology)
 
+    if dut.facts["asic_type"] == "marvell":
+        _TEST_RATE_LIMIT = 625
+
     logging.info("Update the rate limit for the COPP policer")
     copp_utils.limit_policer(dut, _TEST_RATE_LIMIT, test_params.nn_target_namespace)
 


### PR DESCRIPTION
### Description of PR
Modified copp test case to run it on marvell asic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X ] 202205



#### How did you do it?
Modified test_copp.py file to run it on marvell asic. Changed the CIR value according to marvell asic design

#### How did you verify/test it?
Executed test cases on testbed
```
copp/test_copp.py::TestCOPP::test_policer[str-marvell-acs-1-ARP] PASSED                       
copp/test_copp.py::TestCOPP::test_policer[str-marvell-acs-1-IP2ME] PASSED                     
copp/test_copp.py::TestCOPP::test_policer[str-marvell-acs-1-SNMP] PASSED                      
copp/test_copp.py::TestCOPP::test_policer[str-marvell-acs-1-SSH] PASSED                       
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-BGP] PASSED                    
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-DHCP] PASSED                   
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-DHCP6] PASSED                  
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-LACP] PASSED                   
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-LLDP] PASSED                   
copp/test_copp.py::TestCOPP::test_no_policer[str-marvell-acs-1-UDLD] PASSED                   
copp/test_copp.py::TestCOPP::test_add_new_trap[str-marvell-acs-1] PASSED                      
copp/test_copp.py::TestCOPP::test_remove_trap[str-marvell-acs-1-delete_feature_entry] PASSED  
copp/test_copp.py::TestCOPP::test_remove_trap[str-marvell-acs-1-disable_feature_status] PASSED
copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[str-marvell-acs-1] PASSED 
```    

#### Any platform specific information?
Yes
