### PR TITLE
[202205][cacl]Run cacl test case on one dut per hwsku (#7617)

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -210,7 +210,6 @@
       </IPInterfaces>
       <DataAcls/>
       <AclInterfaces>
-{% if card_type is not defined or card_type != 'supervisor' %}
         <AclInterface>
           <InAcl>NTP_ACL</InAcl>
           <AttachTo>NTP</AttachTo>
@@ -222,6 +221,12 @@
           <Type>SNMP</Type>
         </AclInterface>
         <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+{% if card_type is not defined or card_type != 'supervisor' %}
+        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
@@ -230,11 +235,6 @@
           <AttachTo>ERSPANV6</AttachTo>
           <InAcl>EverflowV6</InAcl>
           <Type>EverflowV6</Type>
-        </AclInterface>
-        <AclInterface>
-          <AttachTo>VTY_LINE</AttachTo>
-          <InAcl>ssh-only</InAcl>
-          <Type>SSH</Type>
         </AclInterface>
 {% if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -21,10 +21,10 @@ SONIC_SSH_PORT  = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def test_cacl_function(duthosts, rand_one_dut_hostname, localhost, creds):
+def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds):
     """Test control plane ACL functionality on a SONiC device"""
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dut_mgmt_ip = duthost.mgmt_ip
 
     # Start an NTP client

--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -17,7 +17,7 @@ def generate_expected_rules(duthost):
     return ebtables_rules
 
 
-def test_ebtables_application(duthosts, rand_one_dut_hostname, enum_asic_index):
+def test_ebtables_application(duthosts, enum_rand_one_per_hwsku_hostname, enum_asic_index):
     """
     Test case to ensure ebtables rules are applied are corectly on DUT during init
 
@@ -25,7 +25,7 @@ def test_ebtables_application(duthosts, rand_one_dut_hostname, enum_asic_index):
     rules based on the DuT's configuration and comparing them against the
     actual ebtables rules on the DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     expected_ebtables_rules = generate_expected_rules(duthost)
 
     stdout = duthost.asic_instance(enum_asic_index).command("sudo ebtables -L FORWARD")["stdout"]


### PR DESCRIPTION
What is the motivation for this PR?
cherry-pick of PR https://github.com/sonic-net/sonic-mgmt/pull/7617
Failure seen on test_cacl_function when run on Chasiss Supervisor, works fine on Linecard. This is because the Supervisor does not have SNMP/SSH ACL table, so when the ACLs are loaded in the test case, they don't take effect and ssh to Sup does not stop. Test fails with error:
Failed: SSH port did not stop. Timeout when waiting for <ip> to stop. Failure seen on test_ebtables_application when run on Chassis testbed with different HwSKU with different number of asics. The test case uses rand_one_dut_hostname and enum_asic_index. The rand_one_dut_hostname selects a random dut of the testbed but enum_asic_index is generated based on the first DUT of the testbed. This causes a mismatch between the dut that is selected and asic_index. This causes test case to fail with below error: expected_ebtables_rules = generate_expected_rules(duthost)
>       stdout = duthost.asic_instance(enum_asic_index).command("sudo ebtables -L FORWARD")["stdout"]
E       AttributeError: 'NoneType' object has no attribute 'command'
How did you do it?
For error 1, add SNMP/SSH/NTP acl table in Supervisor minigraph.
Update test_cacl_function to run on one dut per hwsku so that it runs on sup and required linecards.
For error 2, update test_ebtables test to run one dut per hwsku so that it runs on sup and required linecards.

How did you verify/test it?
Both tests are passing on Chassis testbed.
Before minigraph change:
sup-1:/etc/sonic$ show acl table
Name    Type    Binding    Description    Stage
------  ------  ---------  -------------  -------
After minigraph change:
sup-1:/etc/sonic$ show acl table
Name      Type       Binding    Description    Stage
--------  ---------  ---------  -------------  -------
NTP_ACL   CTRLPLANE  NTP        NTP_ACL        ingress
SNMP_ACL  CTRLPLANE  SNMP       SNMP_ACL       ingress
SSH_ONLY  CTRLPLANE  SSH        SSH_ONLY       ingress

(cherry picked from commit 1eb048bb3f3193233950973e5db756cfc1459dbb)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
