### PR TITLE
[pdu controller] update pdu type determining logics 

### DIFF
--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -105,7 +105,7 @@ class PduManager():
 
         if not (shared_pdu and outlet is None):
             if controller is None:
-                controller = get_pdu_controller(pdu_ip, pdu_vars, psu_peer['HwSku'])
+                controller = get_pdu_controller(pdu_ip, pdu_vars, psu_peer['HwSku'], psu_peer['Type'])
                 if not controller:
                     logger.warning('Failed creating pdu controller: {}'.format(psu_peer))
                     return

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -141,7 +141,7 @@ class snmpPduController(PduControllerBase):
             self._probe_lane(lane_id, cmdGen, snmp_auth)
 
     def __init__(self, controller, pdu, hwsku, psu_peer_type):
-        logging.info("Initializing " + self.__class__.__name__)
+        logger.info("Initializing " + self.__class__.__name__)
         PduControllerBase.__init__(self)
         self.controller = controller
         self.snmp_rocommunity = pdu['snmp_rocommunity']

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -140,13 +140,13 @@ class snmpPduController(PduControllerBase):
         for lane_id in range(1, self.max_lanes + 1):
             self._probe_lane(lane_id, cmdGen, snmp_auth)
 
-    def __init__(self, controller, pdu, hwsku):
-        logger.info("Initializing " + self.__class__.__name__)
+    def __init__(self, controller, pdu, hwsku, psu_peer_type):
+        logging.info("Initializing " + self.__class__.__name__)
         PduControllerBase.__init__(self)
         self.controller = controller
         self.snmp_rocommunity = pdu['snmp_rocommunity']
         self.snmp_rwcommunity = pdu['snmp_rwcommunity']
-        self.pduType = hwsku
+        self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}
         self.pduCntrlOid()
@@ -304,9 +304,9 @@ class snmpPduController(PduControllerBase):
         pass
 
 
-def get_pdu_controller(controller_ip, pdu, hwsku):
+def get_pdu_controller(controller_ip, pdu, hwsku, psu_peer_type):
     """
     @summary: Factory function to create the actual PDU controller object.
     @return: The actual PDU controller object. Returns None if something went wrong.
     """
-    return snmpPduController(controller_ip, pdu, hwsku)
+    return snmpPduController(controller_ip, pdu, hwsku, psu_peer_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fixing regression caused by https://github.com/sonic-net/sonic-mgmt/pull/7231

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Rebooting related test was failing due to incorrect pdu controller initialization. 

#### How did you do it?

#### How did you verify/test it?
Tested on lab DUTs. Was able to get outlet status without errors this time. 
```
22:52:14 __init__._fixture_func_decorator         L0059 INFO   | -------------------- fixture toggle_upper_tor_pdu setup starts --------------------
22:52:14 pdu_manager.pdu_manager_factory          L0259 INFO   | Creating pdu manager object
22:52:14 pdu_manager._build_pdu_manager_from_grap L0204 INFO   | Creating pdu manager from graph information
22:52:14 snmp_pdu_controllers.__init__            L0143 INFO   | Initializing snmpPduController
22:52:16 snmp_pdu_controllers.__init__            L0153 INFO   | Initialized snmpPduController
22:52:16 snmp_pdu_controllers.get_outlet_status   L0297 INFO   | Got outlet status: [{'outlet_on': True, 'output_watts': '74', 'outlet_id': '.1.1.12'}]
22:52:16 snmp_pdu_controllers.__init__            L0143 INFO   | Initializing snmpPduController
22:52:17 snmp_pdu_controllers.__init__            L0153 INFO   | Initialized snmpPduController
22:52:17 snmp_pdu_controllers.get_outlet_status   L0297 INFO   | Got outlet status: [{'outlet_on': True, 'output_watts': '69', 'outlet_id': '.1.1.25'}]
22:52:17 __init__._fixture_func_decorator         L0066 INFO   | -------------------- fixture toggle_upper_tor_pdu setup ends --------------------
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
