### PR TITLE
[m0][bgp] Add support for m0 in bgp test to simulate both t0 and t1 scenario

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -145,7 +145,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
 
 
 @pytest.fixture(scope="module")
-def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, request, tbinfo):
+def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, request, tbinfo, topo_scenario):
     """Setup interfaces for the new BGP peers on PTF."""
 
     def _is_ipv4_address(ip_addr):
@@ -449,8 +449,13 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m0"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
         setup_func = _setup_interfaces_t1_or_t2
+    elif tbinfo["topo"]["type"] == "m0":
+        if topo_scenario == "m0_t1_scenario":
+            setup_func = _setup_interfaces_t1_or_t2
+        else:
+            setup_func = _setup_interfaces_t0_or_mx
     else:
         raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1310,8 +1310,8 @@ def pytest_generate_tests(metafunc):        # noqa E302
     asics_selected = None
     asic_fixture_name = None
 
+    tbname, tbinfo = get_tbinfo(metafunc)
     if duts_selected is None:
-        tbname, tbinfo = get_tbinfo(metafunc)
         duts_selected = [tbinfo["duts"][0]]
 
     possible_asic_enums = ["enum_asic_index", "enum_frontend_asic_index", "enum_backend_asic_index",
@@ -1416,6 +1416,12 @@ def pytest_generate_tests(metafunc):        # noqa E302
         metafunc.parametrize("enum_dut_lossy_prio", generate_priority_lists(metafunc, 'lossy'))
     if 'enum_pfc_pause_delay_test_params' in metafunc.fixturenames:
         metafunc.parametrize("enum_pfc_pause_delay_test_params", pfc_pause_delay_test_params(metafunc))
+
+    if 'topo_scenario' in metafunc.fixturenames:
+        if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
+            metafunc.parametrize('topo_scenario', ['m0_t0_scenario', 'm0_t1_scenario'], scope='module')
+        else:
+            metafunc.parametrize('topo_scenario', [None], scope='module')
 
 
 def get_autoneg_tests_data():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1421,7 +1421,7 @@ def pytest_generate_tests(metafunc):        # noqa E302
         if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
             metafunc.parametrize('topo_scenario', ['m0_t0_scenario', 'm0_t1_scenario'], scope='module')
         else:
-            metafunc.parametrize('topo_scenario', [None], scope='module')
+            metafunc.parametrize('topo_scenario', ['default'], scope='module')
 
 
 def get_autoneg_tests_data():


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In current bgp test for m0, just simulate scenario that m0 device performs like t1. But m0 is like both t1 and t0.

#### How did you do it?
Add suport for m0 in bgp test to simulate both t0 and t1 scenario

#### How did you verify/test it?
Run tests on m0 topo and t0 topo
M0 topo:
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer[testbed-m0_t0_scenario] PASSED                                                                                            [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer[testbed-m0_t1_scenario] PASSED                                                                                            [100%]
```
T0 topo:
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer[testbed-default] PASSED                                                                                            [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
