### PR TITLE
Skip both empty line and also new line in the output of portstat.

### DIFF
--- a/tests/common/portstat_utilities.py
+++ b/tests/common/portstat_utilities.py
@@ -66,7 +66,7 @@ def parse_portstat(content_lines):
 
     results = {}
     for line in content_lines[separation_line_number+1:reminder_line_number]:
-        if line == '\n': # skip empty line
+        if not line.strip(): # skip empty line or newline
             continue
         portstats = []
         for pos in positions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

https://github.com/sonic-net/sonic-mgmt/issues/7560 was closed with https://github.com/sonic-net/sonic-mgmt/pull/7537. However, we still observed the the issue in our testing even with https://github.com/sonic-net/sonic-mgmt/pull/7537.  The fix in https://github.com/sonic-net/sonic-mgmt/pull/7537 is incomplete because it only skips new line, but fails to skip empty line. Fix the issue in this PR to skip both new line and empty line.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
