### PR TITLE
Fix parse_portstat to return only port info

### DIFF
--- a/tests/common/portstat_utilities.py
+++ b/tests/common/portstat_utilities.py
@@ -74,6 +74,10 @@ def parse_portstat(content_lines):
             portstats.append(portstat)
 
         intf = portstats[0]
+        # skip lines that are not port stat.
+        if not intf.strip().startswith( 'Ethernet' ):
+            continue
+
         results[intf] = {}
         for idx in range(1, len(portstats)):    # Skip the first column interface name
             results[intf][headers[idx]] = portstats[idx]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

`parse_portstat` does not parse the output of `portstat` correctly and returns non port info, which fails sonic-mgmt tests  https://github.com/sonic-net/sonic-mgmt/issues/7560. The PR is to fix `parse_portstat` to only return port info by validating the port name.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
