### PR TITLE
Skipping ECN cases for cisco-8000 for Vlan based testbeds.

### DIFF
--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -8,6 +8,7 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
 from files.helper import run_ecn_test, is_ecn_marked
+from tests.common.ixia.common_helpers import get_vlan_subnet
 from tests.common.cisco_data import  get_markings_dut, setup_markings_dut
 from tests.ixia.ptf_utils import get_sai_attributes
 
@@ -56,6 +57,8 @@ def test_dequeue_ecn(request,
     duthost = duthosts[rand_one_dut_hostname]
     lossless_prio = int(lossless_prio)
     cisco_platform = (duthost.facts['asic_type'] == "cisco-8000")
+    if cisco_platform and get_vlan_subnet(duthost):
+        pytest.skip("ECN marking is not supported over Vlan members in cisco-8000")
 
     kmin = 50000
     kmax = 51000

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -8,6 +8,7 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
+from tests.common.ixia.common_helpers import get_vlan_subnet
 from files.helper import run_ecn_test, is_ecn_marked
 from tests.common.cisco_data import get_markings_dut, setup_markings_dut
 
@@ -64,6 +65,8 @@ def test_red_accuracy(request,
     pkt_cnt = 2100
     iters = 100
     result_file_name = 'result.txt'
+    if cisco_platform and get_vlan_subnet(duthost):
+        pytest.skip("ECN marking is not supported over Vlan members in cisco-8000")
 
     if cisco_platform:
         original_ecn_markings = get_markings_dut(duthost)


### PR DESCRIPTION
### Description of PR
Cisco-8000 doesn't support ECN marking over vlan switched packets. So we need to skip the cases for this platform.

Summary:
Skips the ECN cases for cisco-8000 platform.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

#### How did you do it?
Added skips for the platform if vlan intf is detected.

#### How did you verify/test it?
Ran it on my TB:
=========================== short test summary info ============================
SKIPPED [1] /data/tests/ixia/ecn/test_red_accuracy.py:82: ECN marking is not supported over Vlan members in cisco-8000
SKIPPED [1] /data/tests/ixia/ecn/test_dequeue_ecn.py:62: ECN marking is not supported over Vlan members in cisco-8000
========================= 2 skipped in 100.68 seconds ==========================
INFO:root:Can not get Allure report URL. Please check logs

#### Any platform specific information?
Specific to cisco-8000.