### PR TITLE
Use enum_rand_one_per_hwsku_hostname so that it has the correct enum_f…

### DIFF
--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -92,12 +92,12 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     check_critical_processes(dut, 60)
 
 
-def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
+def test_restart_swss(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asic_index,
                       localhost, conn_graph_facts, xcvr_skip_list):            # noqa F811
     """
     @summary: This test case is to restart the swss service and check platform status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     all_interfaces = conn_graph_facts["device_conn"][duthost.hostname]
 
     if enum_frontend_asic_index is not None:
@@ -112,11 +112,11 @@ def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
     restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces, xcvr_skip_list)
 
 
-def test_restart_syncd(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
+def test_restart_syncd(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asic_index,
                        localhost, conn_graph_facts, xcvr_skip_list):           # noqa F811
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     restart_service_and_check(localhost, duthost, enum_frontend_asic_index,
                               "syncd", conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list)


### PR DESCRIPTION
…rontend_asic_index for the test_restart_swss/syncd tests

### Description of PR
platform_tests/test_sequential_restart.py::test_restart_swss is failing on chassis that has mixed LCs where the LCs has different number of front-end-asics.
It was found that by passing "rand_one_dut_hostname" as the paramter, it sometimes results to using the var of a LC that has more asics then the one chosen to perform the test that resulted to attempting to restart_swss for an asic that the LC does not have. We should use "enum_rand_one_per_hwsku_hostname" so that the proper front-end-asic is chosen correctly based on the chosen LC.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested the result on a mixed LC chassis where it was consistently failing due to ASIC chosen was from the LC that had more ASIcs then the LC that got picked to run the test.  WIth this change in place, the ASICs were picked correctly.
Here is the sample output of some runs:
Before the fix:
```
2023-03-14T20:58:42.0533860Z platform_tests/test_sequential_restart.py::test_restart_swss[0] PASSED   [ 16%]
2023-03-14T20:58:42.0558898Z platform_tests/test_sequential_restart.py::test_restart_syncd[0] SKIPPED [ 33%]
2023-03-14T21:07:06.7040912Z platform_tests/test_sequential_restart.py::test_restart_swss[1] PASSED   [ 50%]
2023-03-14T21:07:06.7072771Z platform_tests/test_sequential_restart.py::test_restart_syncd[1] SKIPPED [ 66%]
2023-03-14T21:07:06.7116876Z platform_tests/test_sequential_restart.py::test_restart_swss[2] 
2023-03-14T21:07:06.7123301Z -------------------------------- live log call ---------------------------------
2023-03-14T21:07:06.7125994Z 21:07:06 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
2023-03-14T21:07:06.7129418Z   File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
2023-03-14T21:07:06.7131498Z     self.ihook.pytest_pyfunc_call(pyfuncitem=self)
2023-03-14T21:07:06.7134171Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
2023-03-14T21:07:06.7136882Z     return self._hookexec(self, self.get_hookimpls(), kwargs)
2023-03-14T21:07:06.7139642Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
2023-03-14T21:07:06.7141815Z     return self._inner_hookexec(hook, methods, kwargs)
2023-03-14T21:07:06.7144357Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
2023-03-14T21:07:06.7146583Z     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
2023-03-14T21:07:06.7149452Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
2023-03-14T21:07:06.7151304Z     return outcome.get_result()
2023-03-14T21:07:06.7153747Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
2023-03-14T21:07:06.7155583Z     _reraise(*ex)  # noqa
2023-03-14T21:07:06.7157954Z   File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
2023-03-14T21:07:06.7160143Z     res = hook_impl.function(*args)
2023-03-14T21:07:06.7162791Z   File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
2023-03-14T21:07:06.7164790Z     testfunction(**testargs)
2023-03-14T21:07:06.7166784Z   File "/azp/_work/62/s/tests/platform_tests/test_sequential_restart.py", line 99, in test_restart_swss
2023-03-14T21:07:06.7169397Z     interface_list = get_port_map(duthost, enum_frontend_asic_index)
2023-03-14T21:07:06.7171691Z   File "/azp/_work/62/s/tests/common/platform/interface_utils.py", line 147, in get_port_map
2023-03-14T21:07:06.7173878Z     namespace = dut.get_namespace_from_asic_id(asic_index)
2023-03-14T21:07:06.7176134Z   File "/azp/_work/62/s/tests/common/devices/multi_asic.py", line 226, in get_namespace_from_asic_id
2023-03-14T21:07:06.7178993Z     raise ValueError("Invalid asic_id '{}' passed as input".format(asic_id))
2023-03-14T21:07:06.7181390Z ValueError: Invalid asic_id '2' passed as input
2023-03-14T21:07:06.7182219Z 
2023-03-14T21:07:14.7927976Z 
2023-03-14T21:08:05.4856970Z platform_tests/test_sequential_restart.py::test_restart_syncd[2] SKIPPED [100%]
```
After the fix on a 2 ASIC LC:
```
collected 4 items

platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-lc2-1-0] PASSED                                                                                                                                                [ 25%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-lc2-1-0] SKIPPED                                                                                                                                              [ 50%]
platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-lc2-1-1] PASSED                                                                                                                                                [ 75%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-lc2-1-1] SKIPPED                                                                                                                                              [100%]

```
After the fix on a 3 ASIC LC:
```
collected 6 items

platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-lc4-1-0] PASSED                                                                                                                                                [ 16%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-lc4-1-0] SKIPPED                                                                                                                                              [ 33%]
platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-lc4-1-1] PASSED                                                                                                                                                [ 50%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-lc4-1-1] SKIPPED                                                                                                                                              [ 66%]
platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-lc4-1-2] PASSED                                                                                                                                                [ 83%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-lc4-1-2] SKIPPED                                                                                                                                              [100%]
```
IF ran on the SUP which has no front-end-asics, the testcase will treat None as "0" and restart swss0 on the sup:
```
collected 2 items

platform_tests/test_sequential_restart.py::test_restart_swss[str3-8800-sup-2-None] PASSED                                                                                                                                             [ 50%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str3-8800-sup-2-None] SKIPPED                                                                                                                                           [100%]

```
Tested on a Pizza box DUT:
```
collected 2 items

platform_tests/test_sequential_restart.py::test_restart_swss[str2-7050cx3-acs-01-None] PASSED                                                                                                                                         [ 50%]
platform_tests/test_sequential_restart.py::test_restart_syncd[str2-7050cx3-acs-01-None] SKIPPED                                                                                                                                       [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
