### PR TITLE
[sai_qualify]Add timeout value for sai_adhoc cmd

### DIFF
--- a/tests/common/sai_adhoc.py
+++ b/tests/common/sai_adhoc.py
@@ -49,20 +49,21 @@ def get_raw_output(ansible_cmd, param_cmd):
     return raw_output
 
 
-def run_command(host, inv_file, cmd, ignore_error=False):
+def run_command(host, inv_file, cmd, ignore_error=False, run_sec=300):
     """
     Run 'command' Ansible customized ad-hoc command
     implemented under ansible/library
     param:
         host: either DUT hostname or PTF hostname
         inv_file : inventory
-        cmd : customized command"
+        cmd : customized command
+        run_sec : running time in seconds, default is 300
     """
     results = []
     raw_output = ''
     try:
-        ansible_cmd = 'ansible -m shell -i \
-            ./ansible/{} {} -o -a'.format(inv_file, host)
+        ansible_cmd = 'ansible -B {} -m shell -i \
+            ./ansible/{} {} -o -a'.format(run_sec, inv_file, host)
 
         raw_output = get_raw_output(ansible_cmd, cmd)
         output_fields = raw_output.split('(stdout)', 1)[-1].strip()
@@ -156,6 +157,8 @@ if __name__ == '__main__':
         "-c", dest="command", type=str, help="command")
     parser.add_argument(
         "-i", dest="ignore_error", default=False, help="ignore error", action="store_true")
+    parser.add_argument(
+        "-r", dest="run_sec", type=int, default=300, help="running seconds")
 
     args = parser.parse_args()
 
@@ -167,7 +170,7 @@ if __name__ == '__main__':
         host = ptf
 
     if args.op_type == "cmd":
-        run_command(host, inv_name, args.command, args.ignore_error)
+        run_command(host, inv_name, args.command, args.ignore_error, args.run_sec)
     elif args.op_type == "copy":
         run_copy(host, inv_name, args.command, args.ignore_error)
     elif args.op_type == "fetch":

--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -205,7 +205,8 @@ def prepare_ptf_server(ptfhost, duthost, tbinfo, enum_asic_index, request):
         request: Pytest request.
     """
     if not request.config.option.sai_test_skip_setup_env:
-        update_saithrift_ptf(request, ptfhost)
+        #prepared saithrift in pipeline
+        #update_saithrift_ptf(request, ptfhost)
         __create_sai_port_map_file(
             ptfhost, duthost, tbinfo, enum_asic_index)
     yield

--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -205,8 +205,8 @@ def prepare_ptf_server(ptfhost, duthost, tbinfo, enum_asic_index, request):
         request: Pytest request.
     """
     if not request.config.option.sai_test_skip_setup_env:
-        #prepared saithrift in pipeline
-        #update_saithrift_ptf(request, ptfhost)
+        # prepared saithrift in pipeline
+        # update_saithrift_ptf(request, ptfhost)
         __create_sai_port_map_file(
             ptfhost, duthost, tbinfo, enum_asic_index)
     yield

--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -869,11 +869,13 @@ def update_saithrift_ptf(request, ptfhost):
         pytest.fail("No URL specified for python saithrift package")
     pkg_name = py_saithrift_url.split("/")[-1]
     ptfhost.shell("rm -f {}".format(pkg_name))
+    logging.info("Download Python saithrift: [{}]".format(py_saithrift_url))
     result = ptfhost.get_url(
         url=py_saithrift_url, dest="/root", module_ignore_errors=True)
     if result["failed"] or "OK" not in result["msg"]:
         pytest.fail("Download failed/error while \
-            installing python saithrift package")
+            installing python saithrift package. failed:{}. msg:{}".format(
+            result["failed"], result["msg"]))
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
     logging.info("Python saithrift package installed successfully")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### why
For sai_adhoc command(run ansible command in background), it might get the output/return after file a command, i.e. reboot. The command runs successful remotely, cause no return in that running terminal(reboot happen, reboot-terminal ternimated, ssh reconnect happen after reboot, but reboot command has no return), then cannot finish the command.

Then, we need add some timeout value for the command, and terminate it.

Combine with the ignore_error parameter, we can choice if we need to care about the errors.

#### how
Add timeout value for sai_adhoc command

#### Verify
test in testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
