### PR TITLE
Fix lag member ptf to dut test

### DIFF
--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -214,6 +214,10 @@ class LagMemberTrafficTest(BaseTest,RouterUtility):
             src_ip = self.ptf_lag['ip'].split('/')[0]
             dst_ip = self.dut_vlan['ip'].split('/')[0]
 
+            arp_pkt = Ether(src= src_mac, dst=dst_mac)/ARP(op=ARP.who_has, psrc=src_ip, pdst=dst_ip, hwsrc=src_mac)
+            send(self, port_behind_lag, arp_pkt)
+            time.sleep(1)
+
             send_pkt = self.build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac, src_ip=src_ip, dst_ip=dst_ip, icmp_type=8)
             exp_pkt = self.build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac, src_ip=dst_ip, dst_ip=src_ip, icmp_type=0)
             masked_exp_pkt = self.get_mask_pkt(exp_pkt)


### PR DESCRIPTION
### Description of PR
Summary:
Fix dut may learn mac on wrong port in ptf_to_dut_traffic_test

Fixes # (issue)
[issues#6663
](https://github.com/sonic-net/sonic-mgmt/issues/6663)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The lag member test configuration on ptf looks like this:

```
ptf:                              dut:           
submask: 192.168.9.0/24           Vlan109: ip: 192.168.9.1 
eth23: ip: 192.168.9.3------------|-Ethernet92   
                                  |              
                                  |              
bond1: ip: 192.168.9.2------------|-PortChannel1:
| eth1                              | Ethernet4  
| eth2                              | Ethernet8  
| eth6                              | Ethernet24 
| eth7                              | Ethernet28 
| eth20                             | Ethernet80 
| eth21                             | Ethernet84 
| eth22                             | Ethernet88 
| eth24                             | Ethernet96 
```

Both bond1 and eth23 have same subnet mask.
When dut send arp to ptf for ask nexthop, both ports reply 192.168.9.2 is-at here.
So arp might learn on the wrong port, failing the icmp packet forwarding test.

#### How did you do it?
Send arp request form ptf first, let dut learn nexthop on the correct port.

#### How did you verify/test it?
Run and passed the lag_member_test test case.
```
============================ slowest test durations ============================
304.87s teardown pc/test_lag_member.py::test_lag_member_traffic
113.19s setup    pc/test_lag_member.py::test_lag_member_status
12.62s setup    pc/test_lag_member.py::test_lag_member_traffic
9.50s call     pc/test_lag_member.py::test_lag_member_traffic
8.83s teardown pc/test_lag_member.py::test_lag_member_status
0.98s call     pc/test_lag_member.py::test_lag_member_status
=========================== short test summary info ============================
PASSED pc/test_lag_member.py::test_lag_member_status
PASSED pc/test_lag_member.py::test_lag_member_traffic
==================== 2 passed, 2 warnings in 451.20 seconds ====================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
