### PR TITLE
Skip po_update test for asic if no portchannel configured

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -75,6 +75,10 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     int_facts = asichost.interface_facts()['ansible_facts']
 
     port_channels_data = asichost.get_portchannels_and_members_in_ns(tbinfo)
+    if not port_channels_data:
+        pytest.skip(
+            "Skip test as there are no port channels on asic {} on dut {}".format(enum_frontend_asic_index, duthost))
+
     portchannel = None
     portchannel_members = None
     for portchannel in port_channels_data:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

On a multi-asic LC, there may be no portchannel present on an asic. The testcase should skip for the asic if no portchannel is configured.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/7314

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/issues/7314

#### How did you do it?
Add check for port channel presence. If no port channel configured for an asic, skip the test case.

#### How did you verify/test it?
Executed the test suite for a multi-asic LC with at least one asic without port channel on front end ports.


==================================== PASSES ====================================
________________________ test_po_update[sfd-vt2-lc0-0] _________________________
________________________ test_po_update[sfd-vt2-lc0-1] _________________________
- generated xml file: /data/tests/logs/pc/test_po_update.py::test_po_update_2023-02-26-23-45-54.xml -
INFO:root:Can not get Allure report URL. Please check logs
---------------------------- live log sessionfinish ----------------------------
23:50:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
SKIPPED [1] /data/tests/pc/test_po_update.py:73: Skip test as there are no port channels on asic 2 on dut <MultiAsicSonicHost sfd-vt2-lc0>



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
