### PR TITLE
Add specific version for libssl1.1 for copp test case

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -215,7 +215,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
         cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                 rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
-                && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
+                && apt-get install -y python-pip build-essential libssl1.1=1.1.1n-0+deb10u4 libssl-dev libffi-dev python-dev python-setuptools wget cmake \
                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                 && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                 && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_copp test cases failed on 202012 at setup with the following mesasge:

```
root@str-7260cx3-acs-2:/# rm -rf /var/lib/apt/lists/*                 && apt-get update                 && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz                 && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0                 && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0                 && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy                 && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py                 && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py
Get:1 http://debian-archive.trafficmanager.net/debian buster InRelease [122 kB]
Get:2 http://debian-archive.trafficmanager.net/debian-security buster/updates InRelease [34.8 kB]
Get:3 http://debian-archive.trafficmanager.net/debian buster-backports InRelease [51.4 kB]
Get:4 http://debian-archive.trafficmanager.net/debian buster/non-free Sources [85.9 kB]
Get:5 http://debian-archive.trafficmanager.net/debian buster/main Sources [7852 kB]
Get:6 http://debian-archive.trafficmanager.net/debian buster/contrib Sources [42.5 kB]
Get:7 http://debian-archive.trafficmanager.net/debian buster/main amd64 Packages [7909 kB]
Get:8 http://debian-archive.trafficmanager.net/debian buster/non-free amd64 Packages [87.8 kB]
Get:9 http://debian-archive.trafficmanager.net/debian buster/contrib amd64 Packages [50.1 kB]
Get:10 http://debian-archive.trafficmanager.net/debian-security buster/updates/non-free Sources [688 B]
Get:11 http://debian-archive.trafficmanager.net/debian-security buster/updates/main Sources [309 kB]
Get:12 http://debian-archive.trafficmanager.net/debian-security buster/updates/main amd64 Packages [437 kB]
Get:13 http://debian-archive.trafficmanager.net/debian-security buster/updates/non-free amd64 Packages [556 B]
Get:14 http://debian-archive.trafficmanager.net/debian buster-backports/contrib amd64 Packages [9196 B]
Get:15 http://debian-archive.trafficmanager.net/debian buster-backports/non-free amd64 Packages [37.2 kB]
Get:16 http://debian-archive.trafficmanager.net/debian buster-backports/main amd64 Packages [487 kB]
Fetched 17.5 MB in 4s (4332 kB/s)                          
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libssl-dev : Depends: libssl1.1 (= 1.1.1n-0+deb10u4) but 1.1.1n-0+deb10u3 is to be installed
E: Unable to correct problems, you have held broken packages.
```




### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix the issue of setup copp test environment in syncd container.

```
The following packages have unmet dependencies:
 libssl-dev : Depends: libssl1.1 (= 1.1.1n-0+deb10u4) but 1.1.1n-0+deb10u3 is to be installed
E: Unable to correct problems, you have held broken packages.
```
#### How did you do it?
libssl1.1's version is  1.1.1n-0+deb10u3 which is to be installed.
Should install necessary dependency version 1.1.1n-0+deb10u4

#### How did you verify/test it?
Add libssl1.1=1.1.1n-0+deb10u4 before libssl-dev.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
