### PR TITLE
[Voq, chassis] Fix the issue where Ethernet-Rec is considered as an interface with IP address

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -225,7 +225,7 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
         cfg_facts = asic_cfg['ansible_facts']
         cfgd_intfs = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
         cfgd_pos = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
-        eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower()]
+        eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower() and cfgd_intfs[intf] != {}]
         pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
         if port_type_a == "ethernet":
             if len(eths) != 0:
@@ -283,7 +283,7 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
             cfg_facts = asic_cfg['ansible_facts']
             cfgd_intfs = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
             cfgd_pos = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
-            eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower()]
+            eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower() and cfgd_intfs[intf] != {}]
             pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
             if len(eths) != 0:
                 if port_type_a == "ethernet":

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -584,7 +584,8 @@ def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     pos_cfg = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
     nbr_to_test = []
     if eth_cfg != {}:
-        nbr_to_test.extend(select_neighbors(eth_cfg, cfg_facts))
+        eth_ports = [intf for intf in eth_cfg if "ethernet" in intf.lower() and eth_cfg[intf] != {}]
+        nbr_to_test.extend(select_neighbors(eth_ports, cfg_facts))
 
     if pos_cfg != {}:
         nbr_to_test.extend(select_neighbors(pos_cfg, cfg_facts))
@@ -740,7 +741,7 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
         return
 
     eth_cfg = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
-    eth_ports = [intf for intf in eth_cfg]
+    eth_ports = [intf for intf in eth_cfg if "ethernet" in intf.lower() and eth_cfg[intf] != {}]
     local_port = random.choice(eth_ports)
 
     logger.info("We will test port: %s on host %s, asic %s", local_port, per_host.hostname, asic.asic_index)
@@ -927,7 +928,7 @@ def pick_ports(cfg_facts):
     if "PORTCHANNEL_INTERFACE" in cfg_facts:
         intfs.update(cfg_facts['PORTCHANNEL_INTERFACE'])
 
-    eths = [intf for intf in intfs if "ethernet" in intf.lower()]
+    eths = [intf for intf in intfs if "ethernet" in intf.lower() and intfs[intf] != {}]
     pos = [intf for intf in intfs if "portchannel" in intf.lower()]
 
     intfs_to_test = []
@@ -1159,7 +1160,7 @@ class TestGratArp(object):
             return
 
         eth_cfg = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
-        eth_ports = [intf for intf in eth_cfg]
+        eth_ports = [intf for intf in eth_cfg if "ethernet" in intf.lower() and eth_cfg[intf] != {}]
         local_port = random.choice(eth_ports)
 
         logger.info("We will test port: %s on host %s, asic %s", local_port, duthost.hostname, asic.asic_index)


### PR DESCRIPTION
### Approach
#### What is the motivation for this PR?
Fix the issue where Ethernet-Rec is considered as an interface with IP address. 

Since in VoQ chassis the Ethernet-Rec0/Rec1 interface is added to interface table, In the testcase when looking for IP interfaces this recirc interface is also added to the list -- though in this case there is no real IP address. 

#### How did you do it?
Ignore the interfaces with no IP address in INTERFACE table.

#### How did you verify/test it?
Validated the voq/test_voq_ipfwd.py (there are certain known issues which is shown as 12 Failed cases below -- will be fixed via a different PR, not related to this change)

```

================================================================================================== short test summary info ==================================================================================================
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-2-64] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-128-64] - AssertionError: Ping failed: []
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-255-1456] - AssertionError: Ping failed: []
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-2-64] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-128-64] - AssertionError: Ping failed: []
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-255-1456] - AssertionError: Ping failed: [{'ttl_exceed': False, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-2-64] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-128-64] - AssertionError: Ping failed: []
FAILED voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-255-1456] - AssertionError: Ping failed: [{'ttl_exceed': False, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[ethernet-4] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[ethernet-6] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
FAILED voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[portchannel-6] - AssertionError: Ping failed: [{'ttl_exceed': True, 'icmp_seq': u'1'}]
========================================================================================= 12 failed, **115 passed** in 1078.01 seconds ==========================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
