### PR TITLE
New T0 LAG topo with 8 uplinks (2 ports per LAG)

### DIFF
--- a/ansible/roles/eos/templates/t0-8-lag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-8-lag-leaf.j2
@@ -1,0 +1,138 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 2
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/vars/topo_t0-8-lag.yml
+++ b/ansible/vars/topo_t0-8-lag.yml
@@ -76,7 +76,7 @@ topology:
           prefix: 192.168.0.1/22
           prefix_v6: fc02:100::1/64
           tag: 100
-        Vlan200: 
+        Vlan200:
           id: 200
           intfs: [1, 3, 12, 13, 14, 15, 16, 17, 18, 19, 28, 30]
           prefix: 192.168.4.1/22
@@ -245,7 +245,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.33/24
       ipv6: fc0a::21/64
-  
+
   ARISTA06T1:
     properties:
     - common
@@ -269,7 +269,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.34/24
       ipv6: fc0a::22/64
-  
+
   ARISTA07T1:
     properties:
     - common
@@ -293,7 +293,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.35/24
       ipv6: fc0a::23/64
-  
+
   ARISTA08T1:
     properties:
     - common

--- a/ansible/vars/topo_t0-8-lag.yml
+++ b/ansible/vars/topo_t0-8-lag.yml
@@ -1,0 +1,319 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 28
+    - 29
+    - 30
+    - 31
+  disabled_host_interfaces:
+    - 0
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 6
+        - 7
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 8
+        - 9
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 22
+        - 23
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 24
+        - 25
+      vm_offset: 3
+    ARISTA05T1:
+      vlans:
+        - 4
+        - 5
+      vm_offset: 4
+    ARISTA06T1:
+      vlans:
+        - 10
+        - 11
+      vm_offset: 5
+    ARISTA07T1:
+      vlans:
+        - 20
+        - 21
+      vm_offset: 6
+    ARISTA08T1:
+      vlans:
+        - 26
+        - 27
+      vm_offset: 7
+  DUT:
+    vlan_configs:
+      default_vlan_config: two_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [1, 2, 3, 12, 13, 14, 15, 16, 17, 18, 19, 28, 29, 30, 31]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [2, 29, 31]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200: 
+          id: 200
+          intfs: [1, 3, 12, 13, 14, 15, 16, 17, 18, 19, 28, 30]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:200::1/64
+          tag: 200
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1]
+          prefix: 192.168.0.1/23
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan2000:
+          id: 2000
+          intfs: [2, 3]
+          prefix: 192.168.2.1/23
+          prefix_v6: fc02:401::1/64
+          tag: 2000
+        Vlan3000:
+          id: 3000
+          intfs: [12, 13]
+          prefix: 192.168.4.1/23
+          prefix_v6: fc02:402::1/64
+          tag: 3000
+        Vlan4000:
+          id: 4000
+          intfs: [14, 15]
+          prefix: 192.168.6.1/23
+          prefix_v6: fc02:403::1/64
+          tag: 4000
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64
+
+  ARISTA05T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.64
+        - FC00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::21/64
+  
+  ARISTA06T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.66
+        - FC00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+    bp_interface:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::22/64
+  
+  ARISTA07T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.68
+        - FC00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+    bp_interface:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::23/64
+  
+  ARISTA08T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.70
+        - FC00::8D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126
+    bp_interface:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::24/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: New T0 LAG topo (2 links per LAG) template with 8 up links (LAGs). 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
We need to deploy a new T0 LAG topology with 8 up links (LAGs) in the lab - 2 ports per LAG.   

#### How did you do it?
Created a new T0 topo yml file, as well as a leaf template for the 8 EOS uplinks. 

#### How did you verify/test it?
Ran add-topo successfully on a Mellanox SN2700 using ceos, and all 8 uplinks come up with bgp connections paired successfully. 

```
admin@str2-msn2700-spy-1:~$ show int st 

     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin             Type    Asym PFC 

--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  ---------------  ---------- 

     Ethernet0          0,1,2,3     100G   9100     rs     etp1          routed    down     down  QSFP28 or later         off 

     Ethernet4          4,5,6,7     100G   9100     rs     etp2           trunk      up       up  QSFP28 or later         off 

     Ethernet8        8,9,10,11     100G   9100     rs     etp3           trunk      up       up  QSFP28 or later         off 

    Ethernet12      12,13,14,15     100G   9100     rs     etp4           trunk      up       up  QSFP28 or later         off 

    Ethernet16      16,17,18,19     100G   9100     rs     etp5  PortChannel105      up       up  QSFP28 or later         off 

    Ethernet20      20,21,22,23     100G   9100     rs     etp6  PortChannel105      up       up  QSFP28 or later         off 

    Ethernet24      24,25,26,27     100G   9100     rs     etp7  PortChannel101      up       up  QSFP28 or later         off 

    Ethernet28      28,29,30,31     100G   9100     rs     etp8  PortChannel101      up       up  QSFP28 or later         off 

    Ethernet32      32,33,34,35     100G   9100     rs     etp9  PortChannel102      up       up  QSFP28 or later         off 

    Ethernet36      36,37,38,39     100G   9100     rs    etp10  PortChannel102      up       up  QSFP28 or later         off 

    Ethernet40      40,41,42,43     100G   9100     rs    etp11  PortChannel106      up       up  QSFP28 or later         off 

    Ethernet44      44,45,46,47     100G   9100     rs    etp12  PortChannel106      up       up  QSFP28 or later         off 

    Ethernet48      48,49,50,51     100G   9100     rs    etp13           trunk      up       up  QSFP28 or later         off 

    Ethernet52      52,53,54,55     100G   9100     rs    etp14           trunk      up       up  QSFP28 or later         off 

    Ethernet56      56,57,58,59     100G   9100     rs    etp15           trunk      up       up  QSFP28 or later         off 

    Ethernet60      60,61,62,63     100G   9100     rs    etp16           trunk      up       up  QSFP28 or later         off 

    Ethernet64      64,65,66,67     100G   9100     rs    etp17           trunk      up       up  QSFP28 or later         off 

    Ethernet68      68,69,70,71     100G   9100     rs    etp18           trunk      up       up  QSFP28 or later         off 

    Ethernet72      72,73,74,75     100G   9100     rs    etp19           trunk      up       up  QSFP28 or later         off 

    Ethernet76      76,77,78,79     100G   9100     rs    etp20           trunk      up       up  QSFP28 or later         off 

    Ethernet80      80,81,82,83     100G   9100     rs    etp21  PortChannel107      up       up  QSFP28 or later         off 

    Ethernet84      84,85,86,87     100G   9100     rs    etp22  PortChannel107      up       up  QSFP28 or later         off 

    Ethernet88      88,89,90,91     100G   9100     rs    etp23  PortChannel103      up       up  QSFP28 or later         off 

    Ethernet92      92,93,94,95     100G   9100     rs    etp24  PortChannel103      up       up  QSFP28 or later         off 

    Ethernet96      96,97,98,99     100G   9100     rs    etp25  PortChannel104      up       up  QSFP28 or later         off 

   Ethernet100  100,101,102,103     100G   9100     rs    etp26  PortChannel104      up       up  QSFP28 or later         off 

   Ethernet104  104,105,106,107     100G   9100     rs    etp27  PortChannel108      up       up  QSFP28 or later         off 

   Ethernet108  108,109,110,111     100G   9100     rs    etp28  PortChannel108      up       up  QSFP28 or later         off 

   Ethernet112  112,113,114,115     100G   9100     rs    etp29           trunk      up       up  QSFP28 or later         off 

   Ethernet116  116,117,118,119     100G   9100     rs    etp30           trunk      up       up  QSFP28 or later         off 

   Ethernet120  120,121,122,123     100G   9100     rs    etp31           trunk      up       up  QSFP28 or later         off 

   Ethernet124  124,125,126,127     100G   9100     rs    etp32           trunk      up       up  QSFP28 or later         off 

PortChannel101              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel102              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel103              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel104              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel105              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel106              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel107              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 

PortChannel108              N/A     200G   9100    N/A      N/A          routed      up       up              N/A         N/A 
```
```
admin@str2-msn2700-spy-1:~$ show ip bgp sum 

  

IPv4 Unicast Summary: 

BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0 

BGP table version 12777 

RIB entries 12817, using 2358328 bytes of memory 

Peers 8, using 5926464 KiB of memory 

Peer groups 4, using 256 bytes of memory 

  

  

Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName 

-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  -------------- 

10.0.0.57      4  64600       3210       3220         0      0       0  00:03:58             6400  ARISTA01T1 

10.0.0.59      4  64601       3194       3218         0      0       0  00:03:59             6368  ARISTA02T1 

10.0.0.61      4  64602       3192       3215         0      0       0  00:03:52             6368  ARISTA03T1 

10.0.0.63      4  64603       3192       3218         0      0       0  00:03:58             6368  ARISTA04T1 

10.0.0.65      4  64604       3192       3215         0      0       0  00:03:50             6368  ARISTA05T1 

10.0.0.67      4  64605       3192       3215         0      0       0  00:03:50             6368  ARISTA06T1 

10.0.0.69      4  64606       3192       3215         0      0       0  00:03:48             6368  ARISTA07T1 

10.0.0.71      4  64607       3194       3220         0      0       0  00:03:53             6368  ARISTA08T1 

  

Total number of neighbors 8 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
