### PR TITLE
VoQ chassis : skip test_ser.py tests on DNX based devices.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -668,6 +668,7 @@ platform_tests/broadcom/test_ser.py:
       - "platform in ['x86_64-cel_e1031-r0'] and https://github.com/sonic-net/sonic-mgmt/issues/6218"
       - "asic_type not in ['broadcom']"
       - "platform in ['x86_64-arista_720dt_48s'] and https://github.com/sonic-net/sonic-mgmt/issues/7297"
+      - "asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-mgmt/issues/7546"
 
 #######################################
 #####  cli/test_show_platform.py  #####


### PR DESCRIPTION

#### What is the motivation for this PR?
The track Issue : https://github.com/sonic-net/sonic-mgmt/issues/7546

#### How did you do it?
Add the check for asic_subtype for broadcom_dnx

#### How did you verify/test it?
Made sure the test_ser.py is skipped in DNX platforms 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
