### PR TITLE
Fix router mac in the qos_sai test cases.

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -233,6 +233,11 @@ class TestQosSai(QosSaiBase):
         if 'cell_size' in qosConfig[xoffProfile].keys():
             testParams["cell_size"] = qosConfig[xoffProfile]["cell_size"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams
         )
@@ -359,6 +364,11 @@ class TestQosSai(QosSaiBase):
 
         # set poll interval for pfcwd
         duthost.command("pfcwd interval {}".format(pfcwd_timers['pfc_wd_poll_time']))
+
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
 
         logger.info("--- Start Pfcwd on port {}".format(pfcwd_test_port))
         start_wd_on_ports(duthost,
@@ -497,6 +507,11 @@ class TestQosSai(QosSaiBase):
         if 'cell_size' in qosConfig[xonProfile].keys():
             testParams["cell_size"] = qosConfig[xonProfile]["cell_size"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PFCXonTest", testParams=testParams
         )
@@ -560,6 +575,11 @@ class TestQosSai(QosSaiBase):
 
         if "packet_size" in qosConfig[LosslessVoqProfile].keys():
             testParams["packet_size"] = qosConfig[LosslessVoqProfile]["packet_size"]
+
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.LosslessVoq", testParams=testParams
@@ -644,6 +664,11 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_egr_mem" in qosConfig.keys():
             testParams["pkts_num_egr_mem"] = qosConfig["pkts_num_egr_mem"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest",
             testParams=testParams
@@ -712,6 +737,11 @@ class TestQosSai(QosSaiBase):
 
         if "pkts_num_margin" in qosConfig[sharedResSizeKey]:
             testParams["pkts_num_margin"] = qosConfig[sharedResSizeKey]["pkts_num_margin"]
+
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.SharedResSizeTest",
@@ -794,6 +824,11 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_egr_mem" in qosConfig.keys():
             testParams["pkts_num_egr_mem"] = qosConfig["pkts_num_egr_mem"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest",
             testParams=testParams
@@ -868,6 +903,11 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         if "packet_size" in qosConfig[bufPool].keys():
             testParams["packet_size"] = qosConfig[bufPool]["packet_size"]
 
@@ -940,6 +980,11 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_margin" in qosConfig["lossy_queue_1"].keys():
             testParams["pkts_num_margin"] = qosConfig["lossy_queue_1"]["pkts_num_margin"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][dutConfig["testPorts"]["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.LossyQueueTest",
             testParams=testParams
@@ -1008,6 +1053,11 @@ class TestQosSai(QosSaiBase):
             if "pkts_num_margin" in qosConfig[LossyVoq].keys():
                 testParams["pkts_num_margin"] = qosConfig[LossyVoq]["pkts_num_margin"]
 
+            duthost = dutConfig['dutInstance']
+            dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+                dutConfig['dutInterfaces'][testParams["src_port_id"]])
+            testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.LossyQueueVoqTest",
                 testParams=testParams
@@ -1058,6 +1108,10 @@ class TestQosSai(QosSaiBase):
             testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
         else:
             testParams["platform_asic"] = None
+
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpMappingPB",
@@ -1119,6 +1173,10 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpMappingPB",
             testParams=testParams
@@ -1156,6 +1214,11 @@ class TestQosSai(QosSaiBase):
             testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
         else:
             testParams["platform_asic"] = None
+
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.Dot1pToQueueMapping",
@@ -1195,6 +1258,10 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.Dot1pToPgMapping",
             testParams=testParams
@@ -1263,6 +1330,9 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["ecn"] = qosConfig["lossy_queue_1"]["ecn"]
 
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams
         )
@@ -1343,6 +1413,10 @@ class TestQosSai(QosSaiBase):
         if "internal_hdr_size" in qosConfig.keys():
             testParams["internal_hdr_size"] = qosConfig["internal_hdr_size"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PGSharedWatermarkTest",
             testParams=testParams
@@ -1408,6 +1482,10 @@ class TestQosSai(QosSaiBase):
         if "packet_size" in qosConfig["wm_pg_headroom"].keys():
             testParams["packet_size"] = qosConfig["wm_pg_headroom"]["packet_size"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PGHeadroomWatermarkTest",
             testParams=testParams
@@ -1461,6 +1539,10 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PGDropTest", testParams=testParams
         )
@@ -1537,6 +1619,10 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_margin" in qosConfig[queueProfile].keys():
             testParams["pkts_num_margin"] = qosConfig[queueProfile]["pkts_num_margin"]
 
+        duthost = dutConfig['dutInstance']
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.QSharedWatermarkTest",
             testParams=testParams
@@ -1586,6 +1672,9 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpToPgMapping",
             testParams=testParams
@@ -1643,6 +1732,9 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpToPgMapping",
             testParams=testParams
@@ -1707,6 +1799,9 @@ class TestQosSai(QosSaiBase):
         else:
             testParams["platform_asic"] = None
 
+        dutTestParams['basicParams']["router_mac"] = duthost.get_dut_iface_mac(
+            dutConfig['dutInterfaces'][testParams["src_port_id"]])
+        testParams["router_mac"] = dutTestParams['basicParams']["router_mac"]
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams
         )


### PR DESCRIPTION
### Description of PR
In qos_sai testcases, currently the router_mac is obtained from the platform level command, which is not correct for multi-asic platforms. These platforms have different mac address based on asic. We need to update the script to use the correct function to get the correct mac address for the incoming interface.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Qos Sai testcases fail in multi asic platforms since they use the wrong mac address.
#### How did you do it?
Added the correct function call for calculating the mac address instead of router_mac.

#### How did you verify/test it?
Ran the tests on a multi-asic platform.

#### Any platform specific information?
- NIL -
#### Supported testbed topology if it's a new test case?
N/A