### PR TITLE
Skip warm-reboot cases for T2.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -644,6 +644,12 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions:
         - "asic_type in ['cisco-8000']"
 
+pfcwd/test_pfcwd_warm_reboot.py:
+   skip:
+     reason: "Warm Reboot is not supported in T2."
+     conditions:
+        - "'t2' in topo_name"
+
 #######################################
 #####         platform_tests      #####
 #######################################


### PR DESCRIPTION
Since warm-reboot is not targeted for T2, we need to skip it for T2 roles.