### PR TITLE
skip running "platform_tests/api/test_sfp.py::TestSfpApi::test_reset" from Cisco 400G LC. also consolidated all platform_tests skip marker into platform_test.yaml to avoid duplicates.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -645,45 +645,6 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
         - "asic_type in ['cisco-8000']"
 
 #######################################
-#####         platform_tests      #####
-#######################################
-platform_tests/api/test_sfp.py::TestSfpApi::test_reset:
-  skip:
-    reason: "platform does not support sfp reset"
-    conditions:
-      - "platform in ['x86_64-cel_e1031-r0']"
-
-platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
-  skip:
-    reason: "platform does not support"
-    conditions:
-      - "platform in ['x86_64-cel_e1031-r0']"
-
-platform_tests/daemon/test_chassisd.py:
-  skip:
-    reason: "chassisd platform daemon introduced in 202106"
-    conditions:
-      - "release in ['201811', '201911', '202012']"
-
-platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
-  skip:
-    reason: "Get/Set low power mode is not supported in Cisco 8000 platform"
-    conditions:
-      - "asic_type in ['cisco-8000'] or platform in ['x86_64-cel_e1031-r0']"
-
-platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
-  skip:
-    reason: "platform does not support sfp reset"
-    conditions:
-      - "platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6218
-
-platform_tests/test_auto_negotiation.py:
-  skip:
-    reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"
-    conditions: https://github.com/sonic-net/sonic-mgmt/issues/5447
-
-#######################################
 #####           qos               #####
 #######################################
 qos:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -721,7 +721,7 @@ platform_tests/daemon/test_chassisd.py:
     reason: "chassisd platform daemon introduced in 202106"
     conditions:
       - "release in ['201811', '201911', '202012']"
-      
+
 #######################################
 #####  daemon/test_syseepromd.py  #####
 #######################################
@@ -776,7 +776,7 @@ platform_tests/test_auto_negotiation.py:
   skip:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"
     conditions: https://github.com/sonic-net/sonic-mgmt/issues/5447
-    
+
 #######################################
 #####    test_platform_info.py    #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -525,7 +525,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_reset:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "'sw_to3200k' in hwsku"
+      - "('sw_to3200k' in hwsku) or (platform in ['x86_64-88_lc0_36fh_mo-r0', 'x86_64-cel_e1031-r0'])"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_thermals:
   skip:
@@ -543,7 +543,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['mellanox'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0', 'x86_64-cel_e1031-r0']"
 
 #######################################
 #####     api/test_thermal.py     #####
@@ -714,6 +714,15 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
 
 #######################################
+#####   daemon/test_chassisd.py   #####
+#######################################
+platform_tests/daemon/test_chassisd.py:
+  skip:
+    reason: "chassisd platform daemon introduced in 202106"
+    conditions:
+      - "release in ['201811', '201911', '202012']"
+      
+#######################################
 #####  daemon/test_syseepromd.py  #####
 #######################################
 platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
@@ -744,6 +753,30 @@ platform_tests/mellanox/test_reboot_cause.py:
     conditions:
       - "platform in ['x86_64-mlnx_msn2010-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2100-r0', 'x86_64-mlnx_msn2410-r0', 'x86_64-nvidia_sn2201-r0']"
 
+#######################################
+#####     sfp/test_sfputil.py     #####
+#######################################
+platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
+  skip:
+    reason: "Get/Set low power mode is not supported in Cisco 8000 platform"
+    conditions:
+      - "asic_type in ['cisco-8000'] or platform in ['x86_64-cel_e1031-r0']"
+
+platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
+  skip:
+    reason: "platform does not support sfp reset"
+    conditions:
+      - "platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6218
+
+#######################################
+#####  test_auto_negotiation.py   #####
+#######################################
+platform_tests/test_auto_negotiation.py:
+  skip:
+    reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"
+    conditions: https://github.com/sonic-net/sonic-mgmt/issues/5447
+    
 #######################################
 #####    test_platform_info.py    #####
 #######################################


### PR DESCRIPTION

### Description of PR
Since 400G LC is not ready to handle "platform_tests/api/test_sfp.py::TestSfpApi::test_reset" due to link will stayed down after the test and require better coordination between multiple components other than just xcvrd to ensure link will be brought back up after the sfp reset is performed, this test will be marked to skip the Cisco 400G LC platform (other vendors that suffer the same should also add their platforms to this same skip test marker as well).
Later on when the coordination are fixed and the link can be brought back up successfully, we can then remove the platform from this skip condition marker file.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on 100G and 400G CISCO LCs and observe only the 400G LC is being skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
