### PR TITLE
[202012][dualtor] Remove the redundant function definition

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -424,33 +424,6 @@ def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux
         pytest_assert(False, "Failed to toggle all ports to {} from mux simulator".format(target_dut_hostname))
 
 
-def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux_server_url, tbinfo):
-    """Helper function to toggle all ports to active on the target DUT."""
-    logging.info("Toggling mux cable to {}".format(target_dut_hostname))
-    duthost = duthosts[target_dut_hostname]
-    dut_index = tbinfo['duts'].index(target_dut_hostname)
-    if dut_index == 0:
-        data = {"active_side": UPPER_TOR}
-    else:
-        data = {"active_side": LOWER_TOR}
-
-    # Allow retry for mux cable toggling
-    is_toggle_done = False
-    for attempt in range(1, 4):
-        logger.info('attempt={}, toggle active side of all muxcables to {} from mux simulator'.format(
-            attempt,
-            data['active_side']
-        ))
-        _post(mux_server_url, data)
-        time.sleep(5)
-        if _are_muxcables_active(duthost):
-            is_toggle_done = True
-            break
-
-    if not is_toggle_done and not utilities.wait_until(60, 10, 0, _are_muxcables_active, duthost):        
-        pytest_assert(False, "Failed to toggle all ports to {} from mux simulator".format(target_dut_hostname))
-
-
 @pytest.fixture
 def toggle_all_simulator_ports_to_rand_selected_tor(duthosts, mux_server_url, tbinfo, rand_one_dut_hostname):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
in 202012 branch, there is an extra definition of function: _toggle_all_simulator_ports_to_target_dut. Which should be caused by the cherry-pick conflict resolvement.
Let's remove it.

Signed-off-by: Longxiang Lyu [lolv@microsoft.com](mailto:lolv@microsoft.com)

#### How did you do it?
Remove the deprecated second definition.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
