### PR TITLE
[nic_simulator] Remove redundant certificate check decorator

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -602,18 +602,6 @@ class OVSBridge(object):
             return result
 
 
-def validate_request_certificate(response):
-    """Decorator to validate client certificate."""
-    def _validate_request_certificate(rpc_func):
-        @functools.wraps(rpc_func)
-        def _decorated(nic_simulator, request, context):
-            logging.debug("Validate client certificate")
-            # TODO: Add client authentication
-            return rpc_func(nic_simulator, request, context)
-        return _decorated
-    return _validate_request_certificate
-
-
 class InterruptableThread(threading.Thread):
     """Thread class that can be interrupted by Exception raised."""
 
@@ -662,7 +650,6 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
         self.server = None
         self.thread = None
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.AdminReply())
     def QueryAdminForwardingPortState(self, request, context):
         logging.debug("QueryAdminForwardingPortState: request to server %s from client %s\n",
                       self.nic_addr, context.peer())
@@ -675,7 +662,6 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
                       context.peer(), self.nic_addr, response)
         return response
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.AdminReply())
     def SetAdminForwardingPortState(self, request, context):
         logging.debug("SetAdminForwardingPortState: request to server %s from client %s\n",
                       self.nic_addr, context.peer())
@@ -688,22 +674,18 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
                       context.peer(), self.nic_addr, response)
         return response
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.OperationReply())
     def QueryOperationPortState(self, request, context):
         # TODO: Add QueryOperationPortState implementation
         return nic_simulator_grpc_service_pb2.OperationReply()
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.LinkStateReply())
     def QueryLinkState(self, request, context):
         # TODO: add QueryLinkState implementation
         return nic_simulator_grpc_service_pb2.LinkStateReply()
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.ServerVersionReply())
     def QueryServerVersion(self, request, context):
         # TODO: add QueryServerVersion implementation
         return nic_simulator_grpc_service_pb2.ServerVersionReply()
 
-    @validate_request_certificate(nic_simulator_grpc_service_pb2.DropReply())
     def SetDrop(self, request, context):
         logging.debug("SetDrop: request to server %s from client %s\n", self.nic_addr, context.peer())
         portids, directions, recover = request.portid, request.direction, request.recover


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

As pmon uses insecure mode to talk to nic_simulator in sonic-mgmt, let's
remove the redundant certificate check decorator.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Remove the code.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
