### PR TITLE
Add test case supported topology to techsupport UT

### DIFF
--- a/tests/show_techsupport/test_techsupport_no_secret.py
+++ b/tests/show_techsupport/test_techsupport_no_secret.py
@@ -5,6 +5,12 @@ from tests.common.utilities import skip_release
 
 logger = logging.getLogger(__name__)
 
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
 @pytest.fixture
 def check_image_version(duthost):
     """Skips this test if the SONiC image installed on DUT is older than 202112


### PR DESCRIPTION
**What I did**
Add test case supported topology to techsupport UT.

**Why I did it**
Test case supported topology is missing in the UT, the techsupport UT are skipped in some test scenario.

To protect the patch, add this UT to check TACACS will send remote address to server.

**How I verified it**
Pass all UT.

**Details if related**
