### PR TITLE
Fix test_voq_intfs

### DIFF
--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -42,7 +42,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     intf_config_facts = duthost.config_facts(source='persistent',
                                              asic_index=intf_asic.asic_index)['ansible_facts']
     portchannel = intf_config_facts['PORTCHANNEL'].keys()[0]
-    portchannel_members = intf_config_facts['PORTCHANNEL'][portchannel].get('members')
+    portchannel_members = intf_config_facts['PORTCHANNEL_MEMBER'][portchannel].keys()
     portchannel_ips = [x.split("/")[0].lower() for x in intf_config_facts['PORTCHANNEL_INTERFACE'][portchannel].keys()]
     bgp_nbrs_to_portchannel = []
     for a_bgp_neighbor in intf_config_facts['BGP_NEIGHBOR']:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

With https://github.com/sonic-net/sonic-buildimage/pull/14028,  lag members are not added in PORTCHANNEL table in config_db anymore. Fix Fix test_voq_intfs to retrieve lag members from PORTCHANNEL_MEMBER table.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
