### PR TITLE
[system_health] Add support for check_system_health_info both old and new format

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -134,8 +134,11 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
                 # use wait_until to check if SYSTEM_HEALTH_INFO has expected content
                 # avoid waiting for too long or DEFAULT_INTERVAL is not long enough to refresh db
                 category = '{}:{}'.format(container, critical_process)
-                expected_value = "Process '{}' in container '{}' is not running".format(critical_process, container)
-                result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, category, expected_value)
+                expected_values = ["Process '{}' in container '{}' is not running".format(critical_process, container),
+                                   "'{}' is not running".format(critical_process)]
+                result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info_any_of, duthost, category,
+                                    expected_values)
+
                 assert result == True, '{} is not recorded'.format(critical_process)
                 summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
                 assert summary == SUMMARY_NOT_OK, 'Expect summary {}, got {}'.format(SUMMARY_NOT_OK, summary)
@@ -364,6 +367,14 @@ def redis_get_system_health_info(duthost, db_id, key):
     cmd = 'redis-cli --raw -n {} HGETALL \"{}\"'.format(db_id, key)
     output = duthost.shell(cmd)['stdout'].strip()
     return output
+
+def check_system_health_info_any_of(duthost, category, expected_values):
+    value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, category)
+    for expected_value in expected_values:
+        if value == expected_value:
+            return True
+
+    return False
 
 def check_system_health_info(duthost, category, expected_value):
     value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, category)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test failed introduced by this PR https://github.com/sonic-net/sonic-buildimage/pull/13497 has been fixed by this PR https://github.com/sonic-net/sonic-mgmt/pull/7649. But in DUT with old image, it will failed.

#### How did you do it?
Add support for check_system_health_info to support both two formats

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
