### PR TITLE
Stop exabgp processes before remove PTF container (for both old and new exabgp process naming convention)

### DIFF
--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -137,10 +137,12 @@
       name: "exabgpv4:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
+    ignore_errors: true
 
   - name: Stop exabgp processes for IPv6 on PTF
     supervisorctl:
       name: "exabgpv6:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
+    ignore_errors: true
   when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -131,18 +131,67 @@
   ignore_errors: true
   delegate_to: localhost
 
-- block:
+- name: Check and stop exabgp processes on PTF
+  block:
+  - name: Check exabgp processes for IPv4 running on PTF
+    shell: "supervisorctl status exabgpv4:* | grep RUNNING | wc -l"
+    register: exabgpv4_running
+    delegate_to: "{{ ptf_host }}"
+
   - name: Stop exabgp processes for IPv4 on PTF
     supervisorctl:
       name: "exabgpv4:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
-    ignore_errors: true
+    when: exabgpv4_running.stdout|int > 0
+
+  - name: Check exabgp processes for IPv6 running on PTF
+    shell: "supervisorctl status exabgpv6:* | grep RUNNING | wc -l"
+    register: exabgpv6_running
+    delegate_to: "{{ ptf_host }}"
 
   - name: Stop exabgp processes for IPv6 on PTF
     supervisorctl:
       name: "exabgpv6:"
       state: stopped
     delegate_to: "{{ ptf_host }}"
-    ignore_errors: true
+    when: exabgpv6_running.stdout|int > 0
+
+  - name: Check and stop exabgp processes on PTF (for old naming convention)
+    block:
+    - name: Check if exabgp processes running on PTF (for old naming convention)
+      shell: "supervisorctl status | grep RUNNING | grep ^exabgp-.* | wc -l"
+      register: exabgp_running_old
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Stop exabgp processes for IPv4 on PTF (for old naming convention)
+      exabgp:
+        name: "{{ vm_item.key }}"
+        state: "stopped"
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: "{{ ptf_host }}"
+      when: exabgp_running_old.stdout|int > 0
+
+    - name: Stop exabgp processes for IPv6 on PTF (for old naming convention)
+      exabgp:
+        name: "{{ vm_item.key }}-v6"
+        state: "stopped"
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: "{{ ptf_host }}"
+      when: exabgp_running_old.stdout|int > 0
+
+  - name: Get count of exabgp processes running on PTF
+    shell: "supervisorctl status | grep RUNNING | grep ^exabgp.* | wc -l"
+    register: exabgp_running
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Verify no exabgp processes running on PTF
+    assert:
+      that: exabgp_running.stdout|int == 0
+      fail_msg: "exabgp processes are still running on PTF, please check manually"
+
   when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
While removing topo of a testbed, we have to ensure that all the `exabgp` processes are stopped before PTF container be removed:

* For old naming convention, exabgp processes are named like `exabgp-ARISTA01T0` and `exabgp-ARISTA01T0-v6`.
* For new naming convention, exabgp processes are named like `exabgpv4:exabgp-ARISTA01T0` and `exabgpv6:exabgp-ARISTA01T0-v6`.

In this PR, I added some check to ensure both type of `exabgp` processes are stopped.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Ensure all the `exabgp` processes are stopped before PTF container be removed.

#### How did you do it?

1. For the new naming convention, use ansible `supervisor` module to stop process group `exabgpv4` and `exabgpv6`.
2. For the old naming convention, use `exabgp.py` library to stop processes one by one.

#### How did you verify/test it?

Verified on both type of PTF containers.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
