### PR TITLE
Use normal reload before force reload in the core_dump_and_config_check function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1838,7 +1838,7 @@ def __dut_reload(duts_data, node=None, results=None):
             node.copy(src=asic_cfg_file, dest='/etc/sonic/config_db{}.json'.format(asic_index), verbose=False)
             os.remove(asic_cfg_file)
 
-    config_reload(node)
+    config_reload(node, wait_before_force_reload=300)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -2043,7 +2043,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             }
             logger.warning("Core dump or config check failed for {}, results: {}"
                            .format(module_name, json.dumps(check_result)))
-            results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=300)
+            results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)
             logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
         else:
             logger.info("Core dump and config check passed for {}".format(module_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Previously community added a new fixture to check core dumps and compare the config_db.json before and after the test. If there is core dump or config change during the test, a force reload will be performed at the teardown phase. However, sometimes the force reload is executed when the system is not ready, for example,  some test will do warm-reboot, and the test finishes before the warm-reboot is totally completed. In this case, the force reload during the warm-reboot process could cause some problems and the system may take very long time to fully restore, which will affect the following tests. I add a new logic in the config_reload method to support wait before performing the force reload, and use this logic in the core_dump_and_config_check.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To fix the issue cause by the reload in the teardown config check. 
#### How did you do it?
I add a logic in the config_reload() in tests/common/config_reload.py, when doing the config reload from config db, firstly try the normal config reload command 'config reload -y &>/dev/null', if some reload/reboot process is not finished, the command will fail and no new reload is executed. Use the wait_until() function to repeatedly try this until timeout(I use 300s here, should be enough for any reboot/reload process to complete). 
If the normal reload doesn't work during timeout, still execute the force reload.
#### How did you verify/test it?
This has been running in our internal regression for more than 2 weeks, it is working well.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
