### PR TITLE
Fix to retrieve asic host if asic_index is not continuous

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -288,7 +288,10 @@ class MultiAsicSonicHost(object):
     def get_asic_or_sonic_host(self, asic_id):
         if asic_id == DEFAULT_ASIC_ID:
             return self.sonichost
-        return self.asics[asic_id]
+        for asic in self.asics:
+            if asic.asic_index == asic_id:
+                return asic
+        return None
 
     def get_asic_or_sonic_host_from_namespace(self, namespace=DEFAULT_NAMESPACE):
         if not namespace:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_cacl_application.py::test_multiasic_cacl_application fails on T2 Linecard where asics_present are not continuously indexed.
```
def get_asic_or_sonic_host(self, asic_id):
if asic_id == DEFAULT_ASIC_ID:
return self.sonichost
>       return self.asics[asic_id]
E       IndexError: list index out of range
``` 
#### How did you do it?
Fix to get the right asic instance by going through all asics and comparing with requested asic_index.
#### How did you verify/test it?
Ran the  test_cacl_application.py::test_multiasic_cacl_application fails  on the Linecard where asics_present in not continuous.
Passed after the change, below shows passed result on LC with asic present with asic_index 0 and 2 
```
cacl/test_cacl_application.py::test_multiasic_cacl_application[LC-0] PASSED                                                                                                             [ 50%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[LC-2] PASSED                                                                                                             [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
