### PR TITLE
[fixbug-7582]: A new parameter is added for neighbor_vm_restore but the usage in advanceboot_neighbor_restore is not updated

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -111,18 +111,19 @@ def _neighbor_vm_recover_config(node=None, results=None):
     return results
 
 
-def neighbor_vm_restore(duthost, nbrhosts, tbinfo, result):
+def neighbor_vm_restore(duthost, nbrhosts, tbinfo, result=None):
     logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
     if vm_neighbors:
-        if result["check_item"] == "neighbor_macsec_empty":
-            unhealthy_nbrs = []
-            for name, host in nbrhosts.items():
-                if name in result["unhealthy_nbrs"]:
-                    unhealthy_nbrs.append(host)
-            parallel_run(_neighbor_vm_recover_config, (), {}, unhealthy_nbrs, timeout=300)
-            logger.debug('Results of restoring neighbor VMs: {}'.format(unhealthy_nbrs))
+        if result and "check_item" in result:
+            if result["check_item"] == "neighbor_macsec_empty":
+                unhealthy_nbrs = []
+                for name, host in nbrhosts.items():
+                    if name in result["unhealthy_nbrs"]:
+                        unhealthy_nbrs.append(host)
+                parallel_run(_neighbor_vm_recover_config, (), {}, unhealthy_nbrs, timeout=300)
+                logger.debug('Results of restoring neighbor VMs: {}'.format(unhealthy_nbrs))
         else:
             results = parallel_run(_neighbor_vm_recover_bgpd, (), {}, nbrhosts.values(), timeout=300)
             logger.debug('Results of restoring neighbor VMs: {}'.format(json.dumps(dict(results))))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix issue #7582 

#### How did you do it?
Set a default value of "None" for the new parameter

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
