### PR TITLE
[WAN SONiC]testcase to verify is-is router redistribute

### DIFF
--- a/ansible/library/isis_facts.py
+++ b/ansible/library/isis_facts.py
@@ -261,7 +261,7 @@ class IsisModule(object):
 
     def _parse_route_per_area(self, route_items):
         routes = {'ipv4': {}, 'ipv6': {}}
-        reg = r'(\s*\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d+)(\s+\d+\s+)(\S+\s+)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
+        reg = r'\s*(\d+\.\d+\.\d+\.\d+\/\d+)\s+(\d+)\s+(\S*)\s+(\d+\.\d+\.\d+\.\d+|-).*'
         regex_v4route = re.compile(reg)
         regex_v6route = re.compile(r'(\s*[0-9a-fA-F:]+\/\d+)(\s+\d+\s+)(\S+\s+)([0-9a-fA-F:\-]+)')
         for line in [item.strip() for item in route_items if item.strip()]:

--- a/tests/wan/isis/test_isis_redistribute.py
+++ b/tests/wan/isis/test_isis_redistribute.py
@@ -1,0 +1,69 @@
+import pytest
+import logging
+import functools
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+from isis_helpers import config_device_isis
+from isis_helpers import add_dev_isis_attr, del_dev_isis_attr
+from isis_helpers import DEFAULT_ISIS_INSTANCE as isis_instance
+
+MAX_LSP_LIFETIME = 1200
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('wan-com'),
+]
+
+
+@pytest.fixture(scope="function")
+def isis_setup_teardown_basic_config(isis_common_setup_teardown, request):
+    target_devices = []
+    selected_connections = isis_common_setup_teardown
+
+    config_key = "lsp_maximum_lifetime"
+    config_dict = {config_key: MAX_LSP_LIFETIME}
+    for (dut_host, _, _, _) in selected_connections:
+        add_dev_isis_attr(dut_host, config_dict)
+        target_devices.append(dut_host)
+        config_device_isis(dut_host)
+
+    def revert_isis_config(devices):
+        for device in devices:
+            del_dev_isis_attr(dut_host, [config_key])
+            config_device_isis(device)
+
+    request.addfinalizer(functools.partial(revert_isis_config, target_devices))
+
+
+def check_isis_route(duthost):
+    isis_facts = duthost.isis_facts()["ansible_facts"]['isis_facts']
+
+    if "1.1.0.0/16" in isis_facts['route'][isis_instance]['ipv4'].keys():
+        return True
+
+    return False
+
+
+def config_isis_redistribute(duthost):
+    isis_config = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router isis test' "
+        "-c 'redistribute ipv4 static level-2' "
+        "-c 'exit' "
+        "-c 'ip route 1.1.1.1 255.255.0.0 blackhole' "
+        "-c 'exit' "
+    )
+    duthost.shell(isis_config)
+
+
+def test_isis_redistribute(isis_common_setup_teardown, isis_setup_teardown_basic_config):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, _, _) = selected_connections[0]
+
+    config_isis_redistribute(dut_host)
+
+    pytest_assert(wait_until(60, 2, 0, check_isis_route, dut_host),
+                  "No route redistribute into is-is!")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Testcase to verify IS-IS route redistribute static route.
Summary:
Fixes # (issue)
N/A
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To verify IS-IS redistribute static route.
#### How did you do it?
Add new case.
#### How did you verify/test it?
Based on WAN topo to verify.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
WAN topo.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
