### PR TITLE
[VM]Add isis database integrity testcase

### DIFF
--- a/tests/wan/isis/conftest.py
+++ b/tests/wan/isis/conftest.py
@@ -5,6 +5,8 @@ import functools
 from isis_helpers import setup_isis
 from isis_helpers import teardown_isis
 
+MESH_CAST_LIST = ['test_isis_database']
+
 
 def pytest_addoption(parser):
     """
@@ -94,7 +96,7 @@ def isis_dpg_topo(duthosts, nbrhosts, duts_interconnects, tbinfo):
 def isis_common_setup_teardown(isis_dpg_topo, request, rand_selected_dut):
     dut_host = rand_selected_dut
     selected_connections = []
-    if request.config.getoption("--swan_agent"):
+    if request.config.getoption("--swan_agent") or request.module.__name__ in MESH_CAST_LIST:
         selected_connections = isis_dpg_topo
     else:
         for item in isis_dpg_topo:

--- a/tests/wan/isis/test_isis_database.py
+++ b/tests/wan/isis/test_isis_database.py
@@ -1,0 +1,80 @@
+import time
+import pytest
+import logging
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.devices.multi_asic import MultiAsicSonicHost
+from isis_helpers import DEFAULT_ISIS_INSTANCE as isis_instance
+
+
+logger = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.topology('wan-2dut'),
+]
+
+
+def compare_dicts(dict1, dict2, ignore_keys=None):
+    if dict1.keys() != dict2.keys():
+        return False
+    for key in dict1.keys():
+        if ignore_keys is not None and key in ignore_keys:
+            continue
+        if dict1[key] != dict2[key]:
+            return False
+    return True
+
+
+def check_isis_database_integrity(dut_database, nbr_database):
+    pytest_assert(dut_database[isis_instance].keys() == nbr_database[isis_instance].keys(),
+                  'IS-IS database lsp count not equal.')
+
+    ignore_keys = ['local', 'holdtime']
+    for key, _ in dut_database[isis_instance].items():
+        pytest_assert(compare_dicts(dut_database[isis_instance][key],
+                                    nbr_database[isis_instance][key],
+                                    ignore_keys),
+                      'IS-IS lsp {} is not the same.'.format(key))
+
+
+def check_isis_database_detail_integrity(dut_database_detail, nbr_database_detail):
+    pytest_assert(dut_database_detail[isis_instance].keys() == nbr_database_detail[isis_instance].keys(),
+                  'IS-IS detailed database lsp count not equal.')
+
+    for key, _ in dut_database_detail[isis_instance].items():
+        pytest_assert(compare_dicts(dut_database_detail[isis_instance][key],
+                                    nbr_database_detail[isis_instance][key]),
+                      'IS-IS lsp detail {} is not the same.'.format(key))
+
+
+def check_isis_route_integrity(dut_route, nbr_route):
+    pytest_assert(dut_route[isis_instance].keys() == nbr_route[isis_instance].keys(),
+                  'IS-IS route dict is incorrect.')
+    pytest_assert(dut_route[isis_instance]['ipv4'].keys() == nbr_route[isis_instance]['ipv4'].keys(),
+                  'IS-IS ipv4 route count not equal.')
+    pytest_assert(dut_route[isis_instance]['ipv6'].keys() == nbr_route[isis_instance]['ipv6'].keys(),
+                  'IS-IS ipv6 route count not equal.')
+
+
+@pytest.mark.parametrize('check_type', ['database', 'database_detail', 'route'])
+def test_isis_database_integrity(isis_common_setup_teardown, check_type):
+    selected_connections = isis_common_setup_teardown
+
+    if check_type == 'database':
+        time.sleep(30)
+    dut_isis_facts = nbr_isis_facts = None
+    for dut_host, _, nbr_host, _ in selected_connections:
+        if isinstance(dut_host, MultiAsicSonicHost) and isinstance(nbr_host, MultiAsicSonicHost):
+            dut_isis_facts = dut_host.isis_facts()['ansible_facts']['isis_facts']
+            nbr_isis_facts = nbr_host.isis_facts()['ansible_facts']['isis_facts']
+
+    if dut_isis_facts is None or nbr_isis_facts is None:
+        pytest.skip('Skip as no inter-connected dut interface on vtestbed')
+
+    if check_type == 'database':
+        check_isis_database_integrity(dut_isis_facts['database'], nbr_isis_facts['database'])
+    elif check_type == 'database_detail':
+        check_isis_database_detail_integrity(dut_isis_facts['database_detail'], nbr_isis_facts['database_detail'])
+    else:
+        check_isis_route_integrity(dut_isis_facts['route'], nbr_isis_facts['route'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add isis database integrity testcase
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add testcase to check is-is database in different duts to ensure is-is database is synced in different nodes.
#### How did you do it?
Start wan-2dut topology and check that all duts should have the same is-is database and route.
#### How did you verify/test it?
Run testcase and testcase would pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
`wan-2dut`
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
