### PR TITLE
[Bugfix] Fix COPP testcases for non-marvell platform

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -57,7 +57,8 @@ _COPPTestParameters = namedtuple("_COPPTestParameters",
                                   "nn_target_vlanid"])
 
 _TOR_ONLY_PROTOCOL = ["DHCP", "DHCP6"]
-_TEST_RATE_LIMIT = 600
+_TEST_RATE_LIMIT_DEFAULT = 600
+_TEST_RATE_LIMIT_MARVELL = 625
 
 logger = logging.getLogger(__name__)
 
@@ -354,11 +355,12 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
     logging.info("Set up the PTF for COPP tests")
     copp_utils.configure_ptf(ptf, test_params, is_backend_topology)
 
+    rate_limit = _TEST_RATE_LIMIT_DEFAULT
     if dut.facts["asic_type"] == "marvell":
-        _TEST_RATE_LIMIT = 625
+        rate_limit = _TEST_RATE_LIMIT_MARVELL
 
     logging.info("Update the rate limit for the COPP policer")
-    copp_utils.limit_policer(dut, _TEST_RATE_LIMIT, test_params.nn_target_namespace)
+    copp_utils.limit_policer(dut, rate_limit, test_params.nn_target_namespace)
 
     # Multi-asic will not support this mode as of now.
     if test_params.swap_syncd:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes a bug imported by #7472, which defines `_TEST_RATE_LIMIT` as a local variable by mistake. It causes COPP testcases fail on non-marvell DUTs. The error message looks like:

```
    def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
        # ...
        logging.info("Update the rate limit for the COPP policer")
>       copp_utils.limit_policer(dut, _TEST_RATE_LIMIT, test_params.nn_target_namespace)
E       UnboundLocalError: local variable '_TEST_RATE_LIMIT' referenced before assignment
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Fixes a bug imported by #7472, which defines `_TEST_RATE_LIMIT` as a local variable by mistake.

#### How did you do it?

Define global constant variables for test rate limit. In testcases we only read it and assign the value to local variable `rate_limit` depends on ASIC type.

#### How did you verify/test it?

Verified on both Marvell and Broadcom DUTs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
