### PR TITLE
Adding New Testcase to verify Queue Watermark on all ports

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2639,6 +2639,12 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 1024
+                    cell_size: 384
+                    packet_size: 1350
                 shared_res_size_1:
                     dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
                     ecn: 1
@@ -2794,6 +2800,12 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 1024
+                    cell_size: 384
+                    packet_size: 1350
                 shared_res_size_1:
                     dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
                     ecn: 1
@@ -2940,6 +2952,12 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 1024
+                    cell_size: 384
+                    packet_size: 1350
                 shared_res_size_1:
                     dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
                     ecn: 1

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1711,7 +1711,6 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams
         )
 
-
     @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
@@ -1735,6 +1734,8 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
+        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000":
+            pytest.skip("This test is only supported on cisco-8000")
 
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         testPortIps = dutConfig["testPortIps"]

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1710,3 +1710,67 @@ class TestQosSai(QosSaiBase):
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams
         )
+
+
+    @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
+    def testQosSaiQWatermarkAllPorts(
+        self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        resetWatermark
+    ):
+        """
+            Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports
+
+            Args:
+                queueProfile (pytest parameter): queue profile
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                resetWatermark (Fixture): reset queue watermarks
+
+            Returns:
+                None
+
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        testPortIps = dutConfig["testPortIps"]
+
+        if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and 'backend' not in dutTestParams['topo']:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+        else:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "ecn": qosConfig[queueProfile]["ecn"],
+            "dst_port_ids": dutConfig["testPortIds"],
+            "dst_port_ips": [testPortIps[port]['peer_addr'] for port in dutConfig["testPortIds"]],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
+            "pkt_count": qosConfig[queueProfile]["pkt_count"],
+            "cell_size": qosConfig[queueProfile]["cell_size"],
+            "hwsku": dutTestParams['hwsku']
+        })
+
+        if "platform_asic" in dutTestParams["basicParams"]:
+            testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
+        else:
+            testParams["platform_asic"] = None
+
+        if "packet_size" in qosConfig[queueProfile].keys():
+            testParams["packet_size"] = qosConfig[queueProfile]["packet_size"]
+
+        if "pkts_num_margin" in qosConfig[queueProfile].keys():
+            testParams["pkts_num_margin"] = qosConfig[queueProfile]["pkts_num_margin"]
+
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.QWatermarkAllPortTest",
+            testParams=testParams
+        )

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4303,3 +4303,103 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             # Enable tx on dest port
             self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
 
+
+class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
+
+    def runTest(self):
+        time.sleep(5)
+        switch_init(self.client)
+        # Parse input parameters
+        ingress_counters, egress_counters = get_counter_names(self.test_params['sonic_version'])
+        ecn = int(self.test_params['ecn'])
+        router_mac = self.test_params['router_mac']
+        src_port_id = int(self.test_params['src_port_id'])
+        src_port_ip = self.test_params['src_port_ip']
+        src_port_vlan = self.test_params['src_port_vlan']
+        src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        dst_port_ids = self.test_params['dst_port_ids']
+        dst_port_ips = self.test_params['dst_port_ips']
+        dst_port_macs = [self.dataplane.get_mac(
+            0, ptid) for ptid in dst_port_ids]
+
+        asic_type = self.test_params['sonic_asic_type']
+        pkt_count = int(self.test_params['pkt_count'])
+        cell_size = int(self.test_params['cell_size'])
+        prio_list = [2, 3, 4, 8, 5, 46, 48]
+        queue_list = [1, 3, 4, 0, 2, 5, 6]
+        if 'packet_size' in list(self.test_params.keys()):
+            packet_length = int(self.test_params['packet_size'])
+        else:
+            packet_length = 64
+
+        cell_occupancy = (packet_length + cell_size - 1) // cell_size
+        dst_port_ids.remove(src_port_id)
+        dst_port_ips.remove(src_port_ip)
+        dst_port_macs.remove(src_port_mac)
+        ttl = 64
+        assert(router_mac != '')
+        pkt_dst_mac = router_mac
+
+        # Correct any destination ports that may be in a lag
+        for i in range(len(dst_port_ids)):
+            dst_port_id = dst_port_ids[i]
+            dst_port_ip = dst_port_ips[i]
+            real_dst_port_id = get_rx_port(
+                self,
+                0,
+                src_port_id,
+                router_mac,
+                dst_port_ip, src_port_ip
+            )
+            if real_dst_port_id != dst_port_id:
+                dst_port_ids[i] = real_dst_port_id
+
+        margin = int(self.test_params['pkts_num_margin']) if self.test_params.get(
+            'pkts_num_margin') else 8
+
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
+        dst_q_wm_res_bases = [sai_thrift_read_port_watermarks(self.client, port_list[sid])[0] for sid in dst_port_ids]
+        print("queue watermark base for all port is {}".format(dst_q_wm_res_bases), file=sys.stderr)
+
+        try:
+            for i in range(len(prio_list)):
+                dscp = prio_list[i]
+                queue = queue_list[i]
+                for j in range(len(dst_port_ids)):
+                    dst_port_id = dst_port_ids[j]
+                    dst_port_ip = dst_port_ips[j]
+                    self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+                    pkt = construct_ip_pkt(packet_length,
+                                           pkt_dst_mac,
+                                           src_port_mac,
+                                           src_port_ip,
+                                           dst_port_ip,
+                                           dscp,
+                                           src_port_vlan,
+                                           ecn=ecn,
+                                           ttl=ttl)
+
+                    # leakout
+                    if 'cisco-8000' in asic_type:
+                        assert fill_leakout_plus_one(self, src_port_id,
+                               dst_port_id, pkt, queue, asic_type), \
+                               "Failed to fill leakout on dest port {}".format(dst_port_id)
+
+                    # send packet
+                    send_packet(self, src_port_id, pkt, pkt_count)
+                    self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+
+            time.sleep(2)
+            # get all q_wm values for all port
+            dst_q_wm_res_all_port = [sai_thrift_read_port_watermarks(self.client, port_list[sid])[0]
+                                     for sid in dst_port_ids]
+            print("queue watermark for all port is {}".format(dst_q_wm_res_all_port), file=sys.stderr)
+            expected_wm = pkt_count * cell_occupancy
+            # verification of queue watermark for all ports
+            for qwms in dst_q_wm_res_all_port:
+                for qwm in qwms[:-1]:
+                    print("queue_wm value is {}".format(qwm), file=sys.stderr)
+                    assert((expected_wm - margin) * cell_size <= qwm <= (expected_wm + margin) * cell_size)
+
+        finally:
+            self.sai_thrift_port_tx_enable(self.client, asic_type, dst_port_ids)


### PR DESCRIPTION

### Description of PR
Adding a new Testcase to verify Queue Watermark on all ports .

Summary:
This testcase address the issue #6926 


#### What is the motivation for this PR?
This testcase verifies Queue watermark counter on all the ports on the setup .

#### How did you verify/test it?
Verified this testcase on cisco-8000 platform .

