### PR TITLE
Fixed KeyError: 'platform_asic' issue observed while running egress a…

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -410,7 +410,7 @@ def stage(request, duthosts, rand_one_dut_hostname, tbinfo):
     """
     duthost = duthosts[rand_one_dut_hostname]
     pytest_require(
-        request.param == "ingress" or duthost.facts["platform_asic"] == "broadcom-dnx" or duthost.facts["asic_type"] not in ("broadcom"),
+        request.param == "ingress" or duthost.facts.get("platform_asic") == "broadcom-dnx" or duthost.facts["asic_type"] not in ("broadcom"),
         "Egress ACLs are not currently supported on \"{}\" ASICs".format(duthost.facts["asic_type"])
     )
 


### PR DESCRIPTION
Summary:
ACL egress test case are errored out due to KeyError: 'platform_asic' issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ X] 202205

#### How did you do it?
fixed the code and changed below line:-
```
-        request.param == "ingress" or duthost.facts["platform_asic"] == "broadcom-dnx" or duthost.facts["asic_type"] not in ("broadcom"),
+        request.param == "ingress" or duthost.facts.get("platform_asic") == "broadcom-dnx" or duthost.facts["asic_type"] not in ("broadcom"),
```
#### How did you verify/test it?
Verified it on community testbed
```
acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-egress-downlink->uplink] SKIPPED        
acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-egress-uplink->downlink] SKIPPED        
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-egress-downlink->uplink] PASSED        
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-egress-uplink->downlink] PASSED        
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-egress-downlink->uplink] PASSED         
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-egress-uplink->downlink] PASSED         
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-egress-downlink->uplink] PASSED          
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-egress-uplink->downlink] PASSED          
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-egress-downlink->uplink] PASSED            
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-egress-uplink->downlink] PASSED            
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-egress-downlink->uplink] PASSED           
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-egress-uplink->downlink] PASSED           
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-egress-downlink->uplink] PASSED             
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-egress-uplink->downlink] PASSED             
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-egress-downlink->uplink] PASSED           
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-egress-uplink->downlink] PASSED           
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-egress-downlink->uplink] PASSED     
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-egress-uplink->downlink] PASSED     
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-egress-downlink->uplink] PASSED       
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-egress-uplink->downlink] PASSED       
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-egress-downlink->uplink] PASSED      
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-egress-uplink->downlink] PASSED      
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-egress-downlink->uplink] PASSED    
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-egress-uplink->downlink] PASSED    
acl/test_acl.py::TestBasicAcl::test_l4_dport_match_forwarded[ipv4-egress-downlink->uplink] PASSED          
acl/test_acl.py::TestBasicAcl::test_l4_dport_match_forwarded[ipv4-egress-uplink->downlink] PASSED          
acl/test_acl.py::TestBasicAcl::test_l4_sport_match_forwarded[ipv4-egress-downlink->uplink] PASSED          
acl/test_acl.py::TestBasicAcl::test_l4_sport_match_forwarded[ipv4-egress-uplink->downlink] PASSED          
acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_forwarded[ipv4-egress-downlink->uplink] PASSED    
acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_forwarded[ipv4-egress-uplink->downlink] PASSED    
acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_forwarded[ipv4-egress-downlink->uplink] PASSED    
acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_forwarded[ipv4-egress-uplink->downlink] PASSED    
acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_dropped[ipv4-egress-downlink->uplink] PASSED      
acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_dropped[ipv4-egress-uplink->downlink] PASSED      
acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_dropped[ipv4-egress-downlink->uplink] PASSED      
acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_dropped[ipv4-egress-uplink->downlink] PASSED      
acl/test_acl.py::TestBasicAcl::test_ip_proto_match_forwarded[ipv4-egress-downlink->uplink] PASSED          
acl/test_acl.py::TestBasicAcl::test_ip_proto_match_forwarded[ipv4-egress-uplink->downlink] PASSED          
acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_forwarded[ipv4-egress-downlink->uplink] PASSED         
acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_forwarded[ipv4-egress-uplink->downlink] PASSED         
acl/test_acl.py::TestBasicAcl::test_l4_dport_match_dropped[ipv4-egress-downlink->uplink] PASSED            
acl/test_acl.py::TestBasicAcl::test_l4_dport_match_dropped[ipv4-egress-uplink->downlink] PASSED            
acl/test_acl.py::TestBasicAcl::test_l4_sport_match_dropped[ipv4-egress-downlink->uplink] PASSED            
acl/test_acl.py::TestBasicAcl::test_l4_sport_match_dropped[ipv4-egress-uplink->downlink] PASSED            
acl/test_acl.py::TestBasicAcl::test_ip_proto_match_dropped[ipv4-egress-downlink->uplink] PASSED            
acl/test_acl.py::TestBasicAcl::test_ip_proto_match_dropped[ipv4-egress-uplink->downlink] PASSED            
acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_dropped[ipv4-egress-downlink->uplink] PASSED           
acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_dropped[ipv4-egress-uplink->downlink] PASSED           
acl/test_acl.py::TestBasicAcl::test_icmp_match_forwarded[ipv4-egress-downlink->uplink] PASSED              
acl/test_acl.py::TestBasicAcl::test_icmp_match_forwarded[ipv4-egress-uplink->downlink] PASSED    
```          

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A