### PR TITLE
[macsec]: Fix inserting none packet

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+per-file-ignores =
+    # line too long
+    tests/macsec/macsec_helper.py: E501

--- a/ansible/roles/test/files/ptftests/macsec.py
+++ b/ansible/roles/test/files/ptftests/macsec.py
@@ -46,7 +46,8 @@ def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_
         ret = __origin_dp_poll(
             test, device_number=device_number, port_number=port_number, timeout=timeout, exp_pkt=None)
         timeout -= time.time() - start_time
-        # The device number of PTF host is 0, if the target port isn't a injected port(belong to ptf host), Don't need to do MACsec further.
+        # The device number of PTF host is 0, if the target port isn't a injected port(belong to ptf host),
+        # Don't need to do MACsec further.
         if isinstance(ret, test.dataplane.PollFailure) or exp_pkt is None or ret.device != 0:
             return ret
         pkt = scapy.Ether(ret.packet)
@@ -57,15 +58,14 @@ def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_
                 continue
         if ret.port in MACSEC_INFOS and MACSEC_INFOS[ret.port]:
             encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = MACSEC_INFOS[ret.port]
-            pkt, decap_success = __decap_macsec_pkt(pkt, sci, an, sak, encrypt,
-                                send_sci, 0, xpn_en, ssci, salt)
+            pkt, decap_success = __decap_macsec_pkt(pkt, sci, an, sak, encrypt, send_sci, 0, xpn_en, ssci, salt)
             if decap_success and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                 return ret
         recent_packets.append(pkt)
         packet_count += 1
         if timeout <= 0:
             break
-    return test.dataplane.PollFailure(exp_pkt, recent_packets,packet_count)
+    return test.dataplane.PollFailure(exp_pkt, recent_packets, packet_count)
 
 
 if MACSEC_SUPPORTED and os.path.exists(MACSEC_INFO_FILE):

--- a/ansible/roles/test/files/ptftests/macsec.py
+++ b/ansible/roles/test/files/ptftests/macsec.py
@@ -31,7 +31,7 @@ def __decap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=F
         pkt = sa.decrypt(macsec_pkt)
     except cryptography.exceptions.InvalidTag:
         # Invalid MACsec packets
-        return pkt, False
+        return macsec_pkt, False
     pkt = sa.decap(pkt)
     return pkt, True
 

--- a/ansible/roles/test/files/ptftests/macsec.py
+++ b/ansible/roles/test/files/ptftests/macsec.py
@@ -31,9 +31,9 @@ def __decap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=F
         pkt = sa.decrypt(macsec_pkt)
     except cryptography.exceptions.InvalidTag:
         # Invalid MACsec packets
-        return None
+        return pkt, False
     pkt = sa.decap(pkt)
-    return pkt
+    return pkt, True
 
 
 def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pkt=None):
@@ -57,9 +57,9 @@ def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_
                 continue
         if ret.port in MACSEC_INFOS and MACSEC_INFOS[ret.port]:
             encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = MACSEC_INFOS[ret.port]
-            pkt = __decap_macsec_pkt(pkt, sci, an, sak, encrypt,
+            pkt, decap_success = __decap_macsec_pkt(pkt, sci, an, sak, encrypt,
                                 send_sci, 0, xpn_en, ssci, salt)
-            if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+            if decap_success and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                 return ret
         recent_packets.append(pkt)
         packet_count += 1

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -94,6 +94,7 @@ def getns_prefix(host, intf):
 
     return ns_prefix
 
+
 def get_ipnetns_prefix(host, intf):
     ns_prefix = " "
     if host.is_multi_asic:
@@ -103,7 +104,8 @@ def get_ipnetns_prefix(host, intf):
 
     return ns_prefix
 
-def get_macsec_sa_name(sonic_asic, port_name, egress = True):
+
+def get_macsec_sa_name(sonic_asic, port_name, egress=True):
     if egress:
         table = 'MACSEC_EGRESS_SA_TABLE'
     else:
@@ -178,8 +180,9 @@ def check_appl_db(duthost, ctrl_links, policy, cipher_suite, send_sci):
     for port_name, nbr in list(ctrl_links.items()):
         if isinstance(nbr["host"], EosHost):
             continue
-        submit_async_task(__check_appl_db, (duthost, port_name, nbr["host"],
-                        nbr["port"], policy, cipher_suite, send_sci))
+        submit_async_task(
+            __check_appl_db,
+            (duthost, port_name, nbr["host"], nbr["port"], policy, cipher_suite, send_sci))
     wait_all_complete(timeout=180)
     logger.info("Check appl_db finished")
     return True
@@ -376,8 +379,8 @@ def find_portname_from_ptf_id(mg_facts, ptf_id):
     return None
 
 
-def load_macsec_info(duthost, port, force_reload = None):
-    if force_reload  or port not in __macsec_infos:
+def load_macsec_info(duthost, port, force_reload=None):
+    if force_reload or port not in __macsec_infos:
         __macsec_infos[port] = get_macsec_attr(duthost, port)
     return __macsec_infos[port]
 
@@ -415,8 +418,7 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
                 if macsec_info:
                     encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
                     force_reload[ret.port] = False
-                    pkt, decap_success = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
-                                        send_sci, 0, xpn_en, ssci, salt)
+                    pkt, decap_success = decap_macsec_pkt(pkt, sci, an, sak, encrypt, send_sci, 0, xpn_en, ssci, salt)
                     if decap_success and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                         return ret
         # Normally, if __origin_dp_poll returns a PollFailure, the PollFailure object will contain a list of recently received packets
@@ -427,7 +429,7 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
         packet_count += 1
         if timeout <= 0:
             break
-    return test.dataplane.PollFailure(exp_pkt, recent_packets,packet_count)
+    return test.dataplane.PollFailure(exp_pkt, recent_packets, packet_count)
 
 
 def get_macsec_counters(sonic_asic, namespace, name):
@@ -441,7 +443,7 @@ def get_macsec_counters(sonic_asic, namespace, name):
         ]
     cmd = "python -c '{}'".format(';'.join(lines))
     output = sonic_asic.sonichost.command(cmd)["stdout_lines"][0]
-    return {k:int(v) for k,v in list(ast.literal_eval(output).items())}
+    return {k: int(v) for k, v in list(ast.literal_eval(output).items())}
 
 
 __origin_dp_poll = testutils.dp_poll

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -357,7 +357,7 @@ def decap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=Fal
         pkt = sa.decrypt(macsec_pkt)
     except cryptography.exceptions.InvalidTag:
         # Invalid MACsec packets
-        return pkt, False
+        return macsec_pkt, False
     pkt = sa.decap(pkt)
     return pkt, True
 

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -354,9 +354,9 @@ def decap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=Fal
         pkt = sa.decrypt(macsec_pkt)
     except cryptography.exceptions.InvalidTag:
         # Invalid MACsec packets
-        return None
+        return pkt, False
     pkt = sa.decap(pkt)
-    return pkt
+    return pkt, True
 
 
 def check_macsec_pkt(test, ptf_port_id, exp_pkt, timeout=3):
@@ -415,9 +415,9 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
                 if macsec_info:
                     encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt = macsec_info
                     force_reload[ret.port] = False
-                    pkt = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
+                    pkt, decap_success = decap_macsec_pkt(pkt, sci, an, sak, encrypt,
                                         send_sci, 0, xpn_en, ssci, salt)
-                    if pkt is not None and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
+                    if decap_success and ptf.dataplane.match_exp_pkt(exp_pkt, pkt):
                         return ret
         # Normally, if __origin_dp_poll returns a PollFailure, the PollFailure object will contain a list of recently received packets
         # to help with debugging. However, since we call __origin_dp_poll multiple times, only the packets from the most recent call is retained.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
If to decap macsec failed, the packet with empty content will be inserted into the recent packet list. The packet with empty content cannot be parsed by scapy.

#### How did you do it?
If to decap macsec failed, to insert the original packet into the recent packet list.

#### How did you verify/test it?
Check Azp.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
