### PR TITLE
[202205][everflow][m0] Add support for m0 in everflow to simulate both t0 and t1 #7618

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -452,7 +452,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
-        if topo_scenario == "m0_t1_scenario":
+        if topo_scenario == "m0_l3_scenario":
             setup_func = _setup_interfaces_t1_or_t2
         else:
             setup_func = _setup_interfaces_t0_or_mx

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -12,7 +12,9 @@ UPSTREAM_NEIGHBOR_MAP = {
     "t1": "t2",
     "m0": "m1",
     "mx": "m0",
-    "t2": "t3"
+    "t2": "t3",
+    "m0_t0": "m1",
+    "m0_t1": "m1"
 }
 # Describe downstream neighbor of dut in different topos
 DOWNSTREAM_NEIGHBOR_MAP = {
@@ -20,5 +22,7 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "t1": "t0",
     "m0": "mx",
     "mx": "server",
-    "t2": "t1"
+    "t2": "t1",
+    "m0_t0": "server",
+    "m0_t1": "mx"
 }

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -13,8 +13,8 @@ UPSTREAM_NEIGHBOR_MAP = {
     "m0": "m1",
     "mx": "m0",
     "t2": "t3",
-    "m0_t0": "m1",
-    "m0_t1": "m1"
+    "m0_vlan": "m1",
+    "m0_l3": "m1"
 }
 # Describe downstream neighbor of dut in different topos
 DOWNSTREAM_NEIGHBOR_MAP = {
@@ -23,6 +23,6 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "m0": "mx",
     "mx": "server",
     "t2": "t1",
-    "m0_t0": "server",
-    "m0_t1": "mx"
+    "m0_vlan": "server",
+    "m0_l3": "mx"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1342,7 +1342,7 @@ def pytest_generate_tests(metafunc):
 
     if 'topo_scenario' in metafunc.fixturenames:
         if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
-            metafunc.parametrize('topo_scenario', ['m0_t0_scenario', 'm0_t1_scenario'], scope='module')
+            metafunc.parametrize('topo_scenario', ['m0_vlan_scenario', 'm0_l3_scenario'], scope='module')
         else:
             metafunc.parametrize('topo_scenario', ['default'], scope='module')
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -46,7 +46,7 @@ VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
 # Topo that downstream neighbor of DUT are servers
-DOWNSTREAM_SERVER_TOPO = ["t0", "m0_t0"]
+DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
 
 def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
@@ -79,7 +79,7 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scena
 
     topo_type = tbinfo["topo"]["type"]
     if topo_type == "m0":
-        topo_type = "m0_t0" if "m0_t0_scenario" in topo_scenario else "m0_t1"
+        topo_type = "m0_vlan" if "m0_vlan_scenario" in topo_scenario else "m0_l3"
     # Get the list of T0/T2 ports
     for mg_facts in mg_facts_list:
         for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
@@ -376,7 +376,7 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_arp_responder(duthost, ptfhost, setup_info):
-    if setup_info['topo'] not in ['t0', 'm0_t0']:
+    if setup_info['topo'] not in ['t0', 'm0_vlan']:
         yield
         return
     ip_list = [TARGET_SERVER_IP, DEFAULT_SERVER_IP]

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -46,10 +46,10 @@ VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
 # Topo that downstream neighbor of DUT are servers
-DOWNSTREAM_SERVER_TOPO = ["t0"]
+DOWNSTREAM_SERVER_TOPO = ["t0", "m0_t0"]
 
 
-def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo):
+def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
     """
     Generate setup information dictionary for T0 and T1/ T2 topologies.
     """
@@ -78,6 +78,8 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo):
         upstream_acl_capability_facts = upStreamDutHost.acl_capabilities_facts()["ansible_facts"]
 
     topo_type = tbinfo["topo"]["type"]
+    if topo_type == "m0":
+        topo_type = "m0_t0" if "m0_t0_scenario" in topo_scenario else "m0_t1"
     # Get the list of T0/T2 ports
     for mg_facts in mg_facts_list:
         for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
@@ -296,7 +298,7 @@ def get_t2_duthost(duthosts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
+def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     """
     Gather all required test information.
 
@@ -314,8 +316,8 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request):
     elif 't2' in topo:
         pytest_assert(len(duthosts) > 1, "Test must run on whole chassis")
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
-        
-    setup_information = gen_setup_information(downstream_duthost, upstream_duthost, tbinfo)
+
+    setup_information = gen_setup_information(downstream_duthost, upstream_duthost, tbinfo, topo_scenario)
 
     # Disable BGP so that we don't keep on bouncing back mirror packets
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
@@ -374,7 +376,7 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_arp_responder(duthost, ptfhost, setup_info):
-    if setup_info['topo'] != 't0':
+    if setup_info['topo'] not in ['t0', 'm0_t0']:
         yield
         return
     ip_list = [TARGET_SERVER_IP, DEFAULT_SERVER_IP]

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -37,7 +37,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         Setup the route for mirror session destination ip and update monitor port list.
         Remove the route as part of cleanup.
         """
-        if setup_info['topo'] in ['t0', 'm0_t0']:
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             # On T0 testbed, the collector IP is routed to T1
             namespace = setup_info[UP_STREAM]['remote_namespace']
             tx_port = setup_info[UP_STREAM]["dest_port"][0]
@@ -64,7 +64,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
     
     @pytest.fixture(scope='class')
     def everflow_dut(self, setup_info):
-        if setup_info['topo'] in ['t0', 'm0_t0']:
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             dut = setup_info[UP_STREAM]['everflow_dut']
         else:
             dut = setup_info[DOWN_STREAM]['everflow_dut']
@@ -73,7 +73,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='class')
     def everflow_direction(self, setup_info):
-        if setup_info['topo'] in ['t0', 'm0_t0']:
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             direction = UP_STREAM
         else:
             direction = DOWN_STREAM
@@ -553,7 +553,7 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
     @pytest.fixture(scope='class',  autouse=True)
     def setup_acl_table(self, setup_info, setup_mirror_session, config_method):
 
-        if setup_info['topo'] in ['t0', 'm0_t0']:
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             everflow_dut = setup_info[UP_STREAM]['everflow_dut']
             remote_dut = setup_info[UP_STREAM]['remote_dut']
         else:

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -37,7 +37,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         Setup the route for mirror session destination ip and update monitor port list.
         Remove the route as part of cleanup.
         """
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_t0']:
             # On T0 testbed, the collector IP is routed to T1
             namespace = setup_info[UP_STREAM]['remote_namespace']
             tx_port = setup_info[UP_STREAM]["dest_port"][0]
@@ -64,7 +64,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
     
     @pytest.fixture(scope='class')
     def everflow_dut(self, setup_info):
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_t0']:
             dut = setup_info[UP_STREAM]['everflow_dut']
         else:
             dut = setup_info[DOWN_STREAM]['everflow_dut']
@@ -73,7 +73,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='class')
     def everflow_direction(self, setup_info):
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_t0']:
             direction = UP_STREAM
         else:
             direction = DOWN_STREAM
@@ -553,7 +553,7 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
     @pytest.fixture(scope='class',  autouse=True)
     def setup_acl_table(self, setup_info, setup_mirror_session, config_method):
 
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_t0']:
             everflow_dut = setup_info[UP_STREAM]['everflow_dut']
             remote_dut = setup_info[UP_STREAM]['remote_dut']
         else:

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -496,7 +496,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             if vendorAsic in hostvars.keys() and everflow_dut.facts['hwsku'] in hostvars[vendorAsic]:
                 pytest.skip("Skipping test since mirror policing is not supported on {0} {1} platforms".format(vendor, asic))
 
-        if setup_info['topo'] in ['t0', 'm0_t0']:
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             default_tarffic_port_type = dest_port_type
             # Use the second portchannel as missor session nexthop
             tx_port = setup_info[dest_port_type]["dest_port"][1]
@@ -520,7 +520,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             bind_interface_namespace = setup_info[dest_port_type]["everflow_namespace"]
             rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            if setup_info['topo'] in ['t0', 'm0_t0'] and self.acl_stage() == "egress":
+            if setup_info['topo'] in ['t0', 'm0_vlan'] and self.acl_stage() == "egress":
                 # For T0 upstream, the EVERFLOW_DSCP table is binded to one of portchannels
                 bind_interface = setup_info[dest_port_type]["dest_port_lag_name"][0]
                 mirror_port_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
@@ -574,7 +574,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         tx_port_ids = self._get_tx_port_id_list(tx_ports)
         target_ip = "30.0.0.10"
         default_ip = self.DEFAULT_DST_IP
-        if setup['topo'] in ['t0', 'm0_t0'] and direction == DOWN_STREAM:
+        if setup['topo'] in ['t0', 'm0_vlan'] and direction == DOWN_STREAM:
             target_ip = TARGET_SERVER_IP
             default_ip = DEFAULT_SERVER_IP
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -496,7 +496,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             if vendorAsic in hostvars.keys() and everflow_dut.facts['hwsku'] in hostvars[vendorAsic]:
                 pytest.skip("Skipping test since mirror policing is not supported on {0} {1} platforms".format(vendor, asic))
 
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_t0']:
             default_tarffic_port_type = dest_port_type
             # Use the second portchannel as missor session nexthop
             tx_port = setup_info[dest_port_type]["dest_port"][1]
@@ -520,7 +520,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             bind_interface_namespace = setup_info[dest_port_type]["everflow_namespace"]
             rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            if setup_info['topo'] == 't0' and self.acl_stage() == "egress":
+            if setup_info['topo'] in ['t0', 'm0_t0'] and self.acl_stage() == "egress":
                 # For T0 upstream, the EVERFLOW_DSCP table is binded to one of portchannels
                 bind_interface = setup_info[dest_port_type]["dest_port_lag_name"][0]
                 mirror_port_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
@@ -574,7 +574,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         tx_port_ids = self._get_tx_port_id_list(tx_ports)
         target_ip = "30.0.0.10"
         default_ip = self.DEFAULT_DST_IP
-        if 't0' == setup['topo'] and direction == DOWN_STREAM:
+        if setup['topo'] in ['t0', 'm0_t0'] and direction == DOWN_STREAM:
             target_ip = TARGET_SERVER_IP
             default_ip = DEFAULT_SERVER_IP
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/7618
In current everflow test for m0, just simulate scenario that m0 device performs like t1. But m0 is like both t1 and t0.

#### How did you do it?
Add support for m0 in everflow test to simulate both t0 and t1 scenario

#### How did you verify/test it?
Run tests on m0 topo and t0 topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
