### PR TITLE
Set Cisco IOS ISIS metric-style to wide to align with FRR default set…

### DIFF
--- a/tests/wan/isis/template/iosxr_isis_config.j2
+++ b/tests/wan/isis/template/iosxr_isis_config.j2
@@ -7,8 +7,10 @@ router isis {{ isis_instance }}
 {% endif %}
  is-type level-2-only
  address-family ipv4 unicast
+ metric-style wide
  !
  address-family ipv6 unicast
+ metric-style wide
  !
 {% if isis_intfs is defined %}
 {% for name in isis_intfs %}


### PR DESCRIPTION
…tings

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
Set Cisco ISIS metro style configuration to wide
-->
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We build Cisco IOS <> SONiC connectivity and notice Cisco's ISIS metric-style is narrow by default and wide on FRR side.
Use consistent settings on both ends.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
