### PR TITLE
[Python3 migration]Fix Python version-compatible solution for importing urlparse

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -6,7 +6,7 @@ import sys
 if sys.version_info.major > 2:
     from urllib.parse import urlunparse
 else:
-    from urllib.parse import urlunparse
+    from urlparse import urlunparse
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -3,10 +3,11 @@ import logging
 import time
 import tempfile
 import random
+import sys
 if sys.version_info.major > 2:
-    from urllib.parse import urlunparse
+    from urllib.parse import urlparse
 else:
-    from urllib.parse import urlunparse
+    from urlparse import urlparse
 import ipaddress
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes Python version-compatible solution for importing urlparse

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There is a typo when migrating importing urlparse

#### How did you do it?
Change to:
if sys.version_info.major > 2:
    from urllib.parse import urlparse
else:
    from urlparse import urlparse

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
