### PR TITLE
keyerror caused by empty interface_to_front_mapping in ptf

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -11,8 +11,9 @@ from jinja2 import Template
 
 from tests.common import constants
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.dut_utils import check_link_status
 from tests.common.dualtor.dual_tor_utils import update_linkmgrd_probe_interval, recover_linkmgrd_probe_interval
-
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -184,8 +185,9 @@ def _ptf_portmap_file(duthost, ptfhost, tbinfo):
             filename (str): returns the filename copied to PTF host
     """
     intfInfo = duthost.show_interface(command="status")['ansible_facts']['int_status']
-    portList = [port for port in intfInfo if port.startswith('Ethernet') and intfInfo[port]['oper_state'] == 'up'
-                and intfInfo[port]['admin_state'] == 'up']
+    portList = [port for port in intfInfo if port.startswith('Ethernet') and intfInfo[port]['admin_state'] == 'up']
+    pt_assert(wait_until(50, 5, 0, check_link_status, duthost, portList, 'up'), "Partial of Ethernet port didn't go up")
+
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     portMapFile = "/tmp/default_interface_to_front_map.ini"
     with open(portMapFile, 'w') as file:

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -62,6 +62,7 @@ class ThriftInterface(BaseTest):
                     continue
                 interface_front_pair = line.split("@")
                 interface_to_front_mapping[interface_front_pair[0]] = interface_front_pair[1].strip()
+            f.close()
         else:
             exit("No ptf interface<-> switch front port mapping, please specify as parameter or in external file")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

symptom:
Ptf test case hit below keyerror issue:

"ERROR: sai_qos_tests.PFCtest", 
"----------------------------------------------------------------------", 
"Traceback (most recent call last):", 
"  File \"saitests/py3/sai_qos_tests.py\", line 974, in runTest", 
"    self.client, port_list[src_port_id])", 
"KeyError: 17", 
"", 

RCA:
partial of ethernet port didn't go up, need to wait for link state go up

#### How did you do it?

add wait_until to wait link go up

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
