### PR TITLE
assign None to platform_asic as default value when it not exist in test params

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -45,7 +45,7 @@ class ThriftInterface(BaseTest):
             self.server = self.test_params['server']
         else:
             self.server = 'localhost'
-        self.platform_asic = self.test_params['platform_asic']
+        self.platform_asic = self.test_params.get('platform_asic', None)
 
         self.asic_id = self.test_params['asic_id']
         if "port_map" in self.test_params:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

TunnelDscpToPgMapping test failure:

======================================================================
ERROR: sai_qos_tests.TunnelDscpToPgMapping
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_base_test.py\", line 145, in setUp
    ThriftInterface.setUp(self)
  File \"saitests/py3/sai_base_test.py\", line 48, in setUp
    self.platform_asic = self.test_params['platform_asic']
    KeyError: 'platform_asic'

----------------------------------------------------------------------

#### How did you do it?

assign None to platform_asic when it miss in test params

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
