### PR TITLE
[portchannel ]Fix bgp_gr_helper/iface_loopback action failure due to config_db change

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -104,7 +104,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
-    portchannels = config_facts.get('PORTCHANNEL_MEMBER', {})
+    portchannels_memebers = config_facts.get('PORTCHANNEL_MEMBER', {})
     dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
     configurations = tbinfo['topo']['properties']['configuration_properties']
     exabgp_ips = [configurations['common']['nhipv4'], configurations['common']['nhipv6']]
@@ -130,7 +130,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
     # get neighbor device connected ports
     nbr_ports = []
     if test_interface.startswith("PortChannel"):
-        for member in portchannels[test_interface].keys():
+        for member in portchannels_memebers[test_interface].keys():
             nbr_ports.append(dev_nbrs[member]['port'])
         test_neighbor_name = dev_nbrs[member]['name']
     else:

--- a/tests/iface_loopback_action/iface_loopback_action_helper.py
+++ b/tests/iface_loopback_action/iface_loopback_action_helper.py
@@ -144,7 +144,7 @@ def get_portchannel_of_port(config_facts, port):
     """
     portchannels = config_facts['PORTCHANNEL'].keys() if 'PORTCHANNEL' in config_facts else []
     for portchannel in portchannels:
-        portchannel_members = config_facts['PORTCHANNEL'][portchannel].get('members')
+        portchannel_members = config_facts['PORTCHANNEL_MEMBER'][portchannel].keys()
         if port in portchannel_members:
             return portchannel
 


### PR DESCRIPTION
bgp_gr_* and iface_loopback_action* test failed due to "members" field removed by this PR: https://github.com/sonic-net/sonic-buildimage/pull/13660
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: bgp_gr_* and iface_loopback_action* test failed due to "members" field removed by this PR: https://github.com/sonic-net/sonic-buildimage/pull/13660
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
bgp_gr_* and iface_loopback_action* test failed due to "members" field removed by this PR: https://github.com/sonic-net/sonic-buildimage/pull/13660
#### How did you do it?

#### How did you verify/test it?
Run the bgp_gr* test and the iface_loopback_action* cases, and they pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
