### PR TITLE
[iface_namingmode] Ignore dhcp_relay restart error while setup and teardown

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -566,7 +566,8 @@ class TestShowVlan():
         yield
 
         logger.info('Cleaning up the test vlan 100')
-        res = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan del 100'.format(ifmode))
+        res = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan del 100'
+                                 .format(ifmode), module_ignore_errors=True)
         if res["rc"] != 0 and "Restart service dhcp_relay failed with error" not in res["stderr"]:
             pytest.fail("Del vlan failed in teardown")
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -558,11 +558,17 @@ class TestShowVlan():
         """
         dutHostGuest, mode, ifmode = setup_config_mode
         logger.info('Creating a test vlan 100')
-        dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan add 100'.format(ifmode))
+        res = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan add 100'
+                                 .format(ifmode), module_ignore_errors=True)
+        if res["rc"] != 0 and "Restart service dhcp_relay failed with error" not in res["stderr"]:
+            pytest.fail("Add vlan failed in setup")
+
         yield
 
         logger.info('Cleaning up the test vlan 100')
-        dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan del 100'.format(ifmode))
+        res = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan del 100'.format(ifmode))
+        if res["rc"] != 0 and "Restart service dhcp_relay failed with error" not in res["stderr"]:
+            pytest.fail("Del vlan failed in teardown")
 
     def test_show_vlan_brief(self, setup, setup_config_mode):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add/del vlan in without dhcp_relay container would caused setup/teardown error in this case

#### How did you do it?
Ignore dhcp_relay rrestart error while setup and teardown

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
