### PR TITLE
[SAI-PTF] Add 2 T0 port cases for AN/LT

### DIFF
--- a/tests/sai_qualify/cases_brcm_t0.py
+++ b/tests/sai_qualify/cases_brcm_t0.py
@@ -151,4 +151,6 @@ TEST_CASE = [
         "sai_tunnel_test.IPInIPTunnelEncapPipeTtlv4Inv4Test",
         "sai_tunnel_test.SviIPInIPTunnelDecapFloodv4Inv4Test",
         "sai_tunnel_test.SviIPInIPTunnelDecapFloodV6InV4Test",
+        "sai_port_test.PortAutoNegTest",
+        "sai_port_test.PortAutoNegLearnTrainingTest",
         ]


### PR DESCRIPTION
why
Add two port cases for AN/LT
For enable an/lt, add SAI cases to cover the API in this feature

How
Add two cases
- PortAutoNegTest
- PortAutoNegLearnTrainingTest

Verify
run cases on DUT

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
