### PR TITLE
[QoS 202205] remove xfail condition for always pass qos cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
@@ -140,14 +140,6 @@ qos/test_pfc_pause.py::test_no_pfc:
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6716
 
-qos/test_qos_sai.py::TestQosSai::testParameter:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6666
-
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"
@@ -229,30 +221,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit:
       - https://github.com/sonic-net/sonic-mgmt/issues/6666
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6666
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6666
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6666
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

below 4 qos sai testcases alway pass in recent 5 test iterations. remove xfail conditon for them.

testParameter
testQosSaiPgHeadroomWatermark
testQosSaiPgSharedWatermark
testQosSaiQSharedWatermark

#### How did you do it?

remove xfail condition

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
