### PR TITLE
[Qos]Fix saitest issue: asic_type' is not defined.

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1399,13 +1399,15 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[self.src_port_id])
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.client, self.asic_type, port_list[self.src_port_id])
 
         logging.info("Disabling xmit ports: {}".format(self.dst_port_id))
         self.sai_thrift_port_tx_disable(
             self.client, self.asic_type, [self.dst_port_id])
 
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[self.dst_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.client, self.asic_type, port_list[self.dst_port_id])
         num_pkts = (pkts_num_trig_pfc + pkts_num_private_headrooom) // self.cell_occupancy
         logging.info("Send {} pkts to egress out of {}".format(num_pkts, self.dst_port_id))
         # send packets to dst port 1, to cross into shared headrooom
@@ -1415,8 +1417,10 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         time.sleep(8)
         # get a snapshot of counter values at recv and transmit ports
         # queue counters value is not of our interest here
-        recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[self.src_port_id])
-        xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[self.dst_port_id])
+        recv_counters, queue_counters = sai_thrift_read_port_counters(
+            self.client, self.asic_type, port_list[self.src_port_id])
+        xmit_counters, queue_counters = sai_thrift_read_port_counters(
+            self.client, self.asic_type, port_list[self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(recv_counters, recv_counters_base))
         logging.debug("Xmit Counters: {}, Base: {}".format(xmit_counters, xmit_counters_base))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In class of PtfFillBuffer, 'asic_type' is not defined. 
It should use self.asic_type not asic_type.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix saitest issue

#### How did you do it?
use  use self.asic_type instead of asic_type.

#### How did you verify/test it?
run testPfcStormWithSharedHeadroomOccupancy

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
ptf32

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
