### PR TITLE
[dualtor] fix `KeyError` caught in `verify_db` in control plane common utilities 

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -130,7 +130,9 @@ class DBChecker:
             for intf_name in self.intf_names:
                 table_key = '{}{}{}'.format(table, separator, intf_name)
 
-                if db_dump[table_key]['value'][field] != target_value:
+                if table_key not in db_dump:
+                    mismatch_ports[table_key] = ''
+                elif db_dump[table_key]['value'][field] != target_value:
                     mismatch_ports[table_key] = db_dump[table_key]['value']
 
         self.mismatch_ports = mismatch_ports

--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -131,7 +131,7 @@ class DBChecker:
                 table_key = '{}{}{}'.format(table, separator, intf_name)
 
                 if table_key not in db_dump:
-                    mismatch_ports[table_key] = ''
+                    mismatch_ports[table_key] = {}
                 elif db_dump[table_key]['value'][field] != target_value:
                     mismatch_ports[table_key] = db_dump[table_key]['value']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix key error caught in db verification. dualtor tests use `wait_until` to verify db entries, before the entries are populated, we will get `KeyError`. The test will still pass, but there wil be error message in the log. 

```
23:24:15 utilities.wait_until                     L0113 ERROR  | Exception caught while checking get_mismatched_ports:Traceback (most recent call last):
  File "/var/src/sonic-mgmt-int/tests/common/utilities.py", line 107, in wait_until
    check_result = condition(*args, **kwargs)
  File "/var/src/sonic-mgmt-int/tests/common/dualtor/control_plane_utils.py", line 118, in get_mismatched_ports
    if db_dump[table_key]['value'][field] != target_value:
KeyError: 'HW_MUX_CABLE_TABLE|Ethernet180'
, error:'HW_MUX_CABLE_TABLE|Ethernet180'
```

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Avoid misleading error messages. 

#### How did you do it?

#### How did you verify/test it?
Run test on DUTs and confirm the error is gone. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
