### PR TITLE
[Snappi] Modified pfcwd tests to add warm-up traffic

### DIFF
--- a/tests/common/snappi/common_helpers.py
+++ b/tests/common/snappi/common_helpers.py
@@ -679,3 +679,8 @@ def get_ipv6_addrs_in_subnet(subnet, number_of_ip):
         ipv6_list.append(str(address))
 
     return ipv6_list
+
+
+def sec_to_nanosec(secs):
+    """ Convert seconds to nanoseconds """
+    return secs * 1e9

--- a/tests/snappi/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_basic_helper.py
@@ -8,7 +8,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
 from tests.common.snappi.snappi_helpers import get_dut_port_id
 from tests.common.snappi.common_helpers import pfc_class_enable_vector,\
     get_pfcwd_poll_interval, get_pfcwd_detect_time, get_pfcwd_restore_time,\
-    enable_packet_aging, start_pfcwd
+    enable_packet_aging, start_pfcwd, sec_to_nanosec
 from tests.common.snappi.port import select_ports, select_tx_port
 from tests.common.snappi.snappi_helpers import wait_for_arp
 
@@ -70,8 +70,8 @@ def run_pfcwd_basic_test(api,
     detect_time_sec = get_pfcwd_detect_time(host_ans=duthost, intf=dut_port) / 1000.0
     restore_time_sec = get_pfcwd_restore_time(host_ans=duthost, intf=dut_port) / 1000.0
 
-    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
-    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd
+    fake alerts caused by idle links (non-incremented packet counters) during pfcwd detection periods """
     warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
     warm_up_traffic_delay_sec = 0
 
@@ -129,11 +129,6 @@ def run_pfcwd_basic_test(api,
                      data_flow_name_list=[DATA_FLOW1_NAME, DATA_FLOW2_NAME],
                      data_flow_min_loss_rate_list=[flow1_min_loss_rate, 0],
                      data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0])
-
-
-def sec_to_nanosec(secs):
-    """ Convert seconds to nanoseconds """
-    return secs * 1e9
 
 
 def __gen_traffic(testbed_config,
@@ -283,7 +278,7 @@ def __run_traffic(api, config, all_flow_names, exp_dur_sec):
 
     logger.info('Wait for Arp to Resolve ...')
     wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
-    
+
     logger.info('Starting transmit on all flows ...')
     ts = api.transmit_state()
     ts.state = ts.START

--- a/tests/snappi/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi.snappi_helpers import get_dut_port_id
 from tests.common.snappi.common_helpers import pfc_class_enable_vector,\
     get_pfcwd_poll_interval, get_pfcwd_detect_time, get_pfcwd_restore_time,\
-    enable_packet_aging, start_pfcwd
+    enable_packet_aging, start_pfcwd, sec_to_nanosec
 from tests.common.snappi.port import select_ports, select_tx_port
 from tests.common.snappi.snappi_helpers import wait_for_arp
 
@@ -70,8 +70,8 @@ def run_pfcwd_burst_storm_test(api,
     pause_flow_dur_sec = poll_interval_sec * 0.5
     pause_flow_gap_sec = burst_cycle_sec - pause_flow_dur_sec
 
-    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
-    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd
+    fake alerts caused by idle links (non-incremented packet counters) during pfcwd detection periods """
     warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
     warm_up_traffic_delay_sec = 0
 
@@ -102,11 +102,6 @@ def run_pfcwd_burst_storm_test(api,
     __verify_results(rows=flow_stats,
                      data_flow_prefix=DATA_FLOW_PREFIX,
                      pause_flow_prefix=PAUSE_FLOW_PREFIX)
-
-
-def sec_to_nanosec(secs):
-    """ Convert seconds to nanoseconds """
-    return secs * 1e9
 
 
 def __gen_traffic(testbed_config,

--- a/tests/snappi/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -13,7 +13,9 @@ from tests.common.snappi.snappi_helpers import wait_for_arp
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_PREFIX = "Pause Storm"
+WARM_UP_TRAFFIC_NAME = "Warm Up Traffic"
 DATA_FLOW_PREFIX = "Data Flow"
+WARM_UP_TRAFFIC_DUR = 1
 BURST_EVENTS = 15
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
@@ -68,6 +70,11 @@ def run_pfcwd_burst_storm_test(api,
     pause_flow_dur_sec = poll_interval_sec * 0.5
     pause_flow_gap_sec = burst_cycle_sec - pause_flow_dur_sec
 
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
+    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+    warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
+    warm_up_traffic_delay_sec = 0
+
     __gen_traffic(testbed_config=testbed_config,
                   port_config_list=port_config_list,
                   port_id=port_id,
@@ -75,8 +82,9 @@ def run_pfcwd_burst_storm_test(api,
                   pause_flow_dur_sec=pause_flow_dur_sec,
                   pause_flow_count=BURST_EVENTS,
                   pause_flow_gap_sec=pause_flow_gap_sec,
-                  data_flow_prefix=DATA_FLOW_PREFIX,
-                  data_flow_dur_sec=data_flow_dur_sec,
+                  data_flow_prefix_list=[WARM_UP_TRAFFIC_NAME, DATA_FLOW_PREFIX],
+                  data_flow_delay_sec_list=[warm_up_traffic_delay_sec, WARM_UP_TRAFFIC_DUR],
+                  data_flow_dur_sec_list=[warm_up_traffic_dur_sec, data_flow_dur_sec],
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_list=prio_list,
                   prio_dscp_map=prio_dscp_map)
@@ -96,7 +104,9 @@ def run_pfcwd_burst_storm_test(api,
                      pause_flow_prefix=PAUSE_FLOW_PREFIX)
 
 
-sec_to_nanosec = lambda x : x * 1e9
+def sec_to_nanosec(secs):
+    """ Convert seconds to nanoseconds """
+    return secs * 1e9
 
 
 def __gen_traffic(testbed_config,
@@ -106,8 +116,9 @@ def __gen_traffic(testbed_config,
                   pause_flow_count,
                   pause_flow_dur_sec,
                   pause_flow_gap_sec,
-                  data_flow_prefix,
-                  data_flow_dur_sec,
+                  data_flow_prefix_list,
+                  data_flow_delay_sec_list,
+                  data_flow_dur_sec_list,
                   data_pkt_size,
                   prio_list,
                   prio_dscp_map):
@@ -122,8 +133,9 @@ def __gen_traffic(testbed_config,
         pause_flow_count (int): number of PFC pause storms
         pause_flow_dur_sec (float): duration of each PFC pause storm
         pause_flow_gap_sec (float): gap between PFC pause storms
-        data_flow_prefix (str): prefix of names of data flows
-        data_flow_dur_sec (int): duration of all the data flows
+        data_flow_prefix_list (list): list of prefixes of names of data flows
+        data_flow_delay_sec_list (list): list of data flow start delays in second
+        data_flow_dur_sec_list (list): list of durations of all the data flows
         data_pkt_size (int): data packet size in bytes
         prio_list (list): priorities to generate PFC storms and data traffic
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
@@ -157,32 +169,38 @@ def __gen_traffic(testbed_config,
     tx_port_name = testbed_config.ports[tx_port_id].name
     rx_port_name = testbed_config.ports[rx_port_id].name
 
-    for prio in prio_list:
-        data_flow = testbed_config.flows.flow(
-            name='{} Prio {}'.format(data_flow_prefix, prio))[-1]
+    """ For each data flow """
+    for i in range(len(data_flow_prefix_list)):
 
-        data_flow.tx_rx.port.tx_name = tx_port_name
-        data_flow.tx_rx.port.rx_name = rx_port_name
+        """ For each priority """
+        for prio in prio_list:
+            data_flow = testbed_config.flows.flow(
+                name='{} Prio {}'.format(data_flow_prefix_list[i], prio))[-1]
 
-        eth, ipv4 = data_flow.packet.ethernet().ipv4()
-        eth.src.value = tx_mac
-        eth.dst.value = rx_mac
-        eth.pfc_queue.value = prio
+            data_flow.tx_rx.port.tx_name = tx_port_name
+            data_flow.tx_rx.port.rx_name = rx_port_name
 
-        ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = rx_port_config.ip
-        ipv4.priority.choice = ipv4.priority.DSCP
-        ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
-        ipv4.priority.dscp.ecn.value = (
-            ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
+            eth, ipv4 = data_flow.packet.ethernet().ipv4()
+            eth.src.value = tx_mac
+            eth.dst.value = rx_mac
+            eth.pfc_queue.value = prio
 
-        data_flow.size.fixed = data_pkt_size
-        data_flow.rate.percentage = data_flow_rate_percent
-        data_flow.duration.fixed_seconds.seconds = data_flow_dur_sec
-        data_flow.duration.fixed_seconds.delay.nanoseconds = 0
+            ipv4.src.value = tx_port_config.ip
+            ipv4.dst.value = rx_port_config.ip
+            ipv4.priority.choice = ipv4.priority.DSCP
+            ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
+            ipv4.priority.dscp.ecn.value = (
+                ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
 
-        data_flow.metrics.enable = True
-        data_flow.metrics.loss = True
+            data_flow.size.fixed = data_pkt_size
+            data_flow.rate.percentage = data_flow_rate_percent
+            data_flow.duration.fixed_seconds.seconds = (
+                data_flow_dur_sec_list[i])
+            data_flow.duration.fixed_seconds.delay.nanoseconds = int(
+                sec_to_nanosec(data_flow_delay_sec_list[i]))
+
+            data_flow.metrics.enable = True
+            data_flow.metrics.loss = True
 
     """ Generate a series of PFC storms """
     speed_str = testbed_config.layer1[0].speed
@@ -220,7 +238,7 @@ def __gen_traffic(testbed_config,
         pause_pkt.pause_class_6.value = pause_time[6]
         pause_pkt.pause_class_7.value = pause_time[7]
 
-        pause_flow_start_time = id * (pause_flow_dur_sec + pause_flow_gap_sec)
+        pause_flow_start_time = id * (pause_flow_dur_sec + pause_flow_gap_sec) + WARM_UP_TRAFFIC_DUR
 
         pause_flow.rate.pps = pause_pps
         pause_flow.size.fixed = 64

--- a/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_multi_node_helper.py
@@ -14,10 +14,12 @@ from tests.common.snappi.snappi_helpers import wait_for_arp
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
+WARM_UP_TRAFFIC_NAME = "Warm Up Traffic"
 TEST_FLOW_NAME = 'Test Flow'
 TEST_FLOW_AGGR_RATE_PERCENT = 45
 BG_FLOW_NAME = 'Background Flow'
 BG_FLOW_AGGR_RATE_PERCENT = 45
+WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
@@ -143,6 +145,11 @@ def run_pfcwd_multi_node_test(api,
                      asic_type=asic_type)
 
 
+def sec_to_nanosec(secs):
+    """ Convert seconds to nanoseconds """
+    return secs * 1e9
+
+
 def __data_flow_name(name_prefix, src_id, dst_id, prio):
     """
     Generate name for a data flow
@@ -232,6 +239,29 @@ def __gen_traffic(testbed_config,
         N/A
     """
 
+    tx_port_id_list, rx_port_id_list = select_ports(port_config_list=port_config_list,
+                                                    pattern=traffic_pattern,
+                                                    rx_port_id=port_id)
+
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
+    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+    warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
+    warm_up_traffic_delay_sec = 0
+    warm_up_traffic_prio_list = test_flow_prio_list
+    warm_up_traffic_rate_percent = test_flow_rate_percent
+
+    __gen_data_flows(testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     src_port_id_list=tx_port_id_list,
+                     dst_port_id_list=rx_port_id_list,
+                     flow_name_prefix=WARM_UP_TRAFFIC_NAME,
+                     flow_prio_list=warm_up_traffic_prio_list,
+                     flow_rate_percent=warm_up_traffic_rate_percent,
+                     flow_dur_sec=warm_up_traffic_dur_sec,
+                     flow_delay_sec=warm_up_traffic_delay_sec,
+                     data_pkt_size=data_pkt_size,
+                     prio_dscp_map=prio_dscp_map)
+
     """ Generate a PFC pause storm """
     pause_port_id = port_id
     __gen_pause_flow(testbed_config=testbed_config,
@@ -239,11 +269,8 @@ def __gen_traffic(testbed_config,
                      src_port_id=pause_port_id,
                      flow_name=pause_flow_name,
                      pause_prio_list=pause_prio_list,
-                     flow_dur_sec=pfc_storm_dur_sec)
-
-    tx_port_id_list, rx_port_id_list = select_ports(port_config_list=port_config_list,
-                                                    pattern=traffic_pattern,
-                                                    rx_port_id=port_id)
+                     flow_dur_sec=pfc_storm_dur_sec,
+                     flow_delay_sec=WARM_UP_TRAFFIC_DUR)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -253,6 +280,7 @@ def __gen_traffic(testbed_config,
                      flow_prio_list=test_flow_prio_list,
                      flow_rate_percent=test_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
+                     flow_delay_sec=WARM_UP_TRAFFIC_DUR,
                      data_pkt_size=data_pkt_size,
                      prio_dscp_map=prio_dscp_map)
 
@@ -264,6 +292,7 @@ def __gen_traffic(testbed_config,
                      flow_prio_list=bg_flow_prio_list,
                      flow_rate_percent=bg_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
+                     flow_delay_sec=WARM_UP_TRAFFIC_DUR,
                      data_pkt_size=data_pkt_size,
                      prio_dscp_map=prio_dscp_map)
 
@@ -276,6 +305,7 @@ def __gen_data_flows(testbed_config,
                      flow_prio_list,
                      flow_rate_percent,
                      flow_dur_sec,
+                     flow_delay_sec,
                      data_pkt_size,
                      prio_dscp_map):
     """
@@ -290,6 +320,7 @@ def __gen_data_flows(testbed_config,
         flow_prio_list (list): priorities of data flows
         flow_rate_percent (int): rate percentage for each flow
         flow_dur_sec (int): duration of each flow in second
+        flow_delay_sec (int): delay before starting all flows in second
         data_pkt_size (int): packet size of data flows in byte
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
 
@@ -311,6 +342,7 @@ def __gen_data_flows(testbed_config,
                                 flow_prio=prio,
                                 flow_rate_percent=flow_rate_percent,
                                 flow_dur_sec=flow_dur_sec,
+                                flow_delay_sec=flow_delay_sec,
                                 data_pkt_size=data_pkt_size,
                                 prio_dscp_map=prio_dscp_map)
 
@@ -323,6 +355,7 @@ def __gen_data_flow(testbed_config,
                     flow_prio,
                     flow_rate_percent,
                     flow_dur_sec,
+                    flow_delay_sec,
                     data_pkt_size,
                     prio_dscp_map):
     """
@@ -337,6 +370,7 @@ def __gen_data_flow(testbed_config,
         flow_prio_list (list): priorities of the flow
         flow_rate_percent (int): rate percentage for the flow
         flow_dur_sec (int): duration of the flow in second
+        flow_delay_sec (int): delay before starting flow in second
         data_pkt_size (int): packet size of the flow in byte
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
 
@@ -379,6 +413,7 @@ def __gen_data_flow(testbed_config,
     flow.size.fixed = data_pkt_size
     flow.rate.percentage = flow_rate_percent
     flow.duration.fixed_seconds.seconds = flow_dur_sec
+    flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec(flow_delay_sec))
 
     flow.metrics.enable = True
     flow.metrics.loss = True
@@ -389,7 +424,8 @@ def __gen_pause_flow(testbed_config,
                      src_port_id,
                      flow_name,
                      pause_prio_list,
-                     flow_dur_sec):
+                     flow_dur_sec,
+                     flow_delay_sec):
     """
     Generate the configuration for a PFC pause storm
 
@@ -400,6 +436,7 @@ def __gen_pause_flow(testbed_config,
         flow_name (str): flow' name
         pause_prio_list (list): priorities to pause for PFC frames
         flow_dur_sec (float): duration of the flow in second
+        flow_delay_sec (int): delay before starting pause flow in second
 
     Returns:
         N/A
@@ -445,7 +482,7 @@ def __gen_pause_flow(testbed_config,
     pause_flow.rate.pps = pps
     pause_flow.size.fixed = 64
     pause_flow.duration.fixed_packets.packets = int(pkt_cnt)
-    pause_flow.duration.fixed_packets.delay.nanoseconds = 0
+    pause_flow.duration.fixed_packets.delay.nanoseconds = int(sec_to_nanosec(flow_delay_sec))
 
     pause_flow.metrics.enable = True
     pause_flow.metrics.loss = True

--- a/tests/snappi/pfcwd/files/pfcwd_runtime_traffic_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_runtime_traffic_helper.py
@@ -8,9 +8,11 @@ from tests.common.snappi.port import select_ports, select_tx_port
 from tests.common.snappi.snappi_helpers import wait_for_arp
 
 DATA_FLOW_NAME = "Data Flow"
+WARM_UP_TRAFFIC_NAME = "Warm Up Traffic"
 DATA_PKT_SIZE = 1024
 DATA_FLOW_DURATION_SEC = 15
-PFCWD_START_DELAY_SEC = 3
+WARM_UP_TRAFFIC_DUR = 1
+PFCWD_START_DELAY_SEC = 3 + WARM_UP_TRAFFIC_DUR
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
 
@@ -54,12 +56,18 @@ def run_pfcwd_runtime_traffic_test(api,
 
     pytest_assert(port_id is not None,
                   'Fail to get ID for port {}'.format(dut_port))
+    
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
+    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+    warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
+    warm_up_traffic_delay_sec = 0
 
     __gen_traffic(testbed_config=testbed_config,
                   port_config_list=port_config_list,
                   port_id=port_id,
-                  data_flow_name=DATA_FLOW_NAME,
-                  data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
+                  data_flow_name_list=[WARM_UP_TRAFFIC_NAME, DATA_FLOW_NAME],
+                  data_flow_delay_sec_list=[warm_up_traffic_delay_sec, WARM_UP_TRAFFIC_DUR],
+                  data_flow_dur_sec_list=[warm_up_traffic_dur_sec, DATA_FLOW_DURATION_SEC],
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_list=prio_list,
                   prio_dscp_map=prio_dscp_map)
@@ -85,11 +93,17 @@ def run_pfcwd_runtime_traffic_test(api,
                      tolerance=TOLERANCE_THRESHOLD)
 
 
+def sec_to_nanosec(secs):
+    """ Convert seconds to nanoseconds """
+    return secs * 1e9
+
+
 def __gen_traffic(testbed_config,
                   port_config_list,
                   port_id,
-                  data_flow_name,
-                  data_flow_dur_sec,
+                  data_flow_name_list,
+                  data_flow_delay_sec_list,
+                  data_flow_dur_sec_list,
                   data_pkt_size,
                   prio_list,
                   prio_dscp_map):
@@ -100,8 +114,9 @@ def __gen_traffic(testbed_config,
         testbed_config (obj): testbed L1/L2/L3 configuration
         port_config_list (list): list of port configuration
         port_id (int): ID of DUT port to test.
-        data_flow_name (str): data flow name
-        data_flow_dur_sec (int): duration of data flows in second
+        data_flow_name_list (list): list of data flow names
+        data_flow_delay_sec_list (list): list of data flow start delays in second
+        data_flow_dur_sec_list (list): list of data flow durations in second
         data_pkt_size (int): size of data packets in byte
         prio_list (list): priorities of data flows
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
@@ -134,32 +149,38 @@ def __gen_traffic(testbed_config,
     rx_port_name = testbed_config.ports[rx_port_id].name
     data_flow_rate_percent = int(100 / len(prio_list))
 
-    """ For each priority """
-    for prio in prio_list:
-        data_flow = testbed_config.flows.flow(
-            name='{} Prio {}'.format(data_flow_name, prio))[-1]
+    """ For each data flow """
+    for i in range(len(data_flow_name_list)):
 
-        data_flow.tx_rx.port.tx_name = tx_port_name
-        data_flow.tx_rx.port.rx_name = rx_port_name
+        """ For each priority """
+        for prio in prio_list:
+            data_flow = testbed_config.flows.flow(
+                name='{} Prio {}'.format(data_flow_name_list[i], prio))[-1]
 
-        eth, ipv4 = data_flow.packet.ethernet().ipv4()
-        eth.src.value = tx_mac
-        eth.dst.value = rx_mac
-        eth.pfc_queue.value = prio
+            data_flow.tx_rx.port.tx_name = tx_port_name
+            data_flow.tx_rx.port.rx_name = rx_port_name
 
-        ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = rx_port_config.ip
-        ipv4.priority.choice = ipv4.priority.DSCP
-        ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
-        ipv4.priority.dscp.ecn.value = (
-            ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
+            eth, ipv4 = data_flow.packet.ethernet().ipv4()
+            eth.src.value = tx_mac
+            eth.dst.value = rx_mac
+            eth.pfc_queue.value = prio
 
-        data_flow.size.fixed = data_pkt_size
-        data_flow.rate.percentage = data_flow_rate_percent
-        data_flow.duration.fixed_seconds.seconds = data_flow_dur_sec
+            ipv4.src.value = tx_port_config.ip
+            ipv4.dst.value = rx_port_config.ip
+            ipv4.priority.choice = ipv4.priority.DSCP
+            ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
+            ipv4.priority.dscp.ecn.value = (
+                ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
 
-        data_flow.metrics.enable = True
-        data_flow.metrics.loss = True
+            data_flow.size.fixed = data_pkt_size
+            data_flow.rate.percentage = data_flow_rate_percent
+            data_flow.duration.fixed_seconds.seconds = (
+                data_flow_dur_sec_list[i])
+            data_flow.duration.fixed_seconds.delay.nanoseconds = int(
+                sec_to_nanosec(data_flow_delay_sec_list[i]))
+
+            data_flow.metrics.enable = True
+            data_flow.metrics.loss = True
 
 
 def __run_traffic(api, config, duthost, all_flow_names, pfcwd_start_delay_sec, exp_dur_sec):

--- a/tests/snappi/pfcwd/files/pfcwd_runtime_traffic_helper.py
+++ b/tests/snappi/pfcwd/files/pfcwd_runtime_traffic_helper.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi.snappi_helpers import get_dut_port_id
-from tests.common.snappi.common_helpers import start_pfcwd, stop_pfcwd
+from tests.common.snappi.common_helpers import start_pfcwd, stop_pfcwd, sec_to_nanosec
 from tests.common.snappi.port import select_ports, select_tx_port
 from tests.common.snappi.snappi_helpers import wait_for_arp
 
@@ -56,9 +56,9 @@ def run_pfcwd_runtime_traffic_test(api,
 
     pytest_assert(port_id is not None,
                   'Fail to get ID for port {}'.format(dut_port))
-    
-    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd 
-    fake alerts caused by non-incremented packet counters during pfcwd detection periods"""
+
+    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd
+    fake alerts caused by idle links (non-incremented packet counters) during pfcwd detection periods """
     warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
     warm_up_traffic_delay_sec = 0
 
@@ -91,11 +91,6 @@ def run_pfcwd_runtime_traffic_test(api,
                      data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                      data_pkt_size=DATA_PKT_SIZE,
                      tolerance=TOLERANCE_THRESHOLD)
-
-
-def sec_to_nanosec(secs):
-    """ Convert seconds to nanoseconds """
-    return secs * 1e9
 
 
 def __gen_traffic(testbed_config,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: During the pfc watch dog (pfcwd) basic tests, pfc watch dog was being triggered by fake alerts i.e. when it was not supposed to be triggered. This was causing unnecessary test failures. To curb this issue, warm-up data traffic is initially sent before any other traffic (pfc pause storm and data traffic) to prevent pfcwd fake alerts caused by non-incremented packet counters during the pfcwd polling interval. This PR is in addition to #7499. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Existing issue with certain switches where PFC watch dog was being triggered by fake alerts.

#### How did you do it?
Added warm-up data traffic before any other traffic (pfc pause storm and data traffic) to prevent pfcwd fake alerts caused by non-incremented packet counters during the pfcwd polling interval.

#### How did you verify/test it?
The related PFCWD tests pass on a lab switch. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
