### PR TITLE
Fix for snmp_memory_load testcase for DUTs with lower CPU speed

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -109,12 +109,16 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     # Start memory stress generation
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
-                                community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    sysTotalFreeMemory_OID = "1.3.6.1.4.1.2021.4.11.0"
+    snmp_command = "snmpget -v 2c -c public {} {}".format(host_ip,sysTotalFreeMemory_OID) + "| awk '{print $4}'"
+    snmp_free_memory = localhost.shell(snmp_command)['stdout']
     mem_free = duthost.shell("grep MemFree /proc/meminfo | awk '{print $2}'")['stdout']
     mem_total = duthost.shell("grep MemTotal /proc/meminfo | awk '{print $2}'")['stdout']
     percentage = get_percentage_threshold(int(mem_total))
-    pytest_assert(CALC_DIFF(snmp_facts['ansible_sysTotalFreeMemory'], mem_free) < percentage,
+    logger.info("SNMP Free Memory: {}".format(snmp_free_memory))
+    logger.info("DUT Free Memory: {}".format(mem_free))
+    logger.info("Difference: {}".format(CALC_DIFF(int(snmp_free_memory), mem_free)))
+    pytest_assert(CALC_DIFF(int(snmp_free_memory), mem_free) < percentage,
                   "sysTotalFreeMemory differs by more than {}".format(percentage))
 
 def test_snmp_swap(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix  'snmp_memory_load' failure for DUTs with lower CPU speed.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR addresses the 'snmp_memory_load' failure for DUTs with lower CPU speed like Nokia-IXS-7215. The testcase loads the memory and gets 'snmp_facts' and memory statistics from the DUT using /proc/meminfo. But while doing so, the following is observed.

- Getting and parsing 'snmp_facts' to fetch the 'systemTotalFreeMemory' takes much longer time in DUTs with lower CPU speed.
- Getting and comparing /proc/meminfo 'MemFree' stats with snmp_facts' 'systemTotalFreeMemory' leads to too much variation - up to 70%.
- Because of this issue, 'test_snmp_memory_load' test case fails, as it is expecting only upto 4% variation.

#### How did you do it?
In the testcase, instead of using the ansible snmp_facts library, used snmpget to fetch MIB of 'systemTotalFreeMemory' only
and compare with DUT's memory statistics

#### How did you verify/test it?
Run test_snmp_memory_load on IXS-7215 DUT with M0 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
