### PR TITLE
skip test_dst_ip_is_loopback_addr and test_dst_ip_link_local for cisco 8000 in t1 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -48,7 +48,7 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
     reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version. Test also not supported on Broadcom DNX"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_type =='cisco-8000' and topo_name in ['t1', 't1-lag', 't1-56-lag', 't1-64-lag', 't1-64-lag-clet', 't1-4-lag', 't1-backend']) or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -62,7 +62,7 @@ drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
     reason: "Cisco 8000 with 202012 version and broadcom DNX platforms do not drop DIP linklocal packets"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_type =='cisco-8000' and topo_name in ['t1', 't1-lag', 't1-56-lag', 't1-64-lag', 't1-64-lag-clet', 't1-4-lag', 't1-backend']) or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

skip test_dst_ip_is_loopback_addr and test_dst_ip_link_local for cisco 8000 in t1 topo

#### How did you do it?
set skip in tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml

#### How did you verify/test it?
pass local test, make sure both test_dst_ip_is_loopback_addr and test_dst_ip_link_local were skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
