### PR TITLE
Ignore the status in the output of show ACL table

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -83,6 +83,10 @@ def expect_acl_table_match(duthost, table_name, expected_content_list):
     # Use empty list if no output
     lines = output['stdout'].splitlines()
     actual_list = [] if len(lines) < 3 else lines[2].split()
+    # Ignore the status column
+    expected_len = len(expected_content_list)
+    if len(actual_list) >= expected_len:
+        actual_list = actual_list[0:expected_len]
 
     pytest_assert(set(expected_content_list) == set(actual_list), "ACL table doesn't match")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure in test_cacl.py.
```
        pytest_assert(set(expected_content_list) == set(actual_list),
>           "ACL table doesn't match"
        )
E       Failed: ACL table doesn't match
```
The failure is because a new column `status` is appended to the output of `show acl table` command. Hence the check failed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure in `generic_config_updater/test_cacl.py`
#### How did you do it?
Ignore the last column in output.

#### How did you verify/test it?
Verified on `master` branch.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
