### PR TITLE
Modified the everflow policer test case to run it on marvell asic

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -251,6 +251,9 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["innovium"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
 
+        if self.asic_type in ["marvell"]:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
+
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "timestamp")

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -559,6 +559,8 @@ class BaseEverflowTest(object):
         duthost.command(command)
 
     def apply_policer_config(self, duthost, policer_name, config_method, rate_limit=100):
+        if duthost.facts["asic_type"] == "marvell":
+            rate_limit = 125
         for namespace in duthost.get_frontend_asic_namespace_list():
             if config_method == CONFIG_MODE_CLI:
                 sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -491,6 +491,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
         if vendor == 'innovium':
             everflow_tolerance = 11
 
+        rate_limit = 100
+        if vendor == "marvell":
+            rate_limit = 125
+
         for asic in self.MIRROR_POLICER_UNSUPPORTED_ASIC_LIST:
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
             if vendorAsic in hostvars.keys() and everflow_dut.facts['hwsku'] in hostvars[vendorAsic]:
@@ -554,8 +558,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                dst_mirror_ports=mirror_port_id,
                                dst_ports=tx_port_ptf_id,
                                meter_type="packets",
-                               cir="100",
-                               cbs="100",
+                               cir="rate_limit",
+                               cbs="rate_limit",
                                send_time="10",
                                tolerance=everflow_tolerance)
         finally:


### PR DESCRIPTION
### Description of PR
Summary:
Modified the everflow policer test case to run it on marvell asic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ X] Test case(new/improvement)


### Back port request
- [ X] 201911
- [X ] 202012
- [ X] 202205

### Approach
#### What is the motivation for this PR?
#### How did you do it?
Modified the everflow test case and changed the CIR value according to marvell asic design

#### How did you verify/test it?
test case is passing on community testbed
```
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream] PASSED
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] PASSED
```

#### Any platform specific information?
Yes

