### PR TITLE
[snmp] Add sleep to test_snmp_fdb during sending packet and verifying

### DIFF
--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -2,6 +2,7 @@ import pytest
 import ptf.testutils as testutils
 import logging
 import pprint
+import time
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # lgtm[py/unused-import]
@@ -83,6 +84,7 @@ def test_snmp_fdb_send_tagged(ptfadapter, utils_vlan_ports_list, toggle_all_simu
     # Flush dataplane
     ptfadapter.dataplane.flush()
 
+    time.sleep(10)
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     assert 'snmp_fdb' in snmp_facts


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently because the time interval between sending packets and obtaining snmp_facts is too short, there is a small probability that the obtained fdb info may be incomplete and cause failed.

Investigate process:
In previous code, the case process is as below. I repeat step 1-3 **200 times** in 720DT, then find it failed **6 times** because cannot get correct snmp_facts. Then I added time.sleep between step 2 and step 3, and repeated all steps 200 times, no failed happened.

1 If dummy mac is shown in fdb_table, then clear fdb_table and wait it is done.
2 Send icmp packets.
3 Obtain snmp_facts and verify number of received dummy MACs is equals to number of interfaces sent packets.

#### How did you do it?
Add sleep between sending packets and obtaining snmp_facts

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
