### PR TITLE
[test plan][standalone tunnel route] remove cases in orchagent test plan

### DIFF
--- a/docs/testplan/dual_tor/dual_tor_orch_test_plan.md
+++ b/docs/testplan/dual_tor/dual_tor_orch_test_plan.md
@@ -177,6 +177,7 @@ ip route add 1.1.1.1 nexthop via 10.0.0.57 nexthop via 10.0.0.59 nexthop via 10.
     | Verify teardown by shutting peering session one by one | SLB  | After one session is down, verify other peering session is active and routes present|
 
 1. Standalone tunnel route
+
     This test is to verify standalone tunnel route is added properly when there is a `FAILED` or `INCOMPLETE` neighbor entry.
     * Active-Standby DualToR
 
@@ -189,5 +190,3 @@ ip route add 1.1.1.1 nexthop via 10.0.0.57 nexthop via 10.0.0.59 nexthop via 10.
     | Step | Goal | Expected results |
     |-|-|-|
     | Send traffic to some IP in the VLAN subnet but not configured as soc or server address | Forwarding through tunnel | Verify tunnel-route on this ToR | 
-    | Config mux active on the neighbor flushed side | Forwarding through tunnel | Verify tunnel-route on this ToR | 
-    | Config mux auto and bring up ToR to server link on the neighbor flushed side | Forwarding to server directly | Verify traffic is directly forwarded to sever, tunnel-route is removed | 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Remove some test cases involving link shutdown, config changes etc. Orchagent tests should simply verify the functionality of orchagent. Cases involving state machine are included in dualtor_io test plan.  

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
