### PR TITLE
[WAN SONiC]test case of IS-IS log-adjacency-change

### DIFF
--- a/tests/wan/isis/test_isis_log_adjacency_change.py
+++ b/tests/wan/isis/test_isis_log_adjacency_change.py
@@ -1,0 +1,59 @@
+import pytest
+import logging
+import functools
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+from isis_helpers import config_device_isis
+from isis_helpers import add_dev_isis_attr, del_dev_isis_attr
+
+logger = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.topology('wan-com'),
+]
+
+
+@pytest.fixture(scope="function")
+def isis_setup_teardown_log_adjacency_change(isis_common_setup_teardown, request):
+    target_devices = []
+    selected_connections = isis_common_setup_teardown
+
+    config_key = "log_adjacency_changes"
+    config_dict = {config_key: 'True'}
+    for (dut_host, _, _, _) in selected_connections:
+        add_dev_isis_attr(dut_host, config_dict)
+        target_devices.append(dut_host)
+        config_device_isis(dut_host)
+
+    def revert_isis_config(devices):
+        for device in devices:
+            del_dev_isis_attr(dut_host, [config_key])
+            config_device_isis(device)
+
+    request.addfinalizer(functools.partial(revert_isis_config, target_devices))
+
+
+def check_isis_log_adjacency_change(duthost, status):
+    output = duthost.shell("tail -n 1000 /var/log/syslog\
+                           |grep -e '.*%ADJCHANGE: Adjacency to.*to {}'\
+                           |grep -v grep".format(status),
+                           module_ignore_errors=True)
+    if output['stdout'] != '':
+        return True
+    else:
+        return False
+
+
+def test_isis_log_adjacency_change(isis_common_setup_teardown, isis_setup_teardown_log_adjacency_change):
+    selected_connections = isis_common_setup_teardown
+    (dut_host, dut_port, peer_host, peer_port) = selected_connections[0]
+
+    peer_host.shutdown(peer_port)
+    pytest_assert(wait_until(10, 2, 0, check_isis_log_adjacency_change, dut_host, "Down"),
+                  "No adjacency change logs!")
+
+    peer_host.no_shutdown(peer_port)
+    pytest_assert(wait_until(10, 2, 0, check_isis_log_adjacency_change, dut_host, "Up"),
+                  "No adjacency change logs!")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Testcase of verify IS-IS adjacency status change logs
Summary:
Fixes # (issue)
N/A
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To verify isis adjacency change logs
#### How did you do it?
Add new testcase
#### How did you verify/test it?
Based on WAN topo.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
wan topo
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
