### PR TITLE
Fix flaky traffic_shift test - Ignore same aspath routes during validation

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -261,7 +261,7 @@ def check_and_log_routes_diff(duthost, neigh_hosts, orig_routes_on_all_nbrs, cur
                     if isinstance(list(neigh_hosts.items())[0][1]['host'], EosHost):
                         for aspath in aspaths:
                             if str(neigh_hosts[hostname]['conf']['bgp']['asn']) in aspath:
-                                logger.info("Skipping route {} on host {}".format(route, hostname))
+                                logger.debug("Skipping route {} on host {}".format(route, hostname))
                                 skip = True
                                 break
                         if not skip:

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -231,25 +231,47 @@ def verify_current_routes_announced_to_neighs(dut_host, neigh_hosts, orig_routes
     logger.info("Verifying all the original routes(ipv{}) are announced to bgp neighbors".format(ip_ver))
     cur_routes_on_all_nbrs.update(parse_routes_on_neighbors(dut_host, neigh_hosts, ip_ver))
     # Compare current routes after TSB with original routes advertised to neighbors
-    if cur_routes_on_all_nbrs != orig_routes_on_all_nbrs:        
+    if cur_routes_on_all_nbrs != orig_routes_on_all_nbrs:     
         return False           
     return True
 
-def log_missing_routes(orig_routes_on_all_nbrs, cur_routes_on_all_nbrs):
+def check_and_log_routes_diff(duthost, neigh_hosts, orig_routes_on_all_nbrs, cur_routes_on_all_nbrs,ip_ver):
     cur_nbrs = set(cur_routes_on_all_nbrs.keys())
     orig_nbrs = set(orig_routes_on_all_nbrs.keys())
     if cur_nbrs != orig_nbrs:
         logger.warn("Neighbor list mismatch: {}".format(cur_nbrs ^ orig_nbrs))
         return False
-
+    
+    routes_dut = parse_rib(duthost, ip_ver)
     for hostname in orig_routes_on_all_nbrs.keys():
-        if orig_routes_on_all_nbrs[hostname] != cur_routes_on_all_nbrs[hostname]:
-            if len(orig_routes_on_all_nbrs[hostname]) > len(cur_routes_on_all_nbrs[hostname]):
-                logger.warn("Missing routes on host {}: {}".format(hostname, 
-                            set(orig_routes_on_all_nbrs[hostname]) - set(cur_routes_on_all_nbrs[hostname])))
-            else:
-                logger.warn("Additional routes on host {}: {}".format(hostname, 
-                            set(cur_routes_on_all_nbrs[hostname]) - set(orig_routes_on_all_nbrs[hostname])))
+        if orig_routes_on_all_nbrs[hostname] != cur_routes_on_all_nbrs[hostname]:            
+            routes_diff =set(orig_routes_on_all_nbrs[hostname]) ^ set(cur_routes_on_all_nbrs[hostname])                
+        all_diffs_in_host_aspath = True
+        for hostname in orig_routes_on_all_nbrs.keys():
+            if orig_routes_on_all_nbrs[hostname] != cur_routes_on_all_nbrs[hostname]:
+                routes_diff =set(orig_routes_on_all_nbrs[hostname]) ^ set(cur_routes_on_all_nbrs[hostname])
+                for route in routes_diff:
+                    if route not in routes_dut.keys():
+                            all_diffs_in_host_aspath = False
+                            logger.warn("Missing route on host {}: {}".format(hostname, route))
+                            continue
+                    aspaths = routes_dut[route]
+                    # Filter out routes announced by this neigh
+                    skip = False
+                    if isinstance(list(neigh_hosts.items())[0][1]['host'], EosHost):
+                        for aspath in aspaths:
+                            if str(neigh_hosts[hostname]['conf']['bgp']['asn']) in aspath:
+                                logger.info("Skipping route {} on host {}".format(route, hostname))
+                                skip = True
+                                break
+                        if not skip:
+                            all_diffs_in_host_aspath = False
+                            if route in orig_routes_on_all_nbrs[hostname]:
+                                logger.warn("Missing route on host {}: {}".format(hostname, route))
+                            else:
+                                logger.warn("Additional route on host {}: {}".format(hostname, route))
+
+    return all_diffs_in_host_aspath
 
 def verify_loopback_route_with_community(dut_host, neigh_hosts, ip_ver, community):
     logger.info("Verifying only loopback routes are announced to bgp neighbors")
@@ -361,13 +383,12 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     cur_v6_routes = {}
     # Verify that all routes advertised to neighbor at the start of the test
     if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
-        log_missing_routes(orig_v4_routes, cur_v4_routes)
-        pytest.fail("Not all ipv4 routes are announced to neighbors")
+        if not check_and_log_routes_diff(duthost,nbrhosts, orig_v4_routes, cur_v4_routes, 4):
+            pytest.fail("Not all ipv4 routes are announced to neighbors")
 
     if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
-        log_missing_routes(orig_v6_routes, cur_v6_routes)
-        pytest.fail("Not all ipv6 routes are announced to neighbors")
-
+        if not check_and_log_routes_diff(duthost,nbrhosts, orig_v6_routes, cur_v6_routes, 6):
+            pytest.fail("Not all ipv6 routes are announced to neighbors")
 
 def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                    bgpmon_setup_teardown, nbrhosts):
@@ -411,12 +432,12 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
-            log_missing_routes(orig_v4_routes, cur_v4_routes)
-            pytest.fail("Not all ipv4 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v4_routes, cur_v4_routes, 4):
+                pytest.fail("Not all ipv4 routes are announced to neighbors")
 
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
-            log_missing_routes(orig_v6_routes, cur_v6_routes)
-            pytest.fail("Not all ipv6 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v6_routes, cur_v6_routes, 6):
+                pytest.fail("Not all ipv6 routes are announced to neighbors")
 
 
 
@@ -435,8 +456,6 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         pytest.skip("TSA persistence not supported in the image")
 
     try:
-        #cur_nbrhosts = get_bgp_neighbor_hosts(duthost, nbrhosts)
-
         # Get all routes on neighbors before doing TSA
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
         orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
@@ -475,12 +494,13 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
-            log_missing_routes(orig_v4_routes, cur_v4_routes)
-            pytest.fail("Not all ipv4 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v4_routes, cur_v4_routes, 4):
+                pytest.fail("Not all ipv4 routes are announced to neighbors")
 
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
-            log_missing_routes(orig_v6_routes, cur_v6_routes)
-            pytest.fail("Not all ipv6 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v6_routes, cur_v6_routes, 6):
+                pytest.fail("Not all ipv6 routes are announced to neighbors")
+
 
 
 
@@ -503,6 +523,7 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         # Get all routes on neighbors before doing TSA
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
         orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
+
         config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True,
                       traffic_shift_away=True)
 
@@ -528,15 +549,16 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         # Verify DUT is in normal state.
         pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                       "DUT is not in normal state")
+
         # Wait until all routes are announced to neighbors
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
-            log_missing_routes(orig_v4_routes, cur_v4_routes)
-            pytest.fail("Not all ipv4 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v4_routes, cur_v4_routes, 4):
+                pytest.fail("Not all ipv4 routes are announced to neighbors")
 
         if not wait_until(300, 3, 0,verify_current_routes_announced_to_neighs, duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
-            log_missing_routes(orig_v6_routes, cur_v6_routes)
-            pytest.fail("Not all ipv6 routes are announced to neighbors")
+            if not check_and_log_routes_diff(duthost,nbrhosts, orig_v6_routes, cur_v6_routes, 6):
+                pytest.fail("Not all ipv6 routes are announced to neighbors")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When validating routes on neighbor hosts after TSB, the routes may be different from the original list on some neighbors, due to same aspath filtering. Enhanced test to handle this scenario.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
After TSB, while comparing current routes to original routes on a neighbor, ignore the routes advertised by that neighbor.

#### How did you do it?
Ignore routes with aspath list containing the neighbor's aspath during route validation

#### How did you verify/test it?
Run bgp/test_traffic_shift.py on T1 multiple times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
