### PR TITLE
Enhance connection graph and devutils for PDU host vars

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -227,7 +227,7 @@ def pdu_action_on_dut(host, attrs, action):
     if not succeed:
         ret['Summary'] = pdu_info
         return ret
-    pduman = pdu_manager_factory(host, pdu_info, g_conn_graph_facts, pdu_info.values()[0])
+    pduman = pdu_manager_factory(host, pdu_info, g_conn_graph_facts, pdu_info)
 
     if not pduman:
         ret['Summary'].append('Failed to communicate with PDU controller {}'.format(pdu_info.keys()))
@@ -372,7 +372,7 @@ def main():
                         type=str, required=False, default='lab')
     parser.add_argument('-l', '--limit', help='Host: limit to a single dut host name, default all',
                         type=str, required=False)
-    parser.add_argument('--log-level', help='Log level: print logs to STDOUT (if not set to close)', 
+    parser.add_argument('--log-level', help='Log level: print logs to STDOUT (if not set to close)',
                         type=str, required=False, default='warn',
                         choices=['debug', 'info', 'warn', 'error', 'close'])
     parser.add_argument('-u', '--user', help='User: user account to login to host with, default admin',

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -160,6 +160,7 @@ class Parse_Lab_Graph():
                 hostname = dev.attrib['Hostname']
                 if hostname is not None:
                     deviceinfo[hostname] = {}
+                    deviceinfo[hostname]["Hostname"] = hostname
                     hwsku = dev.attrib['HwSku']
                     devtype = dev.attrib['Type']
                     card_type = "Linecard"
@@ -192,6 +193,7 @@ class Parse_Lab_Graph():
             for l3info in devicel3s:
                 hostname = l3info.attrib['Hostname']
                 if hostname is not None:
+                    deviceinfo[hostname]["Hostname"] = hostname
                     management_ip = l3info.find('ManagementIPInterface').attrib['Prefix']
                     deviceinfo[hostname]['ManagementIp'] = management_ip
                     mgmtip = ipaddress.IPNetwork(management_ip)
@@ -216,6 +218,7 @@ class Parse_Lab_Graph():
                     hostname = dev.attrib['Hostname']
                     if hostname is not None:
                         deviceinfo[hostname] = {}
+                        deviceinfo[hostname]["Hostname"] = hostname
                         hwsku = dev.attrib['HwSku']
                         devtype = dev.attrib['Type']
                         protocol = dev.attrib['Protocol']
@@ -271,6 +274,7 @@ class Parse_Lab_Graph():
                     hostname = dev.attrib['Hostname']
                     if hostname is not None:
                         deviceinfo[hostname] = {}
+                        deviceinfo[hostname]["Hostname"] = hostname
                         hwsku = dev.attrib['HwSku']
                         devtype = dev.attrib['Type']
                         protocol = dev.attrib['Protocol']

--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -211,7 +211,7 @@ def _build_pdu_manager_from_graph(pduman, dut_hostname, conn_graph_facts, pdu_va
         return False
 
     for psu_name, psu_peer in list(pdu_info[dut_hostname].items()):
-        pduman.add_controller(psu_name, psu_peer, pdu_vars)
+        pduman.add_controller(psu_name, psu_peer, pdu_vars[psu_peer['Hostname']])
 
     return len(pduman.controllers) > 0
 
@@ -243,7 +243,7 @@ def _build_pdu_manager_from_inventory(pduman, dut_hostname, pdu_hosts, pdu_vars)
             'Type': 'Pdu',
             'peerport': 'probing',
         }
-        pduman.add_controller(ph, psu_peer, pdu_vars)
+        pduman.add_controller(ph, psu_peer, pdu_vars[psu_peer['Hostname']])
 
     return len(pduman.controllers) > 0
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Each DUT could be connected to multiple PDU hosts. The current implementation assumes that all the PDU hosts connected to same DUT shares same set of host variables. In case the PDU hosts are different, this would not work.

#### How did you do it?
This change enhanced the devutils, pdu_manager and connection graph modules to use host vars specific to the PDU hosts while getting pdu manager object for DUTs.
* Add 'Hostname' field for the collected device info in connection graph.
* Pass PDU information of all related PDU hosts down to pdu_manager_factory
* Use host vars of current PDU host while creating pdu manager object.

#### How did you verify/test it?
Run devutils to get PDU status.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
