### PR TITLE
[ci] Use self hosted vmss to get higher node limit.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -81,6 +82,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -91,8 +93,7 @@ stages:
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
 
   - job:
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     displayName: "kvmtest-t0"
     dependsOn:
     - t0_part1
@@ -143,6 +144,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
@@ -190,6 +192,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
@@ -222,6 +225,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
@@ -251,6 +255,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
@@ -265,6 +270,7 @@ stages:
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,6 @@ stages:
     - t0_2vlans_testbedv2
     condition: always()
     continueOnError: false
-    pool: ubuntu-20.04
     variables:
       resultOfPart1: $[ dependencies.t0_part1.result ]
       resultOfPart2: $[ dependencies.t0_part2.result ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,7 @@ stages:
     - t0_2vlans_testbedv2
     condition: always()
     continueOnError: false
+    pool: ubuntu-20.04
     variables:
       resultOfPart1: $[ dependencies.t0_part1.result ]
       resultOfPart2: $[ dependencies.t0_part2.result ]
@@ -160,6 +161,7 @@ stages:
     - t1_lag_testbedv2
     condition: always()
     continueOnError: false
+    pool: ubuntu-20.04
     variables:
       resultOfClassic: $[ dependencies.t1_lag_classic.result ]
       resultOfTestbedV2: $[ dependencies.t1_lag_testbedv2.result ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ stages:
     displayName: "pre-commit-check"
     timeoutInMinutes: 10
     continueOnError: true
+    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
sonic-mgmt uses about 10 ubuntu agent in each PR.
Ms-hosted agent pool has a max pool size 35.
Use vmss instead to reduce queue time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
