### PR TITLE
Fix key Error in tunnel qos test

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -446,6 +446,7 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
             "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
             "port_map_file": dut_config["port_map_file"],
             "sonic_asic_type": dut_config["asic_type"],
+            "platform_asic": dut_config["platform_asic"],
             "cell_size": cell_size
         })
     
@@ -482,6 +483,7 @@ def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_
             "standby_tor_ip": dut_config["unselected_tor_loopback"],
             "server": dut_config["selected_tor_mgmt"],
             "port_map_file": dut_config["port_map_file"],
+            "platform_asic": dut_config["platform_asic"],
             "sonic_asic_type": dut_config["asic_type"],
         })
     # Update qos config into test_params

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -136,6 +136,7 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     asic_type = duthost.facts["asic_type"]
+    platform_asic = duthost.facts['platform_asic']
     # Always use the first portchannel member
     lag_port_name = list(mg_facts['minigraph_portchannels'].values())[0]['members'][0]
     lag_port_ptf_id = mg_facts['minigraph_ptf_indices'][lag_port_name]
@@ -157,6 +158,7 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
 
     return {
         "asic_type": asic_type,
+        "platform_asic": platform_asic,
         "lag_port_name": lag_port_name,
         "lag_port_ptf_id": lag_port_ptf_id,
         "server_port_name": server_port_name,

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -47,7 +47,7 @@ class ThriftInterface(BaseTest):
             self.server = 'localhost'
         self.platform_asic = self.test_params.get('platform_asic', None)
 
-        self.asic_id = self.test_params['asic_id']
+        self.asic_id = self.test_params.get('asic_id', None)
         if "port_map" in self.test_params:
             user_input = self.test_params['port_map']
             splitted_map = user_input.split(",")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix key Error
```
Traceback (most recent call last):
  File \"saitests/py3/sai_base_test.py\", line 145, in setUp
  ThriftInterface.setUp(self)
  File \"saitests/py3/sai_base_test.py\", line 50, in setUp
  self.asic_id = self.test_params['asic_id']
  KeyError: 'asic_id'
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix key Error introduced by #7079

#### How did you do it?
1. Add `platform_asic` in arguments (not necessary after PR #7606
2. Assign `None` to `asic_id` if absent.

#### How did you verify/test it?
Verified on a dualtor testbed.

#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
