### PR TITLE
Change topology mark for test_snmp_default_route and test_snmp_loopback

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -7,7 +7,7 @@ except ImportError:  # python2
     from pipes import quote
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The topology mark should not include 'ptf'.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
-- test_snmp_default_route.py
The original topology mark is 'any', but there is no default route in the 'ptf' topology. 
-- test_snmp_loopback.py
Use "nbrhosts" module to get the VM information.
But it will cause the error if the topology does not have VM(ex: ptf32).
#### How did you verify/test it?
Can skip two test cases on ptf32 topology.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
