### PR TITLE
Exclude sku-sensors-data from the creds fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -640,6 +640,7 @@ def creds_on_dut(duthost):
         r'breakout_speed\.yml',
         r'lag_fanout_ports_test_vars\.yml',
         r'qos\.yml',
+        r'sku-sensors-data\.yml',
         r'mux_simulator_http_port_map\.yml'
         ]
     files = glob.glob("../ansible/group_vars/all/*.yml")
@@ -1710,6 +1711,7 @@ def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
         rtn_dict['basicParams']["platform_asic"] = duthost.facts['platform_asic']
 
     yield rtn_dict
+
 
 @pytest.fixture(scope='module')
 def duts_minigraph_facts(duthosts, tbinfo):

--- a/tests/platform_tests/test_sensors.py
+++ b/tests/platform_tests/test_sensors.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import os
 import pytest
+import yaml
 
 from tests.common.helpers.assertions import pytest_assert
 
@@ -8,10 +10,20 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+SENSORS_DATA_FILE = "../../ansible/group_vars/sonic/sku-sensors-data.yml"
+
+
 def to_json(obj):
     return json.dumps(obj, indent=4)
 
-def test_sensors(duthosts, rand_one_dut_hostname, creds):
+
+@pytest.fixture(scope='module')
+def sensors_data():
+    sensors_data_file_fullpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), SENSORS_DATA_FILE)
+    return yaml.safe_load(open(sensors_data_file_fullpath).read())
+
+
+def test_sensors(duthosts, rand_one_dut_hostname, sensors_data):
     duthost = duthosts[rand_one_dut_hostname]
     # Get platform name
     platform = duthost.facts['platform']
@@ -36,7 +48,7 @@ def test_sensors(duthosts, rand_one_dut_hostname, creds):
             platform = platform.strip('-respined') + '-swb-respined'
 
     # Prepare check list
-    sensors_checks = creds['sensors_checks']
+    sensors_checks = sensors_data['sensors_checks']
 
     if platform not in sensors_checks.keys():
         pytest.skip("Skip test due to not support check sensors for current platform({})".format(platform))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The test_sensors.py script is using the creds fixture to get sku sensors data. This make the creds fixture floated because `sku-sensors-data.yml` is a big file. It does not make sense to include sensors data in a fixture for getting credentials.

#### How did you do it?
This change removed the sensors data from the creds fixture. For the `test_sensors.py` script, updated it to directly read sensors data from file `sku-sensors-data.yml`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
