### PR TITLE
[cacl]: Fix to add eth1-midplane rule for chassis

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -95,7 +95,7 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     """
     docker_network['bridge'] = {'IPv4Address': ipam_info['Config'][0].get('Gateway',
                                                                           ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
-                                'IPv6Address': ipam_info['Config'][1].get('Gateway', 
+                                'IPv6Address': ipam_info['Config'][1].get('Gateway',
                                                                           ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
 
     docker_network['container'] = {}

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -94,9 +94,11 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     IPv6 Gateway would be 'fd00::' + '1'
     """
     docker_network['bridge'] = {'IPv4Address': ipam_info['Config'][0].get('Gateway',
-                                                                          ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
+                                                                          ipam_info['Config'][0].get('Subnet')
+                                                                          .split('/')[0][:-1] + '1'),
                                 'IPv6Address': ipam_info['Config'][1].get('Gateway',
-                                                                          ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
+                                                                          ipam_info['Config'][1].get('Subnet')
+                                                                          .split('/')[0] + '1')}
 
     docker_network['container'] = {}
     for k, v in docker_containers_info.items():

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -95,7 +95,7 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     """
 
     docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
-                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet').split('/')[0] +' 1') }
+                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
 
     docker_network['container'] = {}
     for k, v in docker_containers_info.items():

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -93,7 +93,6 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     IPv4 Gateway would be '240.127.1' + '1'
     IPv6 Gateway would be 'fd00::' + '1'
     """
-
     docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', 
                                                                            ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
                                 'IPv6Address' : ipam_info['Config'][1].get('Gateway', 

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -94,8 +94,10 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     IPv6 Gateway would be 'fd00::' + '1'
     """
 
-    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
-                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
+    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', 
+                                                                           ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
+                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', 
+                                                                           ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
 
     docker_network['container'] = {}
     for k, v in docker_containers_info.items():

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -93,10 +93,10 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
     IPv4 Gateway would be '240.127.1' + '1'
     IPv6 Gateway would be 'fd00::' + '1'
     """
-    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', 
-                                                                           ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
-                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', 
-                                                                           ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
+    docker_network['bridge'] = {'IPv4Address': ipam_info['Config'][0].get('Gateway',
+                                                                          ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
+                                'IPv6Address': ipam_info['Config'][1].get('Gateway', 
+                                                                          ipam_info['Config'][1].get('Subnet').split('/')[0] + '1') }
 
     docker_network['container'] = {}
     for k, v in docker_containers_info.items():

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -554,7 +554,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
         ip6tables_rules.append("-A INPUT -j DROP")
    
     # IP Table rule to allow eth1-midplane traffic for chassis 
-    if not asic_index:
+    if asic_index is None:
         append_midplane_traffic_rules(duthost, iptables_rules)
 
     return iptables_rules, ip6tables_rules

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -82,16 +82,20 @@ def docker_network(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asi
            Sample output when docker hit the issue (Note that the IPv6 gateway is missing):
            "Config": [
                       {
-                       "Subnet": "240.127.1.1/24",
+                       "Subnet": "240.127.1.0/24",
                        "Gateway": "240.127.1.1"
                       },
                       {
                        "Subnet": "fd00::/80"
                       }
                      ]
+    When Gateway IP is missing, form the g/w IP as subnet + '1'.
+    IPv4 Gateway would be '240.127.1' + '1'
+    IPv6 Gateway would be 'fd00::' + '1'
     """
-    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', ipam_info['Config'][0].get('Subnet').split('/')[0]),
-                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet').split('/')[0]+'1') }
+
+    docker_network['bridge'] = {'IPv4Address' : ipam_info['Config'][0].get('Gateway', ipam_info['Config'][0].get('Subnet').split('/')[0][:-1] + '1'),
+                                'IPv6Address' : ipam_info['Config'][1].get('Gateway', ipam_info['Config'][1].get('Subnet').split('/')[0] +' 1') }
 
     docker_network['container'] = {}
     for k, v in docker_containers_info.items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
2 Failures seen on chassis:
1. https://github.com/sonic-net/sonic-host-services/pull/42 added a new rule to allow eth1-midplane traffic on chassis.
```
Failed: Unexpected iptables rules: set([u'-A INPUT -i eth1-midplane -j ACCEPT'])
```
2. If docker network bridge does not show ipv6 gateway address in IPAM, then subnet is assumed as gateway, this is causing
```
Failed: Missing expected ip6tables rules: set(['-A INPUT -s fd00::/80/128 -d fd00::242:f07f:102/128 -j ACCEPT'])
```
#### How did you do it?
1. Add eth1-midplane rule if eth1-midplane interface exists on host namespace.
2. Fix generation of expected rules to generate the right ipv6 gateway IP in docker_network bridge.
#### How did you verify/test it?
Test passes on chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
