### PR TITLE
[SAI-PTF] Rename CaseInvocationReport to CaseInvocationCoverage

### DIFF
--- a/test_reporting/kusto/sai_report_setup.kql
+++ b/test_reporting/kusto/sai_report_setup.kql
@@ -5,11 +5,13 @@
 
 ###############################################################################
 # TESTCASE TABLE SETUP                                                        #
-# 1. Create a CaseInvocationReport table                                      #
+# 1. Create a StaticCaseInvocation table                                      #
 # 2. Setup a policy to automatically ingest data from local JSON results      #
 ###############################################################################
-.create table CaseInvocationReport
+.create table StaticCaseInvocation
 (
+id: string,
+is_azure_used: bool,
 file_name: string,
 case_name: string,
 class_name: string,
@@ -17,11 +19,11 @@ case_invoc: string,
 sai_header: string,
 saiintf_id: string,
 saiintf_method_table: string,
+sai_feature: string,
 sai_api: string,
 saiintf_alias: string,
 test_set: string,
 test_platform: string,
-platform_purpose_attr: string,
 sai_obj_attr_key: string,
 sai_obj_attr_value: string,
 runnable: bool,
@@ -30,8 +32,10 @@ upload_time: string
 )
 
 # See: https://docs.microsoft.com/en-us/azure/data-explorer/ingest-json-formats#ingest-json-records-containing-arrays
-.create table CaseInvocationReport ingestion json mapping
-'CaseInvocationReportMapping' '['
+.create table StaticCaseInvocation ingestion json mapping
+'StaticCaseInvocationMapping' '['
+'{"column":"id","Properties":{"path":"$.id"}},'
+'{"column":"is_azure_used","Properties":{"path":"$.is_azure_used"}},'
 '{"column":"file_name","Properties":{"path":"$.file_name"}},'
 '{"column":"case_name","Properties":{"path":"$.case_name"}},'
 '{"column":"class_name","Properties":{"path":"$.class_name"}},'
@@ -39,27 +43,13 @@ upload_time: string
 '{"column":"sai_header","Properties":{"path":"$.sai_header"}},'
 '{"column":"saiintf_id","Properties":{"path":"$.saiintf_id"}},'
 '{"column":"saiintf_method_table","Properties":{"path":"$.saiintf_method_table"}},'
+'{"column":"sai_feature","Properties":{"path":"$.sai_feature"}},'
 '{"column":"sai_api","Properties":{"path":"$.sai_api"}},'
 '{"column":"saiintf_alias","Properties":{"path":"$.saiintf_alias"}},'
 '{"column":"test_set","Properties":{"path":"$.test_set"}},'
 '{"column":"test_platform","Properties":{"path":"$.test_platform"}},'
-'{"column":"platform_purpose_attr","Properties":{"path":"$.platform_purpose_attr"}},'
 '{"column":"sai_obj_attr_key","Properties":{"path":"$.sai_obj_attr_key"}},'
 '{"column":"sai_obj_attr_value","Properties":{"path":"$.sai_obj_attr_value"}},'
 '{"column":"runnable","Properties":{"path":"$.runnable"}},'
 '{"column":"sai_folder","Properties":{"path":"$.sai_folder"}},'
 '{"column":"upload_time","Properties":{"path":"$.upload_time"}}]'
-
-###############################################################################
-# STAGING TABLE SETUP                                                         #
-# 1. Create a CaseInvocationStaging table to fit the special format           #
-###############################################################################
-.set-or-replace CaseInvocationStaging <|
-CaseInvocationReport
-| extend is_azure_used = False
-| extend sai_api_temp1 = substring(sai_api, 4, strlen(sai_api)-7)
-| extend sai_api_temp2 = iff(sai_api_temp1 contains "attribute", substring(sai_api_temp1, 0, strlen(sai_api_temp1)-10), sai_api_temp1)
-| extend sai_feature_temp = substring(saiintf_method_table, 4, strlen(saiintf_method_table)-10)
-| extend sai_feature = strcat_array(split(sai_feature_temp, '_'), '')
-| extend id = new_guid()
-| distinct id, is_azure_used, file_name, case_name, class_name, case_invoc, sai_header, saiintf_id, saiintf_method_table, sai_feature, sai_api=sai_api_temp2, saiintf_alias, test_set, test_platform, sai_obj_attr_key, sai_obj_attr_value, upload_time, runnable, sai_folder

--- a/test_reporting/kusto/sai_report_setup.kql
+++ b/test_reporting/kusto/sai_report_setup.kql
@@ -5,10 +5,10 @@
 
 ###############################################################################
 # TESTCASE TABLE SETUP                                                        #
-# 1. Create a StaticCaseInvocation table                                      #
+# 1. Create a CaseInvocationCoverage table                                      #
 # 2. Setup a policy to automatically ingest data from local JSON results      #
 ###############################################################################
-.create table StaticCaseInvocation
+.create table CaseInvocationCoverage
 (
 id: string,
 is_azure_used: bool,
@@ -32,8 +32,8 @@ upload_time: string
 )
 
 # See: https://docs.microsoft.com/en-us/azure/data-explorer/ingest-json-formats#ingest-json-records-containing-arrays
-.create table StaticCaseInvocation ingestion json mapping
-'StaticCaseInvocationMapping' '['
+.create table CaseInvocationCoverage ingestion json mapping
+'CaseInvocationCoverageMapping' '['
 '{"column":"id","Properties":{"path":"$.id"}},'
 '{"column":"is_azure_used","Properties":{"path":"$.is_azure_used"}},'
 '{"column":"file_name","Properties":{"path":"$.file_name"}},'

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -100,7 +100,7 @@ class KustoConnector(ReportDBConnector):
     TEST_CASE_TABLE = "TestCases"
     EXPECTED_TEST_RUNS_TABLE = "ExpectedTestRuns"
     PIPELINE_TABLE = "TestReportPipeline"
-    CASE_INVOC_TABLE = "StaticCaseInvocation"
+    CASE_INVOC_TABLE = "CaseInvocationCoverage"
     SAI_HEADER_INVOC_TABLE = "SAIHeaderDefinition"
 
     TABLE_FORMAT_LOOKUP = {
@@ -133,7 +133,7 @@ class KustoConnector(ReportDBConnector):
         TEST_CASE_TABLE: "TestCasesMappingV1",
         EXPECTED_TEST_RUNS_TABLE: "ExpectedTestRunsV1",
         PIPELINE_TABLE: "FlatPipelineMappingV1",
-        CASE_INVOC_TABLE: "StaticCaseInvocationMapping",
+        CASE_INVOC_TABLE: "CaseInvocationCoverageMapping",
         SAI_HEADER_INVOC_TABLE: "SAIHeaderDefinitionMapping",
     }
 

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -100,7 +100,7 @@ class KustoConnector(ReportDBConnector):
     TEST_CASE_TABLE = "TestCases"
     EXPECTED_TEST_RUNS_TABLE = "ExpectedTestRuns"
     PIPELINE_TABLE = "TestReportPipeline"
-    CASE_INVOC_TABLE = "CaseInvocationReport"
+    CASE_INVOC_TABLE = "StaticCaseInvocation"
     SAI_HEADER_INVOC_TABLE = "SAIHeaderDefinition"
 
     TABLE_FORMAT_LOOKUP = {
@@ -133,7 +133,7 @@ class KustoConnector(ReportDBConnector):
         TEST_CASE_TABLE: "TestCasesMappingV1",
         EXPECTED_TEST_RUNS_TABLE: "ExpectedTestRunsV1",
         PIPELINE_TABLE: "FlatPipelineMappingV1",
-        CASE_INVOC_TABLE: "CaseInvocationReportMapping",
+        CASE_INVOC_TABLE: "StaticCaseInvocationMapping",
         SAI_HEADER_INVOC_TABLE: "SAIHeaderDefinitionMapping",
     }
 

--- a/test_reporting/sai_coverage_scanner.md
+++ b/test_reporting/sai_coverage_scanner.md
@@ -33,12 +33,14 @@ python3 test_reporting/sai_coverage/case_scanner.py -p ptf
 
 ## 2. Upload results to Kusto
 
-### a) Upload CaseInvocationReport
+### a) Upload StaticCaseInvocation
 
 Firstly, the corresponding table and mapping should be created in Kusto by the following Kusto commands.
 ```kql
-.create table CaseInvocationReport
+.create table StaticCaseInvocation
 (
+id: string,
+is_azure_used: bool,
 file_name: string,
 case_name: string,
 class_name: string,
@@ -46,11 +48,11 @@ case_invoc: string,
 sai_header: string,
 saiintf_id: string,
 saiintf_method_table: string,
+sai_feature: string,
 sai_api: string,
 saiintf_alias: string,
 test_set: string,
 test_platform: string,
-platform_purpose_attr: string,
 sai_obj_attr_key: string,
 sai_obj_attr_value: string,
 runnable: bool,
@@ -59,8 +61,10 @@ upload_time: string
 )
 
 
-.create table CaseInvocationReport ingestion json mapping
-'CaseInvocationReportMapping' '['
+.create table StaticCaseInvocation ingestion json mapping
+'StaticCaseInvocationMapping' '['
+'{"column":"id","Properties":{"path":"$.id"}},'
+'{"column":"is_azure_used","Properties":{"path":"$.is_azure_used"}},'
 '{"column":"file_name","Properties":{"path":"$.file_name"}},'
 '{"column":"case_name","Properties":{"path":"$.case_name"}},'
 '{"column":"class_name","Properties":{"path":"$.class_name"}},'
@@ -68,11 +72,11 @@ upload_time: string
 '{"column":"sai_header","Properties":{"path":"$.sai_header"}},'
 '{"column":"saiintf_id","Properties":{"path":"$.saiintf_id"}},'
 '{"column":"saiintf_method_table","Properties":{"path":"$.saiintf_method_table"}},'
+'{"column":"sai_feature","Properties":{"path":"$.sai_feature"}},'
 '{"column":"sai_api","Properties":{"path":"$.sai_api"}},'
 '{"column":"saiintf_alias","Properties":{"path":"$.saiintf_alias"}},'
 '{"column":"test_set","Properties":{"path":"$.test_set"}},'
 '{"column":"test_platform","Properties":{"path":"$.test_platform"}},'
-'{"column":"platform_purpose_attr","Properties":{"path":"$.platform_purpose_attr"}},'
 '{"column":"sai_obj_attr_key","Properties":{"path":"$.sai_obj_attr_key"}},'
 '{"column":"sai_obj_attr_value","Properties":{"path":"$.sai_obj_attr_value"}},'
 '{"column":"runnable","Properties":{"path":"$.runnable"}},'
@@ -80,7 +84,7 @@ upload_time: string
 '{"column":"upload_time","Properties":{"path":"$.upload_time"}}]'
 ```
 
-Then, connect to the `CaseInvocationReport` table and ingest data into it.
+Then, connect to the `StaticCaseInvocation` table and ingest data into it.
 ```bash
 # 4. upload the results (json files) to Kusto
 python3 test_reporting/report_uploader.py result/scan SaiTestData -c case_invoc

--- a/test_reporting/sai_coverage_scanner.md
+++ b/test_reporting/sai_coverage_scanner.md
@@ -33,11 +33,11 @@ python3 test_reporting/sai_coverage/case_scanner.py -p ptf
 
 ## 2. Upload results to Kusto
 
-### a) Upload StaticCaseInvocation
+### a) Upload CaseInvocationCoverage
 
 Firstly, the corresponding table and mapping should be created in Kusto by the following Kusto commands.
 ```kql
-.create table StaticCaseInvocation
+.create table CaseInvocationCoverage
 (
 id: string,
 is_azure_used: bool,
@@ -61,8 +61,8 @@ upload_time: string
 )
 
 
-.create table StaticCaseInvocation ingestion json mapping
-'StaticCaseInvocationMapping' '['
+.create table CaseInvocationCoverage ingestion json mapping
+'CaseInvocationCoverageMapping' '['
 '{"column":"id","Properties":{"path":"$.id"}},'
 '{"column":"is_azure_used","Properties":{"path":"$.is_azure_used"}},'
 '{"column":"file_name","Properties":{"path":"$.file_name"}},'
@@ -84,7 +84,7 @@ upload_time: string
 '{"column":"upload_time","Properties":{"path":"$.upload_time"}}]'
 ```
 
-Then, connect to the `StaticCaseInvocation` table and ingest data into it.
+Then, connect to the `CaseInvocationCoverage` table and ingest data into it.
 ```bash
 # 4. upload the results (json files) to Kusto
 python3 test_reporting/report_uploader.py result/scan SaiTestData -c case_invoc


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Rename CaseInvocationReport to CaseInvocationCoverage

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Previous table name is inappropriate, so we rename `CaseInvocationReport` to `CaseInvocationCoverage`. In addition, a runtime scanner will release later, `static` can well descripted the meaning.

#### How did you do it?
- Delete `CaseInvocationReport` related codes.
- Rename `CaseInvocationStaging` to `CaseInvocationCoverage`

#### How did you verify/test it?
Verified by running pipeline.


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
