### PR TITLE
update package fixture to module level for iface_loopback_action

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -67,7 +67,7 @@ def backup_and_restore_config_db_module(duthosts, rand_one_dut_hostname):
         yield func
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def backup_and_restore_config_db_package(duthosts):
 
     for func in _backup_and_restore_config_db(duthosts, "package"):

--- a/tests/iface_loopback_action/conftest.py
+++ b/tests/iface_loopback_action/conftest.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def orig_ports_configuration(request, duthost, ptfhost, tbinfo):
     """
     Get the ports used to do test, return the dict of the port's original vlan, portchannel, infos.
@@ -68,7 +68,7 @@ def orig_ports_configuration(request, duthost, ptfhost, tbinfo):
     yield port_dict
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def ports_configuration(orig_ports_configuration):
     """
     Define the ports parameters
@@ -181,7 +181,7 @@ def generate_ip_list():
     return dut_ip_list, ptf_ip_list
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
           backup_and_restore_config_db_package, nbrhosts, tbinfo):                # noqa: F811
     """
@@ -208,7 +208,7 @@ def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
             vm_host.no_shutdown(peer_port)
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def recover(duthost, ptfhost, ports_configuration):
     """
     restore the original configurations


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
iface_loopback_action folder was new added in #5871.
It uses package level fixture which will run the conftest before sanity check.
In ports_configuration it did some remove vlan member or portchannel member operation, which will cause the following sanity check failure obviously. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Make sanity check run before conftest of iface loopback action.

#### How did you do it?
Use module level fixture instead.

#### How did you verify/test it?
Run iface_loopback_action/test_iface_loopback_action.py without skip-sanity option

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
