### PR TITLE
Fix import issue in wan/isis/test_authentication.py

### DIFF
--- a/tests/wan/isis/conftest.py
+++ b/tests/wan/isis/conftest.py
@@ -23,12 +23,6 @@ def get_target_dut_port(mg_facts, dut_intf):
     return dut_port
 
 
-def get_dut_port_p2p(mg_facts, dut_port):
-    for p2p in mg_facts['minigraph_portchannel_interfaces']:
-        if p2p['attachto'] == dut_port:
-            return (p2p['subnet'], p2p['peer_addr'])
-
-
 def parse_vm_vlan_port(vlan):
     if isinstance(vlan, int):
         dut_index = 0

--- a/tests/wan/isis/test_isis_authentication.py
+++ b/tests/wan/isis/test_isis_authentication.py
@@ -9,7 +9,6 @@ from isis_helpers import config_sonic_isis
 from isis_helpers import config_nbr_isis
 from isis_helpers import remove_nbr_isis_config
 from isis_helpers import remove_sonic_isis_config
-from conftest import get_dut_port_p2p
 from isis_helpers import get_nbr_name
 
 DOCUMENTATION = '''
@@ -25,6 +24,12 @@ pytestmark = [
 
 ITF_AUTH_PASSWRD = 'itf_auth'
 AREA_AUTH_PASSWRD = 'area_auth'
+
+
+def get_dut_port_p2p(mg_facts, dut_port):
+    for p2p in mg_facts['minigraph_portchannel_interfaces']:
+        if p2p['attachto'] == dut_port:
+            return (p2p['subnet'], p2p['peer_addr'])
 
 
 def test_isis_no_auth(isis_common_setup_teardown, nbrhosts, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Script wan/isis/test_authentication.py tries to import a function like below:
```
from conftest import get_dut_port_p2p
```

This caused issue when we try to run pretests in run_tests.sh: ImportError while importing test module '/azp/_work/23/s/tests/wan/isis/test_isis_authentication.py'. Hint: make sure your test modules/packages have valid Python names. Traceback:
wan/isis/test_isis_authentication.py:12: in <module>
    from conftest import get_dut_port_p2p
E   ImportError: cannot import name get_dut_port_p2p

#### How did you do it?
Since function get_dut_port_p2p is only used by this script, moved its definition from wan/isis/conftest into the script itself to unblock other tests.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
