### PR TITLE
[Bugfix] Shutdown all exabgp processes correctly while removing topo

### DIFF
--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -137,12 +137,10 @@
       name: "exabgpv4:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
-    ignore_errors: True
 
   - name: Stop exabgp processes for IPv6 on PTF
     supervisorctl:
       name: "exabgpv6:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
-    ignore_errors: True
   when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -81,25 +81,17 @@
       dest: "/etc/supervisor/conf.d/exabgpv6.conf"
     delegate_to: "{{ ptf_host }}"
 
-  - name: Reread supervisor
-    shell: supervisorctl reread
+  - name: Add exabgpv4 supervisor config and start related processes
+    supervisorctl:
+      name: "exabgpv4:"
+      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
     delegate_to: "{{ ptf_host }}"
 
-  - name: Update supervisor
-    shell: supervisorctl update
+  - name: Add exabgpv6 supervisor config and start related processes
+    supervisorctl:
+      name: "exabgpv6:"
+      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
     delegate_to: "{{ ptf_host }}"
-
-  - name: Restart v4 Exabgp 
-    shell: supervisorctl restart exabgpv4:*
-    delegate_to: "{{ ptf_host }}"
-  
-  - name: Restart v6 Exabgp 
-    shell: supervisorctl restart exabgpv6:*
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Wait for exabgp to (re)start
-    pause:
-      seconds: "{{ 2 * topology['VMs']|dict2items|length }}"
 
   - name: Verify that exabgp processes for IPv4 are started
     wait_for:
@@ -141,20 +133,16 @@
 
 - block:
   - name: Stop exabgp processes for IPv4 on PTF
-    exabgp:
-      name: "{{ vm_item.key }}"
-      state: "stopped"
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
+    supervisorctl:
+      name: "exabgpv4:"
+      state: stopped
     delegate_to: "{{ ptf_host }}"
+    ignore_errors: True
 
   - name: Stop exabgp processes for IPv6 on PTF
-    exabgp:
-      name: "{{ vm_item.key }}-v6"
-      state: "stopped"
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
+    supervisorctl:
+      name: "exabgpv6:"
+      state: stopped
     delegate_to: "{{ ptf_host }}"
+    ignore_errors: True
   when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
While removing topology, previous `announce_routes.yml` cannot stop `exabgp` processes correctly due to generate and pass incorrect process names to `supervisorctl`. In this PR, I fix this issue and use `supervisorctl` instead of `shell` ansible module to interact with PTF host.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

While removing topology, previous `announce_routes.yml` cannot stop `exabgp` processes correctly due to generate and pass incorrect process names to `supervisorctl`. In this PR, I fix this issue and use `supervisorctl` instead of `shell` ansible module to interact with PTF host.

#### How did you do it?

Use `supervisorctl` ansible module to update/start/stop `exabgp` processes.

#### How did you verify/test it?

Verified on a physical M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
