### PR TITLE
Fix gnmi test to support t1 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -387,15 +387,6 @@ generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_upda
       - "not any(i in hwsku for i in ['2700', 'Arista-7170-64C', 'montara', 'newport'])"
 
 #######################################
-#####           gnmi              #####
-#######################################
-gnmi/test_gnmi_configdb.py:
-  skip:
-    reason: "We still have issue for config reload command, and we will enable this test after merging the fix."
-    conditions:
-    - https://github.com/sonic-net/sonic-mgmt/issues/7462
-
-#######################################
 #####           http              #####
 #######################################
 http/test_http_copy.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -341,7 +341,7 @@ ecmp/test_fgnhg.py:
 #######################################
 everflow/test_everflow_per_interface.py:
   skip:
-    reason: "Skip running on dualtor testbed/unsupported platforms or 
+    reason: "Skip running on dualtor testbed/unsupported platforms or
                   multi-asic due to https://github.com/sonic-net/sonic-buildimage/issues/11776"
     conditions_logical_operator: or
     conditions:

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -3,7 +3,7 @@ import shutil
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import GNMI_CONTAINER_NAME, apply_cert_config, create_ext_conf
+from tests.gnmi.helper import GNMI_CONTAINER_NAME, apply_cert_config, recover_cert_config, create_ext_conf
 from tests.generic_config_updater.gu_utils import create_checkpoint, rollback
 
 SETUP_ENV_CP = "test_setup_checkpoint"
@@ -128,4 +128,4 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost):
 
     # Rollback configuration
     rollback(duthost, SETUP_ENV_CP)
-    duthost.shell("systemctl restart %s" % GNMI_CONTAINER_NAME)
+    recover_cert_config(duthost)

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -40,12 +40,14 @@ def apply_cert_config(duthost):
     duthost.shell(dut_command)
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
 
+
 def recover_cert_config(duthost):
     dut_command = "docker exec %s pkill telemetry" % (GNMI_CONTAINER_NAME)
     duthost.shell(dut_command, module_ignore_errors=True)
     dut_command = "docker exec %s supervisorctl start %s" % (GNMI_CONTAINER_NAME, GNMI_PROGRAM_NAME)
     duthost.shell(dut_command)
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
+
 
 def gnmi_capabilities(duthost, localhost):
     ip = duthost.mgmt_ip

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -40,6 +40,12 @@ def apply_cert_config(duthost):
     duthost.shell(dut_command)
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
 
+def recover_cert_config(duthost):
+    dut_command = "docker exec %s pkill telemetry" % (GNMI_CONTAINER_NAME)
+    duthost.shell(dut_command, module_ignore_errors=True)
+    dut_command = "docker exec %s supervisorctl start %s" % (GNMI_CONTAINER_NAME, GNMI_PROGRAM_NAME)
+    duthost.shell(dut_command)
+    time.sleep(GNMI_SERVER_START_WAIT_TIME)
 
 def gnmi_capabilities(duthost, localhost):
     ip = duthost.mgmt_ip

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -26,7 +26,7 @@ def get_first_interface(duthost):
         return None
     admin_index = status_data[0].split().index('Admin')
     for line in status_data:
-        if "trunk" in line:
+        if "routed" not in line:
             interface_status = line.strip()
             assert len(interface_status) > 0, "Failed to read interface properties"
             sl = interface_status.split()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7462

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_gnmi_configdb.py fails and block sanity check

#### How did you do it?
Port vlan type should be trunk or portchannel, and portchannel vlan type should be routed.

#### How did you verify/test it?
Run gNMI end2end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
