### PR TITLE
[dash] Ignore IP.id and IP.chksum fields in the dash vnet test.

### DIFF
--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -48,6 +48,8 @@ def inbound_vnet_packets(dash_config_info):
     pa_mismatch_vxlan_packet["IP"].src = str(remote_pa_ip + 1)
 
     masked_exp_packet = Mask(expected_packet)
+    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "id")
+    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
     masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "sport")
     masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "chksum")
 
@@ -83,6 +85,8 @@ def outbound_vnet_packets(dash_config_info):
     )
 
     masked_exp_packet = Mask(expected_packet)
+    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "id")
+    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
     masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "sport")
     masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "chksum")
     return inner_packet, vxlan_packet, masked_exp_packet


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore IP.id and IP.chksum fields in the dash vnet test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The packet coming from the DPU may have a non-zero IP.id field. The test should not check the data in the field.
#### How did you do it?
Mask IP.id and IP.chksum fields in the expected packet.
#### How did you verify/test it?
Run dash vnet test on the DPU setup.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
