### PR TITLE
[SAI_Qualify] Remove port_config_ini parameter

### DIFF
--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -274,21 +274,27 @@ def compose_sai_ptfv2_running_param(dut_ip, request):
        or request.config.option.enable_ptf_warmboot_test:
         warm_param = WARM_TEST_ARGS
 
-    test_param = "--test-dir {}".format(test_set)
-    test_param += " \"--test-params=thrift_server='{}'; ".format(dut_ip)
-
     port_config_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/port_config.ini'
+    config_db_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/config_db.json'
     if request.config.option.sai_port_config_file:
         port_config_file = request.config.option.sai_port_config_file
-        test_param += " port_config_ini='{}'; ".format(port_config_file)
-
-    config_db_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/config_db.json'
     if request.config.option.sai_config_db_file:
         config_db_file = request.config.option.sai_config_db_file
 
-    test_param += " config_db_json='{}';{}\"".format(
-        config_db_file,
-        warm_param)
+    test_param = "--test-dir {}".format(test_set)
+    if request.config.option.sai_port_config_file:
+        test_param += " \"--test-params=thrift_server='{}';\
+            port_config_ini='{}';config_db_json='{}';{}\"".format(
+            dut_ip,
+            port_config_file,
+            config_db_file,
+            warm_param)
+    else:
+        test_param += " \"--test-params=thrift_server='{}';\
+            config_db_json='{}';{}\"".format(
+            dut_ip,
+            config_db_file,
+            warm_param)
     return test_param
 
 

--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -31,6 +31,7 @@ from conftest import SAI_TEST_PTF_SAI_CASE_DIR_ON_PTF
 from conftest import SAI_TEST_REPORT_TMP_DIR_ON_PTF
 from conftest import SAI_TEST_T0_CASE_DIR_ON_PTF
 from conftest import SAI_TEST_RESOURCE_ON_PTF_DIR
+from conftest import SAI_TEST_INVOCATION_LOG_DIR
 from conftest import WARM_TEST_ARGS
 from conftest import PTF_TEST_CASE_TIMEOUT_IN_SEC
 from conftest import start_sai_test_conatiner_with_retry
@@ -273,18 +274,19 @@ def compose_sai_ptfv2_running_param(dut_ip, request):
        or request.config.option.enable_ptf_warmboot_test:
         warm_param = WARM_TEST_ARGS
 
+    test_param = "--test-dir {}".format(test_set)
+    test_param += " \"--test-params=thrift_server='{}'; ".format(dut_ip)
+
     port_config_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/port_config.ini'
-    config_db_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/config_db.json'
     if request.config.option.sai_port_config_file:
         port_config_file = request.config.option.sai_port_config_file
+        test_param += " port_config_ini='{}'; ".format(port_config_file)
+
+    config_db_file = SAI_TEST_RESOURCE_ON_PTF_DIR + '/config_db.json'
     if request.config.option.sai_config_db_file:
         config_db_file = request.config.option.sai_config_db_file
 
-    test_param = "--test-dir {}".format(test_set)
-    test_param += " \"--test-params=thrift_server='{}';\
-        port_config_ini='{}';config_db_json='{}';{}\"".format(
-        dut_ip,
-        port_config_file,
+    test_param += " config_db_json='{}';{}\"".format(
         config_db_file,
         warm_param)
     return test_param
@@ -498,7 +500,7 @@ def collect_test_result(duthost, ptfhost, request):
     logger.info("Collecting test result and related information.")
     # TODO : collect DUT test report
     collect_sonic_os_and_platform_info(duthost, request)
-    collect_sai_test_report_xml(ptfhost, request)    
+    collect_sai_test_report_xml(ptfhost, request)
     collect_sai_test_invocation_report(ptfhost, request)
 
 
@@ -572,8 +574,8 @@ def store_test_result(ptfhost):
             SAI_TEST_REPORT_DIR_ON_PTF))
         ptfhost.shell("cp {0}/*.* {1}/".format(
             SAI_TEST_REPORT_TMP_DIR_ON_PTF,
-            SAI_TEST_REPORT_DIR_ON_PTF))        
-        
+            SAI_TEST_REPORT_DIR_ON_PTF))
+
     except BaseException as e:  # lgtm [py/catch-base-exception]
         logger.info(
             "Error when restoring test result: {}.".format(e))
@@ -600,6 +602,7 @@ def collect_sai_test_report_xml(ptfhost, request):
         logger.info("Error when Collecting xunit SAI tests log from ptf.\
              Failes as {0}".format(e))
 
+
 def collect_sai_test_invocation_report(ptfhost, request):
     """
     Collect SAI test invocation report.
@@ -610,28 +613,28 @@ def collect_sai_test_invocation_report(ptfhost, request):
     """
     logger.info("Collecting invocation log from ptf")
     try:
-                
+
         logger.info("Copy test invocation logs")
         ptfhost.shell("mkdir -p {}".format(
             SAI_TEST_INVOCATION_LOG_DIR))
         if request.config.option.enable_sai_test \
-            or request.config.option.enable_t0_warmboot_test:
+                or request.config.option.enable_t0_warmboot_test:
             logger.info("Copy test T0 invocation logs")
             ptfhost.shell("mkdir -p {}/{}".format(
-            SAI_TEST_INVOCATION_LOG_DIR, "T0"))
+                SAI_TEST_INVOCATION_LOG_DIR, "T0"))
             ptfhost.shell("cp {}/logs/*.* {}/{}/".format(
-            SAI_TEST_T0_CASE_DIR_ON_PTF,
-            SAI_TEST_INVOCATION_LOG_DIR,
-            "T0"))
+                SAI_TEST_T0_CASE_DIR_ON_PTF,
+                SAI_TEST_INVOCATION_LOG_DIR,
+                "T0"))
         elif request.config.option.enable_ptf_sai_test \
-            or request.config.option.enable_ptf_warmboot_test:   # noqa: E125
+                or request.config.option.enable_ptf_warmboot_test:
             logger.info("Copy test PTF invocation logs")
             ptfhost.shell("mkdir -p {}/{}".format(
-            SAI_TEST_INVOCATION_LOG_DIR, "PTF"))
+                SAI_TEST_INVOCATION_LOG_DIR, "PTF"))
             ptfhost.shell("cp {}/logs/*.* {}/{}/".format(
-            SAI_TEST_PTF_SAI_CASE_DIR_ON_PTF,
-            SAI_TEST_INVOCATION_LOG_DIR,
-            "PTF"))
+                SAI_TEST_PTF_SAI_CASE_DIR_ON_PTF,
+                SAI_TEST_INVOCATION_LOG_DIR,
+                "PTF"))
 
         ptfhost.shell(
             "cd {0} && tar -czvf invocation.tar.gz *".format(


### PR DESCRIPTION
#### What is the motivation for this PR?
After this pr https://github.com/opencomputeproject/SAI/pull/1753, all config data comes from config_db.json, so remove port_config_ini parameter.

#### How did you do it?
Remove the port_config_ini in SAI test.

#### How did you verify/test it?
Run SAI test use pipeline.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
