### PR TITLE
[QoS] Do not enlarge PFC WD polling timer if it is shorter in QoS testPfcStormWithSharedHeadroomOccupancy

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -272,6 +272,8 @@ class TestQosSai(QosSaiBase):
 
         try:
             prev_poll_interval = int(prev_poll_interval)
+            if int(pfcwd_timers['pfc_wd_poll_time']) > prev_poll_interval:
+                pfcwd_timers['pfc_wd_poll_time'] = str(prev_poll_interval)
         except Exception as e:
             logging.debug("Exception: {}, Poll Interval: {}".format(str(e), prev_poll_interval))
             prev_poll_interval = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Do not enlarge PFC WD polling timer if the previous one is shorter in QoS testPfcStormWithSharedHeadroomOccupancy

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Do not enlarge PFC WD polling timer if the previous one is shorter in QoS testPfcStormWithSharedHeadroomOccupancy
Sometimes the PFC WD is enabled before QoS test and the polling timer interval is less than the parameters provided in QoS test. In that case, the test will fail because it's not allowed to configure a polling interval to a value that is less than the restoration or detection timer.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How did you do it?

Reconfigure the PFC WD polling timer only if it has not been configured or is greater than the one provided by the test parameters.

#### How did you verify/test it?

Manual and regression test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
