### PR TITLE
[202205][dualtor_io][active-active] increase wait_until timeout for rebooting active-active dualtor DUT #7602

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -41,7 +41,8 @@ DB_CHECK_FIELD_MAP = {
 
 class DBChecker:
 
-    def __init__(self, duthost, state, health, intf_names='all', cable_type=CableType.default_type):
+    def __init__(self, duthost, state, health, intf_names='all',
+                 cable_type=CableType.default_type, verify_db_timeout=30):
         """
         Create a DBChecker object
         Args:
@@ -62,6 +63,7 @@ class DBChecker:
         self.cable_type = cable_type
         self._parse_intf_names()
         self.mismatch_ports = {}
+        self.VERIFY_DB_TIMEOUT = verify_db_timeout
 
     def _dump_db(self, db, key_pattern):
         """Dump redis database matching specificied key pattern"""
@@ -74,7 +76,7 @@ class DBChecker:
 
     def verify_db(self, db):
         pytest_assert(
-            wait_until(30, 10, 0, self.get_mismatched_ports, db),
+            wait_until(self.VERIFY_DB_TIMEOUT, 10, 0, self.get_mismatched_ports, db),
             "Database states don't match expected state {state},"
             "incorrect {db_name} values {db_states}"
             .format(state=self.state, db_name=DB_NAME_MAP[db],
@@ -142,7 +144,8 @@ class DBChecker:
 def verify_tor_states(
     expected_active_host, expected_standby_host,
     expected_standby_health='healthy', intf_names='all',
-    cable_type=CableType.default_type, skip_state_db=False
+    cable_type=CableType.default_type, skip_state_db=False,
+    verify_db_timeout=30
 ):
     """
     Verifies that the expected states for active and standby ToRs are
@@ -150,26 +153,34 @@ def verify_tor_states(
     """
     if isinstance(expected_active_host, collections.Iterable):
         for duthost in expected_active_host:
-            db_checker = DBChecker(duthost, 'active', 'healthy', intf_names=intf_names, cable_type=cable_type)
+            db_checker = DBChecker(duthost, 'active', 'healthy',
+                                   intf_names=intf_names, cable_type=cable_type,
+                                   verify_db_timeout=verify_db_timeout)
             db_checker.verify_db(APP_DB)
             if not skip_state_db:
                 db_checker.verify_db(STATE_DB)
     elif expected_active_host is not None:
         duthost = expected_active_host
-        db_checker = DBChecker(duthost, 'active', 'healthy', intf_names=intf_names, cable_type=cable_type)
+        db_checker = DBChecker(duthost, 'active', 'healthy',
+                               intf_names=intf_names, cable_type=cable_type,
+                               verify_db_timeout=verify_db_timeout)
         db_checker.verify_db(APP_DB)
         if not skip_state_db:
             db_checker.verify_db(STATE_DB)
 
     if isinstance(expected_standby_host, collections.Iterable):
         for duthost in expected_standby_host:
-            db_checker = DBChecker(duthost, 'standby', expected_standby_health, intf_names=intf_names, cable_type=cable_type)
+            db_checker = DBChecker(duthost, 'standby', expected_standby_health,
+                                   intf_names=intf_names, cable_type=cable_type,
+                                   verify_db_timeout=verify_db_timeout)
             db_checker.verify_db(APP_DB)
             if not skip_state_db:
                 db_checker.verify_db(STATE_DB)
     elif expected_standby_host is not None:
         duthost = expected_standby_host
-        db_checker = DBChecker(duthost, 'standby', expected_standby_health, intf_names=intf_names, cable_type=cable_type)
+        db_checker = DBChecker(duthost, 'standby', expected_standby_health,
+                               intf_names=intf_names, cable_type=cable_type,
+                               verify_db_timeout=verify_db_timeout)
         db_checker.verify_db(APP_DB)
         if not skip_state_db:
             db_checker.verify_db(STATE_DB)

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -78,8 +78,9 @@ def test_active_tor_reboot_upstream(
         verify_tor_states(
             expected_active_host=[upper_tor_host, lower_tor_host],
             expected_standby_host=None,
-            cable_type=cable_type
-    )
+            cable_type=cable_type,
+            verify_db_timeout=60
+        )
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Cherry-pick conflict: 

ea58ddeae       Jing Zhang      Fri Mar 3 15:52:44 2023 -0800   [dualtor_io][active-active] increase `wait_until` timeout for rebooting active-active dualtor DUT (#7602)

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
