### PR TITLE
[CRM]Fix the failure of crm route test caused by fdb learning during the test

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -441,6 +441,23 @@ def get_entries_num(used, available):
     return ((used + available) / 100) + 1
 
 
+def get_crm_resources_fdb_and_ip_route(duthost):
+    keys = ['ipv4_route', 'ipv6_route', 'fdb_entry']
+    output = duthost.shell("crm show resources all")
+    result = {}
+    for line in output['stdout_lines']:
+        if line:
+            line = line.split()
+            if line[0] in keys:
+                counters = {'used': int(line[1]), 'available': int(line[2])}
+                result[line[0]] = counters
+                keys.remove(line[0])
+                if not keys:
+                    break
+    pytest_assert(keys == [], "Failed to get crm resource for {}".format(str(keys)))
+    return result
+
+
 @pytest.mark.usefixtures('disable_route_checker')
 @pytest.mark.parametrize("ip_ver,route_add_cmd,route_del_cmd", [("4", "{} route add 2.{}.2.0/24 via {}",
                                                                 "{} route del 2.{}.2.0/24 via {}"),
@@ -473,21 +490,16 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     del_routes_template = Template(del_template)
     add_routes_template = Template(add_template)
 
-    # Get "crm_stats_ipv[4/6]_route" used and available counter value
-    get_route_stats = "{redis_cli} COUNTERS_DB HMGET \
-                            CRM:STATS crm_stats_ipv{ip_ver}_route_used \
-                            crm_stats_ipv{ip_ver}_route_available"\
-                                .format(redis_cli=asichost.sonic_db_cli,
-                                        ip_ver=ip_ver)
-    crm_stats_route_used, crm_stats_route_available = get_crm_stats(get_route_stats, duthost)
-    logging.info("crm_stats_route_used {} crm_stats_route_available {} "
-                 .format(crm_stats_route_used, crm_stats_route_available))
-
+    # Get ipv[4/6]_route/fdb_entry used and available counter value
+    crm_stats = get_crm_resources_fdb_and_ip_route(duthost)
+    crm_stats_route_used = crm_stats['ipv{}_route'.format(ip_ver)]['used']
+    crm_stats_route_available = crm_stats['ipv{}_route'.format(ip_ver)]['available']
+    crm_stats_fdb_used = crm_stats['fdb_entry']['used']
+    logging.info("crm_stats_route_used {}, crm_stats_route_available {}, crm_stats_fdb_used {}".format(
+        crm_stats_route_used, crm_stats_route_available, crm_stats_fdb_used))
     # Get NH IP
     cmd = "{ip_cmd} -{ip_ver} neigh show dev {crm_intf} nud reachable nud stale \
-            | grep -v fe80".format(ip_cmd=asichost.ip_cmd,
-                                   ip_ver=ip_ver,
-                                   crm_intf=crm_interface[0])
+            | grep -v fe80".format(ip_cmd=asichost.ip_cmd, ip_ver=ip_ver, crm_intf=crm_interface[0])
     out = duthost.shell(cmd)
     pytest_assert(out["stdout"] != "", "Get Next Hop IP failed. Neighbor not found")
     nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
@@ -506,10 +518,17 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     # Make sure CRM counters updated
     time.sleep(CRM_UPDATE_TIME)
 
-    # Get new "crm_stats_ipv[4/6]_route" used and available counter value
-    new_crm_stats_route_used, new_crm_stats_route_available = get_crm_stats(get_route_stats, duthost)
-    logging.info("new_crm_stats_route_used {}, new_crm_stats_route_available {}"
-                 .format(new_crm_stats_route_used, new_crm_stats_route_available))
+    # Get new ipv[4/6]_route/fdb_entry used and available counter value
+    crm_stats = get_crm_resources_fdb_and_ip_route(duthost)
+    new_crm_stats_route_used = crm_stats['ipv{}_route'.format(ip_ver)]['used']
+    new_crm_stats_route_available = crm_stats['ipv{}_route'.format(ip_ver)]['available']
+    crm_stats_fdb_used_after_add_route = crm_stats['fdb_entry']['used']
+    logging.info("new_crm_stats_route_used {}, new_crm_stats_route_available {}, crm_stats_fdb_used_after_add_route {}".
+                 format(new_crm_stats_route_used, new_crm_stats_route_available, crm_stats_fdb_used_after_add_route))
+
+    # Get CRM available route diff in case when FDB updated during test run
+    crm_stats_route_available = get_expected_crm_stats_route_available(crm_stats_route_available, crm_stats_fdb_used,
+                                                                       crm_stats_fdb_used_after_add_route)
 
     # Verify "crm_stats_ipv[4/6]_route_used" counter was incremented
     if not (new_crm_stats_route_used - crm_stats_route_used == total_routes):
@@ -529,8 +548,15 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     # Make sure CRM counters updated
     time.sleep(CRM_UPDATE_TIME)
 
-    # Get new "crm_stats_ipv[4/6]_route" used and available counter value
-    new_crm_stats_route_used, new_crm_stats_route_available = get_crm_stats(get_route_stats, duthost)
+    # Get new ipv[4/6]_route/fdb_entry used and available counter value
+    crm_stats = get_crm_resources_fdb_and_ip_route(duthost)
+    new_crm_stats_route_used = crm_stats['ipv{}_route'.format(ip_ver)]['used']
+    new_crm_stats_route_available = crm_stats['ipv{}_route'.format(ip_ver)]['available']
+    crm_stats_fdb_used_after_del_route = crm_stats['fdb_entry']['used']
+    # Get CRM available route diff in case when FDB updated during test run
+    crm_stats_route_available = get_expected_crm_stats_route_available(crm_stats_route_available,
+                                                                       crm_stats_fdb_used_after_add_route,
+                                                                       crm_stats_fdb_used_after_del_route)
 
     # Verify "crm_stats_ipv[4/6]_route_used" counter was decremented
     pytest_assert(new_crm_stats_route_used - crm_stats_route_used == 0,
@@ -567,8 +593,18 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         RESTORE_CMDS["wait"] = SONIC_RES_UPDATE_TIME
 
     # Verify thresholds for "IPv[4/6] route" CRM resource
-    verify_thresholds(duthost, asichost, crm_cli_res="ipv{ip_ver} route"
-                      .format(ip_ver=ip_ver), crm_cmd=get_route_stats)
+    # Get "crm_stats_ipv[4/6]_route" used and available counter value
+    get_route_stats = "{redis_cli} COUNTERS_DB HMGET \
+                            CRM:STATS crm_stats_ipv{ip_ver}_route_used \
+                            crm_stats_ipv{ip_ver}_route_available"\
+        .format(redis_cli=asichost.sonic_db_cli, ip_ver=ip_ver)
+    verify_thresholds(duthost, asichost, crm_cli_res="ipv{ip_ver} route".format(ip_ver=ip_ver), crm_cmd=get_route_stats)
+
+
+def get_expected_crm_stats_route_available(crm_stats_route_available, crm_stats_fdb_used, crm_stats_fdb_used_new):
+    fdb_entries_diff = crm_stats_fdb_used_new - crm_stats_fdb_used
+    crm_stats_route_available = crm_stats_route_available - fdb_entries_diff
+    return crm_stats_route_available
 
 
 @pytest.mark.parametrize("ip_ver,nexthop", [("4", "2.2.2.2"), ("6", "2001::1")])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Sometimes when the test case test_crm_route is running, there could be fdb leaning happen on the dut. And the resources occupied by fdb entries will cause the crm available counter to decrease because the fdb and route share the same available counter. And the fdb learning is not expected in the test. 
For example:
1. ipv4_route_used: 60, fdb_used: 10, available: 1000
2. Add 10 ipv4 routes, meanwhile 10 fdb entries are learnt for some reason
3. ipv4_route_used:70, fdb_used: 20, available: 980  <-- but the script expects 990 here because the fdb learning is not expected.

In case of this failure, we will see the assert in test log:
```
        # Verify "crm_stats_ipv[4/6]_route_available" counter was incremented 

        pytest_assert(new_crm_stats_route_available - crm_stats_route_available == 0, \ 

>           "\"crm_stats_ipv{}_route_available\" counter was not incremented".format(ip_ver)) 

E       Failed: "crm_stats_ipv4_route_available" counter was not incremented 
```

So we need to consider the fdb learning/aging in the test. 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the occasional failure of test_crm_route cause by fdb learning during the test.
#### How did you do it?
1. Instead of getting the crm counters via redis-db cli, use the command "crm show resources all" to get all the crm counters at the same time - added function get_crm_resources_fdb_and_ip_route(). 
2. And take the fdb "used" counter into account when calculating the expected available counter. 
All the changes for this fix are in - added function get_expected_crm_stats_route_available()
3. Fix the logic in test_crm_route
#### How did you verify/test it?
By automation, test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
