### PR TITLE
[DualTor][Mellanox]Fix dualtor mac move test for Mellanox platforms

### DIFF
--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -139,10 +139,12 @@ def test_mac_move(
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
 
     # active forwarding check after fdb ageout/flush
-    tor.shell("fdbclear")
-    server_traffic_monitor = ServerTrafficMonitor(
-        tor, ptfhost, vmhost, tbinfo, test_port,
-        conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
-    )
-    with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
-        testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
+    # skip Mellanox platforms for the traffic will be flooded in the vlan when there is no fdb entries
+    if not tor.facts['asic_type'] == 'mellanox':
+        tor.shell("fdbclear")
+        server_traffic_monitor = ServerTrafficMonitor(
+            tor, ptfhost, vmhost, tbinfo, test_port,
+            conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
+        )
+        with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
+            testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)


### PR DESCRIPTION
Change-Id: Ibb6edfe552d0623f297c65301bcbc61465786fb6

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the test test_orchagent_mac_move.py, the last check is to verify after fdb is flushed, the traffic to the new neighbor should be dropped due to no fdb entry of the neighbor in the Vlan. However, on Mellanox platforms, the behavior is flooding the traffic instead of dropping it, which will cause the check to fail.
Since this is a valid behavior on Mellanox switches, need to skip this check in this case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Make test test_orchagent_mac_move.py pass on Mellanox platforms.
#### How did you do it?
Skip the the check on active tor after fdb is flushed on Mellanox platforms.
#### How did you verify/test it?
By automation, test passed.
#### Any platform specific information?
The fix is only for Mellanox platforms.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
