### PR TITLE
[VM]Support cisco neighbor in wan IS-IS test

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -491,3 +491,9 @@ class EosHost(AnsibleHostBase):
                 }
             )
         return not self._has_cli_cmd_failed(out)
+
+    def no_isis_interface(self, isis_instance, interface):
+        out = self.eos_config(
+            lines=['no isis enable'],
+            parents=['interface {}'.format(interface)])
+        return not self._has_cli_cmd_failed(out)

--- a/tests/wan/isis/isis_helpers.py
+++ b/tests/wan/isis/isis_helpers.py
@@ -3,6 +3,7 @@ import re
 import time
 from jinja2 import Template
 from tests.common.devices.eos import EosHost
+from tests.common.devices.cisco import CiscoHost
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -14,6 +15,7 @@ DEFAULT_ISIS_INSTANCE = 'test'
 NBR_BACKUP_PATH = '/tmp/isis'
 NBR_BACKUP_FILE = '{}_isis.cfg'
 EOS_ISIS_TEMPLATE = 'wan/isis/template/eos_isis_config.j2'
+IOSXR_ISIS_TEMPLATE = 'wan/isis/template/iosxr_isis_config.j2'
 SONIC_ISIS_TEMPLATE = 'wan/isis/template/sonic_isis_config.j2'
 FRRCFGD_ENABLE_TEMPLATE = 'wan/isis/template/frrconfigd_enable.j2'
 SONIC_ISIS_CFG_FILE = '/tmp/isis_config.json'
@@ -120,6 +122,8 @@ def config_nbr_isis(nbrhost):
     nbr_backup_file = os.path.join(NBR_BACKUP_PATH, NBR_BACKUP_FILE.format(nbrhost.hostname))
     if isinstance(nbrhost, EosHost):
         nbr_isis_template = EOS_ISIS_TEMPLATE
+    elif isinstance(nbrhost, CiscoHost):
+        nbr_isis_template = IOSXR_ISIS_TEMPLATE
 
     res = nbrhost.load_configuration(nbr_isis_template, nbr_backup_file)
     pytest_require(res, 'Failed to load default configuration')
@@ -132,7 +136,7 @@ def config_device_isis(device):
     Args:
         device: Target device host object
     """
-    if isinstance(device, EosHost):
+    if isinstance(device, EosHost) or isinstance(device, CiscoHost):
         config_nbr_isis(device)
     else:
         config_sonic_isis(device)
@@ -205,7 +209,7 @@ def teardown_isis(selected_connections):
         which describes the connection between port_channels in different devices.
     """
     for device in get_dev_ports(selected_connections):
-        if isinstance(device, EosHost):
+        if isinstance(device, EosHost) or isinstance(device, CiscoHost):
             remove_nbr_isis_config(device)
         else:
             remove_sonic_isis_config(device)

--- a/tests/wan/isis/template/iosxr_isis_config.j2
+++ b/tests/wan/isis/template/iosxr_isis_config.j2
@@ -1,0 +1,31 @@
+{% set ethernet_intf_pattern = "GigabitEthernet0/0/0/" %}
+{% set port_channel_pattern = "Bundle-Ether" %}
+{% if isis_instance is defined %}
+router isis {{ isis_instance }}
+{% if isis_net is defined %}
+ net {{ isis_net }}
+{% endif %}
+ is-type level-2-only
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+{% if isis_intfs is defined %}
+{% for name in isis_intfs %}
+{% if name.startswith('Ethernet') %}
+interface {{ ethernet_intf_pattern }}{{ name | regex_replace('Ethernet', '') | int }}
+{% elif name.startswith('Port-Channel') %}
+interface {{ port_channel_pattern }}{{ name | regex_replace('Port-Channel', '') | int }}
+{% else %}
+interface {{ name }}
+{% endif %}
+ circuit-type level-2-only
+ point-to-point
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+{% endfor %}
+{% endif %}
+!
+{% endif %}

--- a/tests/wan/isis/test_isis_holdtime.py
+++ b/tests/wan/isis/test_isis_holdtime.py
@@ -15,14 +15,6 @@ pytestmark = [
 ]
 
 
-def disable_neighbor_isis(nbr_host, interface_name):
-    out = nbr_host.eos_config(
-                              lines=['no isis enable'],
-                              parents=['interface {}'.format(interface_name)])
-    logging.info('Disable neighbor isis config')
-    return out
-
-
 def check_isis_neighbor(duthost, nbr_name, state):
     isis_facts = duthost.isis_facts()["ansible_facts"]['isis_facts']
     if isis_instance not in isis_facts['neighbors']:
@@ -51,8 +43,8 @@ def test_isis_holdtime(isis_common_setup_teardown, nbrhosts):
     pytest_assert(wait_until(10, 2, 0, check_isis_neighbor, dut_host, nbr_name, 'Up'),
                   "ISIS Neighbor {} is not Up state".format(nbr_name))
 
-    # Disable IS-IS config under PortChannel in neighbor device
-    disable_neighbor_isis(nbr_host, nbr_port)
+    # No PortChannel interface from IS-IS config in neighbor device
+    nbr_host.no_isis_interface(isis_instance, nbr_port)
 
     pytest_assert(wait_until(30, 2, 1, check_isis_neighbor, dut_host, nbr_name, 'Down'),
                   "ISIS Neighbor {} is not Down state".format(nbr_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support cisco neighbor in wan IS-IS test
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Support cisco neighbor in wan IS-IS test
#### How did you do it?
1. Add IOSXR IS-IS configure template and load them when specify neighbor type as cisco.
2. Enhance IS-IS load procedure to load IOSXR configuration.
#### How did you verify/test it?
Run wan IS-IS test and testcases would pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
