### PR TITLE
Update cisco-data for multi-asic platforms.

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -114,6 +114,7 @@ def setup_markings_dut(duthost, localhost, **kwargs):
             reboot(duthost, localhost)
     else:
         asic_index = 0
+        json_contents = {}
         for config_file in config_files:
             str_asic_index = str(asic_index)
             dest_file = "/tmp/"

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -137,6 +137,7 @@ def setup_markings_dut(duthost, localhost, **kwargs):
                 if json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] != v:
                     reboot_required = True
                     json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] = v
+            asic_index+=1
     
         if reboot_required:
             index = 0

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -115,6 +115,7 @@ def setup_markings_dut(duthost, localhost, **kwargs):
     else:
         asic_index = 0
         json_contents = {}
+        reboot_required = False
         for config_file in config_files:
             str_asic_index = str(asic_index)
             dest_file = "/tmp/"
@@ -132,13 +133,22 @@ def setup_markings_dut(duthost, localhost, **kwargs):
 
             if required_entry is None:
                 raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
-            reboot_required = False
-            for k,v in kwargs.iteritems():
-                if json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] != v:
-                    reboot_required = True
-                    json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] = v
+            # The kwargs can be either of:
+            # just a key-value pair or
+            # 0:{key-value}, 1:{key-value} and so on.
+            if kwargs.get(str_asic_index, None):
+                for k,v in kwargs[str_asic_index].iteritems():
+                    if json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] != v:
+                        reboot_required = True
+                        json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] = v
+            else:
+                for k,v in kwargs.iteritems():
+                    if json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] != v:
+                        reboot_required = True
+                        json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] = v
+
             asic_index+=1
-    
+
         if reboot_required:
             index = 0
             for _ in json_contents.keys(): 

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -1,70 +1,146 @@
 import json
-import re
 from tests.common.reboot import reboot
-
 
 def is_cisco_device(dut):
     return dut.facts["asic_type"] == "cisco-8000"
-
-def is_model_json_format(duthost):
-    model_json_platforms = ['x86_64-8102_64h_o-r0']
-    return duthost.facts['platform'] in model_json_platforms
 
 def get_markings_config_file(duthost):
     """
         Get the config file where the ECN markings are enabled or disabled.
     """
-    if duthost.facts["asic_type"] != "cisco-8000":
+    asic_type = duthost.facts['asic_type']
+    if asic_type != "cisco-8000":
         raise RuntimeError("This is applicable only to cisco platforms.")
+
     platform = duthost.facts['platform']
     hwsku = duthost.facts['hwsku']
-    if is_model_json_format(duthost):
-        match = re.search(r"\-([^-_]+)_", platform)
-        if match:
-            model = match.group(1)
-        else:
-            raise RuntimeError("Couldn't get the model from platform:{}".format(platform))
+    match = re.search("\-([^-_]+)_", platform)
+    if match:
+       model = match.group(1)
     else:
-        model = "serdes"
-    config_file = "/usr/share/sonic/device/{}/{}/{}.json".format(platform, hwsku, model)
-    return config_file
-
+       raise RuntimeError("Couldn't get the model from platform:{}".format(platform))
+    config_files = []
+    if platform in ['x86_64-88_lc0_36fh_mo-r0']:
+        for asic in [0, 1, 2]:
+            config_files.append("/usr/share/sonic/device/{}/{}/{}/silicon_one.json".format(platform, hwsku, asic))
+    else:
+        config_files.append("/usr/share/sonic/device/{}/{}/{}.json".format(platform, hwsku, model))
+    return config_files
 
 def get_markings_dut(duthost, key_list=['ecn_dequeue_marking', 'ecn_latency_marking', 'voq_allocation_mode']):
     """
         Get the ecn marking values from the duthost.
     """
-    config_file = get_markings_config_file(duthost)
-    dest_file = "/tmp/"
-    contents = duthost.fetch(src=config_file, dest=dest_file)
-    local_file = contents['dest']
-    with open(local_file) as fd:
-        json_contents = json.load(fd)
-    markings_dict = {}
-    # Getting markings from first device.
-    device = json_contents['devices'][0]
-    for key in key_list:
-        markings_dict[key] = device['device_property'][key]
-    return markings_dict
+    config_files = get_markings_config_file(duthost)
+    if len(config_files) == 1:
 
+        dest_file = "/tmp/"
+        contents = duthost.fetch(src=config_file, dest = dest_file)
+        local_file = contents['dest']
+        with open(local_file) as fd:
+            json_contents = json.load(fd)
+        required_entry = None
+        for i in range(len(json_contents['devices'])):
+            try:
+                 json_contents['devices'][i].get('id')
+                 required_entry = i
+            except KeyError:
+                 continue
+
+        if required_entry is None:
+            raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+        original_values = {}
+        for key in key_list:
+            original_values[key] = json_contents['devices'][i][key]
+        return original_values
+
+    else:
+        original_values = {}
+        asic_index = 0
+        for config_file in config_files:
+            str_asic_index = str(asic_index)
+            dest_file = "/tmp/"
+            contents = duthost.fetch(src=config_file, dest = dest_file)
+            local_file = contents['dest']
+            with open(local_file) as fd:
+                json_contents = json.load(fd)
+            required_entry = None
+            for i in range(len(json_contents['devices'])):
+                try:
+                     json_contents['devices'][i].get('id')
+                     required_entry = i
+                except KeyError:
+                     continue
+
+            if required_entry is None:
+                raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+
+            original_values[str_asic_index] = {}
+            for key in key_list:
+                original_values[str_asic_index][key] = json_contents['devices'][required_entry]['device_property'][key]
+            asic_index += 1
+    return original_values
 
 def setup_markings_dut(duthost, localhost, **kwargs):
     """
         Setup dequeue or latency depending on arguments.
         Applicable to cisco-8000 Platforms only.
     """
-    config_file = get_markings_config_file(duthost)
-    dest_file = "/tmp/"
-    contents = duthost.fetch(src=config_file, dest=dest_file)
-    local_file = contents['dest']
-    with open(local_file) as fd:
-        json_contents = json.load(fd)
-    reboot_required = False
-    for device in json_contents['devices']:
+    config_files = get_markings_config_file(duthost)
+    if len(config_files) == 1:
+        dest_file = "/tmp/"
+        contents = duthost.fetch(src=config_file, dest = dest_file)
+        local_file = contents['dest']
+        with open(local_file) as fd:
+            json_contents = json.load(fd)
+        required_entry = None
+        for i in range(len(json_contents['devices'])):
+            try:
+                 json_contents['devices'][i].get('id')
+                 required_entry = i
+            except KeyError:
+                 continue
+
+        if required_entry is None:
+            raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+        reboot_required = False
         for k,v in kwargs.iteritems():
-            if device['device_property'][k] != v:
+            if json_contents['devices'][required_entry][k] != v:
                 reboot_required = True
-                device['device_property'][k] = v
-    if reboot_required:
-        duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
-        reboot(duthost, localhost)
+                json_contents['devices'][required_entry][k] = v
+
+        if reboot_required:
+            duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
+            reboot(duthost, localhost)
+    else:
+        asic_index = 0
+        for config_file in config_files:
+            str_asic_index = str(asic_index)
+            dest_file = "/tmp/"
+            contents = duthost.fetch(src=config_file, dest = dest_file)
+            local_file = contents['dest']
+            with open(local_file) as fd:
+                json_contents[str_asic_index] = json.load(fd)
+            required_entry = None
+            for i in range(len(json_contents[str_asic_index]['devices'])):
+                try:
+                     json_contents[str_asic_index]['devices'][i].get('id')
+                     required_entry = i
+                except KeyError:
+                     continue
+
+            if required_entry is None:
+                raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+            reboot_required = False
+            for k,v in kwargs.iteritems():
+                if json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] != v:
+                    reboot_required = True
+                    json_contents[str_asic_index]['devices'][required_entry]['device_property'][k] = v
+    
+        if reboot_required:
+            index = 0
+            for _ in keys(json_contents): 
+                str_index = str(index)
+                duthost.copy(content=json.dumps(json_contents[str_index], sort_keys=True, indent=4), dest=config_file[index])
+                index+=1
+            reboot(duthost, localhost)

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -140,7 +140,7 @@ def setup_markings_dut(duthost, localhost, **kwargs):
     
         if reboot_required:
             index = 0
-            for _ in keys(json_contents): 
+            for _ in json_contents.keys(): 
                 str_index = str(index)
                 duthost.copy(content=json.dumps(json_contents[str_index], sort_keys=True, indent=4), dest=config_file[index])
                 index+=1

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -33,7 +33,7 @@ def get_markings_dut(duthost, key_list=['ecn_dequeue_marking', 'ecn_latency_mark
     """
     config_files = get_markings_config_file(duthost)
     if len(config_files) == 1:
-
+        config_file = config_files[0]
         dest_file = "/tmp/"
         contents = duthost.fetch(src=config_file, dest = dest_file)
         local_file = contents['dest']
@@ -88,6 +88,7 @@ def setup_markings_dut(duthost, localhost, **kwargs):
     """
     config_files = get_markings_config_file(duthost)
     if len(config_files) == 1:
+        config_file = config_files[0]
         dest_file = "/tmp/"
         contents = duthost.fetch(src=config_file, dest = dest_file)
         local_file = contents['dest']

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -142,6 +142,6 @@ def setup_markings_dut(duthost, localhost, **kwargs):
             index = 0
             for _ in json_contents.keys(): 
                 str_index = str(index)
-                duthost.copy(content=json.dumps(json_contents[str_index], sort_keys=True, indent=4), dest=config_file[index])
+                duthost.copy(content=json.dumps(json_contents[str_index], sort_keys=True, indent=4), dest=config_files[index])
                 index+=1
             reboot(duthost, localhost)


### PR DESCRIPTION
Earlier version of common/cisco_data.py restricted the scripts only to fixed chassis platforms. Updated the lib to provide support for distributed chassis and multi asic platforms as well.