### PR TITLE
[sai_qualify] Add one switch case for check the acl_table_group resource

### DIFF
--- a/tests/sai_qualify/cases_sai_ptf.py
+++ b/tests/sai_qualify/cases_sai_ptf.py
@@ -64,6 +64,7 @@ TEST_CASE = [
         "saiswitch.AvailableNexthopGroupEntryTest",
         "saiswitch.AvailableNexthopGroupMemberEntryTest",
         "saiswitch.AvailableAclTableTest",
+        "saiswitch.AvailableAclTableGroupTest",
         "saiswitch.AvailableIPv4NexthopEntryTest",
         "saiswitch.AvailableIPv6NexthopEntryTest",
         "saiqueue.queueCreateTest",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### Why
Add one switch case for check the acl_table_group resource

#### How
Add one switch case for check the acl_table_group resource

#### Verify
Dut test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
