### PR TITLE
Add an ansible-playbook to collect `show tech` result of a specific testbed

### DIFF
--- a/ansible/collect_show_tech.yml
+++ b/ansible/collect_show_tech.yml
@@ -1,0 +1,63 @@
+# This Playbook run `show techsupport` on DUTs of a specific testbed and fetch the result.
+# 
+# Parameters:
+#   -e testbed_name=vms1-1   - the testbed name specified in testbed.yaml file
+#   -e output_path           - output path for dumped files, default is ./output if not defined
+# 
+# Example Usage:
+#   ansible-playbook collect_show_tech.yml -i lab -e testbed_name=vms1-1
+
+- hosts: sonic
+  gather_facts: no
+  tasks:
+    - name: Check variable testbed_name is defained
+      fail: msg="testbed_name is not defined"
+      when: testbed_name is not defined
+
+    - name: Collect DUTs defined in testbed
+      block:
+        - name: Set default testbed file
+          set_fact:
+            testbed_file: testbed.yaml
+          when: testbed_file is not defined
+        
+        - name: Gather testbed information
+          test_facts:
+            testbed_name: "{{ testbed_name }}"
+            testbed_file: "{{ testbed_file }}"
+        
+        - name: Create group for target DUTs
+          add_host:
+            name: "{{ item }}"
+            groups: target_duts
+          loop: "{{ testbed_facts['duts'] }}"
+      delegate_to: localhost
+      run_once: True
+
+- hosts: target_duts
+  gather_facts: no
+  tasks:
+    - name: Run `show techsupport` on DUT
+      shell: show techsupport --silent | tail -1
+      register: show_tech_result
+
+    - name: Parse the location of dump file
+      set_fact:
+        dump_file: "{{ show_tech_result.stdout_lines[0] }}"
+
+    - name: Set default output path
+      set_fact:
+        output_path: ./output
+      when: output_path is not defined
+
+    - name: Fetch show techsupport dump file from DUTs to localhost
+      fetch:
+        src: "{{ dump_file }}"
+        dest: "{{ output_path }}/"
+        flat: true
+
+    - name: Delete show techsupport dump file on DUTs
+      file:
+        path: "{{ dump_file }}"
+        state: absent
+      become: true

--- a/ansible/collect_show_tech.yml
+++ b/ansible/collect_show_tech.yml
@@ -1,9 +1,9 @@
 # This Playbook run `show techsupport` on DUTs of a specific testbed and fetch the result.
-# 
+#
 # Parameters:
 #   -e testbed_name=vms1-1   - the testbed name specified in testbed.yaml file
 #   -e output_path           - output path for dumped files, default is ./output if not defined
-# 
+#
 # Example Usage:
 #   ansible-playbook collect_show_tech.yml -i lab -e testbed_name=vms1-1
 
@@ -20,12 +20,12 @@
           set_fact:
             testbed_file: testbed.yaml
           when: testbed_file is not defined
-        
+
         - name: Gather testbed information
           test_facts:
             testbed_name: "{{ testbed_name }}"
             testbed_file: "{{ testbed_file }}"
-        
+
         - name: Create group for target DUTs
           add_host:
             name: "{{ item }}"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -20,6 +20,7 @@ function usage
   echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo "    $0 [options] set-l2 <testbed-name> <vault-password-file>"
   echo "    $0 [options] install-image <testbed-name> <inventory> <image-url>"
+  echo "    $0 [options] collect-show-tech <testbed-name> <inventory> <vault-password-file>"
   echo
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.csv')"
@@ -75,6 +76,9 @@ function usage
   echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
   echo "To set DUT of specified testbed to l2 switch mode: $0 set-l2 'testbed-name' ~/.password"
   echo "To install an image on all DUTs in a testbed: $0 install-image 'testbed-name' 'inventory' 'image-url'"
+  echo "To collect show techsupport result of a testbed: $0 collect-show-tech 'testbed-name' 'inventory' ~/.password"
+  echo "    collect-show-tech supports specify output path for dumped files"
+  echo "        -e output_path=<user-specified-path>"
   echo
   echo "You should define your testbed in testbed CSV file"
   echo
@@ -615,6 +619,23 @@ function install_image
   echo Done
 }
 
+function collect_show_tech
+{
+  testbed_name=$1
+  inventory=$2
+  passfile=$3
+  shift
+  shift
+  shift
+
+  echo "Collect show techsupport result on testbed '$testbed_name'"
+
+  ansible-playbook -i "$inventory" collect_show_tech.yml --vault-password-file="$passfile" -e testbed_name="$testbed_name" -e testbed_file=$tbfile $@
+
+  echo Done
+
+}
+
 function read_topologies_from_csv_file
 {
   topologies_by_setup_name=$(cat $tbfile | grep $setup_name | awk 'BEGIN { FS = "," } ; {print $1}')
@@ -804,6 +825,8 @@ case "${subcmd}" in
   restart-ptf) restart_ptf $@
                ;;
   install-image) install_image $@
+               ;;
+  collect-show-tech) collect_show_tech $@
                ;;
   *)           usage
                ;;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add an ansible-playbook to collect `show techsupport` results on all DUTs of a specific testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Add an ansible-playbook to collect `show techsupport` results on all DUTs of a specific testbed.

#### How did you do it?

In the ansible-playbook:
1. Run `show techsupport` on all the DUTs of a specific testbed.
2. Fetch the dumped files to localhost.
3. Delete the dumped files on DUT (to release disk space).
I also integrated this utility to `testbed-cli.sh`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
