### PR TITLE
[platform_test] Fix test_tx_disable_channel failed

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -262,7 +262,7 @@ class TestSfpApi(PlatformApiTestBase):
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
             if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
-                if compliance_code == "Passive Cable":
+                if compliance_code in ["Passive Cable", "Unknown"]:
                    return False
             else:
                 compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
When SFP+CableTechnology is 'unknown' gotten by api get_transceiver_info, api tx_disable_channel will failed due to not server close connection.

tx_disable_channel error:
```
22/02/2023 22:54:59 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/azp/_work/55/s/tests/platform_tests/api/test_sfp.py", line 662, in test_tx_disable_channel
    ret = sfp.tx_disable_channel(platform_api_conn, i, all_channel_mask, False)
  File "/azp/_work/55/s/tests/common/helpers/platform_api/sfp.py", line 133, in tx_disable_channel
    return sfp_api(conn, index, 'tx_disable_channel', [channel_mask, disable])
  File "/azp/_work/55/s/tests/common/helpers/platform_api/sfp.py", line 16, in sfp_api
    resp = conn.getresponse()
  File "/usr/lib/python2.7/httplib.py", line 1178, in getresponse
    response.begin()
  File "/usr/lib/python2.7/httplib.py", line 452, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python2.7/httplib.py", line 416, in _read_status
    raise BadStatusLine("No status line received - the server has closed the connection")
BadStatusLine: No status line received - the server has closed the connection
```

#### How did you do it?
Add support for unknown type.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
