### PR TITLE
Revert "[cacl]Run cacl test case on one dut per hwsku (#7617)"

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -210,7 +210,7 @@
       </IPInterfaces>
       <DataAcls/>
       <AclInterfaces>
-{% if switch_type is not defined or switch_type != 'dpu' %}
+{% if card_type is not defined or card_type != 'supervisor' %}
         <AclInterface>
           <InAcl>NTP_ACL</InAcl>
           <AttachTo>NTP</AttachTo>
@@ -222,12 +222,6 @@
           <Type>SNMP</Type>
         </AclInterface>
         <AclInterface>
-          <AttachTo>VTY_LINE</AttachTo>
-          <InAcl>ssh-only</InAcl>
-          <Type>SSH</Type>
-        </AclInterface>
-{% if card_type is not defined or card_type != 'supervisor' %}
-        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
@@ -237,7 +231,12 @@
           <InAcl>EverflowV6</InAcl>
           <Type>EverflowV6</Type>
         </AclInterface>
-{% if enable_data_plane_acl|default('true')|bool and vm_topo_config['topo_type'] != 'wan' %}
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+{% if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>
           <AttachTo>
 {%- set acl_intfs = [] -%}

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -21,10 +21,10 @@ SONIC_SSH_PORT  = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds):
+def test_cacl_function(duthosts, rand_one_dut_hostname, localhost, creds):
     """Test control plane ACL functionality on a SONiC device"""
 
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     dut_mgmt_ip = duthost.mgmt_ip
 
     # Start an NTP client

--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -17,7 +17,7 @@ def generate_expected_rules(duthost):
     return ebtables_rules
 
 
-def test_ebtables_application(duthosts, enum_rand_one_per_hwsku_hostname, enum_asic_index):
+def test_ebtables_application(duthosts, rand_one_dut_hostname, enum_asic_index):
     """
     Test case to ensure ebtables rules are applied are corectly on DUT during init
 
@@ -25,7 +25,7 @@ def test_ebtables_application(duthosts, enum_rand_one_per_hwsku_hostname, enum_a
     rules based on the DuT's configuration and comparing them against the
     actual ebtables rules on the DuT.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     expected_ebtables_rules = generate_expected_rules(duthost)
 
     stdout = duthost.asic_instance(enum_asic_index).command("sudo ebtables -L FORWARD")["stdout"]


### PR DESCRIPTION
This reverts commit 90b6ef1170e8b8eafe212f91aee0dba7a0818ac2.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revert #7617 on 202205 branch, since it import an syntax error in minigraph jinja template.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Revert #7617 on 202205 branch, since it import an syntax error in minigraph jinja template.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
