### PR TITLE
Enhance qos tests to support single-asic, multi-asic, and multi-dut testing

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1870,22 +1870,6 @@ Totals               6450                 6449
 
         return "RUNNING" in service_status
 
-    def remove_ssh_tunnel_sai_rpc(self):
-        """
-        Removes any ssh tunnels if present created for syncd RPC communication
-
-        Returns:
-            None
-        """
-        try:
-            pid_list = self.shell(
-                'pgrep -f "ssh -o StrictHostKeyChecking=no -fN -L \*:9092"'
-            )["stdout_lines"]
-        except RunAnsibleModuleFail:
-            return
-        for pid in pid_list:
-            self.shell("kill {}".format(pid), module_ignore_errors=True)
-
     def get_up_ip_ports(self):
         """
         Get a list for all up ip interfaces

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -434,8 +434,8 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     duthost.shell_cmds(cmds=cmds)
 
 
-@pytest.fixture(scope='module')
-def dut_qos_maps(rand_selected_front_end_dut):
+@pytest.fixture(scope='class')
+def dut_qos_maps(get_src_dst_asic_and_duts):
     """
     A module level fixture to get QoS map from DUT host.
     Return a dict
@@ -452,34 +452,25 @@ def dut_qos_maps(rand_selected_front_end_dut):
     or an empty dict if failed to parse the output
     """
     maps = {}
+    dut = get_src_dst_asic_and_duts['src_dut']
     try:
-        if rand_selected_front_end_dut.is_multi_asic:
+        if dut.is_multi_asic:
             sonic_cfggen_cmd = "sonic-cfggen -n asic0 -d --var-json"
         else:
             sonic_cfggen_cmd = "sonic-cfggen -d --var-json"
 
         # port_qos_map
-        port_qos_map_data = rand_selected_front_end_dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['port_qos_map'] = json.loads(port_qos_map_data) if port_qos_map_data else None
+        maps['port_qos_map'] = json.loads(dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout'])
         # dscp_to_tc_map
-        dscp_to_tc_map_data = rand_selected_front_end_dut.shell(
-            "{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map_data) if dscp_to_tc_map_data else None
+        maps['dscp_to_tc_map'] = json.loads(dut.shell("{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout'])
         # tc_to_queue_map
-        tc_to_queue_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map_data) if tc_to_queue_map_data else None
+        maps['tc_to_queue_map'] = json.loads(dut.shell("{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout'])
         # tc_to_priority_group_map
-        tc_to_priority_group_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_priority_group_map'] = json.loads(
-            tc_to_priority_group_map_data) if tc_to_priority_group_map_data else None
+        maps['tc_to_priority_group_map'] = json.loads(dut.shell("{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout'])
         # tc_to_dscp_map
-        tc_to_dscp_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map_data) if tc_to_dscp_map_data else None
-    except Exception as e:
-        logger.error("Got exception: " + repr(e))
+        maps['tc_to_dscp_map'] = json.loads(dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout'])
+    except:
+        pass
     return maps
 
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -513,18 +513,21 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
     logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
     logger.info('router_macs={}'.format(router_macs))
 
-    asic_idx = 0
     ports_map = {}
     for ptf_port, dut_intf_map in tbinfo['topo']['ptf_dut_intf_map'].items():
         if str(ptf_port) in disabled_ptf_ports:
             # Skip PTF ports that are connected to disabled VLAN interfaces
             continue
+        asic_idx = 0
+        dut_port = None
 
         if len(dut_intf_map.keys()) == 2:
             # PTF port is mapped to two DUTs -> dualtor topology and the PTF port is a vlan port
             # Packet sent from this ptf port will only be accepted by the active side DUT
-            # DualToR DUTs use same special Vlan interface MAC address
+            # DualToR DUTs use same special Vlan interface MAC addres
             target_dut_indexes = list(map(int, active_dut_map[ptf_port]))
+            target_dut_port = int(list(dut_intf_map.values())[0])
+            target_hostname = duthosts[target_dut_indexes[0]].hostname
             ports_map[ptf_port] = {
                 'target_dut': target_dut_indexes,
                 'target_dest_mac': tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']
@@ -537,26 +540,32 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
             target_dut_index = int(list(dut_intf_map.keys())[0])
             target_dut_port = int(list(dut_intf_map.values())[0])
             router_mac = router_macs[target_dut_index]
-            dut_port = None
-            if len(duts_minigraph_facts[duthosts[target_dut_index].hostname]) > 1:
-                for list_idx, mg_facts_tuple in enumerate(duts_minigraph_facts[duthosts[target_dut_index].hostname]):
+            target_hostname = duthosts[target_dut_index].hostname
+
+            if len(duts_minigraph_facts[target_hostname]) > 1:
+                # Dealing with multi-asic target dut
+                for list_idx, mg_facts_tuple in enumerate(duts_minigraph_facts[target_hostname]):
                     idx, mg_facts = mg_facts_tuple
                     if target_dut_port in list(mg_facts['minigraph_port_indices'].values()):
                         router_mac = duts_running_config_facts[duthosts[target_dut_index].hostname][list_idx][1]\
                         ['DEVICE_METADATA']['localhost']['mac'].lower()
                         asic_idx = idx
-                        for a_dut_port, a_dut_port_index in mg_facts['minigraph_port_indices'].items():
-                            if a_dut_port_index == target_dut_port and "Ethernet-Rec" not in a_dut_port and \
-                                    "Ethernet-IB" not in a_dut_port and "Ethernet-BP" not in a_dut_port:
-                                dut_port = a_dut_port
-                        break
+
             ports_map[ptf_port] = {
                 'target_dut': [target_dut_index],
                 'target_dest_mac': router_mac,
                 'target_src_mac': [router_mac],
-                'dut_port': dut_port,
                 'asic_idx': asic_idx
             }
+
+        _, asic_mg_facts = duts_minigraph_facts[target_hostname][asic_idx]
+        for a_dut_port, a_dut_port_index in asic_mg_facts['minigraph_port_indices'].items():
+            if a_dut_port_index == target_dut_port and "Ethernet-Rec" not in a_dut_port and \
+                    "Ethernet-IB" not in a_dut_port and "Ethernet-BP" not in a_dut_port:
+                dut_port = a_dut_port
+                break
+
+        ports_map[ptf_port]['dut_port'] = dut_port
 
     logger.debug('ptf_test_port_map={}'.format(json.dumps(ports_map, indent=2)))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from tests.common.helpers.parallel import parallel_run
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active         # noqa F401
 
 from tests.common.helpers.constants import (
     ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, ASICS_PRESENT
@@ -1590,6 +1591,59 @@ def duts_running_config_facts(duthosts):
     return cfg_facts
 
 @pytest.fixture(scope='class')
+def dut_test_params_qos(duthosts, tbinfo, ptfhost, get_src_dst_asic_and_duts, lower_tor_host, creds,
+                        mux_server_url, mux_status_from_nic_simulator, duts_running_config_facts, duts_minigraph_facts):
+    if 'dualtor' in tbinfo['topo']['name']:
+        all_duts = [lower_tor_host]
+    else:
+        all_duts = get_src_dst_asic_and_duts['all_duts']
+
+    src_asic = get_src_dst_asic_and_duts['src_asic']
+    dst_asic = get_src_dst_asic_and_duts['dst_asic']
+
+    src_dut = get_src_dst_asic_and_duts['src_dut']
+    src_dut_ip = src_dut.host.options['inventory_manager'].get_host(src_dut.hostname).vars['ansible_host']
+    src_server = "{}:{}".format(src_dut_ip, src_asic.get_rpc_port_ssh_tunnel())
+
+    duthost = all_duts[0]
+    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
+    topo = tbinfo["topo"]["name"]
+
+    rtn_dict = {
+        "topo": topo,
+        "hwsku": mgFacts["minigraph_hwsku"],
+        "basicParams": {
+            "router_mac": duthost.facts["router_mac"],
+            "src_server" : src_server,
+            "port_map_file": ptf_test_port_map_active_active(
+                ptfhost, tbinfo, duthosts, mux_server_url,
+                duts_running_config_facts, duts_minigraph_facts,
+                mux_status_from_nic_simulator()),
+            "sonic_asic_type": duthost.facts['asic_type'],
+            "sonic_version": duthost.os_version,
+            "src_dut_index": get_src_dst_asic_and_duts['src_dut_index'],
+            "src_asic_index": get_src_dst_asic_and_duts['src_asic_index'],
+            "dst_dut_index": get_src_dst_asic_and_duts['dst_dut_index'],
+            "dst_asic_index": get_src_dst_asic_and_duts['dst_asic_index'],
+            "dut_username": creds['sonicadmin_user'],
+            "dut_password": creds['sonicadmin_password']
+        },
+
+    }
+
+    # Add dst server info if src and dst asic are different
+    if src_asic != dst_asic:
+        dst_dut = get_src_dst_asic_and_duts['dst_dut']
+        dst_dut_ip = dst_dut.host.options['inventory_manager'].get_host(dst_dut.hostname).vars['ansible_host']
+        rtn_dict["basicParams"]["dst_server"] = "{}:{}".format(dst_dut_ip, dst_asic.get_rpc_port_ssh_tunnel())
+
+    if 'platform_asic' in duthost.facts:
+        rtn_dict['basicParams']["platform_asic"] = duthost.facts['platform_asic']
+
+    yield rtn_dict
+
+
+@ pytest.fixture(scope='class')
 def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
                     ptf_portmap_file, lower_tor_host, creds):   # noqa F811
     """

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -35,6 +35,8 @@ def eos_to_linux_intf(eos_intf_name, hwsku=None):
     """
     if hwsku == "MLNX-OS":
         linux_intf_name = eos_intf_name.replace("ernet 1/", "sl1p").replace("/", "sp")
+    elif "Nokia" in hwsku:
+        linux_intf_name = eos_intf_name
     else:
         linux_intf_name = eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
     return linux_intf_name

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -5,7 +5,11 @@ import pytest
 import re
 import yaml
 
-from tests.common.fixtures.ptfhost_utils import ptf_portmap_file    # lgtm[py/unused-import]
+import random
+import os
+import sys
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa F401
+import copy
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.dualtor.dual_tor_utils import upper_tor_host,lower_tor_host,dualtor_ports
@@ -56,42 +60,40 @@ class QosBase:
         return self.buffer_model
 
     @pytest.fixture(scope='class', autouse=True)
-    def dutTestParams(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                      dut_test_params, tbinfo):
+    def dutTestParams(self, duthosts, dut_test_params_qos, tbinfo, get_src_dst_asic_and_duts):
         """
             Prepares DUT host test params
             Returns:
                 dutTestParams (dict): DUT host test params
         """
         # update router mac
-        dut_test_params["basicParams"]["asic_id"] = enum_frontend_asic_index
-        if dut_test_params["topo"] in self.SUPPORTED_T0_TOPOS:
-            dut_test_params["basicParams"]["router_mac"] = ''
+        if dut_test_params_qos["topo"] in self.SUPPORTED_T0_TOPOS:
+            dut_test_params_qos["basicParams"]["router_mac"] = ''
 
         elif "dualtor" in tbinfo["topo"]["name"]:
             # For dualtor qos test scenario, DMAC of test traffic is default vlan interface's MAC address.
             # To reduce duplicated code, put "is_dualtor" and "def_vlan_mac" into dutTestParams['basicParams'].
-            dut_test_params["basicParams"]["is_dualtor"] = True
+            dut_test_params_qos["basicParams"]["is_dualtor"] = True
             vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
             if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
                 default_vlan_name = vlan_cfgs['default_vlan_config']
                 if default_vlan_name:
                     for vlan in vlan_cfgs[default_vlan_name].values():
                         if 'mac' in vlan and vlan['mac']:
-                            dut_test_params["basicParams"]["def_vlan_mac"] = vlan['mac']
+                            dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
                             break
-            pytest_assert(dut_test_params["basicParams"]["def_vlan_mac"] is not None, "Dual-TOR miss default VLAN MAC address")
+            pytest_assert(dut_test_params_qos["basicParams"]["def_vlan_mac"] is not None, "Dual-TOR miss default VLAN MAC address")
         else:
             try:
-                duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+                duthost = get_src_dst_asic_and_duts['src_dut']
                 asic = duthost.asic_instance().asic_index
-                dut_test_params['basicParams']["router_mac"] = duthost.shell(
+                dut_test_params_qos['basicParams']["router_mac"] = duthost.shell(
                     'sonic-db-cli -n asic{} CONFIG_DB hget "DEVICE_METADATA|localhost" mac'.format(asic))['stdout']
             except RunAnsibleModuleFail:
-                dut_test_params['basicParams']["router_mac"] = duthost.shell(
+                dut_test_params_qos['basicParams']["router_mac"] = duthost.shell(
                     'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" mac')['stdout']
 
-        yield dut_test_params
+        yield dut_test_params_qos
 
     def runPtfTest(self, ptfhost, testCase='', testParams={}):
         """
@@ -427,7 +429,136 @@ class QosSaiBase(QosBase):
 
         return dutPortIps
 
-    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids):
+    @pytest.fixture(scope='class')
+    def swapSyncd_on_selected_duts(self, request, duthosts, get_src_dst_asic_and_duts, creds, tbinfo, lower_tor_host):
+        """
+            Swap syncd on DUT host
+
+            Args:
+                request (Fixture): pytest request object
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Returns:
+                None
+        """
+        swapSyncd = request.config.getoption("--qos_swap_syncd")
+        public_docker_reg = request.config.getoption("--public_docker_registry")
+        try:
+            if swapSyncd:
+                if public_docker_reg:
+                    new_creds = copy.deepcopy(creds)
+                    new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
+                    new_creds['docker_registry_username'] = ''
+                    new_creds['docker_registry_password'] = ''
+                else:
+                    new_creds = creds
+                for duthost in get_src_dst_asic_and_duts["all_duts"]:
+                    docker.swap_syncd(duthost, new_creds)
+            yield
+        finally:
+            if swapSyncd:
+                for duthost in get_src_dst_asic_and_duts["all_duts"]:
+                    docker.restore_default_syncd(duthost, new_creds)
+
+    @pytest.fixture(scope='class', name="select_src_dst_dut_and_asic",
+                    params=("single_asic", "single_dut_multi_asic", "multi_dut"))
+    def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo, lower_tor_host):
+        test_port_selection_criteria = request.param
+        logger.info("test_port_selection_criteria is {}".format(test_port_selection_criteria))
+        src_dut_index = 0
+        dst_dut_index = 0
+        src_asic_index = 0
+        dst_asic_index = 0
+        topo = tbinfo["topo"]["name"]
+        if 'dualtor' in tbinfo['topo']['name']:
+            # index of lower_tor_host
+            for a_dut_index in range(len(duthosts)):
+                if duthosts[a_dut_index] == lower_tor_host:
+                    lower_tor_dut_index = a_dut_index
+                    break
+
+        duthost = duthosts.frontend_nodes[0]
+        if test_port_selection_criteria == 'single_asic':
+            # We should randomly pick a dut from duthosts.frontend_nodes and a random asic in that selected DUT
+            # for now hard code the first DUT and the first asic
+            if 'dualtor' in tbinfo['topo']['name']:
+                src_dut_index = lower_tor_dut_index
+            else:
+                src_dut_index = 0
+            dst_dut_index = src_dut_index
+            src_asic_index = 0
+            dst_asic_index = 0
+
+        elif test_port_selection_criteria == "single_dut_multi_asic":
+            if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+                pytest.skip("single_dut_multi_asic is not supported on T0 topologies")
+            found_multi_asic_dut = False
+            for a_dut_index in range(len(duthosts.frontend_nodes)):
+                a_dut = duthosts.frontend_nodes[a_dut_index]
+                if a_dut.sonichost.is_multi_asic:
+                    src_dut_index = a_dut_index
+                    dst_dut_index = a_dut_index
+                    src_asic_index = 0
+                    dst_asic_index = 1
+                    found_multi_asic_dut = True
+                    logger.info ("Using dut {} for single_dut_multi_asic testing".format(a_dut.hostname))
+                    break
+            if not found_multi_asic_dut:
+                pytest.skip("Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
+        else:
+            # Dealing with multi-dut
+            if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+                pytest.skip("multi-dut is not supported on T0 topologies")
+            elif topo in self.SUPPORTED_T1_TOPOS:
+                pytest.skip("multi-dut is not supported on T1 topologies")
+
+            if (len(duthosts.frontend_nodes)) < 2:
+                pytest.skip("Don't have 2 frontend nodes - so can't run multi_dut tests")
+
+            src_dut_index = 0
+            dst_dut_index = 1
+            src_asic_index = 0
+            dst_asic_index = 0
+
+        yield {
+            "src_dut_index": src_dut_index,
+            "dst_dut_index": dst_dut_index,
+            "src_asic_index": src_asic_index,
+            "dst_asic_index": dst_asic_index
+        }
+
+    @pytest.fixture(scope='class')
+    def get_src_dst_asic_and_duts(self, duthosts, tbinfo, select_src_dst_dut_and_asic, lower_tor_host):
+        if 'dualtor' in tbinfo['topo']['name']:
+            src_dut = lower_tor_host
+            dst_dut = lower_tor_host
+        else:
+            src_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["src_dut_index"]]
+            dst_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["dst_dut_index"]]
+
+        src_asic = src_dut.asics[select_src_dst_dut_and_asic["src_asic_index"]]
+        dst_asic = dst_dut.asics[select_src_dst_dut_and_asic["dst_asic_index"]]
+
+        all_asics = [src_asic]
+        if src_asic != dst_asic:
+            all_asics.append(dst_asic)
+
+        all_duts = [src_dut]
+        if src_dut != dst_dut:
+            all_duts.append(dst_dut)
+
+        rtn_dict = {
+            "src_asic": src_asic,
+            "dst_asic": dst_asic,
+            "src_dut": src_dut,
+            "dst_dut": dst_dut,
+            "all_asics": all_asics,
+            "all_duts": all_duts
+        }
+        rtn_dict.update(select_src_dst_dut_and_asic)
+        yield rtn_dict
+
+    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts):
         """
             Build map of test ports index and IPs
 
@@ -442,16 +573,27 @@ class QosSaiBase(QosBase):
         dstPorts = request.config.getoption("--qos_dst_ports")
         srcPorts = request.config.getoption("--qos_src_ports")
 
+        src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
+        src_test_port_ids = src_dut_port_ids[get_src_dst_asic_and_duts['src_asic_index']]
+        dst_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['dst_dut_index']]
+        dst_test_port_ids = dst_dut_port_ids[get_src_dst_asic_and_duts['dst_asic_index']]
+
+        src_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['src_dut_index']]
+        src_test_port_ips = src_dut_port_ips[get_src_dst_asic_and_duts['src_asic_index']]
+        dst_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
+        dst_test_port_ips = dst_dut_port_ips[get_src_dst_asic_and_duts['dst_asic_index']]
+
+
         if dstPorts is None:
             if dst_port_ids:
                 pytest_assert(
-                    len(set(testPortIds).intersection(set(dst_port_ids))) == len(set(dst_port_ids)),
-                    "Dest port id passed in qos.yml not valid"
+                    len(set(dst_test_port_ids).intersection(set(dst_port_ids))) == len(set(dst_port_ids)),
+                        "Dest port id passed in qos.yml not valid"
                     )
                 dstPorts = dst_port_ids
-            elif len(testPortIds) >= 4:
+            elif len(dst_test_port_ids) >= 4:
                 dstPorts = [0, 2, 3]
-            elif len(testPortIds) == 3:
+            elif len(dst_test_port_ids) == 3:
                 dstPorts = [0, 2, 2]
             else:
                 dstPorts = [0, 0, 0]
@@ -459,15 +601,15 @@ class QosSaiBase(QosBase):
         if srcPorts is None:
             if src_port_ids:
                 pytest_assert(
-                    len(set(testPortIds).intersection(set(src_port_ids))) == len(set(src_port_ids)),
-                    "Source port id passed in qos.yml not valid"
-                    )
+                    len(set(src_test_port_ids).intersection(set(src_port_ids))) == len(set(src_port_ids)),
+                        "Source port id passed in qos.yml not valid"
+                )
                 # To verify ingress lossless speed/cable-length randomize the source port.
                 srcPorts = [random.choice(src_port_ids)]
             else:
                 srcPorts = [1]
 
-        pytest_assert(len(testPortIds) >= 2, "Provide at least 2 test ports")
+        pytest_assert(len(dst_test_port_ids) >= 1 and len(src_test_port_ids) >= 1, "Provide at least 2 test ports")
         logging.debug(
             "Test Port IDs:{} IPs:{}".format(testPortIds, testPortIps)
         )
@@ -480,36 +622,34 @@ class QosSaiBase(QosBase):
             )
         )
 
-
-        #TODO: Randomize port selection
-        dstPort = dstPorts[0] if dst_port_ids else testPortIds[dstPorts[0]]
-        dstVlan = testPortIps[dstPort]['vlan_id'] if 'vlan_id' in testPortIps[dstPort] else None
-        dstPort2 = dstPorts[1] if dst_port_ids else testPortIds[dstPorts[1]]
-        dstVlan2 = testPortIps[dstPort2]['vlan_id'] if 'vlan_id' in testPortIps[dstPort2] else None
-        dstPort3 = dstPorts[2] if dst_port_ids else testPortIds[dstPorts[2]]
-        dstVlan3 = testPortIps[dstPort3]['vlan_id'] if 'vlan_id' in testPortIps[dstPort3] else None
-        srcPort = srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]
-        srcVlan = testPortIps[srcPort]['vlan_id'] if 'vlan_id' in testPortIps[srcPort] else None
+        # TODO: Randomize port selection
+        dstPort = dstPorts[0] if dst_port_ids else dst_test_port_ids[dstPorts[0]]
+        dstVlan = dst_test_port_ips[dstPort]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort] else None
+        dstPort2 = dstPorts[1] if dst_port_ids else dst_test_port_ids[dstPorts[1]]
+        dstVlan2 = dst_test_port_ips[dstPort2]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort2] else None
+        dstPort3 = dstPorts[2] if dst_port_ids else dst_test_port_ids[dstPorts[2]]
+        dstVlan3 = dst_test_port_ips[dstPort3]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort3] else None
+        srcPort = srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]
+        srcVlan = src_test_port_ips[srcPort]['vlan_id'] if 'vlan_id' in src_test_port_ips[srcPort] else None
         return {
             "dst_port_id": dstPort,
-            "dst_port_ip": testPortIps[dstPort]['peer_addr'],
+            "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
             "dst_port_vlan": dstVlan,
             "dst_port_2_id": dstPort2,
-            "dst_port_2_ip": testPortIps[dstPort2]['peer_addr'],
+            "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
             "dst_port_2_vlan": dstVlan2,
             'dst_port_3_id': dstPort3,
-            "dst_port_3_ip": testPortIps[dstPort3]['peer_addr'],
+            "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
             "dst_port_3_vlan": dstVlan3,
-            "src_port_id": srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]],
-            "src_port_ip": testPortIps[srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]]["peer_addr"],
+            "src_port_id": srcPort,
+            "src_port_ip": src_test_port_ips[srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]]["peer_addr"],
             "src_port_vlan": srcVlan
         }
 
     @pytest.fixture(scope='class', autouse=True)
     def dutConfig(
-        self, request, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-        enum_frontend_asic_index, lower_tor_host, tbinfo, dualtor_ports, dut_qos_maps
-    ):
+        self, request, duthosts, get_src_dst_asic_and_duts,
+            lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps): # noqa F811
         """
             Build DUT host config pertaining to QoS SAI tests
 
@@ -521,16 +661,16 @@ class QosSaiBase(QosBase):
                 dutConfig (dict): Map of DUT config containing dut interfaces,
                 test port IDs, test port IPs, and test ports
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-            dut_asic = duthost.asic_instance(enum_frontend_asic_index)
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dutLagInterfaces = []
+        """
+        Below are dictionaries with key being dut_index and value a dictionary with key asic_index 
+        Example for 2 DUTs with 2 asics each
+            { 0: { 0: <asic0_value>, 1: <asic1_value>}, 1: { 0: <asic0_value>, 1: <asic1_value> }}
+        """
         dutPortIps = {}
         testPortIps = {}
+        testPortIds = {}
+        dualTorPortIndexes = {}
         uplinkPortIds = []
         uplinkPortIps = []
         uplinkPortNames = []
@@ -538,54 +678,62 @@ class QosSaiBase(QosBase):
         downlinkPortIps = []
         downlinkPortNames = []
 
-        mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        src_mgFacts = src_dut.get_extended_minigraph_facts(tbinfo)
         topo = tbinfo["topo"]["name"]
 
-        dualTorPortIndexes = []
 
-        testPortIds = []
         # LAG ports in T1 TOPO need to be removed in Mellanox devices
-        if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+        if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(src_dut):
+            # Only single asic is supported for this scenario, so use src_dut and src_asic - which will be the same
+            # as dst_dut and dst_asic
             pytest_assert(
-                not duthost.sonichost.is_multi_asic, "Fixture not supported on T0 multi ASIC"
+                not src_dut.sonichost.is_multi_asic, "Fixture not supported on T0 multi ASIC"
             )
-            for _, lag in mgFacts["minigraph_portchannels"].items():
+            dutLagInterfaces = []
+            testPortIds[src_dut_index] = {}
+            for _, lag in src_mgFacts["minigraph_portchannels"].items():
                 for intf in lag["members"]:
-                    dutLagInterfaces.append(mgFacts["minigraph_ptf_indices"][intf])
+                    dutLagInterfaces.append(src_mgFacts["minigraph_ptf_indices"][intf])
 
-            testPortIds = set(mgFacts["minigraph_ptf_indices"][port]
-                                for port in mgFacts["minigraph_ports"].keys())
-            testPortIds -= set(dutLagInterfaces)
-            if isMellanoxDevice(duthost):
+            testPortIds[src_dut_index][src_asic_index] = set(src_mgFacts["minigraph_ptf_indices"][port]
+                                for port in src_mgFacts["minigraph_ports"].keys())
+            testPortIds[src_dut_index][src_asic_index] -= set(dutLagInterfaces)
+            if isMellanoxDevice(src_dut):
                 # The last port is used for up link from DUT switch
-                testPortIds -= {len(mgFacts["minigraph_ptf_indices"]) - 1}
-            testPortIds = sorted(testPortIds)
-            pytest_require(len(testPortIds) != 0, "Skip test since no ports are available for testing")
+                testPortIds[src_dut_index][src_asic_index] -= {len(src_mgFacts["minigraph_ptf_indices"]) - 1}
+            testPortIds[src_dut_index][src_asic_index] = sorted(testPortIds[src_dut_index][src_asic_index])
+            pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0, "Skip test since no ports are available for testing")
 
             # get current DUT port IPs
-            dutPortIps = {}
+            dutPortIps[src_dut_index] = {}
+            dutPortIps[src_dut_index][src_asic_index] = {}
+            dualTorPortIndexes[src_dut_index] = {}
+            dualTorPortIndexes[src_dut_index][src_asic_index] = {}
             if 'backend' in topo:
-                intf_map = mgFacts["minigraph_vlan_sub_interfaces"]
+                intf_map = src_mgFacts["minigraph_vlan_sub_interfaces"]
             else:
-                intf_map = mgFacts["minigraph_interfaces"]
+                intf_map = src_mgFacts["minigraph_interfaces"]
 
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps)
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
             for portConfig in intf_map:
                 intf = portConfig["attachto"].split(".")[0]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == 4:
-                    portIndex = mgFacts["minigraph_ptf_indices"][intf]
-                    if portIndex in testPortIds:
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
+                    if portIndex in testPortIds[src_dut_index][src_asic_index]:
                         portIpMap = {'peer_addr': portConfig["peer_addr"]}
                         if 'vlan' in portConfig:
                             portIpMap['vlan_id'] = portConfig['vlan']
-                        dutPortIps.update({portIndex: portIpMap})
-                        if intf in dualtor_ports:
-                            dualTorPortIndexes.append(portIndex)
+                        dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
+                        if intf in dualtor_ports_for_duts:
+                            dualTorPortIndexes[src_dut_index][src_asic_index].append(portIndex)
                     # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
                     # we also need to test them separately
                     # for mellanox device, we run it on t1 topo mocked by ptf32 topo
-                    if use_separated_upkink_dscp_tc_map and isMellanoxDevice(duthost):
-                        neighName = mgFacts["minigraph_neighbors"].get(intf, {}).get("name", "").lower()
+                    if use_separated_upkink_dscp_tc_map and isMellanoxDevice(src_dut):
+                        neighName = src_mgFacts["minigraph_neighbors"].get(intf, {}).get("name", "").lower()
                         if 't0' in neighName:
                             downlinkPortIds.append(portIndex)
                             downlinkPortIps.append(portConfig["peer_addr"])
@@ -595,77 +743,128 @@ class QosSaiBase(QosBase):
                             uplinkPortIps.append(portConfig["peer_addr"])
                             uplinkPortNames.append(intf)
 
-            testPortIps = self.__assignTestPortIps(mgFacts)
+            testPortIps[src_dut_index] = {}
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts)
+
+            # restore currently assigned IPs
+            if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
+                testPortIps.update(dutPortIps)
 
         elif topo in self.SUPPORTED_T1_TOPOS:
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps)
-            for iface,addr in dut_asic.get_active_ip_interfaces(tbinfo).items():
-                vlan_id = None
-                if iface.startswith("Ethernet"):
-                    portName = iface
-                    if "." in iface:
-                        portName, vlan_id = iface.split(".")
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
-                    if vlan_id is not None:
-                        portIpMap['vlan_id'] = vlan_id
-                    dutPortIps.update({portIndex: portIpMap})
-                elif iface.startswith("PortChannel"):
-                    portName = next(
-                        iter(mgFacts["minigraph_portchannels"][iface]["members"])
-                    )
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
-                    dutPortIps.update({portIndex: portIpMap})
-                # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
-                # we also need to test them separately
-                if use_separated_upkink_dscp_tc_map:
-                    neighName = mgFacts["minigraph_neighbors"].get(portName, {}).get("name", "").lower()
-                    if 't0' in neighName:
-                        downlinkPortIds.append(portIndex)
-                        downlinkPortIps.append(addr["peer_ipv4"])
-                        downlinkPortNames.append(portName)
-                    elif 't2' in neighName:
-                        uplinkPortIds.append(portIndex)
-                        uplinkPortIps.append(addr["peer_ipv4"])
-                        uplinkPortNames.append(portName)
 
-            testPortIds = sorted(dutPortIps.keys())
+            # T1 is supported only for 'single_asic' or 'single_dut_multi_asic'.
+            # So use src_dut as the dut
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
+            dutPortIps[src_dut_index] = {}
+            testPortIds[src_dut_index] = {}
+            for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+                dutPortIps[src_dut_index][dut_asic.asic_index] = {}
+                for iface,addr in dut_asic.get_active_ip_interfaces(tbinfo).items():
+                    vlan_id = None
+                    if iface.startswith("Ethernet"):
+                        portName = iface
+                        if "." in iface:
+                            portName, vlan_id = iface.split(".")
+                        portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                        if vlan_id is not None:
+                            portIpMap['vlan_id'] = vlan_id
+                        dutPortIps[src_dut_index][dut_asic.asic_index].update({portIndex: portIpMap})
+                    elif iface.startswith("PortChannel"):
+                        portName = next(
+                            iter(src_mgFacts["minigraph_portchannels"][iface]["members"])
+                        )
+                        portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                        dutPortIps[src_dut_index][dut_asic.asic_index].update({portIndex: portIpMap})
+                    # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
+                    # we also need to test them separately
+                    if use_separated_upkink_dscp_tc_map:
+                        neighName = src_mgFacts["minigraph_neighbors"].get(portName, {}).get("name", "").lower()
+                        if 't0' in neighName:
+                            downlinkPortIds.append(portIndex)
+                            downlinkPortIps.append(addr["peer_ipv4"])
+                            downlinkPortNames.append(portName)
+                        elif 't2' in neighName:
+                            uplinkPortIds.append(portIndex)
+                            uplinkPortIps.append(addr["peer_ipv4"])
+                            uplinkPortNames.append(portName)
+
+                testPortIds[src_dut_index][dut_asic.asic_index] = sorted(dutPortIps[src_dut_index][dut_asic.asic_index].keys())
+
+            # Need to fix this
+            testPortIps[src_dut_index] = {}
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts)
+
+            # restore currently assigned IPs
+            if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
+                testPortIps.update(dutPortIps)
 
         elif tbinfo["topo"]["type"] == "t2":
-            for iface,addr in dut_asic.get_active_ip_interfaces(tbinfo).items():
-                vlan_id = None
+            src_asic = get_src_dst_asic_and_duts['src_asic']
+            dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+            dst_asic = get_src_dst_asic_and_duts['dst_asic']
+
+            # Lets get data for the src dut and src asic
+            dutPortIps[src_dut_index] = {}
+            testPortIds[src_dut_index] = {}
+            dutPortIps[src_dut_index][src_asic_index] = {}
+            active_ips = src_asic.get_active_ip_interfaces(tbinfo)
+            for iface,addr in active_ips.items():
                 if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
-                    if "." in iface:
-                        iface, vlan_id = iface.split(".")
-                    portIndex = mgFacts["minigraph_ptf_indices"][iface]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface }
-                    if vlan_id is not None:
-                        portIpMap['vlan_id'] = vlan_id
-                    dutPortIps.update({portIndex: portIpMap})
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][iface]
+                    portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
+                    dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
                 elif iface.startswith("PortChannel"):
                     portName = next(
-                        iter(mgFacts["minigraph_portchannels"][iface]["members"])
+                        iter(src_mgFacts["minigraph_portchannels"][iface]["members"])
                     )
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': portName }
-                    dutPortIps.update({portIndex: portIpMap})
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
+                    portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': portName}
+                    dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
 
-            testPortIds = sorted(dutPortIps.keys())
+            testPortIds[src_dut_index][src_asic_index] = sorted(dutPortIps[src_dut_index][src_asic_index].keys())
 
-        # restore currently assigned IPs
-        testPortIps.update(dutPortIps)
+            if dst_asic != src_asic:
+                # Dealing with different asic
+                dst_dut = get_src_dst_asic_and_duts['dst_dut']
+                dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+                if dst_dut_index != src_dut_index:
+                    dst_mgFacts = dst_dut.get_extended_minigraph_facts(tbinfo)
+                    dutPortIps[dst_dut_index] = {}
+                    testPortIds[dst_dut_index] = {}
+                else:
+                    dst_mgFacts = src_mgFacts
+                dutPortIps[dst_dut_index][dst_asic_index] = {}
+                active_ips = dst_asic.get_active_ip_interfaces(tbinfo)
+                for iface, addr in active_ips.items():
+                    if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
+                        portIndex = dst_mgFacts["minigraph_ptf_indices"][iface]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
+                        dutPortIps[dst_dut_index][dst_asic_index].update({portIndex: portIpMap})
+                    elif iface.startswith("PortChannel"):
+                        portName = next(
+                            iter(dst_mgFacts["minigraph_portchannels"][iface]["members"])
+                        )
+                        portIndex = dst_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': portName}
+                        dutPortIps[dst_dut_index][dst_asic_index].update({portIndex: portIpMap})
+
+                testPortIds[dst_dut_index][dst_asic_index] = sorted(dutPortIps[dst_dut_index][dst_asic_index].keys())
+
+            # restore currently assigned IPs
+            testPortIps.update(dutPortIps)
 
         qosConfigs = {}
         with open(r"qos/files/qos.yml") as file:
             qosConfigs = yaml.load(file, Loader=yaml.FullLoader)
-
-        vendor = duthost.facts["asic_type"]
-        hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        # Assuming the same chipset for all DUTs so can use src_dut to get asic type
+        vendor = src_dut.facts["asic_type"]
+        hostvars = src_dut.host.options['variable_manager']._hostvars[src_dut.hostname]
         dutAsic = None
         for asic in self.SUPPORTED_ASIC_LIST:
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-            if vendorAsic in hostvars.keys() and mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
+            if vendorAsic in hostvars.keys() and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
                 dutAsic = asic
                 break
 
@@ -685,10 +884,10 @@ class QosSaiBase(QosBase):
         src_port_ids = None
         dst_port_ids = None
         try:
-            if "src_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
+            if "src_port_ids" in qosConfigs['qos_params'][dutAsic][dutTopo]:
                 src_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["src_port_ids"]
 
-            if "dst_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
+            if "dst_port_ids" in qosConfigs['qos_params'][dutAsic][dutTopo]:
                 dst_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["dst_port_ids"]
         except KeyError:
             pass
@@ -697,7 +896,7 @@ class QosSaiBase(QosBase):
         if dualTor:
             testPortIds = dualTorPortIndexes
 
-        testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids)
+        testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts)
         # Update the uplink/downlink ports to testPorts
         testPorts.update({
             "uplink_port_ids": uplinkPortIds,
@@ -706,16 +905,20 @@ class QosSaiBase(QosBase):
             "downlink_port_ids": downlinkPortIds,
             "downlink_port_ips": downlinkPortIps,
             "downlink_port_names": downlinkPortNames
-            })
+        })
         dutinterfaces = {}
 
         if tbinfo["topo"]["type"] == "t2":
-            for ptf_port, ptf_val in dutPortIps.items():
-                dutinterfaces[ptf_port] = ptf_val['port']
+            #dutportIps={0: {0: {0: {'peer_addr': u'10.0.0.1', 'port': u'Ethernet8'}, 2: {'peer_addr': u'10.0.0.5', 'port': u'Ethernet17'}}}}
+            # { 0: 'Ethernet8', 2: 'Ethernet17' }
+            for dut_index,dut_val in dutPortIps.items():
+                for asic_index,asic_val in dut_val.items():
+                    for ptf_port, ptf_val in asic_val.items():
+                        dutinterfaces[ptf_port] = ptf_val['port']
         else:
-            for port, index in mgFacts["minigraph_ptf_indices"].items():
-                if 'Ethernet-Rec' not in port and 'Ethernet-IB' not in port:
-                    dutinterfaces[index] = port
+            dutinterfaces = {
+                index: port for port, index in src_mgFacts["minigraph_ptf_indices"].items()
+            }
 
         yield {
             "dutInterfaces": dutinterfaces,
@@ -723,33 +926,28 @@ class QosSaiBase(QosBase):
             "testPortIps": testPortIps,
             "testPorts": testPorts,
             "qosConfigs": qosConfigs,
-            "dutAsic" : dutAsic,
-            "dutTopo" : dutTopo,
-            "dutInstance" : duthost,
-            "dualTor" : request.config.getoption("--qos_dual_tor"),
-            "dualTorScenario" : len(dualtor_ports) != 0
+            "dutAsic": dutAsic,
+            "dutTopo": dutTopo,
+            "srcDutInstance" : src_dut,
+            "dstDutInstance": get_src_dst_asic_and_duts['dst_dut'],
+            "dualTor": request.config.getoption("--qos_dual_tor"),
+            "dualTorScenario": len(dualtor_ports_for_duts) != 0
         }
 
     @pytest.fixture(scope='class')
-    def ssh_tunnel_to_syncd_rpc(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-        swapSyncd, tbinfo, lower_tor_host
-    ):
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dut_asic.create_ssh_tunnel_sai_rpc()
+    def ssh_tunnel_to_syncd_rpc(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
+        all_asics = get_src_dst_asic_and_duts['all_asics']
+
+        for a_asic in all_asics:
+            a_asic.create_ssh_tunnel_sai_rpc()
 
         yield
 
-        dut_asic.remove_ssh_tunnel_sai_rpc()
+        for a_asic in all_asics:
+            a_asic.remove_ssh_tunnel_sai_rpc()
 
     @pytest.fixture(scope='class')
-    def updateIptables(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapSyncd, tbinfo, lower_tor_host
-    ):
+    def updateIptables(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
         """
             Update iptables on DUT host with drop rule for BGP SYNC packets
 
@@ -760,29 +958,27 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        all_asics = get_src_dst_asic_and_duts['all_asics']
 
-        ipVersions  = [{"ip_version": "ipv4"}, {"ip_version": "ipv6"}]
+        ipVersions = [{"ip_version": "ipv4"}, {"ip_version": "ipv6"}]
 
         logger.info("Add ip[6]tables rule to drop BGP SYN Packet from peer so that we do not ACK back")
         for ipVersion in ipVersions:
-            dut_asic.bgp_drop_rule(state="present", **ipVersion)
+            for a_asic in all_asics:
+                a_asic.bgp_drop_rule(state="present", **ipVersion)
 
         yield
 
         logger.info("Remove ip[6]tables rule to drop BGP SYN Packet from Peer")
         for ipVersion in ipVersions:
-            dut_asic.bgp_drop_rule(state="absent", **ipVersion)
+            for a_asic in all_asics:
+                a_asic.bgp_drop_rule(state="absent", **ipVersion)
 
     @pytest.fixture(scope='class')
     def stopServices(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-            swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status,
-            tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
+        self, duthosts, get_src_dst_asic_and_duts,
+        swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status,
+        tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
         """
             Stop services (lldp-syncs, lldpd, bgpd) on DUT host prior to test start
 
@@ -793,13 +989,14 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-            duthost_upper = upper_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        dst_asic = get_src_dst_asic_and_duts['dst_asic']
+        dst_dut = get_src_dst_asic_and_duts['dst_dut']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        if 'dualtor' in tbinfo['topo']['name']:
+            duthost_upper = upper_tor_host
+
         def updateDockerService(host, docker="", action="", service=""):
             """
                 Helper function to update docker services
@@ -832,59 +1029,79 @@ class QosSaiBase(QosBase):
             validate_check_result(check_result, duthosts, get_mux_status)
 
             try:
-                duthost.shell("ls %s" % file)
-                duthost.shell("sudo cp {} {}".format(file,backup_file))
-                duthost.shell("sudo rm {}".format(file))
-                duthost.shell("sudo touch {}".format(file))
+                lower_tor_host.shell("ls %s" % file)
+                lower_tor_host.shell("sudo cp {} {}".format(file,backup_file))
+                lower_tor_host.shell("sudo rm {}".format(file))
+                lower_tor_host.shell("sudo touch {}".format(file))
             except:
                 pytest.skip('file {} not found'.format(file))
 
             duthost_upper.shell('sudo config feature state mux disabled')
-            duthost.shell('sudo config feature state mux disabled')
+            lower_tor_host.shell('sudo config feature state mux disabled')
 
-        services = [
-            {"docker": dut_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
-            {"docker": dut_asic.get_docker_name("lldp"), "service": "lldpd"},
-            {"docker": dut_asic.get_docker_name("bgp"), "service": "bgpd"},
-            {"docker": dut_asic.get_docker_name("bgp"), "service": "bgpmon"},
-            {"docker": dut_asic.get_docker_name("radv"), "service": "radvd"},
-            {"docker": dut_asic.get_docker_name("swss"), "service": "arp_update"}
+        src_services = [
+            {"docker": src_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
+            {"docker": src_asic.get_docker_name("lldp"), "service": "lldpd"},
+            {"docker": src_asic.get_docker_name("bgp"), "service": "bgpd"},
+            {"docker": src_asic.get_docker_name("bgp"), "service": "bgpmon"},
+            {"docker": src_asic.get_docker_name("radv"), "service": "radvd"},
+            {"docker": src_asic.get_docker_name("swss"), "service": "radvd"}
         ]
+        dst_services = []
+        if src_asic != dst_asic:
+            dst_services = [
+                {"docker": dst_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
+                {"docker": dst_asic.get_docker_name("lldp"), "service": "lldpd"},
+                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpd"},
+                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpmon"},
+                {"docker": dst_asic.get_docker_name("radv"), "service": "radvd"},
+                {"docker": dst_asic.get_docker_name("swss"), "service": "radvd"},
+            ]
 
         feature_list = ['lldp', 'bgp', 'syncd', 'swss']
         if 'dualtor' in tbinfo['topo']['name']:
             disable_container_autorestart(duthost_upper, testcase="test_qos_sai", feature_list=feature_list)
 
-        disable_container_autorestart(duthost, testcase="test_qos_sai", feature_list=feature_list)
-        for service in services:
-            updateDockerService(duthost, action="stop", **service)
 
+        disable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
+        for service in src_services:
+            updateDockerService(src_dut, action="stop", **service)
+        if src_asic != dst_asic:
+            disable_container_autorestart(dst_dut, testcase="test_qos_sai", feature_list=feature_list)
+            for service in dst_services:
+                updateDockerService(dst_dut, action="stop", **service)
         yield
 
-        for service in services:
-            updateDockerService(duthost, action="start", **service)
+        for service in src_services:
+            updateDockerService(src_dut, action="start", **service)
+        if src_asic != dst_asic:
+            for service in dst_services:
+                updateDockerService(dst_dut, action="start", **service)
 
         """ Start mux conatiner for dual ToR """
         if 'dualtor' in tbinfo['topo']['name']:
            try:
-               duthost.shell("ls %s" % backup_file)
-               duthost.shell("sudo cp {} {}".format(backup_file,file))
-               duthost.shell("sudo chmod +x {}".format(file))
-               duthost.shell("sudo rm {}".format(backup_file))
+
+               lower_tor_host.shell("ls %s" % backup_file)
+               lower_tor_host.shell("sudo cp {} {}".format(backup_file,file))
+               lower_tor_host.shell("sudo chmod +x {}".format(file))
+               lower_tor_host.shell("sudo rm {}".format(backup_file))
            except:
                pytest.skip('file {} not found'.format(backup_file))
 
-           duthost.shell('sudo config feature state mux enabled')
-           duthost_upper.shell('sudo config feature state mux enabled')
+           lower_tor_host.shell('sudo config feature state mux enabled')
+           lower_tor_host.shell('sudo config feature state mux enabled')
            logger.info("Start mux container for dual ToR testbed")
 
-        enable_container_autorestart(duthost, testcase="test_qos_sai", feature_list=feature_list)
+        enable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
+        if src_asic != dst_asic:
+            enable_container_autorestart(dst_dut, testcase="test_qos_sai", feature_list=feature_list)
         if 'dualtor' in tbinfo['topo']['name']:
             enable_container_autorestart(duthost_upper, testcase="test_qos_sai", feature_list=feature_list)
 
 
     @pytest.fixture(autouse=True)
-    def updateLoganalyzerExceptions(self, enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+    def updateLoganalyzerExceptions(self, get_src_dst_asic_and_duts, loganalyzer):
         """
             Update loganalyzer ignore regex list
 
@@ -917,13 +1134,14 @@ class QosSaiBase(QosBase):
                 ".*WARNING syncd#SDK:.*sai_set_attribute: Failed attribs check, key:Switch ID.*",
                 ".*WARNING syncd#SDK:.*check_rate: Set max rate to 0.*"
             ]
-            loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
+            for a_dut in get_src_dst_asic_and_duts['all_duts']:
+                loganalyzer[a_dut.hostname].ignore_regex.extend(ignoreRegex)
 
         yield
 
     @pytest.fixture(scope='class', autouse=True)
     def disablePacketAging(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, stopServices
+        self, duthosts, get_src_dst_asic_and_duts, stopServices
     ):
         """
             disable packet aging on DUT host
@@ -935,33 +1153,34 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            if isMellanoxDevice(duthost):
+                logger.info("Disable Mellanox packet aging")
+                duthost.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
+                duthost.command("docker cp /tmp/packets_aging.py syncd:/")
+                duthost.command("docker exec syncd python /packets_aging.py disable")
 
-        if isMellanoxDevice(duthost):
-            logger.info("Disable Mellanox packet aging")
-            duthost.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
-            duthost.command("docker cp /tmp/packets_aging.py syncd:/")
-            duthost.command("docker exec syncd python /packets_aging.py disable")
+            yield
 
-        yield
-
-        if isMellanoxDevice(duthost):
-            logger.info("Enable Mellanox packet aging")
-            duthost.command("docker exec syncd python /packets_aging.py enable")
-            duthost.command("docker exec syncd rm -rf /packets_aging.py")
+            if isMellanoxDevice(duthost):
+                logger.info("Enable Mellanox packet aging")
+                duthost.command("docker exec syncd python /packets_aging.py enable")
+                duthost.command("docker exec syncd rm -rf /packets_aging.py")
 
     def dutArpProxyConfig(self, duthost):
         # so far, only record ARP proxy config to logging for debug purpose
-        vlanInterface = {}
-        try:
-            vlanInterface = json.loads(duthost.shell('sonic-cfggen -d --var-json "VLAN_INTERFACE"')['stdout'])
-        except:
-            logger.info('Failed to read vlan interface config')
-        if not vlanInterface:
-            return
-        for key, value in vlanInterface.items():
-            if 'proxy_arp' in value:
-                logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
+        for a_asic in duthost.asics:
+            vlanInterface = {}
+            try:
+                sonic_cfgen_cmd = 'sonic-cfggen {} -d --var-json "VLAN_INTERFACE"'.format(a_asic.cli_ns_option)
+                vlanInterface = json.loads(duthost.shell(sonic_cfgen_cmd)['stdout'])
+            except:
+                logger.info('Failed to read vlan interface config')
+            if not vlanInterface:
+                return
+            for key, value in vlanInterface.items():
+                if 'proxy_arp' in value:
+                    logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
 
     def dutBufferConfig(self, duthost):
         bufferConfig = {}
@@ -976,7 +1195,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
-        self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
+        self, duthosts, get_src_dst_asic_and_duts,
         dutConfig, ingressLosslessProfile, ingressLossyProfile,
         egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
         tbinfo, lower_tor_host
@@ -992,12 +1211,9 @@ class QosSaiBase(QosBase):
             Returns:
                 QoSConfig (dict): Map containing DUT host QoS configuration
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
         pytest_assert("minigraph_hwsku" in mgFacts, "Could not find DUT SKU")
 
@@ -1034,12 +1250,12 @@ class QosSaiBase(QosBase):
                                                        egressLossyProfile,
                                                        sharedHeadroomPoolSize,
                                                        dutConfig["dualTor"]
-            )
+                                                       )
             qosParams = qpm.run()
 
         elif 'broadcom' in duthost.facts['asic_type'].lower():
             if 'platform_asic' in duthost.facts and duthost.facts['platform_asic'] == 'broadcom-dnx':
-                logger.info("THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
+                logger.info ("THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
                 qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
             else:
                 bufferConfig = self.dutBufferConfig(duthost)
@@ -1078,8 +1294,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def releaseAllPorts(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, dutTestParams,
-        updateIptables, ssh_tunnel_to_syncd_rpc
+        self, duthosts, ptfhost, dutTestParams, updateIptables, ssh_tunnel_to_syncd_rpc
     ):
         """
             Release all paused ports prior to running QoS SAI test cases
@@ -1130,7 +1345,7 @@ class QosSaiBase(QosBase):
             duthost.file(path=file["path"], state="absent")
 
     @pytest.fixture(scope='class', autouse=True)
-    def handleFdbAging(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    def handleFdbAging(self, duthosts, get_src_dst_asic_and_duts):
         """
             Disable FDB aging and reenable at the end of tests
 
@@ -1143,32 +1358,32 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        fdbAgingTime = 0
 
-        self.__deleteTmpSwitchConfig(duthost)
-        duthost.docker_copy_from_asic("swss", "/etc/swss/config.d/switch.json", "/tmp")
-        duthost.replace(
-            dest='/tmp/switch.json',
-            regexp='"fdb_aging_time": ".*"',
-            replace='"fdb_aging_time": "{0}"'.format(fdbAgingTime),
-            backup=True
-        )
-        duthost.docker_copy_to_all_asics("swss", "/tmp/switch.json", "/etc/swss/config.d/switch.json")
-        self.__loadSwssConfig(duthost)
+        fdbAgingTime = 0
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            self.__deleteTmpSwitchConfig(duthost)
+            duthost.docker_copy_from_asic("swss", "/etc/swss/config.d/switch.json", "/tmp")
+            duthost.replace(
+                dest='/tmp/switch.json',
+                regexp='"fdb_aging_time": ".*"',
+                replace='"fdb_aging_time": "{0}"'.format(fdbAgingTime),
+                backup=True
+            )
+            duthost.docker_copy_to_all_asics("swss", "/tmp/switch.json", "/etc/swss/config.d/switch.json")
+            self.__loadSwssConfig(duthost)
 
         yield
-
-        result = duthost.find(path=["/tmp"], patterns=["switch.json.*"])
-        if result["matched"] > 0:
-            src = result["files"][0]["path"]
-            duthost.docker_copy_to_all_asics("swss", src, "/etc/swss/config.d/switch.json")
-            self.__loadSwssConfig(duthost)
-        self.__deleteTmpSwitchConfig(duthost)
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            result = duthost.find(path=["/tmp"], patterns=["switch.json.*"])
+            if result["matched"] > 0:
+                src = result["files"][0]["path"]
+                duthost.docker_copy_to_all_asics("swss", src, "/etc/swss/config.d/switch.json")
+                self.__loadSwssConfig(duthost)
+            self.__deleteTmpSwitchConfig(duthost)
 
     @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
-        self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
+        self, duthosts, get_src_dst_asic_and_duts,
         ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host
     ):
         """
@@ -1188,22 +1403,18 @@ class QosSaiBase(QosBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         saiQosTest = None
         if dutTestParams["topo"] in self.SUPPORTED_T0_TOPOS:
             saiQosTest = "sai_qos_tests.ARPpopulate"
         elif dutTestParams["topo"] in self.SUPPORTED_PTF_TOPOS:
             saiQosTest = "sai_qos_tests.ARPpopulatePTF"
         else:
-            result = dut_asic.command("arp -n")
-            pytest_assert(result["rc"] == 0, "failed to run arp command on {0}".format(duthost.hostname))
-            if result["stdout"].find("incomplete") == -1:
-                saiQosTest = "sai_qos_tests.ARPpopulate"
+            for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+                result = dut_asic.command("arp -n")
+                pytest_assert(result["rc"] == 0, "failed to run arp command on {0}".format(dut_asic.sonichost.hostname))
+                if result["stdout"].find("incomplete") == -1:
+                    saiQosTest = "sai_qos_tests.ARPpopulate"
 
         if saiQosTest:
             testParams = dutTestParams["basicParams"]
@@ -1213,21 +1424,18 @@ class QosSaiBase(QosBase):
             )
 
     @pytest.fixture(scope='class', autouse=True)
-    def dut_disable_ipv6(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host):
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-        duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
+    def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host):
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
         yield
-        duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
+
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(
-        self, request, duthosts, enum_frontend_asic_index,
-        enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host
+        self, request, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
     ):
         """
             Retreives shared headroom pool size
@@ -1240,20 +1448,14 @@ class QosSaiBase(QosBase):
                 size: shared headroom pool size
                       none if it is not defined
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
         yield self.__getSharedHeadroomPoolSize(
             request,
-            duthost.asic_instance(enum_frontend_asic_index)
+            get_src_dst_asic_and_duts['src_asic']
         )
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLosslessProfile(
-        self, request, duthosts, enum_frontend_asic_index,
-        enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports
+        self, request, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives ingress lossless profile
@@ -1267,15 +1469,12 @@ class QosSaiBase(QosBase):
             Returns:
                 ingressLosslessProfile (dict): Map of ingress lossless buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
+        duthost = get_src_dst_asic_and_duts['src_dut']
         srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             pgs = "2-4"
         else:
             pgs = "3-4"
@@ -1291,8 +1490,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLossyProfile(
-        self, request, duthosts, enum_frontend_asic_index,
-        enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
     ):
         """
             Retreives ingress lossy profile
@@ -1306,12 +1504,8 @@ class QosSaiBase(QosBase):
             Returns:
                 ingressLossyProfile (dict): Map of ingress lossy buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
         yield self.__getBufferProfile(
             request,
             dut_asic,
@@ -1323,8 +1517,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLosslessProfile(
-        self, request, duthosts, enum_frontend_asic_index,
-        enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives egress lossless profile
@@ -1338,15 +1531,12 @@ class QosSaiBase(QosBase):
             Returns:
                 egressLosslessProfile (dict): Map of egress lossless buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             queues = "2-4"
         else:
             queues = "3-4"
@@ -1362,8 +1552,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLossyProfile(
-        self, request, duthosts, enum_frontend_asic_index,
-        enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives egress lossy profile
@@ -1377,15 +1566,12 @@ class QosSaiBase(QosBase):
             Returns:
                 egressLossyProfile (dict): Map of egress lossy buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             queues = "0-1"
         else:
             queues = "0-2"
@@ -1401,9 +1587,8 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def losslessSchedProfile(
-            self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-            dutConfig, tbinfo, lower_tor_host
-        ):
+            self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+    ):
         """
             Retreives lossless scheduler profile
 
@@ -1415,22 +1600,18 @@ class QosSaiBase(QosBase):
             Returns:
                 losslessSchedProfile (dict): Map of scheduler parameters
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
         yield self.__getSchedulerParam(
-            duthost.asic_instance(enum_frontend_asic_index),
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSLESS_QUEUE_SCHED
         )
 
     @pytest.fixture(scope='class')
     def lossySchedProfile(
-        self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-        dutConfig, tbinfo, lower_tor_host
-    ):
+        self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+   ):
         """
             Retreives lossy scheduler profile
 
@@ -1442,20 +1623,16 @@ class QosSaiBase(QosBase):
             Returns:
                 lossySchedProfile (dict): Map of scheduler parameters
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
         yield self.__getSchedulerParam(
-            duthost.asic_instance(enum_frontend_asic_index),
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSY_QUEUE_SCHED
         )
 
     @pytest.fixture
     def updateSchedProfile(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+        self, duthosts, get_src_dst_asic_and_duts,
         dutQosConfig, losslessSchedProfile, lossySchedProfile, tbinfo, lower_tor_host
     ):
         """
@@ -1470,11 +1647,6 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
         def updateRedisSchedParam(schedParam):
             """
                 Helper function to updates lossless/lossy scheduler profiles
@@ -1485,17 +1657,18 @@ class QosSaiBase(QosBase):
                 Returns:
                     None
             """
-            duthost.asic_instance(enum_frontend_asic_index).run_redis_cmd(
-                argv = [
-                    "redis-cli",
-                    "-n",
-                    "4",
-                    "HSET",
-                    schedParam["profile"],
-                    "weight",
-                    schedParam["qosConfig"]
-                ]
-            )
+            for a_asic in get_src_dst_asic_and_duts['all_asics']:
+                a_asic.run_redis_cmd(
+                    argv = [
+                        "redis-cli",
+                        "-n",
+                        "4",
+                        "HSET",
+                        schedParam["profile"],
+                        "weight",
+                        schedParam["qosConfig"]
+                    ]
+                )
 
         wrrSchedParams = [
             {
@@ -1529,7 +1702,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture
     def resetWatermark(
-        self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host
+        self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
     ):
         """
             Reset queue watermark
@@ -1540,14 +1713,65 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dut_asic.command("counterpoll watermark enable")
-        dut_asic.command("counterpoll queue enable")
-        dut_asic.command("sleep 70")
-        dut_asic.command("counterpoll watermark disable")
-        dut_asic.command("counterpoll queue disable")
+        for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+            dut_asic.command("counterpoll watermark enable")
+            dut_asic.command("counterpoll queue enable")
+            dut_asic.command("sleep 70")
+            dut_asic.command("counterpoll watermark disable")
+            dut_asic.command("counterpoll queue disable")
+
+    @pytest.fixture(scope='class')
+    def dualtor_ports_for_duts(request, get_src_dst_asic_and_duts):
+        # Fetch dual ToR ports
+        logger.info("Starting fetching dual ToR info")
+
+        fetch_dual_tor_ports_script = "\
+            local remap_enabled = redis.call('HGET', 'SYSTEM_DEFAULTS|tunnel_qos_remap', 'status')\
+            if remap_enabled ~= 'enabled' then\
+                return {}\
+            end\
+            local type = redis.call('HGET', 'DEVICE_METADATA|localhost', 'type')\
+            local expected_neighbor_type\
+            local expected_neighbor_suffix\
+            if type == 'LeafRouter' then\
+                expected_neighbor_type = 'ToRRouter'\
+                expected_neighbor_suffix = 'T0'\
+            else\
+                if type == 'ToRRouter' then\
+                    local subtype = redis.call('HGET', 'DEVICE_METADATA|localhost', 'subtype')\
+                    if subtype == 'DualToR' then\
+                        expected_neighbor_type = 'LeafRouter'\
+                        expected_neighbor_suffix = 'T1'\
+                    end\
+                end\
+            end\
+            if expected_neighbor_type == nil then\
+                return {}\
+            end\
+            local result = {}\
+            local all_ports_with_neighbor = redis.call('KEYS', 'DEVICE_NEIGHBOR|*')\
+            for i = 1, #all_ports_with_neighbor, 1 do\
+                local neighbor = redis.call('HGET', all_ports_with_neighbor[i], 'name')\
+                if neighbor ~= nil and string.sub(neighbor, -2, -1) == expected_neighbor_suffix then\
+                    local peer_type = redis.call('HGET', 'DEVICE_NEIGHBOR_METADATA|' .. neighbor, 'type')\
+                    if peer_type == expected_neighbor_type then\
+                        table.insert(result, string.sub(all_ports_with_neighbor[i], 17, -1))\
+                    end\
+                end\
+            end\
+            return result\
+        "
+
+        duthost = get_src_dst_asic_and_duts['src_dut']
+
+        dualtor_ports_str = get_src_dst_asic_and_duts['src_asic'].run_redis_cmd(
+            argv=["sonic-db-cli", "CONFIG_DB", "eval", fetch_dual_tor_ports_script, "0"])
+        if dualtor_ports_str:
+            dualtor_ports_set = set(dualtor_ports_str)
+        else:
+            dualtor_ports_set = set({})
+
+        logger.info("Finish fetching dual ToR info {}".format(dualtor_ports_set))
+
+        return dualtor_ports_set

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -48,13 +48,14 @@ pytestmark = [
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer):
     """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_attribute:1920 updating switch mac addr failed with error -2"""
     ignore_regex = [
             ".*ERR syncd[0-9]*#syncd.*brcm_sai_set_switch_attribute.*updating switch mac addr failed with error.*"
     ]
     if loganalyzer:
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignore_regex)
+        for a_dut in get_src_dst_asic_and_duts['all_duts']:
+            loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex)
 
 class TestQosSai(QosSaiBase):
     """TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.
@@ -110,21 +111,33 @@ class TestQosSai(QosSaiBase):
 
         return True
 
-    def updateTestPortIdIp(self, dutConfig, qosParams=None):
+    def updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts, qosParams=None):
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        src_testPortIds = dutConfig["testPortIds"][src_dut_index][src_asic_index]
+        dst_testPortIds = dutConfig["testPortIds"][dst_dut_index][dst_asic_index]
+        testPortIds = src_testPortIds + list(set(dst_testPortIds) - set(src_testPortIds))
 
         portIdNames = []
         portIds = []
+
         for idName in dutConfig["testPorts"]:
             if re.match('(?:src|dst)_port\S+id', idName):
                 portIdNames.append(idName)
                 ipName = idName.replace('id', 'ip')
                 pytest_assert(ipName in dutConfig["testPorts"], 'Not find {} for {} in dutConfig'.format(ipName, idName))
                 portIds.append(dutConfig["testPorts"][idName])
-        pytest_assert(self.replaceNonExistentPortId(dutConfig["testPortIds"], portIds), "No enough test ports")
+        pytest_assert(self.replaceNonExistentPortId(testPortIds, set(portIds)), "No enough test ports")
         for idx, idName in enumerate(portIdNames):
             dutConfig["testPorts"][idName] = portIds[idx]
             ipName = idName.replace('id', 'ip')
-            dutConfig["testPorts"][ipName] = dutConfig["testPortIps"][portIds[idx]]['peer_addr']
+            if 'src' in ipName:
+                testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+            else:
+                testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
+            dutConfig["testPorts"][ipName] = testPortIps[portIds[idx]]['peer_addr']
 
         if qosParams != None:
             portIdNames = []
@@ -142,7 +155,7 @@ class TestQosSai(QosSaiBase):
                         portIds.append(ids)
                         # record None to indicate it's just one port
                         portNumbers.append(None)
-            pytest_assert(self.replaceNonExistentPortId(dutConfig["testPortIds"], portIds), "No enough test ports")
+            pytest_assert(self.replaceNonExistentPortId(testPortIds, portIds), "No enough test ports")
             startPos = 0
             for idx, idName in enumerate(portIdNames):
                 if portNumbers[idx] != None:    # port list
@@ -153,17 +166,18 @@ class TestQosSai(QosSaiBase):
                     startPos += 1
 
     def testParameter(
-        self, duthost, dutConfig, dutQosConfig, ingressLosslessProfile,
-        ingressLossyProfile, egressLosslessProfile, dualtor_ports
+        self, duthosts, get_src_dst_asic_and_duts, dutConfig, dutQosConfig, ingressLosslessProfile,
+        ingressLossyProfile, egressLosslessProfile, dualtor_ports_for_duts
     ):
-        logger.info("asictype {}".format(duthost.facts["asic_type"]))
+        logger.info("asictype {}".format(get_src_dst_asic_and_duts['src_dut'].facts["asic_type"]))
         logger.info("config {}".format(dutConfig))
         logger.info("qosConfig {}".format(dutQosConfig))
-        logger.info("dualtor_ports {}".format(dualtor_ports))
+        logger.info("dualtor_ports {}".format(dualtor_ports_for_duts))
 
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
-        self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, xoffProfile, duthosts, get_src_dst_asic_and_duts,
+        ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLosslessProfile
     ):
         """
@@ -195,7 +209,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -310,7 +324,7 @@ class TestQosSai(QosSaiBase):
             testParams["cell_size"] = qosConfig[xonProfile]["cell_size"]
 
         # Params required for generating a PFC Storm
-        duthost = dutConfig["dutInstance"]
+        duthost = dutConfig["srcDutInstance"]
         pfcwd_timers = set_pfc_timers()
         pfcwd_test_port_id = dutConfig["testPorts"]["src_port_id"]
         pfcwd_test_port = dutConfig["dutInterfaces"][pfcwd_test_port_id]
@@ -410,7 +424,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
-        self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
     ):
         """
@@ -444,7 +458,7 @@ class TestQosSai(QosSaiBase):
             else:
                 qosConfig = dutQosConfig["param"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         dst_port_count = set([
             dutConfig["testPorts"]["dst_port_id"],
@@ -504,7 +518,8 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LosslessVoqProfile", ["lossless_voq_1", "lossless_voq_2",
                              "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
-            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts
+            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+            singleMemberPortStaticRoute, nearbySourcePorts, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -527,7 +542,7 @@ class TestQosSai(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
-        self.updateTestPortIdIp(dutConfig, qosConfig[LosslessVoqProfile])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LosslessVoqProfile])
 
         dst_port_id, dst_port_ip = singleMemberPortStaticRoute
         src_port_1_id, src_port_2_id = nearbySourcePorts
@@ -566,7 +581,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiHeadroomPoolSize(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
     ):
         """
@@ -597,8 +612,25 @@ class TestQosSai(QosSaiBase):
         if not dutConfig['dualTor']:
             qosConfig['hdrm_pool_size']['pgs'] = qosConfig['hdrm_pool_size']['pgs'][:2]
             qosConfig['hdrm_pool_size']['dscps'] = qosConfig['hdrm_pool_size']['dscps'][:2]
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
 
-        self.updateTestPortIdIp(dutConfig, qosConfig["hdrm_pool_size"])
+        # Need to adjust hdrm_pool_size src_port_ids, dst_port_id and pgs_num based on how many source and dst ports
+        # present
+        src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
+        if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+            # Src and dst are the same asics, leave one for dst port and the rest for src ports
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+        else:
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -608,9 +640,10 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
             "pgs": qosConfig["hdrm_pool_size"]["pgs"],
             "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
-            "src_port_ips": [testPortIps[port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr']
+                             for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
@@ -651,7 +684,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("sharedResSizeKey", ["shared_res_size_1", "shared_res_size_2"])
     def testQosSaiSharedReservationSize(
-        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig
+        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI shared reservation size
@@ -675,7 +708,7 @@ class TestQosSai(QosSaiBase):
         if not sharedResSizeKey in qosConfig.keys():
             pytest.skip("Shared reservation size parametrization '%s' is not enabled" % sharedResSizeKey)
 
-        self.updateTestPortIdIp(dutConfig, qosConfig[sharedResSizeKey])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[sharedResSizeKey])
 
         port_idx_to_id = testPortIps.keys()
         # Translate requested port indices to available port IDs
@@ -719,7 +752,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiHeadroomPoolWatermark(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,  ptfhost, dutTestParams,
+        self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
         resetWatermark
     ):
@@ -744,7 +777,7 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
         cmd_output = duthost.shell("show headroom-pool watermark", module_ignore_errors=True)
         if cmd_output['rc'] != 0:
             pytest.skip("Headroom pool watermark is not supported")
@@ -755,6 +788,21 @@ class TestQosSai(QosSaiBase):
         if not 'hdrm_pool_size' in qosConfig.keys():
             pytest.skip("Headroom pool size is not enabled on this DUT")
 
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
+        if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+            # Src and dst are the same asics, leave one for dst port and the rest for src ports
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+        else:
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({
@@ -763,9 +811,9 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
             "pgs": qosConfig["hdrm_pool_size"]["pgs"],
             "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
-            "src_port_ips": [testPortIps[port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
@@ -801,7 +849,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
-        self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, request, get_src_dst_asic_and_duts, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLossyProfile, resetWatermark,
     ):
         """
@@ -877,7 +925,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiLossyQueue(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
         ingressLossyProfile
     ):
         """
@@ -903,7 +951,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -948,7 +996,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute
+            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -977,7 +1025,7 @@ class TestQosSai(QosSaiBase):
             original_voq_markings = get_markings_dut(duthost)
             setup_markings_dut(duthost, localhost, voq_allocation_mode="default")
 
-        self.updateTestPortIdIp(dutConfig, qosConfig[LossyVoq])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LossyVoq])
 
         try:
             dst_port_id, dst_port_ip = singleMemberPortStaticRoute
@@ -1018,7 +1066,7 @@ class TestQosSai(QosSaiBase):
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
-        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1037,10 +1085,11 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         # Skip the regular dscp to pg mapping test. Will run another test case instead.
+        duthost = get_src_dst_asic_and_duts['src_dut']
         if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
             pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is applied")
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1201,7 +1250,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDwrr(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
+        self, ptfhost, duthosts, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
     ):
         """
             Test QoS SAI DWRR
@@ -1226,9 +1275,11 @@ class TestQosSai(QosSaiBase):
             qosConfigWrr = qosConfig[portSpeedCableLength]["wrr"]
         else:
             qosConfigWrr = qosConfig["wrr"]
+
+        duthost = get_src_dst_asic_and_duts['src_dut']
         qos_remap_enable = is_tunnel_qos_remap_enabled(duthost)
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1269,7 +1320,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
-        self, pgProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
         resetWatermark
     ):
         """
@@ -1305,7 +1356,7 @@ class TestQosSai(QosSaiBase):
         elif "wm_pg_shared_lossy" in pgProfile:
             pktsNumFillShared = int(qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1349,7 +1400,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPgHeadroomWatermark(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
     ):
         """
             Test QoS SAI PG headroom watermark test
@@ -1374,7 +1425,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1467,7 +1518,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
-        self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         resetWatermark
     ):
         """
@@ -1503,7 +1554,7 @@ class TestQosSai(QosSaiBase):
                 qosConfig = dutQosConfig["param"]
             triggerDrop = qosConfig[queueProfile]["pkts_num_trig_egr_drp"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1543,7 +1594,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDscpToPgMapping(
-        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
+        self, get_src_dst_asic_and_duts, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -1578,7 +1629,7 @@ class TestQosSai(QosSaiBase):
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
-            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"]
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -1650,7 +1701,7 @@ class TestQosSai(QosSaiBase):
 
 
     def testQosSaiDwrrWeightChange(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         updateSchedProfile
     ):
         """
@@ -1678,6 +1729,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfigWrrChg = qosConfig["wrr_chg"]
 
+        duthost = get_src_dst_asic_and_duts['src_dut']
         qos_remap_enable = is_tunnel_qos_remap_enabled(duthost)
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -12,6 +12,8 @@ import ptf
 from ptf.base_tests import BaseTest
 from ptf import config
 import ptf.testutils as testutils
+import json
+import socket
 
 ################################################################
 #
@@ -23,11 +25,11 @@ import switch_sai_thrift.switch_sai_rpc as switch_sai_rpc
 from thrift.transport import TSocket
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
-import socket
 import sys
 import paramiko
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 
+# dictionary of interface_to_front_mapping with key 'src' or 'dst' and the ports for those target
 interface_to_front_mapping = {}
 
 from switch import (sai_thrift_port_tx_enable,
@@ -41,44 +43,78 @@ class ThriftInterface(BaseTest):
         BaseTest.setUp(self)
 
         self.test_params = testutils.test_params_get()
-        if "server" in self.test_params:
-            self.server = self.test_params['server']
+        # server is a list [ <server_ip_for_dut1>, <server_ip_for_dut2>, ... }
+        if "src_server" in self.test_params:
+            # server has format <server_ip>:<server_port>
+            src_server = self.test_params['src_server'].strip().split(":")
+            self.src_server_ip = src_server[0]
+            src_server_port = src_server[1]
         else:
-            self.server = 'localhost'
-        self.platform_asic = self.test_params.get('platform_asic', None)
+            self.src_server_ip = 'localhost'
+            src_server_port = 9092
 
-        self.asic_id = self.test_params.get('asic_id', None)
-        if "port_map" in self.test_params:
-            user_input = self.test_params['port_map']
-            splitted_map = user_input.split(",")
-            for item in splitted_map:
-                interface_front_pair = item.split("@")
-                interface_to_front_mapping[interface_front_pair[0]] = interface_front_pair[1]
-        elif "port_map_file" in self.test_params:
+        if "dst_server" in self.test_params:
+            # server has format <server_ip>:<server_port>
+            dst_server = self.test_params['dst_server'].strip().split(":")
+            self.dst_server_ip = dst_server[0]
+            dst_server_port = dst_server[1]
+        else:
+            self.dst_server_ip = self.src_server_ip
+            dst_server_port = src_server_port
+
+        if "port_map_file" in self.test_params:
             user_input = self.test_params['port_map_file']
-            f = open(user_input, 'r')
-            for line in f:
-                if (len(line) > 0 and (line[0] == '#' or line[0] == ';' or line[0]=='/')):
-                    continue
-                interface_front_pair = line.split("@")
-                interface_to_front_mapping[interface_front_pair[0]] = interface_front_pair[1].strip()
-            f.close()
+            interface_to_front_mapping['src'] = {}
+            with open(user_input) as f:
+                ptf_test_port_map = json.load(f)
+                src_dut_index = self.test_params['src_dut_index']
+                self.src_asic_index = self.test_params.get('src_asic_index', None)
+                dst_dut_index = self.test_params['dst_dut_index']
+                self.dst_asic_index = self.test_params.get('dst_asic_index', None)
+                for a_ptf_port, a_ptf_port_info in ptf_test_port_map.items():
+                    if src_dut_index in a_ptf_port_info['target_dut'] and \
+                            a_ptf_port_info['asic_idx'] == self.src_asic_index:
+                        interface_to_front_mapping['src'][a_ptf_port] = a_ptf_port_info['dut_port']
+                if src_dut_index != dst_dut_index or self.src_asic_index != self.dst_asic_index:
+                    interface_to_front_mapping['dst'] = {}
+                    for a_ptf_port, a_ptf_port_info in ptf_test_port_map.items():
+                        if dst_dut_index in a_ptf_port_info['target_dut'] and \
+                                a_ptf_port_info['asic_idx'] == self.dst_asic_index:
+                            interface_to_front_mapping['dst'][a_ptf_port] = a_ptf_port_info['dut_port']
         else:
             exit("No ptf interface<-> switch front port mapping, please specify as parameter or in external file")
-
+        # dictionary with key 'src' or 'dst'
+        self.clients = {}
         # Set up thrift client and contact server
-        self.transport = TSocket.TSocket(self.server, 9092)
-        self.transport = TTransport.TBufferedTransport(self.transport)
-        self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
 
-        self.client = switch_sai_rpc.Client(self.protocol)
-        self.transport.open()
+        # Below are dictionaries with key dut_index, and value the value for dut at dut_index.
+        self.src_transport = TSocket.TSocket(self.src_server_ip, src_server_port)
+        self.src_transport = TTransport.TBufferedTransport(self.src_transport)
+        self.src_protocol = TBinaryProtocol.TBinaryProtocol(self.src_transport)
+        self.src_client = switch_sai_rpc.Client(self.src_protocol)
+        self.src_transport.open()
+        self.clients['src'] = self.src_client
+        if self.src_server_ip == self.dst_server_ip and src_server_port == dst_server_port:
+            # using the same client for dst as the src.
+            self.dst_client = self.src_client
+        else:
+            # using different client for dst
+            self.dst_transport = TSocket.TSocket(self.dst_server_ip, dst_server_port)
+            self.dst_transport = TTransport.TBufferedTransport(self.dst_transport)
+            self.dst_protocol = TBinaryProtocol.TBinaryProtocol(self.dst_transport)
+            self.dst_client = switch_sai_rpc.Client(self.dst_protocol)
+            self.dst_transport.open()
+            self.clients['dst'] = self.dst_client
+
+        self.platform_asic = self.test_params.get('platform_asic', None)
 
     def tearDown(self):
         if config["log_dir"] != None:
             self.dataplane.stop_pcap()
         BaseTest.tearDown(self)
-        self.transport.close()
+        self.src_transport.close()
+        if self.dst_client != self.src_client:
+            self.dst_transport.close()
 
     def exec_cmd_on_dut(self, hostname, username, password, cmd):
         client = paramiko.SSHClient()
@@ -113,29 +149,30 @@ class ThriftInterface(BaseTest):
 
         return stdOut, stdErr, retValue
 
-    def sai_thrift_port_tx_enable(self, client, asic_type, port_list, last_port=True):
+    def sai_thrift_port_tx_enable(self, client, asic_type, port_list, target='dst', last_port=True):
         if self.platform_asic and self.platform_asic == "broadcom-dnx" and last_port:
             # need to enable watchdog on the source asic using cint script
-            cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog enable\"".format(self.asic_id)
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.server,
+            cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog enable\"".format(self.src_asic_index)
+            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.asic_id,
-                                                                                            self.server))
+            assert ('Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+                                                                                            self.src_server_ip))
 
-        sai_thrift_port_tx_enable(client, asic_type, port_list)
-    def sai_thrift_port_tx_disable(self, client, asic_type, port_list):
+        sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
+
+    def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             # need to enable watchdog on the source asic using cint script
-            cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog disable\"".format(self.asic_id)
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.server,
+            cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog disable\"".format(self.src_asic_index)
+            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1]), "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.asic_id,
-                                                                                         self.server)
-        sai_thrift_port_tx_disable(client, asic_type, port_list)
+            assert ('Success rv = 0' in stdOut[1]), "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+                                                                                        self.src_server_ip)
+        sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
 
 class ThriftInterfaceDataPlane(ThriftInterface):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -214,12 +214,12 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
     # Returns whether 1 packet was successfully enqueued.
     if asic_type in ['cisco-8000']:
         queue_counters_base = sai_thrift_read_queue_occupancy(
-            test_case.client, dst_port_id)
+            test_case.dst_client, dst_port_id)
         max_packets = 500
         for packet_i in range(max_packets):
             send_packet(test_case, src_port_id, pkt, 1)
             queue_counters = sai_thrift_read_queue_occupancy(
-                test_case.client, dst_port_id)
+                test_case.clients['dst'], dst_port_id)
             if queue_counters[queue] > queue_counters_base[queue]:
                 print("fill_leakout_plus_one: Success, sent %d packets, queue occupancy bytes rose from %d to %d" % (
                     packet_i + 1, queue_counters_base[queue], queue_counters[queue]), file=sys.stderr)
@@ -231,7 +231,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         self.router_mac = self.test_params['router_mac']
@@ -292,20 +292,20 @@ class ARPpopulatePTF(sai_base_test.ThriftInterfaceDataPlane):
 
 class ReleaseAllPorts(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         asic_type = self.test_params['sonic_asic_type']
 
-        self.sai_thrift_port_tx_enable(
-            self.client, asic_type, list(port_list.keys()))
+        for target, a_client in self.clients.items():
+            self.sai_thrift_port_tx_enable(a_client, asic_type, list(port_list[target].keys()), target=target)
 
 # DSCP to queue mapping
 
 
 class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
-    def get_port_id(self, port_name):
-        sai_port_id = self.client.sai_thrift_get_port_id_by_front_port(
+    def get_port_id(self, client, port_name):
+        sai_port_id = client.sai_thrift_get_port_id_by_front_port(
             port_name
         )
         print("Port name {}, SAI port id {}".format(
@@ -314,7 +314,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         return sai_port_id
 
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         router_mac = self.test_params['router_mac']
         dst_port_id = int(self.test_params['dst_port_id'])
@@ -348,13 +348,13 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         test_dst_port_name = self.test_params.get("test_dst_port_name")
         sai_dst_port_id = None
         if test_dst_port_name is not None:
-            sai_dst_port_id = self.get_port_id(test_dst_port_name)
+            sai_dst_port_id = self.get_port_id(self.dst_client, test_dst_port_name)
         else:
-            sai_dst_port_id = port_list[dst_port_id]
+            sai_dst_port_id = port_list['dst'][dst_port_id]
 
         time.sleep(10)
         # port_results is not of our interest here
-        port_results, queue_results_base = sai_thrift_read_port_counters(self.client, asic_type, sai_dst_port_id)
+        port_results, queue_results_base = sai_thrift_read_port_counters(self.dst_client, asic_type, sai_dst_port_id)
 
         # DSCP Mapping test
         try:
@@ -407,7 +407,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             time.sleep(10)
-            port_results, queue_results = sai_thrift_read_port_counters(self.client, asic_type, sai_dst_port_id)
+            port_results, queue_results = sai_thrift_read_port_counters(self.dst_client, asic_type, sai_dst_port_id)
 
             print(list(map(operator.sub, queue_results,
                   queue_results_base)), file=sys.stderr)
@@ -463,7 +463,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
 class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -508,7 +508,8 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             for queue, dot1ps in list(queue_dot1p_map.items()):
-                port_results, queue_results_base = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+                port_results, queue_results_base = sai_thrift_read_port_counters(
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
                 # send pkts with dot1ps that map to the same queue
                 for dot1p in dot1ps:
@@ -541,7 +542,8 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
 
                 # validate queue counters increment by the correct pkt num
                 time.sleep(8)
-                port_results, queue_results = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+                port_results, queue_results = sai_thrift_read_port_counters(
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
                 print(queue_results_base, file=sys.stderr)
                 print(queue_results, file=sys.stderr)
                 print(list(map(operator.sub, queue_results,
@@ -587,7 +589,7 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
 
 class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -639,7 +641,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for pg, dscps in list(pg_dscp_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 # send pkts with dscps that map to the same pg
                 for dscp in dscps:
@@ -660,7 +662,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print(pg_cntrs_base, file=sys.stderr)
                 print(pg_cntrs, file=sys.stderr)
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
@@ -695,7 +697,8 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     tos = dscps[dscp_recv_cnt] << 2
                     tos |= 1
                     try:
-                        if (recv_pkt.payload.tos == tos) and (recv_pkt.payload.src == src_port_ip) and (recv_pkt.payload.dst == dst_port_ip) and \
+                        if (recv_pkt.payload.tos == tos) and (recv_pkt.payload.src == src_port_ip) and \
+                            (recv_pkt.payload.dst == dst_port_ip) and \
                            (recv_pkt.payload.ttl == exp_ttl) and (recv_pkt.payload.id == exp_ip_id):
 
                             dscp_recv_cnt += 1
@@ -714,7 +717,8 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 # Tunnel DSCP to PG mapping test
 class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
-    def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp, outer_dscp, dst_ip, ecn=1):
+    def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp,
+                           outer_dscp, dst_ip, ecn=1):
         pkt = simple_tcp_packet(
                 eth_dst=standby_tor_mac,
                 ip_src='1.1.1.1',
@@ -740,7 +744,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         This test case is to tx some ip_in_ip packet from Mux tunnel, and check if the traffic is
         mapped to expected PGs.
         """
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         active_tor_mac = self.test_params['active_tor_mac']
@@ -769,7 +773,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             # Disable tx on EGRESS port so that headroom buffer cannot be free
-            self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
             # There are packet leak even port tx is disabled (18 packets leak on TD3 found)
             # Hence we send some packet to fill the leak before testing
@@ -798,23 +802,25 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                                             outer_dscp=0,
                                             dst_ip=dst_port_ip
                                         )
-                pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[src_port_id])
+                pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
+                                                                            port_list['src'][src_port_id])
                 send_packet(self, src_port_id, pkt, PKT_NUM)
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
-                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[src_port_id])
+                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, 
+                                                                       port_list['src'][src_port_id])
 
                 assert(pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg] <= (PKT_NUM + ERROR_TOLERANCE[pg]) * cell_size)
                 assert(pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg] >= (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size)
         finally:
             # Enable tx on dest port
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 # DOT1P to pg mapping
 class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -855,7 +861,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for pg, dot1ps in list(pg_dot1p_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 # send pkts with dot1ps that map to the same pg
                 for dot1p in dot1ps:
@@ -889,7 +895,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print(pg_cntrs_base, file=sys.stderr)
                 print(pg_cntrs, file=sys.stderr)
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
@@ -935,7 +941,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -971,7 +977,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # dscp  3 -> pg 3
             # dscp  4 -> pg 4
             pg_dropped_cntrs_old = sai_thrift_read_pg_drop_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
 
         # Prepare IP packet data
         ttl = 64
@@ -1012,8 +1018,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(
+            self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1026,7 +1034,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
@@ -1056,22 +1064,31 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 10)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_base, self, src_port_id, pkt, 10)
 
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
-            assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly PFC counter increase, {}'.format(test_stage)
+            assert(recv_counters[pg] == recv_counters_base[pg]), \
+                'unexpectedly PFC counter increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert(recv_counters[cntr] == recv_counters_base[cntr]), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send 1 packet to trigger pfc
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -1080,18 +1097,23 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger PFC'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert(recv_counters[pg] > recv_counters_base[pg]), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert(recv_counters[cntr] == recv_counters_base[cntr]), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, (pkts_num_trig_ingr_drp -
@@ -1101,18 +1123,25 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert(recv_counters[pg] > recv_counters_base[pg]), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert(recv_counters[cntr] == recv_counters_base[cntr]), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send 1 packet to trigger ingress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -1121,13 +1150,18 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'.format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert(recv_counters[pg] > recv_counters_base[pg]), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
-
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            # recv port ingress drop
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info ("On J2C+ don't support port level drop counters - so ignoring this step for now")
             else:
@@ -1140,14 +1174,14 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
             if '201811' not in sonic_version and 'mellanox' in asic_type:
                 pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 logging.info("Dropped packet counters on port #{} :{} {} packets, current dscp: {}".format(
                     src_port_id, pg_dropped_cntrs[dscp], pg_dropped_cntrs_old[dscp], dscp))
                 # Check that counters per lossless PG increased
                 assert pg_dropped_cntrs[dscp] > pg_dropped_cntrs_old[dscp]
             if '201811' not in sonic_version and 'cisco-8000' in asic_type:
                 pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 logging.info("Dropped packet counters on port #{} :{} {} packets, current dscp: {}".format(
                     src_port_id, pg_dropped_cntrs[dscp], pg_dropped_cntrs_old[dscp], dscp))
                 # check that counters per lossless PG increased
@@ -1159,13 +1193,13 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                         assert pg_dropped_cntrs[i] == pg_dropped_cntrs_old[i]
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -1254,9 +1288,12 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
         print("actual dst_port_id: {}".format(dst_port_id), file=sys.stderr)
 
         # get a snapshot of counter values at recv and transmit ports
-        recv_counters_base1, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_1_id])
-        recv_counters_base2, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_2_id])
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base1, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, port_list['src'][src_port_1_id])
+        recv_counters_base2, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, port_list['src'][src_port_2_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.dst_client, port_list['dst'][dst_port_id])
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1265,7 +1302,7 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
         else:
             margin = 2
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             assert(fill_leakout_plus_one(self, src_port_1_id, dst_port_id, pkt, int(self.test_params['pg']), asic_type))
@@ -1289,9 +1326,12 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
 
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters1, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_1_id])
-            recv_counters2, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_2_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters1, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, port_list['src'][src_port_1_id])
+            recv_counters2, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, port_list['src'][src_port_2_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, port_list['dst'][dst_port_id])
             # recv port no pfc
             pfc_txd = recv_counters1[pg] - recv_counters_base1[pg]
             assert pfc_txd == 0, "Unexpected PFC TX {} on port {}".format(pfc_txd, src_port_1_id)
@@ -1327,9 +1367,12 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
             # queue counters value is not of our interest here
             recv_counters_base1 = recv_counters1
             recv_counters_base2 = recv_counters2
-            recv_counters1, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_1_id])
-            recv_counters2, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_2_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters1, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, port_list['src'][src_port_1_id])
+            recv_counters2, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, port_list['src'][src_port_2_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, port_list['dst'][dst_port_id])
             # recv port pfc
             assert recv_counters1[pg] > recv_counters_base1[pg], "PFC TX counters did not increase for port {}".format(src_port_1_id)
             assert recv_counters2[pg] > recv_counters_base2[pg], "PFC TX counters did not increase for port {}".format(src_port_2_id)
@@ -1345,7 +1388,7 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
                 assert diff == 0, "Unexpected egress drop {} on port {}".format(diff, dst_port_id)
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # Base class used for individual PTF runs used in the following: testPfcStormWithSharedHeadroomOccupancy
 
@@ -1398,7 +1441,7 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
     def runTest(self):
 
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         self.parse_test_params()
         pkts_num_trig_pfc = int(self.test_params['pkts_num_trig_pfc'])
@@ -1420,14 +1463,15 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id]
+        )
 
         logging.info("Disabling xmit ports: {}".format(self.dst_port_id))
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id]
+        )
         num_pkts = (pkts_num_trig_pfc + pkts_num_private_headrooom) // self.cell_occupancy
         logging.info("Send {} pkts to egress out of {}".format(num_pkts, self.dst_port_id))
         # send packets to dst port 1, to cross into shared headrooom
@@ -1438,9 +1482,9 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         # get a snapshot of counter values at recv and transmit ports
         # queue counters value is not of our interest here
         recv_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         xmit_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(recv_counters, recv_counters_base))
         logging.debug("Xmit Counters: {}, Base: {}".format(xmit_counters, xmit_counters_base))
@@ -1459,25 +1503,29 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
 
     def runTest(self):
         time.sleep(1)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         self.parse_test_params()
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_id])
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id]
+        )
 
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.dst_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id]
+        )
 
         logging.info("Enable xmit ports: {}".format(self.dst_port_id))
-        self.sai_thrift_port_tx_enable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         # allow enough time for the dut to sync up the counter values in counters_db
         time.sleep(8)
 
         # get new base counter values at recv ports
-        recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_id])
+        recv_counters, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         # no ingress drop
         for cntr in self.ingress_counters:
             assert(recv_counters[cntr] == recv_counters_base[cntr])
@@ -1487,8 +1535,10 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
         time.sleep(30)
 
         # get the current snapshot of counter values at recv and transmit ports
-        recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_id])
-        xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.dst_port_id])
+        recv_counters, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
+        xmit_counters, queue_counters = sai_thrift_read_port_counters(
+            self.dst_client, self.asic-type, port_list['dst'][self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(
             recv_counters, recv_counters_base))
@@ -1509,10 +1559,9 @@ class PtfEnableDstPorts(PfcStormTestWithSharedHeadroom):
 
     def runTest(self):
         time.sleep(1)
-        switch_init(self.client)
+        switch_init(self.clients)
         self.parse_test_params()
-        self.sai_thrift_port_tx_enable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 # This test looks to measure xon threshold (pg_reset_floor)
@@ -1531,7 +1580,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
         last_pfc_counter = 0
         recv_port_counters = []
         transmit_port_counters = []
@@ -1575,7 +1624,9 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(
+            self.src_client, asic_type, port_list['src'][src_port_id]
+        )
 
         # The number of packets that will trek into the headroom space;
         # We observe in test that if the packets are sent to multiple destination ports,
@@ -1663,8 +1714,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         step_id = 1
         step_desc = 'disable TX for dst_port_id, dst_port_2_id, dst_port_3_id'
         sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [
-                                   dst_port_id, dst_port_2_id, dst_port_3_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
         try:
             '''
@@ -1689,8 +1739,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_desc = 'send packets to dst port 1, occupying the xon'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
 
-            xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id]
+            xmit_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id]
             )
 
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
@@ -1723,15 +1773,17 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 sys.stderr.write('send_packet(src_port_id, pkt, ({} + {} - {} - {}) // {})\n'.format(pkts_num_leak_out, pkts_num_trig_pfc, pkts_num_dismiss_pfc, hysteresis, cell_occupancy))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_base, self, src_port_id, pkt, 40)
 
             # send packets to dst port 2, occupying the shared buffer
             step_id += 1
             step_desc = 'send packets to dst port 2, occupying the shared buffer'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
 
-            xmit_2_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_2_id]
+            xmit_2_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id]
             )
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 send_packet(
@@ -1756,15 +1808,15 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 sys.stderr.write('send_packet(src_port_id, pkt2, ({} + {} + {}) // {} + {} - 1)\n'.format(pkts_num_leak_out, pkts_num_dismiss_pfc, hysteresis, cell_occupancy, margin))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_2_id], TRANSMITTED_PKTS, xmit_2_counters_base, self, src_port_id, pkt2, 40)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_2_id], TRANSMITTED_PKTS,
+                                               xmit_2_counters_base, self, src_port_id, pkt2, 40)
 
             # send 1 packet to dst port 3, triggering PFC
             step_id += 1
             step_desc = 'send 1 packet to dst port 3, triggering PFC'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            xmit_3_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_3_id]
-            )
+            xmit_3_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 send_packet(self, src_port_id, pkt3,
                             pkts_num_egr_mem + pkts_num_leak_out + 1)
@@ -1777,16 +1829,20 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 sys.stderr.write('send_packet(src_port_id, pkt3, ({} + 1)\n'.format(pkts_num_leak_out))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_3_id], TRANSMITTED_PKTS, xmit_3_counters_base, self, src_port_id, pkt3, 40)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_3_id], TRANSMITTED_PKTS,
+                                               xmit_3_counters_base, self, src_port_id, pkt3, 40)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
-            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_2_id])
-            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_3_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
 
             port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
@@ -1813,18 +1869,17 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_id += 1
             step_desc = 'enable TX for dst_port_2_id, to drain off buffer in dst_port_2'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_2_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_2_id], last_port=False)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
-            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_2_id])
-            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_3_id])
-
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
             port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
@@ -1850,13 +1905,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_id += 1
             step_desc = 'enable TX for dst_port_3_id, to drain off buffer in dst_port_3'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_3_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_3_id], last_port=False)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get new base counter values at recv ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
 
             port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
@@ -1874,10 +1929,12 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(30)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
-            xmit_2_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_2_id])
-            xmit_3_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_3_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
 
             port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
@@ -1890,7 +1947,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             port_cnt_tbl.add_row(['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
-            # recv port no pfc
+           # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(pg, port_counter_fields[pg], step_id, step_desc)
             # recv port no ingress drop
             for cntr in ingress_counters:
@@ -1902,15 +1959,14 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert(xmit_3_counters[cntr] == xmit_3_counters_base[cntr]), 'unexpectedly egress drop on xmit port 3 (counter: {}), at step {} {}'.format(port_counter_fields[cntr], step_id, step_desc)
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [
-                                      dst_port_id, dst_port_2_id, dst_port_3_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
 
 class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         self.dynamic_threshold = self.test_params.get('dynamic_threshold', False)
@@ -1959,14 +2015,17 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             self.pkt_size_factor = 1
 
         if self.pkts_num_trig_pfc:
-            print(("pkts num: leak_out: %d, trig_pfc: %d, hdrm_full: %d, hdrm_partial: %d, pkt_size %d" % (self.pkts_num_leak_out,
-                  self.pkts_num_trig_pfc, self.pkts_num_hdrm_full, self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
+            print(("pkts num: leak_out: %d, trig_pfc: %d, hdrm_full: %d, hdrm_partial: %d, pkt_size %d" % (
+                self.pkts_num_leak_out, self.pkts_num_trig_pfc, self.pkts_num_hdrm_full,
+                self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
         elif self.pkts_num_trig_pfc_shp:
-            print(("pkts num: leak_out: {}, trig_pfc: {}, hdrm_full: {}, hdrm_partial: {}, pkt_size {}".format(self.pkts_num_leak_out,
-                  self.pkts_num_trig_pfc_shp, self.pkts_num_hdrm_full, self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
+            print(("pkts num: leak_out: {}, trig_pfc: {}, hdrm_full: {}, hdrm_partial: {}, pkt_size {}".format(
+                self.pkts_num_leak_out, self.pkts_num_trig_pfc_shp, self.pkts_num_hdrm_full,
+                self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
 
         # used only for headroom pool watermark
-        if all(key in self.test_params for key in ['hdrm_pool_wm_multiplier', 'buf_pool_roid', 'cell_size', 'max_headroom']):
+        if all(key in self.test_params for key in [
+            'hdrm_pool_wm_multiplier', 'buf_pool_roid', 'cell_size', 'max_headroom']):
            self.cell_size = int(self.test_params['cell_size'])
            self.wm_multiplier = self.test_params['hdrm_pool_wm_multiplier']
            print("Wm multiplier: %d buf_pool_roid: %s" % (
@@ -2030,10 +2089,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes])
         for srcPortIdx, srcPortId in enumerate(self.src_port_ids):
             port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
-            rx_curr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[srcPortId])
+            rx_curr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][srcPortId])
             port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
-        tx_curr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[self.dst_port_id])
+        tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
         port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
@@ -2051,16 +2110,15 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_bases = [sai_thrift_read_port_counters(self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.dst_port_id])
+        recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[0] for sid in self.src_port_ids]
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
         # Pause egress of dut xmit port
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
             # send packets to leak out
@@ -2127,8 +2185,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                                         ip_ttl=ttl)
                 pkt_cnt = 0
 
-                recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-                while (recv_counters[sidx_dscp_pg_tuples[i][2]] == recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]]) and (pkt_cnt < 10):
+                recv_counters, _ = sai_thrift_read_port_counters(
+                    self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
+                while (recv_counters[sidx_dscp_pg_tuples[i][2]] ==
+                       recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]]) and (pkt_cnt < 10):
                     send_packet(
                         self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 1)
                     pkt_cnt += 1
@@ -2137,8 +2197,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
                     # get a snapshot of counter values at recv and transmit ports
                     # queue_counters value is not of our interest here
-                    recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-
+                    recv_counters, _ = sai_thrift_read_port_counters(
+                        self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 time.sleep(8)   # wait pfc counter refresh
                 self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
                     'To trigger PFC, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
@@ -2149,7 +2209,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert(recv_counters[sidx_dscp_pg_tuples[i][2]] >
                        recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (
-                    pkt_cnt, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], sidx_dscp_pg_tuples[i][2] - 2), file=sys.stderr)
+                    pkt_cnt, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], sidx_dscp_pg_tuples[i][2] - 2),
+                      file=sys.stderr)
                 sys.stderr.flush()
 
             print("PFC triggered", file=sys.stderr)
@@ -2158,7 +2219,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             upper_bound = 2 * margin + 1
             if self.wm_multiplier:
                 hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                    self.client, self.buf_pool_roid)
+                    self.src_client, self.buf_pool_roid)
                 print("Actual headroom pool watermark value to start: %d" %
                       hdrm_pool_wm, file=sys.stderr)
                 assert (hdrm_pool_wm <= (upper_bound *
@@ -2190,7 +2251,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
                     'To fill headroom pool, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
-                recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
+                recv_counters, _ = sai_thrift_read_port_counters(
+                    self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 # assert no ingress drop
                 for cntr in self.ingress_counters:
                     # corner case: in previous step in which trigger PFC, a few packets were dropped, and dropping don't keep increasing constantaly.
@@ -2203,7 +2265,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     wm_pkt_num += (self.pkts_num_hdrm_full if i !=
                                    self.pgs_num - 1 else self.pkts_num_hdrm_partial)
                     hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                        self.client, self.buf_pool_roid)
+                        self.src_client, self.buf_pool_roid)
                     expected_wm = wm_pkt_num * self.cell_size * self.wm_multiplier
                     upper_bound_wm = expected_wm + \
                         (upper_bound * self.cell_size * self.wm_multiplier)
@@ -2230,18 +2292,18 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
                 'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info("On J2C+ don't support port level drop counters - so ignoring this step for now")
             else:
                 # assert ingress drop
                 for cntr in self.ingress_counters:
-                    assert(
-                        recv_counters[cntr] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr])
+                    assert(recv_counters[cntr] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr])
 
             # assert no egress drop at the dut xmit port
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.dst_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info("On J2C+ don't support port level drop counters - so ignoring this step for now")
@@ -2252,7 +2314,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             print("pg hdrm filled", file=sys.stderr)
             if self.wm_multiplier:
                 # assert hdrm pool wm still remains the same
-                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(self.client, self.buf_pool_roid)
+                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(self.src_client, self.buf_pool_roid)
                 sys.stderr.write('After PG headroom filled, actual headroom pool watermark {}, upper_bound {}\n'.format(hdrm_pool_wm, upper_bound_wm))
                 if 'innovium' not in self.asic_type:
                     assert(expected_wm <= hdrm_pool_wm)
@@ -2260,20 +2322,19 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 # at this point headroom pool should be full. send few more packets to continue causing drops
                 print("overflow headroom pool", file=sys.stderr)
                 send_packet(self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 10)
-                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(self.client, self.buf_pool_roid)
+                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(self.src_client, self.buf_pool_roid)
                 assert(hdrm_pool_wm <= self.max_headroom)
             sys.stderr.flush()
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
          # Parse input parameters
         self.testbed_type = self.test_params['testbed_type']
@@ -2366,12 +2427,14 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                    self.cell_size >= self.shared_limit_bytes
 
         # get a snapshot of counter values at recv and transmit ports
-        recv_counters_bases = [sai_thrift_read_port_counters(self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
-        xmit_counters_bases = [sai_thrift_read_port_counters(self.client, self.asic_type, port_list[sid])[0] for sid in self.dst_port_ids]
+        recv_counters_bases = [sai_thrift_read_port_counters(
+            self.src_client, self.asic_type, port_list['src'][sid])[0] for sid in self.src_port_ids]
+        xmit_counters_bases = [sai_thrift_read_port_counters(
+            self.dst_client, self.asic_type, port_list['dst'][sid])[0] for sid in self.dst_port_ids]
 
         # Disable all dst ports
         uniq_dst_ports = list(set(self.dst_port_ids))
-        self.sai_thrift_port_tx_disable(self.client, self.asic_type, uniq_dst_ports)
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, uniq_dst_ports)
 
         try:
             for i in range(len(self.src_port_ids)):
@@ -2403,7 +2466,8 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                         "Verifying XOFF hasn't been triggered yet on final iteration", file=sys.stderr)
                     sys.stderr.flush()
                     time.sleep(8)
-                    recv_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[src_port_id])[0]
+                    recv_counters = sai_thrift_read_port_counters(
+                        self.src_client, self.asic_type, port_list['src'][src_port_id])[0]
                     xoff_txd = recv_counters[self.pg_cntr_indices[i]] - \
                         recv_counters_bases[i][self.pg_cntr_indices[i]]
                     assert xoff_txd == 0, "XOFF triggered too early on final iteration, XOFF count is %d" % xoff_txd
@@ -2425,14 +2489,17 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                         "Verifying XOFF has now been triggered on final iteration", file=sys.stderr)
                     sys.stderr.flush()
                     time.sleep(8)
-                    recv_counters = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[src_port_id])[0]
+                    recv_counters = sai_thrift_read_port_counters(
+                        self.src_client, self.asic_type, port_list['src'][src_port_id])[0]
                     xoff_txd = recv_counters[self.pg_cntr_indices[i]] - \
                         recv_counters_bases[i][self.pg_cntr_indices[i]]
                     assert xoff_txd > 0, "Failed to trigger XOFF on final iteration"
 
             # Verify no ingress/egress drops for all ports
-            recv_counters_list = [sai_thrift_read_port_counters(self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
-            xmit_counters_list = [sai_thrift_read_port_counters(self.client, self.asic_type, port_list[sid])[0] for sid in self.dst_port_ids]
+            recv_counters_list = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
+                                                                0] for sid in self.src_port_ids]
+            xmit_counters_list = [sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][sid])[
+                                                                0] for sid in self.dst_port_ids]
             for i in range(len(self.src_port_ids)):
                 for cntr in self.ingress_counters:
                     drops = recv_counters_list[i][cntr] - \
@@ -2444,15 +2511,14 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     assert drops == 0, "Detected %d egress drops" % drops
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, uniq_dst_ports)
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, uniq_dst_ports)
 
 # TODO: remove sai_thrift_clear_all_counters and change to use incremental counter values
 
 
 class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -2470,19 +2536,21 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         limit = self.test_params['limit']
         min_limit = self.test_params['min_limit']
         cell_size = self.test_params['cell_size']
+        asic_type = self.test_params['sonic_asic_type']
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
 
         # STOP PORT FUNCTION
         sched_prof_id = sai_thrift_create_scheduler_profile(
-            self.client, STOP_PORT_MAX_RATE)
+            self.src_client, STOP_PORT_MAX_RATE)
         attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
         attr = sai_thrift_attribute_t(
             id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-        self.client.sai_thrift_set_port_attribute(port_list[dst_port_id], attr)
+        self.dst_client.sai_thrift_set_port_attribute(port_list['dst'][dst_port_id], attr)
 
         # Clear Counters
-        sai_thrift_clear_all_counters(self.client)
+        sai_thrift_clear_all_counters(self.src_client, 'src')
+        sai_thrift_clear_all_counters(self.dst_client, 'dst')
 
         # send packets
         try:
@@ -2506,12 +2574,13 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
 
             # Clear Counters
-            sai_thrift_clear_all_counters(self.client)
+            sai_thrift_clear_all_counters(self.src_client, 'src')
+            sai_thrift_clear_all_counters(self.dst_client, 'dst')
 
             # Set receiving socket buffers to some big value
             for p in list(self.dataplane.ports.values()):
@@ -2520,12 +2589,12 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             # RELEASE PORT
             sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.client, RELEASE_PORT_MAX_RATE)
+                self.src_client, RELEASE_PORT_MAX_RATE)
             attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
             attr = sai_thrift_attribute_t(
                 id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(
-                port_list[dst_port_id], attr)
+            self.dst_client.sai_thrift_set_port_attribute(
+                port_list['dst'][dst_port_id], attr)
 
             # if (ecn == 1) - capture and parse all incoming packets
             marked_cnt = 0
@@ -2564,7 +2633,7 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(5)
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
             if (ecn == 0):
@@ -2587,18 +2656,18 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             # RELEASE PORT
             sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.client, RELEASE_PORT_MAX_RATE)
+                self.src_client, RELEASE_PORT_MAX_RATE)
             attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
             attr = sai_thrift_attribute_t(
                 id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(
-                port_list[dst_port_id], attr)
+            self.dst_client.sai_thrift_set_port_attribute(
+                port_list['dst'][dst_port_id], attr)
             print("END OF TEST")
 
 
 class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         ecn = int(self.test_params['ecn'])
@@ -2612,9 +2681,9 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
         qos_remap_enable = bool(self.test_params.get('qos_remap_enable', False))
         print("dst_port_id: %d, src_port_id: %d qos_remap_enable: %d" %
-              (dst_port_id, src_port_id, qos_remap_enable), file=sys.stderr)
+              (dst_port_id, src_port_id, qos_remap_enable))
         print("dst_port_mac: %s, src_port_mac: %s, src_port_ip: %s, dst_port_ip: %s" % (
-            dst_port_mac, src_port_mac, src_port_ip, dst_port_ip), file=sys.stderr)
+            dst_port_mac, src_port_mac, src_port_ip, dst_port_ip))
         asic_type = self.test_params['sonic_asic_type']
         default_packet_length = 1500
         exp_ip_id = 110
@@ -2644,7 +2713,8 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 # 46   5    5
                 # 48   6    6
                 prio_list = [3, 4, 8, 0, 5, 46, 48]
-                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts, queue_1_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
+                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
+                             queue_1_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
             else:
                 # When qos_remap is enabled, the map is as below
                 # DSCP TC QUEUE
@@ -2655,10 +2725,12 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 # 46   5    5
                 # 48   7    7
                 prio_list = [3, 4, 8, 0, 46, 48]
-                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts, queue_1_num_of_pkts, queue_5_num_of_pkts, queue_7_num_of_pkts]
+                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
+                             queue_1_num_of_pkts, queue_5_num_of_pkts, queue_7_num_of_pkts]
         else:
             prio_list = [3, 4, 1, 0, 2, 5, 6]
-            q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_1_num_of_pkts, queue_0_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
+            q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_1_num_of_pkts,
+                         queue_0_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
         q_cnt_sum = sum(q_pkt_cnt)
         # Send packets to leak out
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
@@ -2687,12 +2759,12 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         )
         print("actual dst_port_id: {}".format(dst_port_id), file=sys.stderr)
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         send_packet(self, src_port_id, pkt, pkts_num_leak_out)
 
         # Get a snapshot of counter values
-        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # Send packets to each queue based on priority/dscp field
         for prio, pkt_cnt in zip(prio_list, q_pkt_cnt):
@@ -2713,7 +2785,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
 
         # Release port
-        self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
         cnt = 0
         pkts = []
@@ -2772,7 +2844,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # Read counters
         print("DST port counters: ")
-        port_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         print(list(map(operator.sub, queue_counters,
               queue_counters_base)), file=sys.stderr)
 
@@ -2782,7 +2854,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
 class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -2849,8 +2921,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -2863,13 +2935,14 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
             # actual leakout by sending packets and reading actual leakout from HW
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
+            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or \
+                    hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 pkts_num_leak_out = 0
 
             if asic_type == 'cisco-8000':
@@ -2886,8 +2959,11 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, pkts_num_leak_out +
                             pkts_num_trig_egr_drp - 1 - margin)
 
-            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
-                xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+
+            if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or \
+                    hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
+                xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
                 actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - xmit_counters_base[TRANSMITTED_PKTS]
                 send_packet(self, src_port_id, pkt, actual_pkts_num_leak_out)
 
@@ -2895,8 +2971,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -2912,8 +2988,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -2931,14 +3007,14 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                     assert(xmit_counters[cntr] > xmit_counters_base[cntr])
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
         # Parse input parameters
         self.dscp = int(self.test_params['dscp'])
         self.ecn = int(self.test_params['ecn'])
@@ -2990,8 +3066,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         flow_1_udp = 2048
         pkt = self._build_testing_pkt(flow_1_udp)
 
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                              port_list[self.dst_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                              port_list['dst'][self.dst_port_id])
         # add slight tolerance in threshold characterization to consider
         # the case that npu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -3000,7 +3076,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             margin = 2
 
-        self.sai_thrift_port_tx_disable(self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
             # send packets to begin egress drop on flow1, requires sending the "single"
@@ -3011,8 +3087,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt, self.pkts_num_trig_egr_drp)
             time.sleep(2)
             # Verify egress drop
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.dst_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                             port_list['dst'][self.dst_port_id])
             for cntr in egress_counters:
                 diff = xmit_counters[cntr] - xmit_counters_base[cntr]
                 assert diff > 0, "Failed to cause TX drop on port {}".format(self.dst_port_id)
@@ -3026,8 +3102,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                 xmit_counters_base = xmit_counters
                 send_packet(self, self.src_port_id, pkt2, 1)
                 time.sleep(2)
-                xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                 port_list[self.dst_port_id])
+                xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                 port_list['dst'][self.dst_port_id])
                 drop_counts = [xmit_counters[cntr] - xmit_counters_base[cntr] for cntr in egress_counters]
                 assert len(set(drop_counts)) == 1, \
                     "Egress drop counters were different at port {}, counts: {}".format(self.dst_port_id, drop_counts)
@@ -3045,14 +3121,14 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("Did not find a second flow in mode '{}'".format(self.flow_config), file=sys.stderr)
                 assert self.flow_config == "shared", "Failed to find a flow that uses a second queue despite being in mode '{}'".format(self.flow_config)
             # Cleanup for multi-flow test
-            self.sai_thrift_port_tx_enable(self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
             time.sleep(2)
             # Test multi-flow with detected multi-flow udp ports
-            self.sai_thrift_port_tx_disable(self.client, self.asic_type, [self.dst_port_id])
-            recv_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                  port_list[self.src_port_id])
-            xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                  port_list[self.dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
+            recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type,
+                                                                  port_list['src'][self.src_port_id])
+            xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                  port_list['dst'][self.dst_port_id])
             assert fill_leakout_plus_one(self, self.src_port_id, self.dst_port_id, pkt,
                                          int(self.test_params['pg']), self.asic_type), \
                                          "Failed to fill leakout on dest port {}".format(self.dst_port_id)
@@ -3068,10 +3144,10 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt2, short_of_drop_npkts)
             # allow enough time for counters to update
             time.sleep(2)
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type,
+                                                             port_list['src'][self.src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                             port_list['dst'][self.dst_port_id])
             # recv port no pfc
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
@@ -3091,8 +3167,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt2, npkts)
             # allow enough time for counters to update
             time.sleep(2)
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type, port_list[self.dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][self.src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
             # recv port no pfc
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
@@ -3106,7 +3182,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert drops > 0, "Failed to detect egress drops ({})".format(drops)
             print("Successfully dropped {} packets".format(drops), file=sys.stderr)
         finally:
-            self.sai_thrift_port_tx_enable(self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 # pg shared pool applied to both lossy and lossless traffic
@@ -3129,17 +3205,17 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                       + ['Ing Pg{} Pkt'.format(pg)]
                                       + ['Ing Pg{} Share Wm'.format(pg)])
         if sport_cntr == None:
-            sport_cntr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
         if sport_pg_cntr == None:
-            sport_pg_cntr = sai_thrift_read_pg_counters(self.client, port_list[src_port_id])
+            sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         if sport_pg_share_wm == None:
-            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[src_port_id])
+            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
         if dport_cntr == None:
-            dport_cntr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         if dport_pg_cntr == None:
-            dport_pg_cntr = sai_thrift_read_pg_counters(self.client, port_list[dst_port_id])
+            dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
         if dport_pg_share_wm == None:
-            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[dst_port_id])
+            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         stats_tbl.add_row(['base src port']
                         + [sport_cntr_base[fieldIdx] for fieldIdx in port_counter_indexes]
                         + [sport_pg_cntr_base[pg]]
@@ -3160,7 +3236,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3225,18 +3301,18 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 "pkts_num_margin") else 2
 
         # Get a snapshot of counter values
-        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
-        pg_cntrs_base = sai_thrift_read_pg_counters(self.client, port_list[src_port_id])
-        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.client, port_list[dst_port_id])
-        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[src_port_id])
-        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.client, asic_type, port_list[dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
+        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
+        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3246,7 +3322,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             pg_min_pkts_num = 0
 
             # send packets to fill pg min but not trek into shared pool
@@ -3266,12 +3342,12 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if pg_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
             pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
@@ -3321,19 +3397,19 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("pkts num to send: %d, total pkts: %d, pg shared: %d" %
                       (pkts_num, expected_wm, total_shared), file=sys.stderr)
 
-                send_packet(self, src_port_id, pkt, pkts_num)
+                send_packet(self, src_port_id, pkt,int(pkts_num))
                 time.sleep(8)
 
                 if pg_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
-                    dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                    dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
 
                 pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                    self.client, asic_type, port_list[src_port_id])
+                    self.src_client, asic_type, port_list['src'][src_port_id])
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
 
@@ -3363,12 +3439,11 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
-
 
             self.show_stats('To overflow PG share pool, send {} pkt'.format(pkts_num),
                 asic_type, pg, src_port_id, dst_port_id, ingress_counters, egress_counters,
@@ -3382,15 +3457,15 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if platform_asic and platform_asic == "broadcom-dnx":
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                     pkts_num, ((expected_wm + cell_occupancy) * (packet_length + internal_hdr_size)), pg_shared_wm_res[pg]), file=sys.stderr)
-                assert (expected_wm * (packet_length + internal_hdr_size) <= (expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
-
+                assert (expected_wm * (packet_length + internal_hdr_size) <= (
+                        expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
             else:
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                     pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]), file=sys.stderr)
-                assert (expected_wm * cell_size <= pg_shared_wm_res[pg] <= (expected_wm + margin + cell_occupancy) * cell_size)
-
+                assert (expected_wm * cell_size <= pg_shared_wm_res[pg] <= (
+                        expected_wm + margin + cell_occupancy) * cell_size)
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # pg headroom is a notion for lossless traffic only
 
@@ -3398,7 +3473,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3467,9 +3542,9 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3489,10 +3564,9 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
 
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[src_port_id])
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info ("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " + \
                               "stat - so ignoring this step for now")
@@ -3521,7 +3595,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size *
                       cell_occupancy, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size * cell_occupancy)), file=sys.stderr)
@@ -3541,7 +3615,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("exceeded pkts num sent: %d" % (pkts_num), file=sys.stderr)
             print("lower bound: %d, actual value: %d, upper bound: %d" %
                   ((expected_wm - margin) * cell_size * cell_occupancy, pg_headroom_wm_res[pg],
@@ -3558,12 +3632,12 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     cell_occupancy <= pg_headroom_wm_res[pg])
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp=int(self.test_params['dscp'])
@@ -3611,11 +3685,10 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
             pass_iterations=0
             assert iterations > 0, "Need at least 1 iteration"
             for test_i in range(iterations):
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
                 pg_dropped_cntrs_base=sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 # Send packets to trigger PFC
                 print("Iteration {}/{}, sending {} packets to trigger PFC".format(
@@ -3625,11 +3698,11 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                 # Account for leakout
                 if 'cisco-8000' in asic_type:
                     queue_counters=sai_thrift_read_queue_occupancy(
-                        self.client, dst_port_id)
+                        self.dst_client, dst_port_id)
                     occ_pkts=queue_counters[queue] // (packet_length + 24)
                     leaked_pkts=pkts_num_trig_pfc - occ_pkts
                     print("resending leaked packets {}".format(
-                        leaked_pkts), file=sys.stderr)
+                        leaked_pkts))
                     send_packet(self, src_port_id, pkt, leaked_pkts)
 
                 # Trigger drop
@@ -3639,7 +3712,7 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, pkt_inc)
 
                 pg_dropped_cntrs=sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 pg_drops=pg_dropped_cntrs[pg] - pg_dropped_cntrs_base[pg]
 
                 actual_num_trig_ingr_drp=pkts_num_trig_ingr_drp + \
@@ -3650,16 +3723,16 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("expected trig drop: {}, actual trig drop: {}, diff: {}".format(
                     pkts_num_trig_ingr_drp, actual_num_trig_ingr_drp, ingr_drop_diff), file=sys.stderr)
 
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
             print("pass iterations: {}, total iterations: {}, margin: {}".format(
                 pass_iterations, iterations, margin), file=sys.stderr)
             assert pass_iterations >= int(
-                0.75 * iterations), "Passed iterations {} insufficient to meet minimum required iterations {}".format(pass_iterations, int(0.75 * iterations))
+                0.75 * iterations), "Passed iterations {} insufficient to meet minimum required iterations {}".format(
+                pass_iterations, int(0.75 * iterations))
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
@@ -3681,18 +3754,20 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                       + ['Que{} Share Wm'.format(que)])
 
         if sport_cntr == None:
-            sport_cntr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
         if sport_pg_cntr == None:
-            sport_pg_cntr = sai_thrift_read_pg_counters(self.client, port_list[src_port_id])
+            sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         if None in [sport_pg_share_wm, sport_pg_headroom_wm, sport_que_share_wm]:
-            sport_que_share_wm, sport_pg_share_wm, sport_pg_headroom_wm = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
+            sport_que_share_wm, sport_pg_share_wm, sport_pg_headroom_wm = \
+                sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
 
         if dport_cntr == None:
-            dport_cntr, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         if dport_pg_cntr == None:
-            dport_pg_cntr = sai_thrift_read_pg_counters(self.client, port_list[dst_port_id])
+            dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
         if None in [dport_pg_share_wm, dport_pg_headroom_wm, dport_que_share_wm]:
-            dport_que_share_wm, dport_pg_share_wm, dport_pg_headroom_wm = sai_thrift_read_port_watermarks(self.client, port_list[dst_port_id])
+            dport_que_share_wm, dport_pg_share_wm, dport_pg_headroom_wm = \
+                sai_thrift_read_port_watermarks(self.src_client, port_list['dst'][dst_port_id])
 
         stats_tbl.add_row(['base src port']
                         + [sport_cntr_base[fieldIdx] for fieldIdx in port_counter_indexes]
@@ -3722,7 +3797,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         ingress_counters, egress_counters = get_counter_names(self.test_params['sonic_version'])
@@ -3796,13 +3871,13 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem=int(self.test_params['pkts_num_egr_mem'])
 
-        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
-        pg_cntrs_base = sai_thrift_read_pg_counters(self.client, port_list[src_port_id])
-        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.client, port_list[dst_port_id])
-        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.client, port_list[src_port_id])
-        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.client, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
+        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
+        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.dst_client, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3812,7 +3887,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             que_min_pkts_num = 0
 
             # send packets to fill queue min but not trek into shared pool
@@ -3830,12 +3905,14 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if que_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_history, self, src_port_id, pkt, 40)
 
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
-                self.client, port_list[dst_port_id])
+                self.dst_client, port_list['dst'][dst_port_id])
             pg_cntrs=sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 que_min_pkts_num, pkts_num_fill_min, q_wm_res[queue]), file=sys.stderr)
             print("Received packets: %d" %
@@ -3853,7 +3930,11 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             elif 'cisco-8000' in asic_type:
                 assert(q_wm_res[queue] <= (margin + 1) * cell_size)
             else:
-                assert(q_wm_res[queue] <= 1 * cell_size)
+                if platform_asic and platform_asic == "broadcom-dnx":
+                    logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " + \
+                                 "stat - so ignoring this step for now")
+                else:
+                    assert(q_wm_res[queue] <= 1 * cell_size)
 
             # send packet batch of fixed packet numbers to fill queue shared
             # first round sends only 1 packet
@@ -3876,10 +3957,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     fragment=total_shared - expected_wm
 
                 if 'cisco-8000' in asic_type:
-                    self.sai_thrift_port_tx_disable(
-                        self.client, asic_type, [dst_port_id])
-                    assert(fill_leakout_plus_one(self, src_port_id,
-                           dst_port_id, pkt, queue, asic_type))
+                    self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+                    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
                     pkts_total += pkts_num
                     pkts_num=pkts_total - 1
 
@@ -3890,19 +3969,21 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 if 'cisco-8000' in asic_type:
                     self.sai_thrift_port_tx_enable(
-                        self.client, asic_type, [dst_port_id])
+                        self.dst_client, asic_type, [dst_port_id])
 
                 time.sleep(8)
 
                 if que_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
-                    dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters, port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
-                    self.client, port_list[dst_port_id])
+                    self.dst_client, port_list['dst'][dst_port_id])
                 pg_cntrs=sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin)
@@ -3925,8 +4006,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkts_num=pkts_inc
 
             if 'cisco-8000' in asic_type:
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
                 assert(fill_leakout_plus_one(self, src_port_id,
                        dst_port_id, pkt, queue, asic_type))
                 pkts_total += pkts_num
@@ -3936,14 +4016,13 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
 
             if 'cisco-8000' in asic_type:
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
-                self.client, port_list[dst_port_id])
+                self.dst_client, port_list['dst'][dst_port_id])
             pg_cntrs=sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
             print("exceeded pkts num sent: %d, actual value: %d, lower bound: %d, upper bound: %d" % (
@@ -3966,7 +4045,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert(q_wm_res[queue] <= (expected_wm + margin) * cell_size)
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # TODO: buffer pool roid should be obtained via rpc calls
 # based on the pg or queue index
@@ -3974,7 +4053,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp=int(self.test_params['dscp'])
@@ -4007,7 +4086,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'cisco-8000' in asic_type:
             # Some small amount of memory is always occupied
             buffer_pool_wm_base=sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid)
+                self.src_client, buf_pool_roid)
 
         # Prepare TCP packet data
         tos=dscp << 2
@@ -4059,13 +4138,13 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             # the impact caused by lossy traffic
             #
             # TH2 uses scheduler-based TX enable, this does not require sending packets to leak out
-            self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             pkts_num_to_send += (pkts_num_leak_out + pkts_num_fill_min)
             send_packet(self, src_port_id, pkt, pkts_num_to_send)
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
             buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid) - buffer_pool_wm_base
+                self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 (pkts_num_leak_out + pkts_num_fill_min), pkts_num_fill_min, buffer_pool_wm), file=sys.stderr)
             if pkts_num_fill_min:
@@ -4099,8 +4178,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("pkts num to send: %d, total pkts: %d, shared: %d" %
                       (pkts_num, expected_wm, total_shared), file=sys.stderr)
 
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
                 pkts_num_to_send += pkts_num
                 if 'cisco-8000' in asic_type:
                     assert(fill_leakout_plus_one(self, src_port_id,
@@ -4108,11 +4186,10 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     send_packet(self, src_port_id, pkt, pkts_num_to_send - 1)
                 else:
                     send_packet(self, src_port_id, pkt, pkts_num_to_send)
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
                 time.sleep(8)
                 buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
-                    self.client, buf_pool_roid) - buffer_pool_wm_base
+                    self.src_client, buf_pool_roid) - buffer_pool_wm_base
                 print("lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (lower_bound_margin, (expected_wm - lower_bound_margin)
                       * cell_size, buffer_pool_wm, upper_bound_margin, (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
                 assert(buffer_pool_wm <= (expected_wm + \
@@ -4123,7 +4200,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkts_num=pkts_inc
 
             # overflow the shared pool
-            self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             pkts_num_to_send += pkts_num
             if 'cisco-8000' in asic_type:
                 assert(fill_leakout_plus_one(self, src_port_id,
@@ -4132,10 +4209,10 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 send_packet(self, src_port_id, pkt, pkts_num_to_send)
 
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
             buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid) - buffer_pool_wm_base
+                self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                 pkts_num, (expected_wm * cell_size), buffer_pool_wm), file=sys.stderr)
             assert(expected_wm == total_shared)
@@ -4144,7 +4221,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(buffer_pool_wm <= (expected_wm + extra_cap_margin) * cell_size)
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 class PacketTransmit(sai_base_test.ThriftInterfaceDataPlane):
@@ -4232,7 +4309,7 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
         Traffic is ingressed from IPinIP tunnel(LAG port), and then being decaped at active tor, and then egress to server.
         Tx is disabled on the egress port to trigger PFC pause.
         """
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         active_tor_mac = self.test_params['active_tor_mac']
@@ -4265,11 +4342,11 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             # Disable tx on EGRESS port so that headroom buffer cannot be free
-            self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             # Make a snapshot of transmitted packets
-            tx_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            tx_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # Make a snapshot of received packets
-            rx_counters_base, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            rx_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             if tunnel_traffic_test:
                 # Build IPinIP packet for testing
                 pkt = self._build_testing_ipinip_pkt(active_tor_mac=active_tor_mac,
@@ -4294,22 +4371,24 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num_trig_pfc)
             time.sleep(8)
             # Read TX_OK again to calculate leaked packet number
-            tx_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[dst_port_id])
+            tx_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             leaked_packet_number = tx_counters[TRANSMITTED_PKTS] - tx_counters_base[TRANSMITTED_PKTS]
             # Send packets to compensate the leaked packets
             send_packet(self, src_port_id, pkt, leaked_packet_number)
             time.sleep(8)
             # Read rx counter again. No PFC pause frame should be triggered
-            rx_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             # Verify no pfc
             assert(rx_counters[pg] == rx_counters_base[pg])
             rx_counters_base = rx_counters
             # Send some packets to trigger PFC
             send_packet(self, src_port_id, pkt, 1 + 2 * pkts_num_margin)
             time.sleep(8)
-            rx_counters, _ = sai_thrift_read_port_counters(self.client, asic_type, port_list[src_port_id])
+            rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             # Verify PFC pause frame is generated on expected PG
             assert(rx_counters[pg] > rx_counters_base[pg])
         finally:
             # Enable tx on dest port
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
+

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -32,11 +32,12 @@ from switch_sai_thrift.sai_headers import *
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
-switch_inited = 0
+switch_inited=0
+# All below are dictionary with key 'src' or 'dst' and val is value for that client
 port_list = {}
-sai_port_list = []
-front_port_list = []
-table_attr_list = []
+sai_port_list = {}
+front_port_list = {}
+table_attr_list = {}
 router_mac = '00:77:66:55:44:00'
 rewrite_mac1 = '00:77:66:55:45:01'
 rewrite_mac2 = '00:77:66:55:46:01'
@@ -48,44 +49,56 @@ STOP_PORT_MAX_RATE = 1
 RELEASE_PORT_MAX_RATE = 0
 
 
-def switch_init(client):
+def switch_init(clients):
     global switch_inited
     if switch_inited:
         return
 
-    switch_attr_list = client.sai_thrift_get_switch_attribute()
-    attr_list = switch_attr_list.attr_list
-    for attribute in attr_list:
-        if attribute.id == SAI_SWITCH_ATTR_PORT_NUMBER:
-            print("max ports: " + attribute.value.u32)
-        elif attribute.id == SAI_SWITCH_ATTR_PORT_LIST:
-            for port_id in attribute.value.objlist.object_id_list:
-                attr_value = sai_thrift_attribute_value_t(booldata=1)
-                attr = sai_thrift_attribute_t(
-                    id=SAI_PORT_ATTR_ADMIN_STATE, value=attr_value)
-                client.sai_thrift_set_port_attribute(port_id, attr)
-                sai_port_list.append(port_id)
-        else:
-            print("unknown switch attribute")
+    def _get_data_for_client(client, target):
+        _port_list = {}
+        _sai_port_list = []
+        _front_port_list = []
+        switch_attr_list = client.sai_thrift_get_switch_attribute()
+        attr_list = switch_attr_list.attr_list
+        for attribute in attr_list:
+            if attribute.id == SAI_SWITCH_ATTR_PORT_NUMBER:
+                print("max ports {}".format(attribute.value.u32), file=sys.stderr)
+            elif attribute.id == SAI_SWITCH_ATTR_PORT_LIST:
+                for port_id in attribute.value.objlist.object_id_list:
+                    attr_value = sai_thrift_attribute_value_t(booldata=1)
+                    attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_ADMIN_STATE, value=attr_value)
+                    client.sai_thrift_set_port_attribute(port_id, attr)
+                    _sai_port_list.append(port_id)
+            else:
+                print("unknown switch attribute", file=sys.stderr)
 
-    # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
-    # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
-    attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
-    attr = sai_thrift_attribute_t(
-        id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
-    client.sai_thrift_set_switch_attribute(attr)
+        # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
+        # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
+        attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
+        attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
+        client.sai_thrift_set_switch_attribute(attr)
 
-    # wait till the port are up
-    time.sleep(10)
+        # wait till the port are up
+        time.sleep(10)
 
-    thrift_attr = client.sai_thrift_get_port_list_by_front_port()
-    if thrift_attr.id == SAI_SWITCH_ATTR_PORT_LIST:
-        for port_id in thrift_attr.value.objlist.object_id_list:
-            front_port_list.append(port_id)
+        thrift_attr = client.sai_thrift_get_port_list_by_front_port()
+        if thrift_attr.id == SAI_SWITCH_ATTR_PORT_LIST:
+            for port_id in thrift_attr.value.objlist.object_id_list:
+                _front_port_list.append(port_id)
 
-    for interface, front in interface_to_front_mapping.items():
-        sai_port_id = client.sai_thrift_get_port_id_by_front_port(front)
-        port_list[int(interface)] = sai_port_id
+        for interface, front in interface_to_front_mapping[target].items():
+            sai_port_id = client.sai_thrift_get_port_id_by_front_port(front)
+            _port_list[int(interface)] = sai_port_id
+        return _port_list, _sai_port_list, _front_port_list
+
+    port_list['src'], sai_port_list['src'], front_port_list['src'] = _get_data_for_client(clients['src'], 'src')
+    if 'dst' not in clients:
+        port_list['dst'] = port_list['src']
+        sai_port_list['dst'] = sai_port_list['src']
+        front_port_list['dst'] = front_port_list['src']
+    else:
+        port_list['dst'], sai_port_list['dst'], front_port_list['dst'] = \
+            _get_data_for_client(clients['dst'], 'dst')
 
     switch_inited = 1
 
@@ -667,8 +680,8 @@ def sai_thrift_create_pool_profile(client, pool_type, size, threshold_mode):
     return pool_id
 
 
-def sai_thrift_clear_all_counters(client):
-    for port in sai_port_list:
+def sai_thrift_clear_all_counters(client, target):
+    for port in sai_port_list[target]:
         queue_list = []
         client.sai_thrift_clear_port_all_stats(port)
         port_attr_list = client.sai_thrift_get_port_attribute(port)
@@ -684,7 +697,7 @@ def sai_thrift_clear_all_counters(client):
             client.sai_thrift_clear_queue_stats(queue, cnt_ids, len(cnt_ids))
 
 
-def sai_thrift_port_tx_disable(client, asic_type, port_ids):
+def sai_thrift_port_tx_disable(client, asic_type, port_ids, target='dst'):
     if asic_type == 'mellanox':
         # Close DST port
         sched_prof_id = sai_thrift_create_scheduler_profile(
@@ -699,10 +712,10 @@ def sai_thrift_port_tx_disable(client, asic_type, port_ids):
             id=SAI_PORT_ATTR_PKT_TX_ENABLE, value=attr_value)
 
     for port_id in port_ids:
-        client.sai_thrift_set_port_attribute(port_list[port_id], attr)
+        client.sai_thrift_set_port_attribute(port_list[target][port_id], attr)
 
 
-def sai_thrift_port_tx_enable(client, asic_type, port_ids):
+def sai_thrift_port_tx_enable(client, asic_type, port_ids, target='dst'):
     if asic_type == 'mellanox':
         # Release port
         sched_prof_id = sai_thrift_create_scheduler_profile(
@@ -717,7 +730,7 @@ def sai_thrift_port_tx_enable(client, asic_type, port_ids):
             id=SAI_PORT_ATTR_PKT_TX_ENABLE, value=attr_value)
 
     for port_id in port_ids:
-        client.sai_thrift_set_port_attribute(port_list[port_id], attr)
+        client.sai_thrift_set_port_attribute(port_list[target][port_id], attr)
 
 
 def sai_thrift_read_port_counters(client, asic_type, port):
@@ -907,9 +920,9 @@ def sai_thrift_read_headroom_pool_watermark(client, buffer_pool_id):
     return wm_vals[0]
 
 
-def sai_thrift_read_queue_occupancy(client, port_id):
+def sai_thrift_read_queue_occupancy(client, target, port_id):
     queue_list = []
-    port_attr_list = client.sai_thrift_get_port_attribute(port_list[port_id])
+    port_attr_list = client.sai_thrift_get_port_attribute(port_list[target][port_id])
     attr_list = port_attr_list.attr_list
     for attribute in attr_list:
         if attribute.id == SAI_PORT_ATTR_QOS_QUEUE_LIST:

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -171,7 +171,8 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
 
 
 def collect_dut_lossless_prio(dut):
-    config_facts = dut.config_facts(host=dut.hostname, source="running")['ansible_facts']
+    dut_asic = dut.asic_instance()
+    config_facts = dut_asic.config_facts(host=dut.hostname, source="running")['ansible_facts']
 
     if "PORT_QOS_MAP" not in config_facts.keys():
         return []
@@ -189,7 +190,8 @@ def collect_dut_lossless_prio(dut):
     return result
 
 def collect_dut_all_prio(dut):
-    config_facts = dut.config_facts(host=dut.hostname, source="running")['ansible_facts']
+    dut_asic = dut.asic_instance()
+    config_facts = dut_asic.config_facts(host=dut.hostname, source="running")['ansible_facts']
 
     if "DSCP_TO_TC_MAP" not in config_facts.keys():
         return []


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is same as PR https://github.com/sonic-net/sonic-mgmt/pull/6946 from 'master' branch that can't be cherry-picked without merge conflicts into '202205' branch.

The existing QoS (test_qos_sai.py) is written to accomodata a single asic on a single Dut. But, we require the same tests to be executed against a T2 chassis (with single/multi-asic linecards) and multi-asic pizza boxes.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
All the test cases create a list of src and dst ports. For the different modes, here is the distribution of the src and dst ports:
- single_asic: The src and dst ports are on the same asic on the same linecard.
- single_dut_multi_asic: On a multi-asic DUT/linecard, the src port is on an asic, while the dst ports are on another asic on the same DUT/linecard
- multi_dut: The src port is on an asic on one of the DUT/linecards, and the dst port is on another asic on another DUT/linecard. This is currently only required for T2 topology

#### How did you do it?
Approach to accomplish this is the following:
- All the tests have to parameterized for the 3 modes defined above.
  - This is done using the 'select_src_and_dst_dut_and_asic' fixture that is parameterized for 'single_asic', 'single_dut_multi_asic', 'multi_dut' - Based on the mode, it sets the src_dut_index, dst_dut_index, src_asic_index and dst_asic_index
  - Added fixture 'get_src_dst_asic_and_duts' that returns dictionary of the src_dut_index, dst_dut_index, src_asic_index, and dst_asic_index, and the src_dut and dst_dut (instances of MultiAsicSonicHost), src_asic and dst_asic (instances of Asic), and also a list of all DUTs and all Asics
- dutConfig is modified such that testPortIds and testPortIps are collecting from all the duts and asics involved and stored in a dictionary with key being the dutIndex and value being a dictionary per asic index.
   - __buildTestPorts then sets the src and dst ports based on the src_dut_index, dst_dut_index, src_asic_index and dst_asic_index
- All the other fixtures and tests, we use 'get_src_dst_asci_and_duts' fixture instead of enum_rand_one_frontend_hostname and enum_frontend_index.
  - The code instead the fixtures and tests is modified to the actions on the correct src/dst dut or asic. For example: - swap_syncd fixture would swap syncd docker on all DUT's (both src and dst) instead of just one DUT as before. - stopServices - do it all_duts (src and dst duts)

- Similarly, changes to saitests involved dealing with multiple DUTs (and thus multiple sai clients) and modifying other data structure like 'interface_to_front_mapping' in sai_base_test.py and port_list, sai_port_list, front_port_list in switch.py to deal with multiple duts (modified to be dictionary with key being 'src' and 'dst')
  - tests in sai_qos_tests.py pass src_dut_index, src_asic_index, dst_dut_index and dst_asic_index in the testParams.
     - The saitests classes then use this to do the actions on the right client and ports.

Assumptions:
- For multi-dut, we are assuming that hwsku for all the cards are same.

#### How did you verify/test it?
This is verified on T0, T1, dual ToR as well as t2 topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
