### PR TITLE
Add regex for syslog timestamp in extract_log

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -150,6 +150,7 @@ def convert_date(fct, s):
 
     return dt
 
+
 def comparator(l, r):
     nl = extract_number(l[0])
     nr = extract_number(r[0])

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -116,7 +116,6 @@ def extract_number(s):
     else:
         return int(ns[0])
 
-
 def convert_date(fct, s):
     dt = None
     re_result = re.findall(r'^\S{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.?\d*', s)
@@ -137,13 +136,19 @@ def convert_date(fct, s):
         if (dt - fct).days > 183:
             dt.replace(year = dt.year - 1)
     else:
-        re_result = re.findall(r'^\d{4}-\d{2}-\d{2}\.\d{2}:\d{2}:\d{2}\.\d{6}', s)
-        str_date = re_result[0]
-        dt = datetime.datetime.strptime(str_date, '%Y-%m-%d.%X.%f')
+        re_result = re.findall(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}', s)
+        if len(re_result) > 0:
+            str_date = re_result[0]
+            str_date = str_date.replace("T", " ")
+            dt = datetime.datetime.strptime(str_date, '%Y-%m-%d %X.%f')
+        else:
+            re_result = re.findall(r'^\d{4}-\d{2}-\d{2}\.\d{2}:\d{2}:\d{2}\.\d{6}', s)
+            if len(re_result) > 0:
+                str_date = re_result[0]
+                dt = datetime.datetime.strptime(str_date, '%Y-%m-%d.%X.%f')
     locale.setlocale(locale.LC_ALL, loc)
 
     return dt
-
 
 def comparator(l, r):
     nl = extract_number(l[0])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Warm-reboot test is failing at extracting timestamp from syslog

#### How did you do it?
Add regex for this timestamp format: 2023-02-28T15:42:27.355561+00:00

#### How did you verify/test it?
Warm reboot test originally failed at preboot when parsing through syslog. Adding the regex fixed the failure.
Ran convert_date with all three formats of syslog timestamp logs
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
