### PR TITLE
[advanced-reboot] Check OS version at runtime during upgrade path tests

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -190,7 +190,7 @@ def analyze_log_file(duthost, messages, result, offset_from_kexec):
     elif is_mellanox_device(duthost):
         derived_patterns.update(OTHER_PATTERNS.get("MLNX"))
     # get image specific regexes
-    if "20191130" in duthost.os_version:
+    if "20191130" in get_current_sonic_version(duthost):
         derived_patterns.update(OTHER_PATTERNS.get("201911"))
         service_patterns.update(SERVICE_PATTERNS.get("201911"))
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix bug where regex set is selected for the base image, rather than target image for the upgrade path testcase
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?


During upgrade path, regex picking should be done based on the version currently running on the device.

This bug has created issues in 201911 to 202205 upgrade path, where for post upgrade timing collection the test picks 201911 regex.

#### How did you do it?

Fix this by checking the current running version to select that version's regex for timing data collection.
#### How did you verify/test it?

Tested on a physical device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
