### PR TITLE
[ansible] Consider tacacs when deploying fanout

### DIFF
--- a/ansible/group_vars/fanout/secrets.yml
+++ b/ansible/group_vars/fanout/secrets.yml
@@ -14,3 +14,6 @@ fanout_network_password: netpassword
 # Credential for accessing the Linux shell
 fanout_shell_user: shelladmin
 fanout_shell_password: shellpassword
+
+#fanout_tacacs_sonic_user: admin
+#fanout_tacacs_sonic_password: password

--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -1,6 +1,8 @@
 - name: set login to tacacs if tacacs is defined
   set_fact: ansible_ssh_user={{ fanout_tacacs_eos_user }} ansible_ssh_password={{ fanout_tacacs_eos_password }}
-  when: fanout_tacacs_eos_user is defined and fanout_tacacs_eos_password is defined
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_eos_user is defined and fanout_tacacs_eos_password is defined
 
 - name: prepare fanout switch admin login info
   set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_password={{ fanout_admin_password }}

--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -1,5 +1,12 @@
+- name: set login to tacacs if tacacs is defined
+  set_fact: ansible_ssh_user={{ fanout_tacacs_eos_user }} ansible_ssh_password={{ fanout_tacacs_eos_password }}
+  when: fanout_tacacs_eos_user is defined and fanout_tacacs_eos_password is defined
+
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_pass={{ fanout_admin_password }}
+  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_password={{ fanout_admin_password }}
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_eos_user is not defined and fanout_tacacs_eos_password is not defined
 
 - name: create persistent shell login
   file: path=/mnt/flash/rc.eos state=touch

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -6,8 +6,20 @@
 ### specified in this playbook, you would need to come up with your own fanout switch deployment
 ### playbook
 ################################################################################################
+- name: set login to tacacs if tacacs is defined
+  set_fact: ansible_ssh_user={{ fanout_tacacs_mlnx_user }} ansible_ssh_password={{ fanout_tacacs_mlnx_password }}
+  when: fanout_tacacs_mlnx_user is defined and fanout_tacacs_mlnx_password is defined
+  tags: always
+
 - name: prepare fanout switch admin login info
   set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }} peer_hwsku={{device_info[inventory_hostname]['HwSku']}}
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_mlnx_user is not defined and fanout_tacacs_mlnx_password is not defined
+  tags: always
+
+- name: prepare peer hwsku
+  set_fact: peer_hwsku={{ device_info[inventory_hostname]['HwSku'] }}
   tags: always
 
 ##########################################

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -14,7 +14,7 @@
   tags: always
 
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }} peer_hwsku={{device_info[inventory_hostname]['HwSku']}}
+  set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_mlnx_user is not defined and fanout_tacacs_mlnx_password is not defined

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -8,7 +8,9 @@
 ################################################################################################
 - name: set login to tacacs if tacacs is defined
   set_fact: ansible_ssh_user={{ fanout_tacacs_mlnx_user }} ansible_ssh_password={{ fanout_tacacs_mlnx_password }}
-  when: fanout_tacacs_mlnx_user is defined and fanout_tacacs_mlnx_password is defined
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_mlnx_user is defined and fanout_tacacs_mlnx_password is defined
   tags: always
 
 - name: prepare fanout switch admin login info

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -6,10 +6,9 @@
 
 - name: prepare fanout switch admin login info
   set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
-  when: fanout_tacacs_sonic_user is not defined and fanout_tacacs_sonic_password is not defined
-
-- name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_sonic_user is not defined and fanout_tacacs_sonic_password is not defined
 
 - name: retrieve SONiC version
   shell: cat /etc/sonic/sonic_version.yml | grep ":"

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -2,7 +2,9 @@
 
 - name: set login to tacacs if tacacs is defined
   set_fact: ansible_ssh_user={{ fanout_tacacs_sonic_user }} ansible_ssh_password={{ fanout_tacacs_sonic_password }}
-  when: fanout_tacacs_sonic_user is defined and fanout_tacacs_sonic_password is defined
+  when: >
+    fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
+    fanout_tacacs_sonic_user is defined and fanout_tacacs_sonic_password is defined
 
 - name: prepare fanout switch admin login info
   set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,5 +1,13 @@
 - debug: msg="{{ device_info[inventory_hostname] }}"
 
+- name: set login to tacacs if tacacs is defined
+  set_fact: ansible_ssh_user={{ fanout_tacacs_sonic_user }} ansible_ssh_password={{ fanout_tacacs_sonic_password }}
+  when: fanout_tacacs_sonic_user is defined and fanout_tacacs_sonic_password is defined
+
+- name: prepare fanout switch admin login info
+  set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
+  when: fanout_tacacs_sonic_user is not defined and fanout_tacacs_sonic_password is not defined
+
 - name: prepare fanout switch admin login info
   set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
 

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -13,6 +13,8 @@
 
 - set_fact: sw_type="{{ device_info[inventory_hostname]['Type'] }}"
 
+# fanout_tacacs_user can override fanout_tacacs_sonic_user, 
+# fanout_tacacs_sonic_user can override fanout_sonic_user
 - name: set login info if fanout_tacacs_user and fanout_tacacs_password is defined
   set_fact: ansible_ssh_user={{ fanout_tacacs_user }} ansible_ssh_password={{ fanout_tacacs_password }}
   when: fanout_tacacs_user is defined and fanout_tacacs_password is defined

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -13,6 +13,11 @@
 
 - set_fact: sw_type="{{ device_info[inventory_hostname]['Type'] }}"
 
+- name: set login info if fanout_tacacs_user and fanout_tacacs_password is defined
+  set_fact: ansible_ssh_user={{ fanout_tacacs_user }} ansible_ssh_password={{ fanout_tacacs_password }}
+  when: fanout_tacacs_user is defined and fanout_tacacs_password is defined
+  tags: always
+
 - set_fact: os='eos'
   when: os is not defined
   tags: always


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Currently when deploying fanout, only the variable fanout_sonic_user/password, fanout_eos_user/password is considered. I add ansible_tacacs_user/password, ansible_tacacs_sonic/password that can override fanout_eos_user so current setup will not be broken.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There is a need to add tacacs account to fanout without affecting current fanout devices that still uses local credentials.

#### How did you do it?
Add fanout_tacacs_sonic_user/password that can override fanout_sonic_user/password, and also a fanout_tacacs_user/password that can override fanout_tacacs_sonic_user/password.

#### How did you verify/test it?
Verified in lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
