### PR TITLE
Add mark in the beginning of the scripts.

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import pytest
 from .arp_utils import MacToInt, IntToMac, get_crm_resources, fdb_cleanup, \
                       clear_dut_arp_cache, increment_ipv6_addr, get_fdb_dynamic_mac_count
 import ptf.testutils as testutils
@@ -14,6 +15,10 @@ ARP_SRC_MAC = "00:00:01:02:03:04"
 ENTRIES_NUMBERS = 12000
 
 logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 LOOP_TIMES_LEVEL_MAP = {
     'debug': 1,

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -2,11 +2,16 @@ import pexpect
 import logging
 import time
 import re
+import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 
 TOTAL_PACKETS = 100
 logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 
 def test_console_escape(duthost_console, duthost):

--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 
@@ -7,6 +8,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TMOUT = "900"
 SET_TMOUT = "10"
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 
 def test_timeout(duthost_console, duthost):

--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import math
+import pytest
 
 from collections import defaultdict
 from tests.common.utilities import wait_until
@@ -20,6 +21,10 @@ LOOP_TIMES_LEVEL_MAP = {
 }
 
 logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 
 def get_fdb_dict(ptfadapter, vlan_table, dummay_mac_count):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Perviously, there is no pytestmark at the beginning of the scripts, so nightly test will skip all these scripts. These scripts are designed to run on all topologies, so I add mark 
```
pytestmark = [
    pytest.mark.topology('any')
]
```
at the beginning of all scripts. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Perviously, there is no pytestmark at the beginning of the scripts, so nightly test will skip all these scripts. These scripts are designed to run on all topologies, so I add mark 
```
pytestmark = [
    pytest.mark.topology('any')
]
```
at the beginning of all scripts. 

#### How did you do it?
Add mark 
```
pytestmark = [
    pytest.mark.topology('any')
]
```
at the beginning of all scripts. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
