### PR TITLE
Modified the test case to send v6 packet for ACL TABLE TYPE=MIRRORV6 …

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -135,11 +135,15 @@ def apply_acl_rule(rand_selected_dut, tbinfo, apply_mirror_session, ip_ver):
     BaseEverflowTest.remove_acl_rule_config(rand_selected_dut, table_name)
 
 
-def generate_testing_packet(ptfadapter, duthost, mirror_session_info, router_mac):
-    packet = testutils.simple_tcp_packet(
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
-            eth_dst=router_mac
-        )
+def generate_testing_packet(ptfadapter, duthost, mirror_session_info, router_mac, ip_ver):
+    if ip_ver == 'ipv4':
+        packet = \
+            testutils.simple_tcp_packet(eth_src=ptfadapter.dataplane.get_mac(0,
+                0), eth_dst=router_mac)
+    else:
+        packet = \
+            testutils.simple_tcpv6_packet(eth_src=ptfadapter.dataplane.get_mac(0,
+                0), eth_dst=router_mac)
     setup = {}
     setup["router_mac"] = router_mac
     exp_packet = BaseEverflowTest.get_expected_mirror_packet(mirror_session_info, setup, duthost, packet, False)
@@ -177,7 +181,7 @@ def test_everflow_per_interface(ptfadapter, rand_selected_dut, apply_acl_rule, t
     ingress from unselected ports are not captured
     """
     everflow_config = apply_acl_rule
-    packet, exp_packet = generate_testing_packet(ptfadapter, rand_selected_dut, everflow_config['mirror_session_info'], rand_selected_dut.facts["router_mac"])
+    packet, exp_packet = generate_testing_packet(ptfadapter, rand_selected_dut, everflow_config['mirror_session_info'], rand_selected_dut.facts["router_mac"], ip_ver)
     uplink_ports = get_uplink_ports(rand_selected_dut, tbinfo)
     # Verify that packet ingressed from INPUT_PORTS (candidate ports) are mirrored
     for port, ptf_idx in everflow_config['candidate_ports'].items():


### PR DESCRIPTION


Summary:
Fixes # (issue)
Modified the test case to send v6 packet for ACL TABLE TYPE=MIRRORV6 from INPUT_PORTS are mirrored
Previously script was sending v4 packet only to test both( ACL TABLE_TYPE_MIRRORV6 and MIRROR) from INPUT_PORTS

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ X] 202205

#### How did you do it?
Modified the test script and added support to send ipv6 packets

#### How did you verify/test it?
Ran test cases with the changes. test cases are passing

#### Any platform specific information?
n/a

#### Supported testbed topology if it's a new test case?
n/a

