### PR TITLE
[drop_packets]: Skip test_dst_ip_link_local and test_dst_ip_is_loopback

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -102,6 +102,7 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
       - "asic_type in ['broadcom', 'cisco-8000']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
+- drop_packets/test_drop_counters.py::test_loopback_filter:
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
   # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.
   # All router interfaces has attribute "sx_interface_attributes_t.loopback_enable" - enabled.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -46,9 +46,9 @@ drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version. Test also not supported on Broadcom DNX"
+    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version. Test also not supported on Broadcom DNX or 8800-LC"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx']) or (platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0'])"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -62,7 +62,7 @@ drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
     reason: "Cisco 8000 with 202012 version and broadcom DNX platforms do not drop DIP linklocal packets"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx'])"
+      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx']) or (platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0'])"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -102,7 +102,7 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
       - "asic_type in ['broadcom', 'cisco-8000']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
-- drop_packets/test_drop_counters.py::test_loopback_filter:
+drop_packets/test_drop_counters.py::test_loopback_filter:
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
   # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.
   # All router interfaces has attribute "sx_interface_attributes_t.loopback_enable" - enabled.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -102,8 +102,6 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
       - "asic_type in ['broadcom', 'cisco-8000']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
-
-
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
   # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.
   # All router interfaces has attribute "sx_interface_attributes_t.loopback_enable" - enabled.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -46,9 +46,9 @@ drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version. Test also not supported on Broadcom DNX or 8800-LC"
+    reason: "Cisco 8000 platform does not drop DIP loopback packets. Test also not supported on Broadcom DNX"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx']) or (platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0'])"
+      - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -60,9 +60,9 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
-    reason: "Cisco 8000 with 202012 version and broadcom DNX platforms do not drop DIP linklocal packets"
+    reason: "Cisco 8000 and broadcom DNX platforms do not drop DIP linklocal packets"
     conditions:
-      - "(asic_type=='cisco-8000' and release in ['202012']) or (asic_subtype in ['broadcom-dnx']) or (platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0'])"
+      - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
   skip:
@@ -102,7 +102,8 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
       - "asic_type in ['broadcom', 'cisco-8000']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
-drop_packets/test_drop_counters.py::test_loopback_filter:
+
+
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
   # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.
   # All router interfaces has attribute "sx_interface_attributes_t.loopback_enable" - enabled.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
cisco-8000 will not drop packets with destination IP as loopback or destination IP as Link Local.

#### How did you do it?
Skip the test_dst_ip_link_local and test_dst_ip_is_loopback for cisco-8000 asic_type
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
