### PR TITLE
Skip VOQ test cases for Non-voq platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -962,17 +962,11 @@ vlan/test_vlan_ping.py:
 #######################################
 #####             voq             #####
 #######################################
-voq/test_voq_init.py:
+voq:
   skip:
     reason: cisco-8000 platform is not VOQ based thus all VOQ testcases are not applicable to this platform and should be skipped
     conditions:
-      - "asic_type in ['cisco-8000']"
-
-voq/test_voq_intfs.py:
-  skip:
-    reason: cisco-8000 platform is not VOQ based thus all VOQ testcases are not applicable to this platform and should be skipped
-    conditions:
-      - "asic_type in ['cisco-8000']"
+      - "asic_type in ['cisco-8000'] and len(VOQ_INBAND_INTERFACE) == 0"
 
 voq/test_voq_ipfwd.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -670,21 +670,15 @@ qos:
 
 qos/test_buffer.py:
   skip:
-    reason: "These tests don't apply to cisco 8000 platforms, since they support only traditional model."
+    reason: "These tests don't apply to cisco 8000 platforms or T2, since they support only traditional model."
     conditions:
-      - "asic_type in ['cisco-8000']"
+      - "asic_type in ['cisco-8000'] or 't2' in topo_name"
 
 qos/test_buffer_traditional.py:
   skip:
     reason: "Buffer traditional test is only supported 201911 branch and not yet supported on multi-ASIC platform."
     conditions:
       - "is_multi_asic==True or release not in ['201911']"
-
-qos/test_buffer.py:
-  skip:
-    reason: "Tests are relevant to dynamic buffering not required on T2"
-    conditions:
-      - "'t2' in topo_name"
 
 qos/test_pfc_pause.py::test_pfc_pause_lossless:
   # For this test, we use the fanout connected to the DUT to send PFC pause frames.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -962,6 +962,18 @@ vlan/test_vlan_ping.py:
 #######################################
 #####             voq             #####
 #######################################
+voq/test_voq_init.py:
+  skip:
+    reason: cisco-8000 platform is not VOQ based thus all VOQ testcases are not applicable to this platform and should be skipped
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+voq/test_voq_intfs.py:
+  skip:
+    reason: cisco-8000 platform is not VOQ based thus all VOQ testcases are not applicable to this platform and should be skipped
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 voq/test_voq_ipfwd.py:
   skip:
     reason: "Did not find any asic in the DUTs (linecards) that are connected to T1 VM's."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -964,9 +964,9 @@ vlan/test_vlan_ping.py:
 #######################################
 voq:
   skip:
-    reason: cisco-8000 platform is not VOQ based thus all VOQ testcases are not applicable to this platform and should be skipped
+    reason: Skip all HW SKUs that are not VOQ based (No Inband interface present) from running VOQ test cases
     conditions:
-      - "asic_type in ['cisco-8000'] and len(VOQ_INBAND_INTERFACE) == 0"
+      - "len(VOQ_INBAND_INTERFACE) == 0"
 
 voq/test_voq_ipfwd.py:
   skip:


### PR DESCRIPTION
### Description of PR
VOQ testcases are meant for VOQ based HW SKU.
Since Cisco-8000 is not VOQ based we need to skip these tests.

To achieve this skip, we are adding a check in the skip marker file so that anything under the VOQ test folder will be skipped for HW SKUs that do not have the VOQ INBAND interface (only VOQ based HW SKU will have VOQ INBAND interface)

While submitting this PR the pre-commit check flagged an unrelated item (qos/test_buffer has duplicated entries that has different rules) that needs fix so I also fixed it by combining the two entries as an "OR" operation on a single entry.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
While testing on Cisco T2 chassis which is NOT VOQ based HW SKU all VOQ testcases were expected to fail. Therefore it is more proper to skip them.

#### How did you do it?

#### How did you verify/test it?
Manual run the VOQ tests and observed with this change in place they are all being skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
