### PR TITLE
refine sai_thrift_read_port_counters

### DIFF
--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -231,7 +231,8 @@ def setup(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ansible_facts, minig
             "router_mac": None,
             "pfc_to_dscp": None,
             "lossless_priorities": None,
-            "lossy_priorities": None
+            "lossy_priorities": None,
+            "sonic_asic_type": duthost.facts['asic_type']
             },
         "server_ports_oids": [],
         "fanout_inventory": request.config.getoption("--fanout_inventory")

--- a/tests/pfc_asym/test_pfc_asym.py
+++ b/tests/pfc_asym/test_pfc_asym.py
@@ -74,7 +74,6 @@ def test_pfc_asym_on_handle_pfc_all_prio(ptfhost, setup, enable_pfc_asym, pfc_st
     @param pfc_storm_runner: Fixture which start/stop PFC generator on Fanout switch
     @param enable_pfc_asym: Fixture which enable/disable asymmetric PFC on all server interfaces
     """
-    import pdb; pdb.set_trace()
     pfc_storm_runner.server_ports = True
     pfc_storm_runner.run()
 

--- a/tests/pfc_asym/test_pfc_asym.py
+++ b/tests/pfc_asym/test_pfc_asym.py
@@ -74,6 +74,7 @@ def test_pfc_asym_on_handle_pfc_all_prio(ptfhost, setup, enable_pfc_asym, pfc_st
     @param pfc_storm_runner: Fixture which start/stop PFC generator on Fanout switch
     @param enable_pfc_asym: Fixture which enable/disable asymmetric PFC on all server interfaces
     """
+    import pdb; pdb.set_trace()
     pfc_storm_runner.server_ports = True
     pfc_storm_runner.run()
 

--- a/tests/saitests/pfc_asym.py
+++ b/tests/saitests/pfc_asym.py
@@ -66,6 +66,7 @@ class PfcAsymBaseTest(ThriftInterfaceDataPlane):
         self.pfc_to_dscp = self.test_params['pfc_to_dscp']
         self.lossless_priorities = map(int, self.test_params['lossless_priorities'])
         self.lossy_priorities = map(int, self.test_params['lossy_priorities'])
+        self.asic_type = self.test_params['sonic_asic_type']
 
         self.setUpArpResponder(self.server_ports)
         self.shell(["supervisorctl", "start", "arp_responder"])
@@ -142,7 +143,7 @@ class PfcAsymOffOnTxTest(PfcAsymBaseTest):
         # 1. Verify that some packets are dropped on src ports, which means that Rx queue is full
         # 2. Verify that PFC frames are generated for lossless priorities
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("\nLossless: port_counters = {}\n queue_counters = {}\nserver port = {}".format(
                 port_counters, queue_counters, sp))
             assert(port_counters[self.INGRESS_DROP] > 0)
@@ -154,7 +155,7 @@ class PfcAsymOffOnTxTest(PfcAsymBaseTest):
 
         # Verify that PFC frames are not generated for lossy priorities
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("\Lossy: port_counters = {}\n queue_counters = {}\nserver_ports = {}".format(
                 port_counters, queue_counters, sp))
             for p in self.lossy_priorities:
@@ -203,13 +204,13 @@ class PfcAsymOffRxTest(PfcAsymBaseTest):
 
         # Verify that packets are not dropped on src port
         port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.non_server_port['oid'])
+            self.client, self.asic_type, self.non_server_port['oid'])
         assert(port_counters[self.INGRESS_DROP] == 0)
 
         # 1. Verify that packets are not dropped on dst ports
         # 2. Verify that packets are transmitted from dst ports
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("Lossy - EGRESS_DROP: port_counters = {}\n queue_counters = {}\nserver_port = {}".format(
                 port_counters, queue_counters, sp))
             assert(port_counters[self.EGRESS_DROP] == 0)
@@ -221,14 +222,14 @@ class PfcAsymOffRxTest(PfcAsymBaseTest):
 
         # Verify that some packets are dropped on src port, which means that Rx queue is full
         port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.non_server_port['oid'])
+            self.client, self.asic_type, self.non_server_port['oid'])
         self.log("\nLossless - INGRESS_DROP: port_counters = {}\n queue_counters = {}".format(
             port_counters, queue_counters))
         assert(port_counters[self.INGRESS_DROP] > 0)
 
         # Verify that some packets are dropped on dst ports, which means that Tx buffer is full
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("\nLossless - EGRESS_DROP: port_counters = {}\n queue_counters = {}\nserver_port = {}".format(
                 port_counters, queue_counters, sp))
             assert(port_counters[self.EGRESS_DROP] > 0)
@@ -276,14 +277,14 @@ class PfcAsymOnRxTest(PfcAsymBaseTest):
 
         # Verify that packets are not dropped on src port
         port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.non_server_port['oid'])
+            self.client, self.asic_type, self.non_server_port['oid'])
         self.log("Lossy - INGRESS_DROP: port_counters = {}\n queue_counters = {}".format(
             port_counters, queue_counters))
         assert(port_counters[self.INGRESS_DROP] == 0)
 
         # Verify that some packets are dropped on dst ports, which means that Tx buffer is full
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("Lossy - EGRESS_DROP: port_counters = {}\n queue_counters = {}\nserver_port = {}".format(
                 port_counters, queue_counters, sp))
             assert(port_counters[self.EGRESS_DROP] > 0)
@@ -293,14 +294,14 @@ class PfcAsymOnRxTest(PfcAsymBaseTest):
 
         # Verify that some packets are dropped on src port, which means that Rx queue is full
         port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.non_server_port['oid'])
+            self.client, self.asic_type, self.non_server_port['oid'])
         self.log("Lossy - INGRESS_DROP: port_counters = {}\n queue_counters = {}".format(
             port_counters, queue_counters))
         assert(port_counters[self.INGRESS_DROP] > 0)
 
         # Verify that some packets are dropped on dst ports, which means that Tx buffer is full
         for sp in self.server_ports:
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, sp['oid'])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, sp['oid'])
             self.log("\nLossless - EGRESS_DROP: port_counters = {}\n queue_counters = {}\nserver_port = {}".format(
                 port_counters, queue_counters, sp))
             assert(port_counters[self.EGRESS_DROP] > 0)

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -720,7 +720,7 @@ def sai_thrift_port_tx_enable(client, asic_type, port_ids):
         client.sai_thrift_set_port_attribute(port_list[port_id], attr)
 
 
-def sai_thrift_read_port_counters(client, port):
+def sai_thrift_read_port_counters(client, asic_type, port):
     port_cnt_ids = []
     port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_DISCARDS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_IN_DISCARDS)
@@ -739,11 +739,14 @@ def sai_thrift_read_port_counters(client, port):
     port_cnt_ids.append(SAI_PORT_STAT_IF_IN_UCAST_PKTS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS)
-    port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_QLEN)
+    if asic_type != 'mellanox':
+        port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_QLEN)
 
     counters_results = []
     counters_results = client.sai_thrift_get_port_stats(
         port, port_cnt_ids, len(port_cnt_ids))
+    if asic_type == 'mellanox':
+        counters_results.append(0)
 
     queue_list = []
     port_attr_list = client.sai_thrift_get_port_attribute(port)


### PR DESCRIPTION
…pport SAI_PORT_STAT_IF_OUT_QLEN

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

refine sai_thrift_read_port_counters(), even on platform whici not support SAI_PORT_STAT_IF_OUT_QLEN

#### How did you do it?

check asic_type in sai_thrift_read_port_counters.
return default value 0, when paltform not support SAI_PORT_STAT_IF_OUT_QLEN

#### How did you verify/test it?
pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
