### PR TITLE
Update PortAlias mapping for Cisco-8101-O32, Cisco-8101-O8C48 and Cisco-8101-C64 hwsku

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -240,6 +240,22 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Cisco-8101-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
+        elif hwsku == "Cisco-8101-O32":
+            for i in range(0, 32):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
+        elif hwsku == "Cisco-8101-O8C48":
+            for i in range(0, 12):
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % (i*4*2)
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % ((i*4*2) + 4)
+            for i in range(12, 20):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
+            for i in range(20, 32):
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % ((i*4*2)
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % ((i*4*2) + 4)
+        elif hwsku == "Cisco-8101-C64":
+            for i in range(0, 32):
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % (i*4*2)
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % ((i*4*2) + 4)
         elif hwsku in ["8800-LC-48H-O"]:
             for i in range(0, 48, 1):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % (i * 4)


### PR DESCRIPTION

### Description of PR
This PR takes care of PortAlias name mapping for Cisco-8101-O32, Cisco-8101-O8C48 and Cisco-8101-C64 hwsku with breakout as per sonic-port-name.md


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Update the PortAlias mapping for breakout ports as per the sonic port name convention

#### How did you verify/test it?

Run the python script with the same logic to create the name mapping

#### Any platform specific information?

No

