### PR TITLE
[nic_simulator_control] Add backoff for retries

### DIFF
--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -41,11 +41,24 @@ class ForwardingState(object):
     STANDBY = False
 
 
+GRPC_CLIENT_TIMEOUT_MAX = 60
+
+
 def call_grpc(func, args=None, kwargs=None, timeout=5, retries=3, ignore_errors=False):
+
+    def inc_timeout():
+        kwargs["timeout"] += 5
+        if kwargs["timeout"] > GRPC_CLIENT_TIMEOUT_MAX:
+            kwargs["timeout"] = GRPC_CLIENT_TIMEOUT_MAX
+
     if args is None:
         args = []
     if kwargs is None:
         kwargs = {}
+
+    if timeout > GRPC_CLIENT_TIMEOUT_MAX:
+        raise ValueError("Only allow timeout up to %ss, received %ss." % (GRPC_CLIENT_TIMEOUT_MAX, timeout))
+
     kwargs["timeout"] = timeout
     for i in range(retries - 1):
         try:
@@ -55,6 +68,7 @@ def call_grpc(func, args=None, kwargs=None, timeout=5, retries=3, ignore_errors=
             logger.debug("Calling %s %dth time results error(%r)" % (func, i + 1, e))
         else:
             return response
+        inc_timeout()
 
     try:
         response = func(*args, **kwargs)
@@ -264,7 +278,7 @@ def set_drop_active_active(mux_config, nic_simulator_client):       # noqa F811
             drop_requests=drop_requests
         )
         client_stub = nic_simulator_client()
-        call_grpc(client_stub.SetDrop, [request])
+        call_grpc(client_stub.SetDrop, [request], timeout=10)
 
     def _set_drop_active_active(interface_names, portids, directions):
         """

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -57,7 +57,7 @@ def call_grpc(func, args=None, kwargs=None, timeout=5, retries=3, ignore_errors=
         kwargs = {}
 
     if timeout > GRPC_CLIENT_TIMEOUT_MAX:
-        raise ValueError("Only allow timeout up to %ss, received %ss." % (GRPC_CLIENT_TIMEOUT_MAX, timeout))
+        timeout = GRPC_CLIENT_TIMEOUT_MAX
 
     kwargs["timeout"] = timeout
     for i in range(retries - 1):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
`test_link_drop.py` occasionally fails because of gRPC timeout.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add incremental backoff for the gRPC client.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
