### PR TITLE
[dualtor][active-active] Allow up to two disruptions after BGP shutdown

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -178,7 +178,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
-            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC, allowed_disruption=2,
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix `test_active_tor_shutdown_bgp_sessions_upstream` failure on `dualtor-mixed` testbed.
```
E       Traffic to server 192.168.0.22 was disrupted 2 times. Allowed number of disruptions: 1
```
The issue is caused by the periodic mux probe: https://github.com/sonic-net/sonic-linkmgrd/pull/151.
There might be a race condition between the periodical mux probe return and the link prober unknown event.
If the periodical mux probe comes first and mux status is `standby` already(peer ToR toggled), the ToR will try to toggle to active first, and when the link prober unknown event comes, the ToR will toggle to standby then.
So there will be two disruptions in this case. As the final state is correct, the two disruption result is acceptable.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Allow up two disruptions in `test_active_tor_shutdown_bgp_sessions_upstream`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
