### PR TITLE
fix the issue which timeout is too short for bgp shut

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -198,10 +198,12 @@ def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
     MAX_DIFF = 5
     sumv4, sumv6 = duthost.get_ip_route_summary()
     rtn_val = True
-    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and abs(int(float(sumv4['ebgp']['routes'])) - int(float(num_v4_routes))) >= MAX_DIFF:
+    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and \
+            abs(int(float(sumv4['ebgp']['routes'])) - int(float(num_v4_routes))) >= MAX_DIFF:
         logger.info("IPv4 ebgp routes: {}".format(float(sumv4['ebgp']['routes'])))
         rtn_val = False
-    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and abs(int(float(sumv6['ebgp']['routes'])) - int(float(num_v6_routes))) >= MAX_DIFF:
+    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and \
+            abs(int(float(sumv6['ebgp']['routes'])) - int(float(num_v6_routes))) >= MAX_DIFF:
         logger.info("IPv6 ebgp routes: {}".format(float(sumv6['ebgp']['routes'])))
         rtn_val = False
     return rtn_val

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -198,11 +198,11 @@ def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
     MAX_DIFF = 5
     sumv4, sumv6 = duthost.get_ip_route_summary()
     rtn_val = True
-    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and \
-            abs(int(float(sumv4['ebgp']['routes'])) - int(float(num_v4_routes))) >= MAX_DIFF:
+    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and abs(int(float(sumv4['ebgp']['routes'])) - int(float(num_v4_routes))) >= MAX_DIFF:
+        logger.info("IPv4 ebgp routes: {}".format(float(sumv4['ebgp']['routes'])))
         rtn_val = False
-    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and \
-            abs(int(float(sumv6['ebgp']['routes'])) - int(float(num_v6_routes))) >= MAX_DIFF:
+    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and abs(int(float(sumv6['ebgp']['routes'])) - int(float(num_v6_routes))) >= MAX_DIFF:
+        logger.info("IPv6 ebgp routes: {}".format(float(sumv6['ebgp']['routes'])))
         rtn_val = False
     return rtn_val
 
@@ -226,7 +226,7 @@ def shutdown_ebgp(duthosts, rand_one_dut_hostname):
         # Shutdown all eBGP neighbors
         duthost.command("sudo config bgp shutdown all")
         # Verify that the total eBGP routes are 0.
-        pytest_assert(wait_until(30, 2, 0, check_ebgp_routes, 0, 0, duthost),
+        pytest_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
                       "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
         pytest_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                       "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
flaky failure for platform test on 2700 platforms

#### How did you do it?
2 changes:
1. To extend the timeout from 30 seconds to 60, and increase the delay from 0 to 5 seconds.
2. To add some debug log

#### How did you verify/test it?
Run local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
