### PR TITLE
Fix issue in testPfcStormWithSharedHeadroomOccupancy

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -386,13 +386,6 @@ class TestQosSai(QosSaiBase):
         except Exception as e:
             raise e
         finally:
-            if prev_poll_interval:
-                logger.info("--- Restore original poll interval {} ---".format(prev_poll_interval))
-                duthost.command("pfcwd interval {}".format(prev_poll_interval))
-            else:
-                logger.info("--- Set Default Polling Interval ---".format())
-                duthost.command("pfcwd interval {}".format("200"))
-
             if prev_state:
                 logger.info("--- Restore original config {} for PfcWd on {} ---".format(prev_state, pfcwd_test_port))
                 start_wd_on_ports(duthost,
@@ -403,6 +396,13 @@ class TestQosSai(QosSaiBase):
             else:
                 logger.info("--- Stop PfcWd on {} ---".format(pfcwd_test_port))
                 duthost.command("pfcwd stop {}".format(pfcwd_test_port))
+
+            if prev_poll_interval:
+                logger.info("--- Restore original poll interval {} ---".format(prev_poll_interval))
+                duthost.command("pfcwd interval {}".format(prev_poll_interval))
+            else:
+                logger.info("--- Set Default Polling Interval ---".format())
+                duthost.command("pfcwd interval {}".format("200"))
 
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.PtfEnableDstPorts", testParams=testParams


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix issue when the polling timer is recovered at the end of test

```
RunAnsibleModuleFail: run module command failed, Ansible Results =>
{"changed": true, "cmd": ["pfcwd", "interval", "800"], "delta": "0:00:00.614236", "end": "2023-03-20 04:03:39.275514", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2023-03-20 04:03:38.661278", "stderr": "unable to use polling interval = 800ms, value is bigger than one of the configured detection time values, please choose a smaller polling_interval", "stderr_lines": ["unable to use polling interval = 800ms, value is bigger than one of the configured detection time values, please choose a smaller polling_interval"], "stdout": "", "stdout_lines": []}
```
Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

We only reconfigure PFC WD polling timer when it is less than the existing value. When we recover the polling timer, we are enlarging it, which causes an error because we make the polling timer less than the detection timer, and restoration timer which are the same value as the current polling timer.

Fix
Restore, which is to enlarge, the detection timer and the restoration timer first and then the polling timer. The previous detection timer and the restoration timer are the same as the polling timer to be recovered.

#### How did you verify/test it?

Run regression test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
