### PR TITLE
[platform] Fixed validation in test case "test_show_platform_fan" for DPU devices

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -309,6 +309,10 @@ def check_fan_status(duthost, cmd):
     fan_status_output_lines = duthost.command(cmd)["stdout_lines"]
     fans = verify_show_platform_fan_output(duthost, fan_status_output_lines)
 
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    if not fans and config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu':
+        return True
+
     # Check that all fans are showing valid status and also at-least one PSU is OK.
     num_fan_ok = 0
     for a_fan in fans.values():


### PR DESCRIPTION
### Description of PR
Fixed validation in test case "test_show_platform_fan" for DPU devices

Fixed issue when test failed in case when device does not have FANs and command "show platform fan" returned one line with message "Fan Not detected" Now in this case test will not fail(will not start validation that FANs in OK state because they not available) on DPU devices

Summary: Fixed validation in test case "test_show_platform_fan" for DPU devices
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fixed validation in test case "test_show_platform_fan" for DPU devices to support test case run on DPU device

#### How did you do it?
See code

#### How did you verify/test it?
Executed test case platform_tests/cli/test_show_platform.py

#### Any platform specific information?
DPU

#### Supported testbed topology if it's a new test case?

### Documentation

