### PR TITLE
Fix portstat parser to accommodate new reminder message in portstat output

### DIFF
--- a/tests/common/portstat_utilities.py
+++ b/tests/common/portstat_utilities.py
@@ -41,12 +41,14 @@ def parse_portstat(content_lines):
     header_line = ''
     separation_line = ''
     separation_line_number = 0
+    reminder_line_number = len(content_lines)
     for idx, line in enumerate(content_lines):
         if line.find('----') >= 0:
             header_line = content_lines[idx-1]
             separation_line = content_lines[idx]
             separation_line_number = idx
-            break
+        if 'Reminder' in line:
+            reminder_line_number = idx
 
     try:
         positions = parse_column_positions(separation_line)
@@ -63,7 +65,9 @@ def parse_portstat(content_lines):
         return {}
 
     results = {}
-    for line in content_lines[separation_line_number+1:]:
+    for line in content_lines[separation_line_number+1:reminder_line_number]:
+        if line == '\n': # skip empty line
+            continue
         portstats = []
         for pos in positions:
             portstat = line[pos[0]:pos[1]].strip()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
portstat/test_portstat.py::test_portstat_clear fails with error:
```
tmp_ok_cnt = before_portstat[intf]['rx_ok'].replace(',','')
>           rx_ok_before = int(0 if tmp_ok_cnt == 'N/A' else tmp_ok_cnt)
E           ValueError: invalid literal for int() with base 10: ''
```
#### How did you do it?
With the recent change in portstat cli https://github.com/sonic-net/sonic-utilities/pull/2466, the output of portstat shows a reminder in multi-asic platforms.
This is causing additional lines to be parsed in portstat output.
This change is to avoid parsing the reminder line or empty line in the portstat output.
#### How did you verify/test it?
Test case passes on multi-asic Linecard after this fix.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
