### PR TITLE
[DSCP Remapping] Ignore IP flags in the encapsulated packet in dscp remapping test

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -43,6 +43,7 @@ def build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac, active
     exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "id") # since src and dst changed, ID would change too
     exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "ttl") # ttl in outer packet is kept default (64)
     exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "chksum") # checksum would differ as the IP header is not the same
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "flags")  # "Don't fragment" flag may be set in the outer header
 
     return pkt, exp_tunnel_pkt
 


### PR DESCRIPTION
Change-Id: I3e0e6cd592835b0a9154f7ebf1da4673405532a3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The IP flags should be ignored when verifying encapsulated packets, because the "Don't fragment" flag may be set on some platforms, for example the Mellanox platforms, when the packet is encapsulated.
Here is a similar PR for another dualtor test: https://github.com/sonic-net/sonic-mgmt/pull/7354.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Ignore IP flags in the encapsulated packet in dscp remapping test to allow dscp remapping test pass on Mellanox platforms.
#### How did you do it?
Ignore IP flags in the exp_tunnel_pkt.
#### How did you verify/test it?
By automation, all related tests passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
