### PR TITLE
[T2 Logical Chassis] Enhanced platform_tests/test_thermal_state_db.py to handle logical chassis by skipping thermal sensors that are not part of the logical chassis

### DIFF
--- a/tests/platform_tests/cli/util.py
+++ b/tests/platform_tests/cli/util.py
@@ -81,6 +81,8 @@ def get_skip_mod_list(duthost, mod_key=None):
         'psus':
           - PSU4
           - PSU5
+        'thermals':
+          - TEMPERATURE_INFO_2
     @return a list of modules/peripherals to be skipped in check for platform test
     """
 

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -70,7 +70,7 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
     num_thermals = get_expected_num_thermals(duthosts, enum_rand_one_per_hwsku_hostname)
     thermal_out = duthost.command("redis-dump -d 6 -y -k \"TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
-    pytest_assert(len(out_dict.keys()) == num_thermals, 
+    pytest_assert(len(out_dict.keys()) == num_thermals,
                   "num of thermal sensors incorrect expected {} but got {}".format(num_thermals, len(out_dict.keys())))
     result = check_therm_data(out_dict)
     pytest_assert(not result,

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -71,7 +71,7 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
     thermal_out = duthost.command("redis-dump -d 6 -y -k \"TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
     pytest_assert(len(out_dict.keys()) == num_thermals, 
-              "number of thermal sensors incorrect expected {} but got {}".format(num_thermals, len(out_dict.keys())))
+                  "num of thermal sensors incorrect expected {} but got {}".format(num_thermals, len(out_dict.keys())))
     result = check_therm_data(out_dict)
     pytest_assert(not result,
                   "Warning status incorrect for following thermal sensors:\n{}".format("\n".join(result)))

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -71,7 +71,7 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
     thermal_out = duthost.command("redis-dump -d 6 -y -k \"TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
     pytest_assert(len(out_dict.keys()) == num_thermals, 
-                  "number of thermal sensors incorrect expected  {} but got {}".format(num_thermals, len(out_dict.keys())))
+              "number of thermal sensors incorrect expected {} but got {}".format(num_thermals, len(out_dict.keys())))
     result = check_therm_data(out_dict)
     pytest_assert(not result,
                   "Warning status incorrect for following thermal sensors:\n{}".format("\n".join(result)))

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -70,7 +70,8 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
     num_thermals = get_expected_num_thermals(duthosts, enum_rand_one_per_hwsku_hostname)
     thermal_out = duthost.command("redis-dump -d 6 -y -k \"TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
-    pytest_assert(len(out_dict.keys()) == num_thermals, "number of thermal sensors incorrect expected  {} but got {}".format(num_thermals, len(out_dict.keys())))
+    pytest_assert(len(out_dict.keys()) == num_thermals, 
+                  "number of thermal sensors incorrect expected  {} but got {}".format(num_thermals, len(out_dict.keys())))
     result = check_therm_data(out_dict)
     pytest_assert(not result,
                   "Warning status incorrect for following thermal sensors:\n{}".format("\n".join(result)))
@@ -100,9 +101,11 @@ def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo)
     for thermal in thermal_skip_list:
         skip_thermal = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"{}|*\"".format(chassis_db_ip, thermal))
         skip_dict = json.loads(skip_thermal['stdout'])
-        #delete each key from the global dictionary
+        """
+        delete all keys that we know should not be checked from the global dictionary
+        """
         for skip_sensor_key in skip_dict.keys():
-            if out_dict.has_key(skip_sensor_key):
+            if skip_sensor_key in out_dict.keys():
                 del out_dict[skip_sensor_key]
 
     actual_num_thermal_sensors = len(out_dict.keys())


### PR DESCRIPTION
### Description of PR
To support T2 Logical chassis (classify set of LCs and SUPs as a logical chassis where not all physically inserted LCs though belong to the same physical chassis belong to the same logical chassis), this platform_tests/test_thermal_state_db.py when testing the "test_thermal_global_state_db()" it was counting all the thermal sensor info for all the physical LCs and SUP.  This breaks the logical chassis testing where not all the physically inserted LCs should be used for the test.

This PR is to ensure that when it reads from the global state DB for the thermal sensor data, it will properly skip over those thermal sensors that does not belong to the logical chassis based on the new skip_module field "thermals" specified in the inventory file.  This way the test will be able to handle logical chassis correctly.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
To allow logical chassis to be tested correctly.

#### How did you do it?
Verified the test run on logical chassis and ensure the test is functioning correctly with this change.

#### How did you verify/test it?
1. Tried without adding the "thermals" in the inventory skip_module list and observe the test failed at the actual/expected count validation where the actual was greater than expected due to one LC ws not suppose to be counted.
2. Tried again by specifying the correct "thermals" in the inventory skip_module list and observe the test passes successfully.
3. ried again by specifying extra "thermals" in the inventory skip_module list and observe the test failed due to actual/expected count validation failed due tosomething that was expected to be there is missing from the gobal state DB.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
