### PR TITLE
Restore linkmgrd prober interval in dualtor after test in 202205

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1343,35 +1343,24 @@ def remove_static_routes(duthost, route_dst):
     duthost.shell('ip route del {}/{}'.format(str(route_dst), subnet_mask_len), module_ignore_errors=True)
 
 
-def increase_linkmgrd_probe_interval(duthosts, tbinfo):
+def recover_linkmgrd_probe_interval(duthosts, tbinfo):
     '''
-    Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
+    Recover the linkmgrd probe interval to default value
     '''
-    if 'dualtor' not in tbinfo['topo']['name']:
-        return
-
-    probe_interval_ms = 1000
-
-    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
-
-    cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                    .format(probe_interval_ms))
-    cmds.append("config save -y")
-    duthosts.shell_cmds(cmds=cmds)
+    default_probe_interval_ms = 100
+    update_linkmgrd_probe_interval(duthosts, tbinfo, default_probe_interval_ms)
 
 
 def update_linkmgrd_probe_interval(duthosts, tbinfo, probe_interval_ms):
     '''
-    Temporarily modify linkmgrd probe interval
+    Update the linkmgrd probe interval
     '''
     if 'dualtor' not in tbinfo['topo']['name']:
         return
 
-    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
-    cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'.format(probe_interval_ms))
-    duthosts.shell_cmds(cmds=cmds)
+    logger.info("Update linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
+    duthosts.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                   .format(probe_interval_ms))
 
 
 @pytest.fixture(scope='module')

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 
 from tests.common import constants
 from tests.common.helpers.assertions import pytest_assert as pt_assert
-from tests.common.dualtor.dual_tor_utils import increase_linkmgrd_probe_interval
+from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval, recover_linkmgrd_probe_interval
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ ICMP_RESPONDER_CONF_TEMPL = "icmp_responder.conf.j2"
 GARP_SERVICE_PY = 'garp_service.py'
 GARP_SERVICE_CONF_TEMPL = 'garp_service.conf.j2'
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
+PROBER_INTERVAL_MS = 1000
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -232,7 +233,8 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     global icmp_responder_session_started
 
-    increase_linkmgrd_probe_interval(duthosts, tbinfo)
+    update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
+    duthosts.shell("config save -y")
 
     duthost = duthosts[0]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -279,7 +281,8 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
         yield
         return
 
-    increase_linkmgrd_probe_interval(duthosts, tbinfo)
+    update_linkmgrd_probe_interval(duthosts, tbinfo, PROBER_INTERVAL_MS)
+    duthosts.shell("config save -y")
 
     duthost = duthosts[rand_one_dut_hostname]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
@@ -305,6 +308,9 @@ def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request
 
     logging.info("Stop running icmp_responder")
     ptfhost.shell("supervisorctl stop icmp_responder")
+    logging.info("Recover linkmgrd probe interval")
+    recover_linkmgrd_probe_interval(duthosts, tbinfo)
+    duthosts.shell("config save -y")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1734,7 +1734,7 @@ def __dut_reload(duts_data, node=None, results=None):
     config_reload(node)
 
 @pytest.fixture(scope="module", autouse=True)
-def core_dump_and_config_check(duthosts, request):
+def core_dump_and_config_check(duthosts, tbinfo, request):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.
     If so, we will reload the running config after test case running.
@@ -1828,12 +1828,17 @@ def core_dump_and_config_check(duthosts, request):
             EXCLUDE_CONFIG_TABLE_NAMES = set([])
             # The keys that we don't care
             # Current skipped keys:
-            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder` fixture to account for the lower performance of the ICMP responder/mux simulator
-            #    compared to real servers and mux cables. It's appropriate to persist this change since the testbed will always be using the ICMP responder
-            #    and mux simulator. Linkmgrd is the only service to consume this table so it should not affect other test cases.
-            EXCLUDE_CONFIG_KEY_NAMES = [
-                'MUX_LINKMGR|LINK_PROBER'
-            ]
+            # 1. "MUX_LINKMGR" table is edited by the `run_icmp_responder_session` fixture in dualtor-mixed 
+            # to account for the lower performance of the ICMP responder/mux simulator, 
+            # compared to real servers and mux cables. It's appropriate to persist this change 
+            # since the testbed will always be using the ICMP responder and mux simulator. 
+            # Linkmgrd is the only service to consume this table so it should not affect other test cases.
+            if "mixed" in tbinfo["topo"]["name"]:
+                EXCLUDE_CONFIG_KEY_NAMES = [
+                    'MUX_LINKMGR|LINK_PROBER'
+                ]
+            else:
+                EXCLUDE_CONFIG_KEY_NAMES = []
 
             def _remove_entry(table_name, key_name, config):
                 if table_name in config and key_name in config[table_name]:

--- a/tests/dualtor/test_toggle_mux.py
+++ b/tests/dualtor/test_toggle_mux.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
-from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval
+from tests.common.dualtor.dual_tor_utils import recover_linkmgrd_probe_interval, update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until
 
 
@@ -13,8 +13,6 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
-
-DEFAUL_INTERVAL_V4 = 100
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -45,7 +43,7 @@ def get_interval_v4(duthosts):
 def reset_link_prober_interval_v4(duthosts, get_interval_v4, tbinfo):
     cur_interval_v4 = get_interval_v4
     if cur_interval_v4 is not None:
-        update_linkmgrd_probe_interval(duthosts, tbinfo, DEFAUL_INTERVAL_V4)
+        recover_linkmgrd_probe_interval(duthosts, tbinfo)
 
     # NOTE: as there is no icmp_responder running, the device is stucked in consistently probing
     # the mux status. If there is a previous case that has fixture run_icmp_responder called, the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fixture run_icmp_responder(scope="module") will increase linkmgrd_probe_interval to 1s to reduce performance expectations and improve consistency, but won't restore after test. When we reload config during sanity check(will use golden config) in one side of dualtor, that will cause different configurations between two tors.
#### How did you do it?
Restore linkmgrd_probe_interval after teardown, remove ignore linkmgrd_probe_interval check.
Dualtor-mixed will always run icmp responder, so don't need to restore at present, also need to keep ignore linkmgrd_probe_interval check in dualtor-mixed, since increase linkmgrd_probe_interval will run before sanity check, if sanity check fail, linkmgrd_probe_interval will recover to default value
PR in master: https://github.com/sonic-net/sonic-mgmt/pull/7417
Have some merge conflicts, so create a separate PR for 202205
#### How did you verify/test it?
Check running config and configdb during/after test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
