### PR TITLE
Add library and sample scripts for running ansible in pure python

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -1,0 +1,309 @@
+"""Script for upgrading SONiC image for nightly tests.
+
+Main purpose of this script is to upgrade SONiC image for nightly tests. Based on the arguments passed in, the script
+may power cycle the devices before upgrade. Or only power cycle the devices only when they are unreachable.
+
+Before upgrade to the target image, this script may upgrade to a previous image firstly. This is to avoid that the
+devices are already running the target image. Then image upgrading could be skipped. The problem is that the current
+image may has been updated by people for debugging purpose. Upgrade to a previous image firstly can ensure that the
+target image is clean.
+"""
+import argparse
+import logging
+import os
+import requests
+import sys
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+base_path = os.path.realpath(os.path.join(_self_dir, ".."))
+if base_path not in sys.path:
+    sys.path.append(base_path)
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
+if ansible_path not in sys.path:
+    sys.path.append(ansible_path)
+
+
+from devutil.devices import init_localhost, init_testbed_sonichosts                 # noqa E402
+
+from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory     # noqa E402
+
+logger = logging.getLogger(__name__)
+
+
+RC_INIT_FAILED = 1
+RC_UPGRADE_PREV_FAILED = 2
+RC_UPGRADE_FAILED = 3
+RC_ENABLE_FIPS_FAILED = 4
+
+
+def validate_args(args):
+    _log_level_map = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL
+    }
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=_log_level_map[args.log_level],
+        format="%(asctime)s %(filename)s#%(lineno)d %(levelname)s - %(message)s"
+    )
+
+    args.skip_prev_image = False
+    if not args.prev_image_url:
+        args.prev_image_url = "{}.PREV.1".format(args.image_url)
+    logger.info("PREV_IMAGE_URL={}".format(args.prev_image_url))
+
+    try:
+        res_prev_image = requests.head(args.prev_image_url, timeout=20)
+        if res_prev_image.status_code != 200:
+            logger.info("Not able to get prev_image at {}, skip upgrading to prev_image.".format(args.prev_image_url))
+            args.skip_prev_image = True
+    except Exception as e:
+        logger.info(
+            "Downloading prev image {} failed with {}, skip upgrading to prev image".format(
+                args.prev_image_url, repr(e)
+            )
+        )
+        args.skip_prev_image = True
+
+
+def get_pdu_managers(sonichosts, conn_graph_facts):
+    """Get PDU managers for all the devices to be upgraded.
+
+    Args:
+        sonichosts (SonicHosts): Instance of class SonicHosts
+        conn_graph_facts (dict): Connection graph dict.
+
+    Returns:
+        dict: A dict of PDU managers. Key is device hostname. Value is the PDU manager object for the device.
+    """
+    pdu_managers = {}
+    for hostname in sonichosts.hostnames:
+        pdu_links = conn_graph_facts["device_pdu_links"][hostname]
+        pdu_hostnames = [peer_info["peerdevice"] for peer_info in pdu_links.values()]
+        pdu_vars = {}
+        for pdu_hostname in pdu_hostnames:
+            pdu_vars[pdu_hostname] = sonichosts.get_host_visible_vars(pdu_hostname)
+
+        pdu_managers[hostname] = pdu_manager_factory(hostname, None, conn_graph_facts, pdu_vars)
+    return pdu_managers
+
+
+def main(args):
+    logger.info("Validating arguments")
+    validate_args(args)
+
+    logger.info("Initializing hosts")
+    localhost = init_localhost(args.inventory, options={"verbosity": args.verbosity})
+    sonichosts = init_testbed_sonichosts(
+        args.inventory, args.testbed_name, testbed_file=args.tbfile, options={"verbosity": args.verbosity}
+    )
+
+    if not localhost or not sonichosts:
+        sys.exit(RC_INIT_FAILED)
+
+    conn_graph_facts = localhost.conn_graph_facts(
+        hosts=sonichosts.hostnames,
+        filepath=os.path.join(ansible_path, "files")
+    )["localhost"]["ansible_facts"]
+
+    if args.always_power_cycle or args.power_cycle_unreachable:
+        pdu_managers = get_pdu_managers(sonichosts, conn_graph_facts)
+
+    # Power cycle before upgrade
+    if args.always_power_cycle:
+        logger.info("Power cycle before upgrade")
+        for hostname, pdu_manager in pdu_managers.items():
+            logger.info("Turn off power outlets to {}".format(hostname))
+            pdu_manager.turn_off_outlet()
+        localhost.pause(seconds=30, prompt="Pause between power off/on")
+        for hostname, pdu_manager in pdu_managers.items():
+            logger.info("Turn on power outlets to {}".format(hostname))
+            pdu_manager.turn_on_outlet()
+        localhost.pause(seconds=180, prompt="Add some sleep to allow power cycled DUTs to come back")
+
+    # Power cycle when unreachable
+    elif args.power_cycle_unreachable:
+        logger.info("Power cycle unreachable")
+        ping_results = {}
+        needs_sleep = False
+        for hostname, ip in zip(sonichosts.hostnames, sonichosts.ipaddrs):
+            logger.info("Ping {} @{} from localhost".format(hostname, ip))
+            ping_failed = localhost.command(
+                "timeout 2 ping {} -c 1".format(ip), module_ignore_errors=True
+            ).get("localhost", {}).get("failed")
+            if ping_failed:
+                logger.info("Ping {} @{} from localhost failed. Going to power off it".format(hostname, ip))
+                ping_results[hostname] = ping_failed
+                pdu_managers[hostname].turn_off_outlet()
+                needs_sleep = True
+
+        if needs_sleep:
+            localhost.pause(seconds=30, prompt="Pause between power off/on")
+
+        for hostname, ping_failed in ping_results.items():
+            if ping_failed:
+                logger.info("Power on {}".format(hostname))
+                pdu_managers[hostname].turn_on_outlet()
+
+        if needs_sleep:
+            localhost.pause(seconds=180, prompt="Add some sleep to allow power cycled DUTs to come back")
+
+    # Upgrade to prev image
+    if not args.skip_prev_image:
+        logger.info("upgrade to prev image at {}".format(args.prev_image_url))
+        upgrade_success = sonichosts.upgrade_image(
+            localhost,
+            args.prev_image_url,
+            upgrade_type=args.upgrade_type,
+            onie_pause_time=args.onie_pause_time
+        )
+
+        if not upgrade_success:
+            logger.error("Upgrade prev_image {} failed".format(args.prev_image_url))
+            sys.exit(RC_UPGRADE_PREV_FAILED)
+        else:
+            logger.info("Upgraded to prev_image {}.".format(args.prev_image_url))
+
+        for hostname, version in sonichosts.sonic_version.items():
+            logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+
+    # Upgrade to target image
+    logger.info("upgrade to target image at {}".format(args.image_url))
+    upgrade_success = sonichosts.upgrade_image(
+        localhost,
+        args.image_url,
+        upgrade_type=args.upgrade_type,
+        onie_pause_time=args.onie_pause_time
+    )
+    if not upgrade_success:
+        logger.error("Upgrade image {} failed".format(args.image_url))
+        sys.exit(RC_UPGRADE_FAILED)
+    else:
+        logger.info("Upgraded to image {}".format(args.prev_image_url))
+    for hostname, version in sonichosts.sonic_version.items():
+        logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+
+    # Enable FIPS
+    if args.enable_fips:
+        logger.info("Need to enable FIPS")
+        try:
+            sonichosts.command("sonic-installer set-fips", module_attrs={"become": True})
+            sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
+        except Exception as e:
+            logger.error("Failed to enable FIPS mode: {}".repr(e))
+            sys.exit(RC_ENABLE_FIPS_FAILED)
+
+    localhost.pause(seconds=180, prompt="Pause after reboot")
+    logger.info("===== UPGRADE IMAGE DONE =====")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Tool for SONiC image upgrade during nightly tests.")
+
+    parser.add_argument(
+        "-i", "--inventory",
+        type=str,
+        dest="inventory",
+        required=True,
+        help="Ansible inventory file")
+
+    parser.add_argument(
+        "-t", "--testbed-name",
+        type=str,
+        required=True,
+        dest="testbed_name",
+        help="Testbed name. DUTs of the specified testbed will be upgraded."
+    )
+
+    parser.add_argument(
+        "-u", "--url",
+        type=str,
+        dest="image_url",
+        required=True,
+        help="SONiC image url."
+    )
+
+    parser.add_argument(
+        "--prev-url",
+        type=str,
+        dest="prev_image_url",
+        default=None,
+        help="SONiC image url."
+    )
+
+    parser.add_argument(
+        "--tbfile",
+        type=str,
+        dest="tbfile",
+        default="testbed.yaml",
+        help="Testbed definition file."
+    )
+
+    parser.add_argument(
+        "--always-power-cycle",
+        type=bool,
+        dest="always_power_cycle",
+        default=False,
+        help="Always power cycle DUTs before upgrade."
+    )
+
+    parser.add_argument(
+        "--power-cycle-unreachable",
+        type=bool,
+        dest="power_cycle_unreachable",
+        default=True,
+        help="Only power cycle unreachable DUTs."
+    )
+
+    parser.add_argument(
+        "--onie-pause-time",
+        type=int,
+        dest="onie_pause_time",
+        default=30,
+        help="Seconds to pause after booted into onie."
+    )
+
+    parser.add_argument(
+        "-y", "--type",
+        type=str,
+        choices=["sonic", "onie"],
+        dest="upgrade_type",
+        required=False,
+        default="sonic",
+        help="Upgrade type."
+    )
+
+    parser.add_argument(
+        "--enable-fips",
+        type=bool,
+        dest="enable_fips",
+        required=False,
+        default=False,
+        help="Enable FIPS."
+    )
+
+    parser.add_argument(
+        "-v", "--verbosity",
+        type=int,
+        dest="verbosity",
+        default=2,
+        help="Log verbosity (0-3)."
+    )
+
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        dest="log_level",
+        choices=["debug", "info", "warning", "error", "critical"],
+        default="debug",
+        help="Loglevel"
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/ansible/devutil/ansible_hosts.py
+++ b/ansible/devutil/ansible_hosts.py
@@ -1,0 +1,1000 @@
+"""Basic classes and functions for running ansible modules on devices by python.
+
+This idea is mainly inspired by the pytest-ansible plugin. With the classes and functions defined here, we can run any
+ansible modules on any hosts defined in inventory file.
+
+Instead of writing ansible playbook to operate on the testbed devices, we can just write python.
+
+Comparing with ansible playbook, we can take advantage of a real programming language. The drawback is that python
+programming experience is required.
+
+Comparing with pytest-ansible, we do not need pytest. This design supports some ansible features not supported by
+pytest-ansible:
+* fork: Pytest-ansible does not support running ansible modules in parallel. This design uses ansible's builtin forking
+    capability to run modules in parallel.
+* module attributes: Ansible supports additional module attributes that can be specified for each task in playbook.
+    These module attributes can affect execution of the modules, for example "become", "async", etc. Pytest-ansible
+    does not support these attributes. With this design, we can use keyword argument `module_attrs` to specify
+    module attributes while calling an ansible module.
+
+Not all ansible's builtin features are supported by this design. For example:
+* Notify and event handler. (We can use python's libs to support that)
+
+This idea is still new. I haven't figured out all of its potentials and limitations. Feedbacks, suggestions and
+contributions are more than welcomed.
+"""
+import copy
+import inspect
+import json
+import logging
+
+from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.inventory.manager import InventoryManager
+from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+from ansible.playbook.play import Play
+
+from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
+from ansible import context
+from ansible.module_utils.common.collections import ImmutableDict
+
+logger = logging.getLogger("ansible_hosts")
+
+try:
+    from ansible.executor import task_result
+    task_result._IGNORE = ("skipped", )
+except Exception as e:
+    logging.error("Hack for https://github.com/ansible/pytest-ansible/issues/47 failed: {}".format(repr(e)))
+
+
+class UnsupportedAnsibleModule(Exception):
+    pass
+
+
+class RunAnsibleModuleFailed(Exception):
+    pass
+
+
+class NoAnsibleHostError(Exception):
+    pass
+
+
+class MultipleAnsibleHostsError(Exception):
+    pass
+
+
+class ResultCollector(CallbackBase):
+    """Call back for getting single ansible module execution result on ansible hosts.
+
+    Args:
+        CallbackBase (class): Base class for all callbacks defined in ansible.
+    """
+    def __init__(self, *args, **kwargs):
+        super(ResultCollector, self).__init__(*args, **kwargs)
+        self._results = {}
+
+    def v2_runner_on_ok(self, result):
+        hostname = result._host.get_name()
+
+        res = dict(reachable=True, failed=False)
+        res.update(result._result)
+        self._results[hostname] = res
+
+    def v2_runner_on_failed(self, result, *args, **kwargs):
+        hostname = result._host.get_name()
+
+        res = dict(reachable=True, failed=True)
+        res.update(result._result)
+        self._results[hostname] = res
+
+    def v2_runner_on_unreachable(self, result, *args, **kwargs):
+        hostname = result._host.get_name()
+
+        res = dict(reachable=False, failed=True)
+        res.update(result._result)
+        self._results[hostname] = res
+
+    @property
+    def results(self):
+        """Property for returning execution result of single ansible module on ansible hosts.
+
+        The result is a dict keyed by hostname. Value is the ansible module execution result on that host.
+        Sample result:
+        {
+            "VM0100": {
+                "stderr_lines": [],
+                "cmd": "pwd",
+                "stdout": "/root",
+                "delta": "0:00:00.001744",
+                "stdout_lines": [
+                    "/root"
+                ],
+                "ansible_facts": {
+                    "discovered_interpreter_python": "/usr/bin/python"
+                },
+                "end": "2023-03-20 01:11:01.748306",
+                "_ansible_no_log": false,
+                "start": "2023-03-20 01:11:01.746562",
+                "changed": true,
+                "failed": false,
+                "reachable": true,
+                "stderr": "",
+                "rc": 0,
+                "invocation": {
+                    "module_args": {
+                        "warn": true,
+                        "executable": null,
+                        "_uses_shell": true,
+                        "strip_empty_ends": true,
+                        "_raw_params": "pwd",
+                        "removes": null,
+                        "argv": null,
+                        "creates": null,
+                        "chdir": null,
+                        "stdin_add_newline": true,
+                        "stdin": null
+                    }
+                }
+            },
+            "VM0101": {
+                "stderr_lines": [],
+                "cmd": "pwd",
+                "stdout": "/root",
+                "delta": "0:00:00.001764",
+                "stdout_lines": [
+                    "/root"
+                ],
+                "ansible_facts": {
+                    "discovered_interpreter_python": "/usr/bin/python"
+                },
+                "end": "2023-03-20 01:11:01.748302",
+                "_ansible_no_log": false,
+                "start": "2023-03-20 01:11:01.746538",
+                "changed": true,
+                "failed": false,
+                "reachable": true,
+                "stderr": "",
+                "rc": 0,
+                "invocation": {
+                    "module_args": {
+                        "warn": true,
+                        "executable": null,
+                        "_uses_shell": true,
+                        "strip_empty_ends": true,
+                        "_raw_params": "pwd",
+                        "removes": null,
+                        "argv": null,
+                        "creates": null,
+                        "chdir": null,
+                        "stdin_add_newline": true,
+                        "stdin": null
+                    }
+                }
+            }
+        }
+
+        Returns:
+            dict: Result is a dict. Key is hostname. Value is ansible module execution result on that host.
+        """
+        return self._results
+
+
+class BatchResultsCollector(CallbackBase):
+    """Call back for getting multiple ansible module execution results on ansible hosts.
+
+    Args:
+        CallbackBase (class): Base class for all callbacks defined in ansible.
+    """
+    def __init__(self, *args, **kwargs):
+        super(BatchResultsCollector, self).__init__(*args, **kwargs)
+        self._results = {}
+
+    def v2_runner_on_ok(self, result, *args, **kwargs):
+        hostname = result._host.get_name()
+        if hostname not in self._results:
+            self._results[hostname] = []
+
+        res = dict(reachable=True, failed=False)
+        res.update(result._result)
+        self._results[hostname].append(res)
+
+    def v2_runner_on_failed(self, result, *args, **kwargs):
+        hostname = result._host.get_name()
+        if hostname not in self._results:
+            self._results[hostname] = []
+
+        res = dict(reachable=True, failed=True)
+        res.update(result._result)
+        self._results[hostname].append(res)
+
+    def v2_runner_on_unreachable(self, result):
+        hostname = result._host.get_name()
+        if hostname not in self._results:
+            self._results[hostname] = []
+
+        res = dict(reachable=False, failed=True)
+        res.update(result._result)
+        self._results[hostname].append(result._result)
+
+    @property
+    def results(self):
+        """Property for returning multiple ansible module execution results of multiple ansible hosts.
+
+        The result is a dict keyed by hostname. Value is list of the ansible module execution results on that host.
+        Sample result:
+        {
+            "vlab-01": [
+                {
+                    "stderr_lines": [],
+                    "cmd": [
+                        "pwd"
+                    ],
+                    "stdout": "/home/admin",
+                    "delta": "0:00:00.002754",
+                    "stdout_lines": [
+                        "/home/admin"
+                    ],
+                    "ansible_facts": {
+                        "discovered_interpreter_python": "/usr/bin/python"
+                    },
+                    "end": "2023-03-20 01:17:02.602775",
+                    "_ansible_no_log": false,
+                    "start": "2023-03-20 01:17:02.600021",
+                    "changed": true,
+                    "failed": false,
+                    "reachable": true,
+                    "stderr": "",
+                    "rc": 0,
+                    "invocation": {
+                        "module_args": {
+                            "creates": null,
+                            "executable": null,
+                            "_uses_shell": false,
+                            "strip_empty_ends": true,
+                            "_raw_params": "pwd",
+                            "removes": null,
+                            "argv": null,
+                            "warn": true,
+                            "chdir": null,
+                            "stdin_add_newline": true,
+                            "stdin": null
+                        }
+                    }
+                },
+                {
+                    "stderr_lines": [],
+                    "cmd": "ls",
+                    "end": "2023-03-20 01:17:02.812231",
+                    "_ansible_no_log": false,
+                    "stdout": "config.json\nmyfile",
+                    "changed": true,
+                    "rc": 0,
+                    "failed": false,
+                    "reachable": true,
+                    "stderr": "",
+                    "delta": "0:00:00.003928",
+                    "invocation": {
+                        "module_args": {
+                            "creates": null,
+                            "executable": null,
+                            "_uses_shell": true,
+                            "strip_empty_ends": true,
+                            "_raw_params": "ls",
+                            "removes": null,
+                            "argv": null,
+                            "warn": true,
+                            "chdir": null,
+                            "stdin_add_newline": true,
+                            "stdin": null
+                        }
+                    },
+                    "stdout_lines": [
+                        "config.json",
+                        "myfile"
+                    ],
+                    "start": "2023-03-20 01:17:02.808303"
+                }
+            ]
+        }
+
+        Returns:
+            dict: Result is a dict. Key is hostname. Value is ansible module execution result.
+        """
+        return self._results
+
+
+class AnsibleHosts(object):
+    """Basic class for running ansible modules on hosts defined in ansible inventory file.
+
+    Instance of this class is for running ansible modules on hosts defined in ansible inventory file. The class
+    instance is not a python list. It represents a list of hosts matching specified pattern in specified ansible
+    inventory file.
+    """
+    def __init__(
+            self,
+            inventories,
+            hosts_pattern,
+            options={},
+            hostvars={}):
+        """Constructor of AnsibleHosts.
+
+        Args:
+            inventories (str or list): Inventory file or a list of inventory files. Consumed by ansible under the hood.
+            hosts_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
+                Follow the same rules of specifying ansible hosts in ansible play book.
+                Examples:
+                    "vlab-01"
+                    "VM0100, VM0101"
+                    ["VM0100", "VM0101"]
+                    "server_1:&vm_host"
+            options (dict, optional): Options affecting ansible execution. Supports options that can be passed in from
+                ansible-playbook command line. Defaults to {}.
+                Examples:
+                    options={"become": True, "forks": 10}
+            hostvars (dict, optional): Additional ansible variables for ansible hosts. Similar as using `-e` argument
+                of ansible-playbook command line to specify additional host variables. Defaults to {}.
+
+        Raises:
+            NoAnsibleHostError: Raise this exception when no host matching specified pattern in inventory file.
+        """
+        self.inventories = inventories
+        self.hosts_pattern = hosts_pattern
+
+        # Default options
+        self._options = {
+            "forks": 5,
+            "connection": "smart",
+            "verbosity": 2,
+            "become_method": "sudo"
+        }
+        if options:
+            self._options.update(options)
+
+        context.CLIARGS = ImmutableDict(**self._options)
+
+        self.loader = DataLoader()
+        self.im = InventoryManager(loader=self.loader, sources=self.inventories)
+        self.vm = VariableManager(loader=self.loader, inventory=self.im)
+
+        self.hosts = self.im.get_hosts(self.hosts_pattern)      # List of <class 'ansible.inventory.host.Host'>
+        if len(self.hosts) == 0:
+            raise NoAnsibleHostError(
+                "No hosts '{}' in inventory files '{}'".format(self.hosts_pattern, self.inventories)
+            )
+        self.hosts_count = len(self.hosts)
+        self.hostnames = [_host.name for _host in self.hosts]                       # List of hostname (str)
+        self.ipaddrs = [_host.vars.get("ansible_host") for _host in self.hosts]     # List of IPs (str)
+
+        if hostvars:
+            self.vm.extra_vars.update(hostvars)
+
+        self._loaded_tasks = []
+
+    def get_host(self, hostname, strict=False):
+        """Tool for getting ansible.inventory.host.Host object from self.inventories using ansible inventory manager.
+
+        Args:
+            hostname (str): Hostname
+            strict (bool, optional): If strict==True, only get host with hostname from hosts matching
+                self.hosts_pattern in self.inventories. If strict=False, get any host with hostname from
+                self.inventories. Defaults to False.
+
+        Returns:
+            ansible.inventory.host.Host or None: Object of class ansible.inventory.host.Host or None.
+        """
+        if strict:
+            # Only get host with hostname from self.hosts
+            for _host in self.hosts:
+                if _host.name == hostname:
+                    return _host
+            else:
+                return None
+        else:
+            # Get host with hostname from whole inventory
+            return self.im.get_host(hostname)
+
+    def get_hosts(self, hosts_pattern):
+        """Tool for getting list of ansible.inventory.host.Host objects from self.inventories using ansible inventory
+        manager. Ansible inventory manager is used under the hood.
+
+        Args:
+            hosts_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
+                Follow the same rules of specifying ansible hosts in ansible play book.
+
+        Returns:
+            list: List of ansible.inventory.host.Host objects.
+        """
+        return self.im.get_hosts(hosts_pattern)
+
+    def get_host_vars(self, hostname, strict=False):
+        """Tool for getting variables of specified host from self.inventories. Variables defined in group_vars and
+        host_vars are not included. Only ansible inventory manager is used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            strict (bool, optional): If strict==True, only get variables of host with hostname from hosts matching
+                self.hosts_pattern in self.inventories. If strict=False, get variables of any host with hostname from
+                self.inventories. Defaults to False.
+
+        Returns:
+            dict: Dict of variables. Key is variable name. Value is variable value.
+        """
+        _host = self.get_host(hostname, strict=strict)
+        if not _host:
+            return {}
+        return _host.get_vars()
+
+    def get_host_var(self, hostname, var, strict=False):
+        """Tool for getting variable value of specified host from self.inventories. Variables defined in group_vars and
+        host_vars are not included. Only ansible inventory manager is used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            var (str): Variable name.
+            strict (bool, optional): If strict==True, only get variable value of host with hostname from hosts matching
+                self.hosts_pattern in self.inventories. If strict=False, get variable value of any host with hostname
+                from self.inventories. Defaults to False.
+
+        Returns:
+            Any: Variable value, possible types: str, int, bool, list, dict.
+        """
+        return self.get_host_vars(hostname, strict=strict).get(var, None)
+
+    def get_host_visible_vars(self, hostname, strict=False):
+        """Tool for getting visible variables of specified host. Variables may be defined in inventory files, any
+        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            strict (bool, optional): If strict==True, only get visible variables of host with hostname from hosts
+                matching self.hosts_pattern in self.inventories. If strict=False, get visible variables of any host
+                with hostname from self.inventories. Defaults to False.
+
+        Returns:
+            dict: Dict of variables. Key is variable name. Value is variable value.
+        """
+        _host = self.get_host(hostname, strict=strict)
+        if not _host:
+            return {}
+        return self.vm.get_vars(host=_host)
+
+    def get_host_visible_var(self, hostname, var, strict=False):
+        """Tool for getting visible variable value of specified host. Variable may be defined in inventory files, any
+        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            var (str): Variable name.
+            strict (bool, optional): If strict==True, only get visible variable value of host with hostname from hosts
+                matching self.hosts_pattern in self.inventories. If strict=False, get visible variable value of any host
+                with hostname from self.inventories. Defaults to False.
+
+        Returns:
+            Any: Variable value, possible types: str, int, bool, list, dict.
+        """
+        return self.get_host_visible_vars(hostname, strict=strict).get(var, None)
+
+    def __getattr__(self, attr):
+        """For finding ansible module and return a function for running that ansible module.
+
+        Args:
+            attr (str): Name of an attribute of current object. Usually ansible module name.
+
+        Raises:
+            UnsupportedAnsibleModule: Unable to find ansible module specified by `attr` from ansible builtin modules
+                or current visible customized modules.
+
+        Returns:
+            callable: A function for running ansible module specified by `attr`.
+        """
+        if not module_loader.has_plugin(attr):
+            raise UnsupportedAnsibleModule("Unsupported ansible module \"{}\"".format(attr))
+        self.module_name = attr
+        return self._run_ansible_module
+
+    def _build_task(self, module_name, args=[], kwargs={}, module_attrs={}):
+        """Build a dict reprents a task in ansible playbook.
+
+        Args:
+            module_name (str): Name of the ansible module to be executed in the task.
+            args (list, optional): Positional arguments of ansible module. Enclosed in a list. Defaults to [].
+            kwargs (dict, optional): Keyword arguments of ansible module. Enclosed in a dict. Defaults to {}.
+            module_attrs (dict, optional): Attributes affect module execution, eg: become, async, poll, etc.
+                Check ansible module reference documentation for module attributes applicable to modules.
+                * https://docs.ansible.com/ansible/2.9/modules/list_of_all_modules.html
+                * https://docs.ansible.com/ansible/latest/collections/index.html
+
+        Returns:
+            dict: A dict reprents a task in ansible playbook.
+        """
+        kwargs = copy.deepcopy(kwargs)  # Avoid argument passed by reference issue
+        if args:
+            kwargs["_raw_params"] = " ".join(args)
+
+        task_data = {
+            "action": {
+                "module": module_name,
+                "args": kwargs
+            },
+        }
+        if module_attrs:
+            task_data.update(module_attrs)
+
+        return task_data
+
+    def _build_play(self, tasks=[]):
+        """Build a dict  reprents an ansible playbook.
+
+        The list of tasks may include single or multiple tasks.
+
+        Args:
+            tasks (list, optional): List of dict reprents task in ansible playbook. Defaults to [].
+
+        Returns:
+            dict: A dict represents an ansible playbook.
+        """
+        return Play().load(
+            {
+                "hosts": self.hosts_pattern,    # Playbook will be executed on hosts matching `self.hosts_pattern`
+                "gather_facts": "no",
+                "tasks": tasks,
+            },
+            variable_manager=self.vm,
+            loader=self.loader,
+        )
+
+    def _run_play(self, play):
+        """Use ansible's TaskQueueManager to run a playbook described in a dict.
+
+        Args:
+            play (dict): A dict represents an ansible playbook.
+
+        Returns:
+            dict: Results of running ansible modules in playbook. If task list length is 1, ResultCollector is used
+                as result collector callback. If task list length is greater than 1, BatchResultsCollector is used as
+                result collector callback.
+        """
+        play_tasks = play.get_tasks()[0]
+
+        if len(play_tasks) > 1:
+            callback = BatchResultsCollector()
+        else:
+            callback = ResultCollector()
+
+        tqm = TaskQueueManager(
+            inventory=self.im,
+            variable_manager=self.vm,
+            loader=self.loader,
+            passwords=dict(vault_pass="secret"),
+            stdout_callback=callback,
+            forks=self._options.get("forks")
+        )
+        tqm.run(play)
+
+        return callback.results
+
+    def _run_ansible_module(self, *args, **kwargs):
+        """Function for running ansible module.
+
+        Special keyword arguments:
+            module_ignore_errors: If this argument is set to True, no RunAnsibleModuleFailed exception will be raised.
+            module_attrs: A dict for specifying module attributes that may affect execution of the ansible module.
+                Reference documents:
+                * https://docs.ansible.com/ansible/2.9/modules/list_of_all_modules.html
+                * https://docs.ansible.com/ansible/latest/collections/index.html
+            verbosity: integer from 0-3.
+
+        Raises:
+            RunAnsibleModuleFailed: Raise this exception if result is failed AND keyword argument
+                `module_ignore_errors` is False.
+
+        Returns:
+            dict: Ansible module execution result. Sample result:
+                {
+                    "VM0100": {
+                        "stderr_lines": [],
+                        "cmd": "pwd",
+                        "stdout": "/root",
+                        "delta": "0:00:00.001744",
+                        "stdout_lines": [
+                            "/root"
+                        ],
+                        "ansible_facts": {
+                            "discovered_interpreter_python": "/usr/bin/python"
+                        },
+                        "end": "2023-03-20 01:11:01.748306",
+                        "_ansible_no_log": false,
+                        "start": "2023-03-20 01:11:01.746562",
+                        "changed": true,
+                        "failed": false,
+                        "reachable": true,
+                        "stderr": "",
+                        "rc": 0,
+                        "invocation": {
+                            "module_args": {
+                                "warn": true,
+                                "executable": null,
+                                "_uses_shell": true,
+                                "strip_empty_ends": true,
+                                "_raw_params": "pwd",
+                                "removes": null,
+                                "argv": null,
+                                "creates": null,
+                                "chdir": null,
+                                "stdin_add_newline": true,
+                                "stdin": null
+                            }
+                        }
+                    },
+                    "VM0101": {
+                        "stderr_lines": [],
+                        "cmd": "pwd",
+                        "stdout": "/root",
+                        "delta": "0:00:00.001764",
+                        "stdout_lines": [
+                            "/root"
+                        ],
+                        "ansible_facts": {
+                            "discovered_interpreter_python": "/usr/bin/python"
+                        },
+                        "end": "2023-03-20 01:11:01.748302",
+                        "_ansible_no_log": false,
+                        "start": "2023-03-20 01:11:01.746538",
+                        "changed": true,
+                        "failed": false,
+                        "reachable": true,
+                        "stderr": "",
+                        "rc": 0,
+                        "invocation": {
+                            "module_args": {
+                                "warn": true,
+                                "executable": null,
+                                "_uses_shell": true,
+                                "strip_empty_ends": true,
+                                "_raw_params": "pwd",
+                                "removes": null,
+                                "argv": null,
+                                "creates": null,
+                                "chdir": null,
+                                "stdin_add_newline": true,
+                                "stdin": null
+                            }
+                        }
+                    }
+                }
+        """
+        previous_frame = inspect.currentframe().f_back
+        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+
+        verbosity = kwargs.pop("verbosity", self._options.get("verbosity"))
+        module_ignore_errors = kwargs.pop("module_ignore_errors", False)
+        module_attrs = kwargs.pop("module_attrs", {})
+
+        task_headline = "===== [{}] {} ".format(self.hosts_pattern, self.module_name)
+        task_headline_suffix = "=" * (120 - len(task_headline))
+        task_headline += task_headline_suffix
+
+        if verbosity <= 0:          # Do not log module calls at all.
+            pass
+        elif verbosity == 1:        # Log module name only. Do not log args.
+            logger.debug(task_headline)
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{}".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name
+            ))
+        elif verbosity == 2:        # Log args without indention.
+            logger.debug(task_headline)
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name,
+                json.dumps(args),
+                json.dumps(kwargs)
+            ))
+        elif verbosity >= 3:        # Log args with indention.
+            logger.debug(task_headline)
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{},\nargs={},\nkwargs={}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name,
+                json.dumps(args, indent=4),
+                json.dumps(kwargs, indent=4)
+            ))
+
+        # Build task/play, run the play, get results
+        task = self._build_task(self.module_name, args=args, kwargs=kwargs, module_attrs=module_attrs)
+        play = self._build_play(tasks=[task])
+        res = self._run_play(play)
+
+        if verbosity <= 0:          # Do not log module results at all
+            pass
+        elif verbosity == 1:        # Log module name only. Do not log module results.
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} executed\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name
+            ))
+        elif verbosity == 2:        # Log module results without indention.
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name,
+                json.dumps(res)
+            ))
+        elif verbosity >= 3:        # Log module results with indention.
+            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} Result =>\n{}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name,
+                json.dumps(res, indent=4)
+            ))
+
+        if not module_ignore_errors and any([host_result["failed"] for host_result in res.values()]):
+            raise RunAnsibleModuleFailed("{}::{}#{}: [{}] AnsibleModule::{} failed".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                self.module_name
+            ))
+
+        return res
+
+    def run_module(self, module_name, args=[], kwargs={}):
+        """Run ansible module in an explicity way.
+
+        Method `self.__getattr__` combined with `self._run_ansible_module` supports call ansible module in an
+        implicit way like below:
+            myhost.<module_name>(*args, **kwargs)
+        We directly use the `.` operator to get a function for running ansible module specified by `module_name`.
+
+        Since "Zen of python" prefers explicit over implicit, this method is to support running ansible module
+        in an explicit way.
+
+        Args:
+            module_name (str): Ansible module name. Can be builtin module or customized module.
+            args (list, optional): Positional arguments of ansible module. Enclosed in a list. Defaults to [].
+            kwargs (dict, optional): Keyword arguments of ansible module. Enclosed in a dict. Defaults to {}.
+                Supports special keyword arguments like:
+                    * "module_ignore_errors"
+
+
+        Raises:
+            UnsupportedAnsibleModule: Unable to find ansible module specified by `module_name` from ansible builtin
+                modules or current visible customized modules.
+
+        Returns:
+            dict: Ansible module execution result.
+        """
+        if not module_loader.has_plugin(module_name):
+            raise UnsupportedAnsibleModule("Unsupported ansible module \"{}\"".format(module_name))
+        self.module_name = module_name
+
+        return self._run_ansible_module(*args, **kwargs)
+
+    def load_module(self, module_name, args=[], kwargs={}, module_attrs={}):
+        """Load a module with arguments into a task list.
+
+        This method load a module with arguments into a task list. Method `self.run_loaded_modules` can run the loaded
+        modules in a single play.
+
+        Args:
+            module_name (str): Ansible module name. Can be builtin module or customized module.
+            args (list, optional): Positional arguments of ansible module. Defaults to [].
+            kwargs (dict, optional): Keyword arguments of ansible module. Defaults to {}.
+            module_attrs (dict, optional): Module attributes affect module execution.
+        """
+        self._loaded_tasks.append(self._build_task(module_name, args=args, kwargs=kwargs, module_attrs=module_attrs))
+
+    def clear_loaded_modules(self):
+        """Clear the list of loaded ansible modules.
+        """
+        self._loaded_tasks = []
+
+    def run_loaded_modules(self, verbosity=2):
+        """Run the list of loaded ansible modules.
+
+        Args:
+            verbosity (int): Verbosity value from 0-3.
+
+        Returns:
+            dict: Ansible module execution results. Sample result:
+                {
+                    "vlab-01": [
+                        {
+                            "stderr_lines": [],
+                            "cmd": [
+                                "pwd"
+                            ],
+                            "stdout": "/home/admin",
+                            "delta": "0:00:00.002754",
+                            "stdout_lines": [
+                                "/home/admin"
+                            ],
+                            "ansible_facts": {
+                                "discovered_interpreter_python": "/usr/bin/python"
+                            },
+                            "end": "2023-03-20 01:17:02.602775",
+                            "_ansible_no_log": false,
+                            "start": "2023-03-20 01:17:02.600021",
+                            "changed": true,
+                            "failed": false,
+                            "reachable": true,
+                            "stderr": "",
+                            "rc": 0,
+                            "invocation": {
+                                "module_args": {
+                                    "creates": null,
+                                    "executable": null,
+                                    "_uses_shell": false,
+                                    "strip_empty_ends": true,
+                                    "_raw_params": "pwd",
+                                    "removes": null,
+                                    "argv": null,
+                                    "warn": true,
+                                    "chdir": null,
+                                    "stdin_add_newline": true,
+                                    "stdin": null
+                                }
+                            }
+                        },
+                        {
+                            "stderr_lines": [],
+                            "cmd": "ls",
+                            "end": "2023-03-20 01:17:02.812231",
+                            "_ansible_no_log": false,
+                            "stdout": "config.json\nmyfile",
+                            "changed": true,
+                            "rc": 0,
+                            "failed": false,
+                            "reachable": true,
+                            "stderr": "",
+                            "delta": "0:00:00.003928",
+                            "invocation": {
+                                "module_args": {
+                                    "creates": null,
+                                    "executable": null,
+                                    "_uses_shell": true,
+                                    "strip_empty_ends": true,
+                                    "_raw_params": "ls",
+                                    "removes": null,
+                                    "argv": null,
+                                    "warn": true,
+                                    "chdir": null,
+                                    "stdin_add_newline": true,
+                                    "stdin": null
+                                }
+                            },
+                            "stdout_lines": [
+                                "config.json",
+                                "myfile"
+                            ],
+                            "start": "2023-03-20 01:17:02.808303"
+                        }
+                    ]
+                }
+        """
+        if len(self._loaded_tasks) == 0:
+            logger.info("No loaded task.")
+            return {}
+
+        previous_frame = inspect.currentframe().f_back
+        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+
+        tasks = self._loaded_tasks[:]
+        self.clear_loaded_modules()
+
+        task_names = [task["action"]["module"] for task in tasks]
+
+        if len(task_names) > 100:
+            truncated_task_names = task_names[:100] + "..."
+        else:
+            truncated_task_names = task_names
+
+        play_headline = "===== [{}] {} ".format(self.hosts_pattern, ",".join(truncated_task_names))
+        play_headline_suffix = "=" * (120 - len(play_headline))
+        play_headline += play_headline_suffix
+
+        if verbosity <= 0:
+            pass
+        elif verbosity == 1:
+            logger.debug(play_headline)
+            logger.debug("{}::{}#{}: [{}] Tasks: {}".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                task_names
+            ))
+        elif verbosity == 2:
+            logger.debug(play_headline)
+            logger.debug("{}::{}#{}: [{}] Tasks: {}".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                json.dumps(tasks)
+            ))
+        elif verbosity >= 3:
+            logger.debug(play_headline)
+            logger.debug("{}::{}#{}: [{}] Tasks:\n{}".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                json.dumps(tasks, indent=4)
+            ))
+
+        play = self._build_play(tasks=tasks)
+        results = self._run_play(play)
+
+        if verbosity <= 0:
+            pass
+        elif verbosity == 1:
+            logger.debug("{}::{}#{}: [{}] Executed tasks: {}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                task_names
+            ))
+        elif verbosity == 2:
+            logger.debug("{}::{}#{}: [{}] Results => {}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                json.dumps(results)
+            ))
+        elif verbosity >= 3:
+            logger.debug("{}::{}#{}: [{}] Results =>\n{}\n".format(
+                filename,
+                function_name,
+                line_number,
+                self.hosts_pattern,
+                json.dumps(results, indent=4)
+            ))
+
+        return results
+
+
+class AnsibleHost(AnsibleHosts):
+    """Basic class for running ansible modules on single host defined in ansible inventory file.
+
+    Parent class AnsibleHosts supports running ansible module on hosts matching hosts_pattern, which could be single
+    or multiple hosts.
+
+    This class ensures that the pattern only matches single host in inventory file. If the pattern matches more than
+    one host, `__init__` will raise exception MultipleAnsibleHostsError.
+
+    Args:
+        AnsibleHosts (_type_): _description_
+    """
+    def __init__(
+            self,
+            inventories,
+            host_pattern,
+            options={},
+            hostvars={}):
+        super(AnsibleHost, self).__init__(inventories, host_pattern, options=options, hostvars=hostvars)
+        if self.hosts_count > 1:
+            raise MultipleAnsibleHostsError("'{}' matches more than 1 host in '{}'".format(host_pattern, inventories))
+        self.host = self.hosts[0]
+        self.hostvars = self.host.get_vars()
+        self.hostname = self.hostvars.get("inventory_hostname")
+        self.ipaddr = self.hostvars.get("ansible_host")
+        self.host_visible_vars = self.vm.get_vars(host=self.host)

--- a/ansible/devutil/ansible_hosts.py
+++ b/ansible/devutil/ansible_hosts.py
@@ -494,7 +494,7 @@ class AnsibleHosts(object):
         return self._run_ansible_module
 
     def _build_task(self, module_name, args=[], kwargs={}, module_attrs={}):
-        """Build a dict reprents a task in ansible playbook.
+        """Build a dict represents a task in ansible playbook.
 
         Args:
             module_name (str): Name of the ansible module to be executed in the task.
@@ -506,7 +506,7 @@ class AnsibleHosts(object):
                 * https://docs.ansible.com/ansible/latest/collections/index.html
 
         Returns:
-            dict: A dict reprents a task in ansible playbook.
+            dict: A dict represents a task in ansible playbook.
         """
         kwargs = copy.deepcopy(kwargs)  # Avoid argument passed by reference issue
         if args:
@@ -524,12 +524,12 @@ class AnsibleHosts(object):
         return task_data
 
     def _build_play(self, tasks=[]):
-        """Build a dict  reprents an ansible playbook.
+        """Build a dict represents an ansible playbook.
 
         The list of tasks may include single or multiple tasks.
 
         Args:
-            tasks (list, optional): List of dict reprents task in ansible playbook. Defaults to [].
+            tasks (list, optional): List of dict represents task in ansible playbook. Defaults to [].
 
         Returns:
             dict: A dict represents an ansible playbook.
@@ -755,7 +755,7 @@ class AnsibleHosts(object):
         return res
 
     def run_module(self, module_name, args=[], kwargs={}):
-        """Run ansible module in an explicity way.
+        """Run ansible module in an explicit way.
 
         Method `self.__getattr__` combined with `self._run_ansible_module` supports call ansible module in an
         implicit way like below:

--- a/ansible/devutil/ansible_hosts.py
+++ b/ansible/devutil/ansible_hosts.py
@@ -1,6 +1,6 @@
 """Basic classes and functions for running ansible modules on devices by python.
 
-This idea is mainly inspired by the pytest-ansible plugin. With the classes and functions defined here, we can run any
+This idea is mainly inspired by the pytest-ansible project. With the classes and functions defined here, we can run any
 ansible modules on any hosts defined in inventory file.
 
 Instead of writing ansible playbook to operate on the testbed devices, we can just write python.
@@ -77,21 +77,21 @@ class ResultCollector(CallbackBase):
     def v2_runner_on_ok(self, result):
         hostname = result._host.get_name()
 
-        res = dict(reachable=True, failed=False)
+        res = dict(hostname=hostname, reachable=True, failed=False)
         res.update(result._result)
         self._results[hostname] = res
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
         hostname = result._host.get_name()
 
-        res = dict(reachable=True, failed=True)
+        res = dict(hostname=hostname, reachable=True, failed=True)
         res.update(result._result)
         self._results[hostname] = res
 
     def v2_runner_on_unreachable(self, result, *args, **kwargs):
         hostname = result._host.get_name()
 
-        res = dict(reachable=False, failed=True)
+        res = dict(hostname=hostname, reachable=False, failed=True)
         res.update(result._result)
         self._results[hostname] = res
 
@@ -100,79 +100,6 @@ class ResultCollector(CallbackBase):
         """Property for returning execution result of single ansible module on ansible hosts.
 
         The result is a dict keyed by hostname. Value is the ansible module execution result on that host.
-        Sample result:
-        {
-            "VM0100": {
-                "stderr_lines": [],
-                "cmd": "pwd",
-                "stdout": "/root",
-                "delta": "0:00:00.001744",
-                "stdout_lines": [
-                    "/root"
-                ],
-                "ansible_facts": {
-                    "discovered_interpreter_python": "/usr/bin/python"
-                },
-                "end": "2023-03-20 01:11:01.748306",
-                "_ansible_no_log": false,
-                "start": "2023-03-20 01:11:01.746562",
-                "changed": true,
-                "failed": false,
-                "reachable": true,
-                "stderr": "",
-                "rc": 0,
-                "invocation": {
-                    "module_args": {
-                        "warn": true,
-                        "executable": null,
-                        "_uses_shell": true,
-                        "strip_empty_ends": true,
-                        "_raw_params": "pwd",
-                        "removes": null,
-                        "argv": null,
-                        "creates": null,
-                        "chdir": null,
-                        "stdin_add_newline": true,
-                        "stdin": null
-                    }
-                }
-            },
-            "VM0101": {
-                "stderr_lines": [],
-                "cmd": "pwd",
-                "stdout": "/root",
-                "delta": "0:00:00.001764",
-                "stdout_lines": [
-                    "/root"
-                ],
-                "ansible_facts": {
-                    "discovered_interpreter_python": "/usr/bin/python"
-                },
-                "end": "2023-03-20 01:11:01.748302",
-                "_ansible_no_log": false,
-                "start": "2023-03-20 01:11:01.746538",
-                "changed": true,
-                "failed": false,
-                "reachable": true,
-                "stderr": "",
-                "rc": 0,
-                "invocation": {
-                    "module_args": {
-                        "warn": true,
-                        "executable": null,
-                        "_uses_shell": true,
-                        "strip_empty_ends": true,
-                        "_raw_params": "pwd",
-                        "removes": null,
-                        "argv": null,
-                        "creates": null,
-                        "chdir": null,
-                        "stdin_add_newline": true,
-                        "stdin": null
-                    }
-                }
-            }
-        }
 
         Returns:
             dict: Result is a dict. Key is hostname. Value is ansible module execution result on that host.
@@ -195,7 +122,7 @@ class BatchResultsCollector(CallbackBase):
         if hostname not in self._results:
             self._results[hostname] = []
 
-        res = dict(reachable=True, failed=False)
+        res = dict(hostname=hostname, reachable=True, failed=False)
         res.update(result._result)
         self._results[hostname].append(res)
 
@@ -204,7 +131,7 @@ class BatchResultsCollector(CallbackBase):
         if hostname not in self._results:
             self._results[hostname] = []
 
-        res = dict(reachable=True, failed=True)
+        res = dict(hostname=hostname, reachable=True, failed=True)
         res.update(result._result)
         self._results[hostname].append(res)
 
@@ -213,7 +140,7 @@ class BatchResultsCollector(CallbackBase):
         if hostname not in self._results:
             self._results[hostname] = []
 
-        res = dict(reachable=False, failed=True)
+        res = dict(hostname=hostname, reachable=False, failed=True)
         res.update(result._result)
         self._results[hostname].append(result._result)
 
@@ -222,81 +149,6 @@ class BatchResultsCollector(CallbackBase):
         """Property for returning multiple ansible module execution results of multiple ansible hosts.
 
         The result is a dict keyed by hostname. Value is list of the ansible module execution results on that host.
-        Sample result:
-        {
-            "vlab-01": [
-                {
-                    "stderr_lines": [],
-                    "cmd": [
-                        "pwd"
-                    ],
-                    "stdout": "/home/admin",
-                    "delta": "0:00:00.002754",
-                    "stdout_lines": [
-                        "/home/admin"
-                    ],
-                    "ansible_facts": {
-                        "discovered_interpreter_python": "/usr/bin/python"
-                    },
-                    "end": "2023-03-20 01:17:02.602775",
-                    "_ansible_no_log": false,
-                    "start": "2023-03-20 01:17:02.600021",
-                    "changed": true,
-                    "failed": false,
-                    "reachable": true,
-                    "stderr": "",
-                    "rc": 0,
-                    "invocation": {
-                        "module_args": {
-                            "creates": null,
-                            "executable": null,
-                            "_uses_shell": false,
-                            "strip_empty_ends": true,
-                            "_raw_params": "pwd",
-                            "removes": null,
-                            "argv": null,
-                            "warn": true,
-                            "chdir": null,
-                            "stdin_add_newline": true,
-                            "stdin": null
-                        }
-                    }
-                },
-                {
-                    "stderr_lines": [],
-                    "cmd": "ls",
-                    "end": "2023-03-20 01:17:02.812231",
-                    "_ansible_no_log": false,
-                    "stdout": "config.json\nmyfile",
-                    "changed": true,
-                    "rc": 0,
-                    "failed": false,
-                    "reachable": true,
-                    "stderr": "",
-                    "delta": "0:00:00.003928",
-                    "invocation": {
-                        "module_args": {
-                            "creates": null,
-                            "executable": null,
-                            "_uses_shell": true,
-                            "strip_empty_ends": true,
-                            "_raw_params": "ls",
-                            "removes": null,
-                            "argv": null,
-                            "warn": true,
-                            "chdir": null,
-                            "stdin_add_newline": true,
-                            "stdin": null
-                        }
-                    },
-                    "stdout_lines": [
-                        "config.json",
-                        "myfile"
-                    ],
-                    "start": "2023-03-20 01:17:02.808303"
-                }
-            ]
-        }
 
         Returns:
             dict: Result is a dict. Key is hostname. Value is ansible module execution result.
@@ -304,196 +156,93 @@ class BatchResultsCollector(CallbackBase):
         return self._results
 
 
-class AnsibleHosts(object):
-    """Basic class for running ansible modules on hosts defined in ansible inventory file.
+class AnsibleHostsBase(object):
+    """Base class for running ansible modules on hosts defined in ansible inventory file.
 
-    Instance of this class is for running ansible modules on hosts defined in ansible inventory file. The class
-    instance is not a python list. It represents a list of hosts matching specified pattern in specified ansible
-    inventory file.
+    This class defines the basic methods for running ansible modules on hosts defined in ansible inventory file.
+
+    DO NOT use this class directly. Use AnsibleHosts or AnsibleHostsParallel instead.
     """
     def __init__(
             self,
             inventories,
-            hosts_pattern,
+            host_pattern,
+            loader=None,
+            inventory_manager=None,
+            variable_manager=None,
             options={},
             hostvars={}):
-        """Constructor of AnsibleHosts.
+        """Constructor for AnsibleHostsBase.
 
         Args:
-            inventories (str or list): Inventory file or a list of inventory files. Consumed by ansible under the hood.
-            hosts_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
+            inventories (str or list): Path to ansible inventory file or list of inventory files.
+            host_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
                 Follow the same rules of specifying ansible hosts in ansible play book.
                 Examples:
                     "vlab-01"
                     "VM0100, VM0101"
                     ["VM0100", "VM0101"]
                     "server_1:&vm_host"
+            loader (DataLoader, optional): Ansible DataLoader. Defaults to None.
+            inventory_manager (InventoryManager, optional): Ansible InventoryManager. Defaults to None.
+            variable_manager (VariableManager, optional): Ansible VariableManager. Defaults to None.
             options (dict, optional): Options affecting ansible execution. Supports options that can be passed in from
                 ansible-playbook command line. Defaults to {}.
                 Examples:
                     options={"become": True, "forks": 10}
             hostvars (dict, optional): Additional ansible variables for ansible hosts. Similar as using `-e` argument
                 of ansible-playbook command line to specify additional host variables. Defaults to {}.
-
-        Raises:
-            NoAnsibleHostError: Raise this exception when no host matching specified pattern in inventory file.
         """
         self.inventories = inventories
-        self.hosts_pattern = hosts_pattern
+        self.host_pattern = host_pattern
+        if loader:
+            self.loader = loader
+        else:
+            self.loader = DataLoader()
 
-        # Default options
-        self._options = {
-            "forks": 5,
+        if inventory_manager:
+            if isinstance(inventories, list):
+                sources = inventories
+            else:
+                sources = [inventories]
+            if set(sources) != set(inventory_manager._sources):
+                inventory_manager._sources = sources
+                inventory_manager.parse_sources()
+            self.im = inventory_manager
+        else:
+            self.im = InventoryManager(loader=self.loader, sources=self.inventories)
+
+        if variable_manager:
+            self.vm = variable_manager
+        else:
+            self.vm = VariableManager(loader=self.loader, inventory=self.im)
+
+        self.options = {
+            "forks": 6,
             "connection": "smart",
             "verbosity": 2,
             "become_method": "sudo"
         }
         if options:
-            self._options.update(options)
-
-        context.CLIARGS = ImmutableDict(**self._options)
-
-        self.loader = DataLoader()
-        self.im = InventoryManager(loader=self.loader, sources=self.inventories)
-        self.vm = VariableManager(loader=self.loader, inventory=self.im)
-
-        self.hosts = self.im.get_hosts(self.hosts_pattern)      # List of <class 'ansible.inventory.host.Host'>
-        if len(self.hosts) == 0:
-            raise NoAnsibleHostError(
-                "No hosts '{}' in inventory files '{}'".format(self.hosts_pattern, self.inventories)
-            )
-        self.hosts_count = len(self.hosts)
-        self.hostnames = [_host.name for _host in self.hosts]                       # List of hostname (str)
-        self.ipaddrs = [_host.vars.get("ansible_host") for _host in self.hosts]     # List of IPs (str)
+            self.options.update(options)
 
         if hostvars:
             self.vm.extra_vars.update(hostvars)
 
-        self._loaded_tasks = []
+        # Ansible inventory hosts, list of <class 'ansible.inventory.host.Host'>
+        self.ans_inv_hosts = self.im.get_hosts(self.host_pattern)
+        if len(self.ans_inv_hosts) == 0:
+            raise NoAnsibleHostError(
+                "No host '{}' in inventory files '{}'".format(self.hostname, self.inventories)
+            )
+        self.hostnames = [host.name for host in self.ans_inv_hosts]
+        self.hosts_count = len(self.hostnames)
+        self.ips = [host.get_vars().get("ansible_host", None) for host in self.ans_inv_hosts]
 
-    def get_host(self, hostname, strict=False):
-        """Tool for getting ansible.inventory.host.Host object from self.inventories using ansible inventory manager.
+        self._loaded_modules = []
 
-        Args:
-            hostname (str): Hostname
-            strict (bool, optional): If strict==True, only get host with hostname from hosts matching
-                self.hosts_pattern in self.inventories. If strict=False, get any host with hostname from
-                self.inventories. Defaults to False.
-
-        Returns:
-            ansible.inventory.host.Host or None: Object of class ansible.inventory.host.Host or None.
-        """
-        if strict:
-            # Only get host with hostname from self.hosts
-            for _host in self.hosts:
-                if _host.name == hostname:
-                    return _host
-            else:
-                return None
-        else:
-            # Get host with hostname from whole inventory
-            return self.im.get_host(hostname)
-
-    def get_hosts(self, hosts_pattern):
-        """Tool for getting list of ansible.inventory.host.Host objects from self.inventories using ansible inventory
-        manager. Ansible inventory manager is used under the hood.
-
-        Args:
-            hosts_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
-                Follow the same rules of specifying ansible hosts in ansible play book.
-
-        Returns:
-            list: List of ansible.inventory.host.Host objects.
-        """
-        return self.im.get_hosts(hosts_pattern)
-
-    def get_host_vars(self, hostname, strict=False):
-        """Tool for getting variables of specified host from self.inventories. Variables defined in group_vars and
-        host_vars are not included. Only ansible inventory manager is used under the hood.
-
-        Args:
-            hostname (str): Hostname.
-            strict (bool, optional): If strict==True, only get variables of host with hostname from hosts matching
-                self.hosts_pattern in self.inventories. If strict=False, get variables of any host with hostname from
-                self.inventories. Defaults to False.
-
-        Returns:
-            dict: Dict of variables. Key is variable name. Value is variable value.
-        """
-        _host = self.get_host(hostname, strict=strict)
-        if not _host:
-            return {}
-        return _host.get_vars()
-
-    def get_host_var(self, hostname, var, strict=False):
-        """Tool for getting variable value of specified host from self.inventories. Variables defined in group_vars and
-        host_vars are not included. Only ansible inventory manager is used under the hood.
-
-        Args:
-            hostname (str): Hostname.
-            var (str): Variable name.
-            strict (bool, optional): If strict==True, only get variable value of host with hostname from hosts matching
-                self.hosts_pattern in self.inventories. If strict=False, get variable value of any host with hostname
-                from self.inventories. Defaults to False.
-
-        Returns:
-            Any: Variable value, possible types: str, int, bool, list, dict.
-        """
-        return self.get_host_vars(hostname, strict=strict).get(var, None)
-
-    def get_host_visible_vars(self, hostname, strict=False):
-        """Tool for getting visible variables of specified host. Variables may be defined in inventory files, any
-        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
-
-        Args:
-            hostname (str): Hostname.
-            strict (bool, optional): If strict==True, only get visible variables of host with hostname from hosts
-                matching self.hosts_pattern in self.inventories. If strict=False, get visible variables of any host
-                with hostname from self.inventories. Defaults to False.
-
-        Returns:
-            dict: Dict of variables. Key is variable name. Value is variable value.
-        """
-        _host = self.get_host(hostname, strict=strict)
-        if not _host:
-            return {}
-        return self.vm.get_vars(host=_host)
-
-    def get_host_visible_var(self, hostname, var, strict=False):
-        """Tool for getting visible variable value of specified host. Variable may be defined in inventory files, any
-        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
-
-        Args:
-            hostname (str): Hostname.
-            var (str): Variable name.
-            strict (bool, optional): If strict==True, only get visible variable value of host with hostname from hosts
-                matching self.hosts_pattern in self.inventories. If strict=False, get visible variable value of any host
-                with hostname from self.inventories. Defaults to False.
-
-        Returns:
-            Any: Variable value, possible types: str, int, bool, list, dict.
-        """
-        return self.get_host_visible_vars(hostname, strict=strict).get(var, None)
-
-    def __getattr__(self, attr):
-        """For finding ansible module and return a function for running that ansible module.
-
-        Args:
-            attr (str): Name of an attribute of current object. Usually ansible module name.
-
-        Raises:
-            UnsupportedAnsibleModule: Unable to find ansible module specified by `attr` from ansible builtin modules
-                or current visible customized modules.
-
-        Returns:
-            callable: A function for running ansible module specified by `attr`.
-        """
-        if not module_loader.has_plugin(attr):
-            raise UnsupportedAnsibleModule("Unsupported ansible module \"{}\"".format(attr))
-        self.module_name = attr
-        return self._run_ansible_module
-
-    def _build_task(self, module_name, args=[], kwargs={}, module_attrs={}):
+    @staticmethod
+    def build_task(module_name, args=[], kwargs={}, module_attrs={}):
         """Build a dict represents a task in ansible playbook.
 
         Args:
@@ -508,7 +257,7 @@ class AnsibleHosts(object):
         Returns:
             dict: A dict represents a task in ansible playbook.
         """
-        kwargs = copy.deepcopy(kwargs)  # Avoid argument passed by reference issue
+        kwargs = copy.deepcopy(kwargs)  # Copy to avoid argument passed by reference issue
         if args:
             kwargs["_raw_params"] = " ".join(args)
 
@@ -523,59 +272,277 @@ class AnsibleHosts(object):
 
         return task_data
 
-    def _build_play(self, tasks=[]):
-        """Build a dict represents an ansible playbook.
-
-        The list of tasks may include single or multiple tasks.
-
-        Args:
-            tasks (list, optional): List of dict represents task in ansible playbook. Defaults to [].
-
-        Returns:
-            dict: A dict represents an ansible playbook.
-        """
-        return Play().load(
-            {
-                "hosts": self.hosts_pattern,    # Playbook will be executed on hosts matching `self.hosts_pattern`
-                "gather_facts": "no",
-                "tasks": tasks,
+    @staticmethod
+    def run_tasks(
+            hosts,
+            loader,
+            inventory_manager,
+            variable_manager,
+            options={
+                "forks": 6,
+                "connection": "smart",
+                "verbosity": 2,
+                "become_method": "sudo"
             },
-            variable_manager=self.vm,
-            loader=self.loader,
-        )
+            passwords={"vault_pass": "any"},
+            gather_facts=False,
+            tasks=[]):
+        """Use ansible's TaskQueueManager to run tasks on hosts.
 
-    def _run_play(self, play):
-        """Use ansible's TaskQueueManager to run a playbook described in a dict.
+        Defined this method as a static method on purpose so that scripts may use this method to run ansible tasks
+        without initializing instances of AnsibleHosts or AnsibleHost.
 
         Args:
-            play (dict): A dict represents an ansible playbook.
+            hosts (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
+            loader (DataLoader): Ansible DataLoader.
+            inventory_manager (InventoryManager): Ansible InventoryManager.
+            variable_manager (VariableManager): Ansible VariableManager.
+            options (dict, optional): Options affecting ansible execution. Supports options that can be passed in from
+                ansible-playbook command line. Defaults to {}.
+            passwords (dict, optional): Passwords for ansible. Defaults to {"vault_pass": "any"}.
+            gather_facts (bool, optional): Whether to gather facts before running tasks. Defaults to False.
+            tasks (list, optional): List of tasks to be run on hosts. Defaults to [].
 
         Returns:
             dict: Results of running ansible modules in playbook. If task list length is 1, ResultCollector is used
                 as result collector callback. If task list length is greater than 1, BatchResultsCollector is used as
                 result collector callback.
         """
-        play_tasks = play.get_tasks()[0]
+        tqm = None
+        try:
+            context.CLIARGS = ImmutableDict(**options)
 
-        if len(play_tasks) > 1:
-            callback = BatchResultsCollector()
+            play = Play().load(
+                {
+                    "hosts": hosts,
+                    "gather_facts": "yes" if gather_facts else "no",
+                    "tasks": tasks,
+                },
+                variable_manager=variable_manager,
+                loader=loader,
+            )
+
+            play_tasks = play.get_tasks()[0]
+
+            if len(play_tasks) > 1:
+                callback = BatchResultsCollector()
+            else:
+                callback = ResultCollector()
+
+            tqm = TaskQueueManager(
+                inventory=inventory_manager,
+                variable_manager=variable_manager,
+                loader=loader,
+                passwords=passwords,
+                stdout_callback=callback,
+                forks=options.get("forks")
+            )
+            tqm.run(play)
+            return callback.results
+        finally:
+            if tqm is not None:
+                tqm.cleanup()
+
+    def _log_modules(self, caller_info, module_info, verbosity):
+        """Log ansible modules to be executed.
+
+        Args:
+            caller_info (tuple): Caller information. Tuple of (filename, line_number, function_name, lines, index) got
+                from inspect.stack().
+            module_info (dict or list): Information of ansible modules to be executed. If only one module is executed,
+                module_info is a dict. If multiple modules are executed, module_info is a list of dicts.
+            verbosity (int): Verbosity level. If verbosity is 0, no log will be printed.
+        """
+        if verbosity <= 0:      # Do not log anything
+            return
+
+        filename, line_number, function_name, lines, index = caller_info
+
+        if isinstance(self, AnsibleHosts):
+            hosts_str = json.dumps(self.hostnames)
+        elif isinstance(self, AnsibleHost):
+            hosts_str = json.dumps(self.hostnames[0])
         else:
-            callback = ResultCollector()
+            raise TypeError("Unsupported type of object: {}".format(type(self)))
 
-        tqm = TaskQueueManager(
-            inventory=self.im,
-            variable_manager=self.vm,
-            loader=self.loader,
-            passwords=dict(vault_pass="secret"),
-            stdout_callback=callback,
-            forks=self._options.get("forks")
-        )
-        tqm.run(play)
+        if isinstance(module_info, dict):
+            module_names = json.dumps(module_info.get("module_name", ""))
+            hint_str = "AnsibleModule::{}".format(module_names)
+        elif isinstance(module_info, list):
+            module_names = ", ".join([module_item.get("module_name", "") for module_item in module_info])
+            hint_str = "AnsibleModules::{}".format(json.dumps(module_names))
+        else:
+            raise TypeError("Got {}, expected tuple or list of tuples, tuple items: "
+                            "module_name, module_args, module_kwargs, module_attrs".format(type(module_info)))
 
-        return callback.results
+        task_headline = "===== {} -> {} ".format(self.host_pattern, module_names)
+        task_headline += "=" * (120 - len(task_headline))
+        logger.debug(task_headline)
+
+        caller_str = "{}::{}#{}".format(filename, function_name, line_number)
+
+        if verbosity == 1:          # Log module name only. Do not log args.
+            logger.debug("{}: {} {}".format(
+                caller_str,
+                hosts_str,
+                hint_str,
+            ))
+        elif verbosity >= 2:
+            if verbosity == 2:      # Log module name and args without indention
+                indent = None
+                newline = ""
+            elif verbosity >= 3:    # Log module name and args with indention
+                indent = 4
+                newline = "\n"
+
+            logger.debug("{}: {} -> {}, {}{}{}".format(
+                caller_str,
+                hosts_str,
+                hint_str,
+                newline,
+                json.dumps(module_info, indent=indent),
+                newline
+            ))
+
+    def _log_results(self, caller_info, module_info, results, verbosity):
+        """Log ansible module results.
+
+        Args:
+            caller_info (tuple): Caller information. Tuple of (filename, line_number, function_name, lines, index) got
+                from inspect.stack().
+            module_info (dict or list): Information of ansible modules to be executed. If only one module is executed,
+                module_info is a dict. If multiple modules are executed, module_info is a list of dicts.
+            results (dict): Results of ansible modules.
+            verbosity (int): Verbosity level. If verbosity is 0, no log will be printed.
+        """
+        if verbosity <= 0:      # Do not log anything
+            return
+
+        if isinstance(self, AnsibleHosts):
+            hosts_str = json.dumps(self.hostnames)
+        elif isinstance(self, AnsibleHost):
+            hosts_str = json.dumps(self.hostnames[0])
+            results = results.get(self.hostnames[0], {})
+        else:
+            raise TypeError("Unsupported type of object: {}".format(type(self)))
+
+        filename, line_number, function_name, lines, index = caller_info
+        caller_str = "{}::{}#{}".format(filename, function_name, line_number)
+
+        if isinstance(module_info, dict):
+            module_names = json.dumps(module_info.get("module_name", ""))
+            hint_str = "AnsibleModule::{}".format(module_names)
+        elif isinstance(module_info, list):
+            module_names = ", ".join([module_item.get("module_name", "") for module_item in module_info])
+            hint_str = "AnsibleModules::{}".format(json.dumps(module_names))
+        else:
+            raise TypeError("Got {}, expected tuple or list of tuples, tuple items: "
+                            "module_name, module_args, module_kwargs, module_attrs".format(type(module_info)))
+
+        if verbosity == 1:      # Log module only
+            logger.debug("{}: {} -> {} executed".format(
+                caller_str,
+                hosts_str,
+                hint_str
+            ))
+        elif verbosity >= 2:    # Log result without indention
+            if verbosity == 2:
+                indent = None
+                newline = ""
+            elif verbosity >= 3:
+                indent = 4
+                newline = "\n"
+
+            logger.debug("{}: {} -> {} | Results =>{}{}{}".format(
+                caller_str,
+                hosts_str,
+                hint_str,
+                newline,
+                json.dumps(results, indent=indent),
+                newline
+            ))
+
+    def _check_results(self, caller_info, module_info, results, module_ignore_errors, verbosity):
+        """Check ansible module results.
+
+        Args:
+            caller_info (tuple): Caller information. Tuple of (filename, line_number, function_name, lines, index) got
+                from inspect.stack().
+            module_info (dict or list): Information of ansible modules to be executed. If only one module is executed,
+                module_info is a dict. If multiple modules are executed, module_info is a list of dicts.
+            results (dict): Results of ansible modules.
+            module_ignore_errors (bool): Ignore module errors or not. If True, no error will be raised even if module
+                execution failed.
+            verbosity (int): Verbosity level. If verbosity is 0, details of failed modules will not be included in the
+                error message.
+        """
+        if module_ignore_errors:
+            return
+
+        filename, line_number, function_name, lines, index = caller_info
+        caller_str = "{}::{}#{}".format(filename, function_name, line_number)
+
+        if isinstance(self, AnsibleHosts):
+            hosts_str = json.dumps(self.hostnames)
+        elif isinstance(self, AnsibleHost):
+            hosts_str = json.dumps(self.hostnames[0])
+            results = results.get(self.hostnames[0], {})
+        else:
+            raise TypeError("Unsupported type of object: {}".format(type(self)))
+
+        if isinstance(module_info, dict):
+            module_names = json.dumps(module_info.get("module_name", ""))
+            hint_str = "AnsibleModule::{}".format(module_names)
+        elif isinstance(module_info, list):
+            module_names = ", ".join([module_item.get("module_name", "") for module_item in module_info])
+            hint_str = "AnsibleModules::{}".format(json.dumps(module_names))
+        else:
+            raise TypeError("Got {}, expected tuple or list of tuples, tuple items: "
+                            "module_name, module_args, module_kwargs, module_attrs".format(type(module_info)))
+
+        err_msg = ""
+        if verbosity <= 0:      # No information of module and result
+            err_msg = "Run ansible module failed"
+        elif verbosity == 1:    # Log module name only. Do not log args and result
+            err_msg = "{}: {} -> {} failed".format(
+                caller_str,
+                hosts_str,
+                hint_str
+            )
+        elif verbosity >= 2:    # Log module name, args and result
+            if verbosity == 2:
+                indent = None
+            elif verbosity >= 3:
+                indent = 4
+
+            err_msg = "{}: {} -> {} failed, Results => {}".format(
+                caller_str,
+                hosts_str,
+                hint_str,
+                json.dumps(results, indent=indent)
+            )
+
+        if isinstance(self, AnsibleHosts):
+            if isinstance(module_info, dict):
+                failed = any([res["failed"] for res in results.values()])
+            else:
+                failed = any([any([res["failed"] for res in module_results]) for module_results in results.values()])
+        elif isinstance(self, AnsibleHost):
+            if isinstance(module_info, dict):
+                failed = results["failed"]
+            else:
+                failed = any([res["failed"] for res in results])
+        if failed:
+            raise RunAnsibleModuleFailed(err_msg)
 
     def _run_ansible_module(self, *args, **kwargs):
-        """Function for running ansible module.
+        """Run ansible module.
+
+        DO NOT call this function directly. Use instance_name.<ansible_module_name>() instead.
+
+        This class has "__getattr__" defined. This function will be called when an attribute is not found in the
+        instance. This function will parse the attribute name and consider the attribute name as an Ansible module name.
+        Then it will call this function to run the Ansible module.
 
         Special keyword arguments:
             module_ignore_errors: If this argument is set to True, no RunAnsibleModuleFailed exception will be raised.
@@ -589,8 +556,17 @@ class AnsibleHosts(object):
             RunAnsibleModuleFailed: Raise this exception if result is failed AND keyword argument
                 `module_ignore_errors` is False.
 
+        Args:
+            *args: Positional arguments of ansible module.
+            **kwargs: Keyword arguments of ansible module.
+
         Returns:
-            dict: Ansible module execution result. Sample result:
+            dict: Ansible module execution result. If this function is executed on AnsibleHosts instance, the result
+                is a dict of dicts. Key is hostname, value is ansible module execution result on that host. If this
+                function is executed on AnsibleHost instance (for single host), the result is a dict, which is ansible
+                module execution result on the host of AnsibleHost instance.
+
+            Sample result for AnsibleHosts:
                 {
                     "VM0100": {
                         "stderr_lines": [],
@@ -611,6 +587,7 @@ class AnsibleHosts(object):
                         "reachable": true,
                         "stderr": "",
                         "rc": 0,
+                        "hostname": "VM0100",
                         "invocation": {
                             "module_args": {
                                 "warn": true,
@@ -646,6 +623,7 @@ class AnsibleHosts(object):
                         "reachable": true,
                         "stderr": "",
                         "rc": 0,
+                        "hostname": "VM0101",
                         "invocation": {
                             "module_args": {
                                 "warn": true,
@@ -663,134 +641,140 @@ class AnsibleHosts(object):
                         }
                     }
                 }
+
+            Sample result for AnsibleHost:
+                {
+                    "stderr_lines": [],
+                    "cmd": [
+                        "pwd"
+                    ],
+                    "stdout": "/home/admin",
+                    "delta": "0:00:00.002754",
+                    "stdout_lines": [
+                        "/home/admin"
+                    ],
+                    "ansible_facts": {
+                        "discovered_interpreter_python": "/usr/bin/python"
+                    },
+                    "end": "2023-03-20 01:17:02.602775",
+                    "_ansible_no_log": false,
+                    "start": "2023-03-20 01:17:02.600021",
+                    "changed": true,
+                    "failed": false,
+                    "reachable": true,
+                    "stderr": "",
+                    "rc": 0,
+                    "hostname": "vlab-01",
+                    "invocation": {
+                        "module_args": {
+                            "creates": null,
+                            "executable": null,
+                            "_uses_shell": false,
+                            "strip_empty_ends": true,
+                            "_raw_params": "pwd",
+                            "removes": null,
+                            "argv": null,
+                            "warn": true,
+                            "chdir": null,
+                            "stdin_add_newline": true,
+                            "stdin": null
+                        }
+                    }
+                }
         """
-        previous_frame = inspect.currentframe().f_back
-        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+        caller_info = kwargs.pop("caller_info", None)
+        if not caller_info:
+            previous_frame = inspect.currentframe().f_back
+            caller_info = inspect.getframeinfo(previous_frame)
 
-        verbosity = kwargs.pop("verbosity", self._options.get("verbosity"))
-        module_ignore_errors = kwargs.pop("module_ignore_errors", False)
-        module_attrs = kwargs.pop("module_attrs", {})
+        module_args = copy.deepcopy(args)
+        module_kwargs = copy.deepcopy(kwargs)
 
-        task_headline = "===== [{}] {} ".format(self.hosts_pattern, self.module_name)
-        task_headline_suffix = "=" * (120 - len(task_headline))
-        task_headline += task_headline_suffix
+        verbosity = module_kwargs.pop("verbosity", None)
+        if not verbosity:
+            verbosity = self.options.get("verbosity", 2)
+        module_ignore_errors = module_kwargs.pop("module_ignore_errors", False)
+        module_attrs = module_kwargs.pop("module_attrs", {})
 
-        if verbosity <= 0:          # Do not log module calls at all.
-            pass
-        elif verbosity == 1:        # Log module name only. Do not log args.
-            logger.debug(task_headline)
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{}".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name
-            ))
-        elif verbosity == 2:        # Log args without indention.
-            logger.debug(task_headline)
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name,
-                json.dumps(args),
-                json.dumps(kwargs)
-            ))
-        elif verbosity >= 3:        # Log args with indention.
-            logger.debug(task_headline)
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{},\nargs={},\nkwargs={}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name,
-                json.dumps(args, indent=4),
-                json.dumps(kwargs, indent=4)
-            ))
+        module_info = {
+            "module_name": self.module_name,
+            "args": module_args,
+            "kwargs": module_kwargs,
+            "module_attrs": module_attrs
+        }
+        self._log_modules(caller_info, module_info, verbosity)
 
-        # Build task/play, run the play, get results
-        task = self._build_task(self.module_name, args=args, kwargs=kwargs, module_attrs=module_attrs)
-        play = self._build_play(tasks=[task])
-        res = self._run_play(play)
+        task = self.build_task(**module_info)
+        results = self.run_tasks(self.host_pattern, self.loader, self.im, self.vm, self.options, tasks=[task])
 
-        if verbosity <= 0:          # Do not log module results at all
-            pass
-        elif verbosity == 1:        # Log module name only. Do not log module results.
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} executed\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name
-            ))
-        elif verbosity == 2:        # Log module results without indention.
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name,
-                json.dumps(res)
-            ))
-        elif verbosity >= 3:        # Log module results with indention.
-            logger.debug("{}::{}#{}: [{}] AnsibleModule::{} Result =>\n{}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name,
-                json.dumps(res, indent=4)
-            ))
+        self._log_results(caller_info, module_info, results, verbosity)
+        self._check_results(caller_info, module_info, results, module_ignore_errors, verbosity)
 
-        if not module_ignore_errors and any([host_result["failed"] for host_result in res.values()]):
-            raise RunAnsibleModuleFailed("{}::{}#{}: [{}] AnsibleModule::{} failed".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                self.module_name
-            ))
+        if isinstance(self, AnsibleHost):
+            results = results[self.hostnames[0]]
 
-        return res
+        return results
 
-    def run_module(self, module_name, args=[], kwargs={}):
-        """Run ansible module in an explicit way.
-
-        Method `self.__getattr__` combined with `self._run_ansible_module` supports call ansible module in an
-        implicit way like below:
-            myhost.<module_name>(*args, **kwargs)
-        We directly use the `.` operator to get a function for running ansible module specified by `module_name`.
-
-        Since "Zen of python" prefers explicit over implicit, this method is to support running ansible module
-        in an explicit way.
+    def __getattr__(self, attr):
+        """For finding ansible module and return a function for running that ansible module.
 
         Args:
-            module_name (str): Ansible module name. Can be builtin module or customized module.
-            args (list, optional): Positional arguments of ansible module. Enclosed in a list. Defaults to [].
-            kwargs (dict, optional): Keyword arguments of ansible module. Enclosed in a dict. Defaults to {}.
-                Supports special keyword arguments like:
-                    * "module_ignore_errors"
+            attr (str): Attribute name of current object. Usually ansible module name.
 
+        Raises:
+            UnsupportedAnsibleModule: Unable to find ansible module specified by `attr` from ansible builtin modules
+                or current visible customized modules.
+
+        Returns:
+            callable: A function for running ansible module specified by `attr`.
+        """
+        if not module_loader.has_plugin(attr):
+            raise UnsupportedAnsibleModule("Unsupported ansible module \"{}\"".format(attr))
+        self.module_name = attr
+
+        return self._run_ansible_module
+
+    def run_module(self, module_name, args=[], kwargs={}):
+        """Run ansible module specified by `module_name`.
+
+        Special keyword arguments:
+            module_ignore_errors: If this argument is set to True, no RunAnsibleModuleFailed exception will be raised.
+            module_attrs: A dict for specifying module attributes that may affect execution of the ansible module.
+                Reference documents:
+                * https://docs.ansible.com/ansible/2.9/modules/list_of_all_modules.html
+                * https://docs.ansible.com/ansible/latest/collections/index.html
+            verbosity: integer from 0-3.
+
+        Args:
+            module_name (str): Ansible module name.
+            args (list): Ansible module arguments.
+            kwargs (dict): Ansible module keyword arguments.
 
         Raises:
             UnsupportedAnsibleModule: Unable to find ansible module specified by `module_name` from ansible builtin
-                modules or current visible customized modules.
 
         Returns:
-            dict: Ansible module execution result.
+            dict: A dict for ansible module execution result. Same as the result of `self._run_ansible_module`.
         """
         if not module_loader.has_plugin(module_name):
             raise UnsupportedAnsibleModule("Unsupported ansible module \"{}\"".format(module_name))
         self.module_name = module_name
 
+        previous_frame = inspect.currentframe().f_back
+        caller_info = inspect.getframeinfo(previous_frame)
+        kwargs.update({"caller_info": caller_info})
+
         return self._run_ansible_module(*args, **kwargs)
 
     def load_module(self, module_name, args=[], kwargs={}, module_attrs={}):
-        """Load a module with arguments into a task list.
+        """Load a module with arguments into a list.
 
-        This method load a module with arguments into a task list. Method `self.run_loaded_modules` can run the loaded
+        This method load a module with arguments into a list. Method `self.run_loaded_modules` can run the loaded
         modules in a single play.
+
+        Comparing with `self.run_module` or `self._run_ansible_module`, special keyword arguments are not supported
+        in `kwargs` of `self.load_module`. The special keyword arguments are supported by the `self.run_loaded_modules`
+        method.
 
         Args:
             module_name (str): Ansible module name. Can be builtin module or customized module.
@@ -798,14 +782,21 @@ class AnsibleHosts(object):
             kwargs (dict, optional): Keyword arguments of ansible module. Defaults to {}.
             module_attrs (dict, optional): Module attributes affect module execution.
         """
-        self._loaded_tasks.append(self._build_task(module_name, args=args, kwargs=kwargs, module_attrs=module_attrs))
+        self._loaded_modules.append(
+            {
+                "module_name": module_name,
+                "args": args,
+                "kwargs": kwargs,
+                "module_attrs": module_attrs
+            }
+        )
 
     def clear_loaded_modules(self):
         """Clear the list of loaded ansible modules.
         """
-        self._loaded_tasks = []
+        self._loaded_modules = []
 
-    def run_loaded_modules(self, verbosity=2):
+    def run_loaded_modules(self, module_ignore_errors=False, verbosity=2):
         """Run the list of loaded ansible modules.
 
         Args:
@@ -836,6 +827,7 @@ class AnsibleHosts(object):
                             "reachable": true,
                             "stderr": "",
                             "rc": 0,
+                            "hostname": "vlab-01",
                             "invocation": {
                                 "module_args": {
                                     "creates": null,
@@ -864,6 +856,7 @@ class AnsibleHosts(object):
                             "reachable": true,
                             "stderr": "",
                             "delta": "0:00:00.003928",
+                            "hostname": "vlab-01",
                             "invocation": {
                                 "module_args": {
                                     "creates": null,
@@ -888,113 +881,227 @@ class AnsibleHosts(object):
                     ]
                 }
         """
-        if len(self._loaded_tasks) == 0:
+        if len(self._loaded_modules) == 0:
             logger.info("No loaded task.")
             return {}
 
         previous_frame = inspect.currentframe().f_back
-        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+        caller_info = inspect.getframeinfo(previous_frame)
 
-        tasks = self._loaded_tasks[:]
+        loaded_modules = copy.deepcopy(self._loaded_modules)
         self.clear_loaded_modules()
+        self._log_modules(caller_info, self._loaded_modules, verbosity)
 
-        task_names = [task["action"]["module"] for task in tasks]
+        tasks = [
+            self.build_task(**module) for module in loaded_modules
+        ]
+        results = self.run_tasks(self.host_pattern, self.loader, self.im, self.vm, self.options, tasks=tasks)
 
-        if len(task_names) > 100:
-            truncated_task_names = task_names[:100] + "..."
-        else:
-            truncated_task_names = task_names
-
-        play_headline = "===== [{}] {} ".format(self.hosts_pattern, ",".join(truncated_task_names))
-        play_headline_suffix = "=" * (120 - len(play_headline))
-        play_headline += play_headline_suffix
-
-        if verbosity <= 0:
-            pass
-        elif verbosity == 1:
-            logger.debug(play_headline)
-            logger.debug("{}::{}#{}: [{}] Tasks: {}".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                task_names
-            ))
-        elif verbosity == 2:
-            logger.debug(play_headline)
-            logger.debug("{}::{}#{}: [{}] Tasks: {}".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                json.dumps(tasks)
-            ))
-        elif verbosity >= 3:
-            logger.debug(play_headline)
-            logger.debug("{}::{}#{}: [{}] Tasks:\n{}".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                json.dumps(tasks, indent=4)
-            ))
-
-        play = self._build_play(tasks=tasks)
-        results = self._run_play(play)
-
-        if verbosity <= 0:
-            pass
-        elif verbosity == 1:
-            logger.debug("{}::{}#{}: [{}] Executed tasks: {}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                task_names
-            ))
-        elif verbosity == 2:
-            logger.debug("{}::{}#{}: [{}] Results => {}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                json.dumps(results)
-            ))
-        elif verbosity >= 3:
-            logger.debug("{}::{}#{}: [{}] Results =>\n{}\n".format(
-                filename,
-                function_name,
-                line_number,
-                self.hosts_pattern,
-                json.dumps(results, indent=4)
-            ))
+        self._log_results(caller_info, loaded_modules, results, verbosity)
+        self._check_results(caller_info, loaded_modules, results, module_ignore_errors, verbosity)
 
         return results
 
+    def get_inv_host(self, hostname, strict=False):
+        """Tool for getting ansible.inventory.host.Host object from self.inventories using ansible inventory manager.
 
-class AnsibleHost(AnsibleHosts):
-    """Basic class for running ansible modules on single host defined in ansible inventory file.
+        Args:
+            hostname (str): Hostname
+            strict (bool, optional): If strict==True, only get host with hostname matching self.host_pattern in
+                self.inventories. If strict=False, get any host with hostname from self.inventories. Defaults to False.
 
-    Parent class AnsibleHosts supports running ansible module on hosts matching hosts_pattern, which could be single
-    or multiple hosts.
+        Returns:
+            ansible.inventory.host.Host or None: Object of class ansible.inventory.host.Host or None.
+        """
+        if strict:
+            # Only get host with hostname from self.ans_inv_hosts
+            for _host in self.ans_inv_hosts:
+                if _host.name == hostname:
+                    return _host
+            else:
+                return None
+        else:
+            # Get host with hostname from whole inventory
+            return self.im.get_host(hostname)
 
-    This class ensures that the pattern only matches single host in inventory file. If the pattern matches more than
-    one host, `__init__` will raise exception MultipleAnsibleHostsError.
+    def get_inv_hosts(self, host_pattern):
+        """Tool for getting list of ansible.inventory.host.Host objects from self.inventories using ansible inventory
+        manager. Ansible inventory manager is used under the hood.
 
-    Args:
-        AnsibleHosts (_type_): _description_
-    """
+        Args:
+            host_pattern (str or list): Host pattern string or list of host pattern strings. Interpreted by ansible.
+                Follow the same rules of specifying ansible hosts in ansible play book.
+
+        Returns:
+            list: List of ansible.inventory.host.Host objects.
+        """
+        return self.im.get_hosts(host_pattern)
+
+    def get_host_vars(self, hostname, strict=False):
+        """Tool for getting variables of specified host from self.inventories. Variables defined in group_vars and
+        host_vars are not included. Only ansible inventory manager is used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            strict (bool, optional): If strict==True, only get variables of host with hostname from hosts matching
+                self.host_pattern in self.inventories. If strict=False, get variables of any host with hostname from
+                self.inventories. Defaults to False.
+
+        Returns:
+            dict: Dict of variables. Key is variable name. Value is variable value.
+        """
+        _host = self.get_inv_host(hostname, strict=strict)
+        if not _host:
+            return {}
+        return _host.get_vars()
+
+    def get_host_var(self, hostname, var, strict=False):
+        """Tool for getting variable value of specified host from self.inventories. Variables defined in group_vars and
+        host_vars are not included. Only ansible inventory manager is used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            var (str): Variable name.
+            strict (bool, optional): If strict==True, only get variable value of host with hostname from hosts matching
+                self.host_pattern in self.inventories. If strict=False, get variable value of any host with hostname
+                from self.inventories. Defaults to False.
+
+        Returns:
+            Any: Variable value, possible types: str, int, bool, list, dict.
+        """
+        return self.get_host_vars(hostname, strict).get(var, None)
+
+    def get_host_visible_vars(self, hostname, strict=False):
+        """Tool for getting visible variables of specified host. Variables may be defined in inventory files, any
+        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            strict (bool, optional): If strict==True, only get visible variables of host with hostname from hosts
+                matching self.host_pattern in self.inventories. If strict=False, get visible variables of any host
+                with hostname from self.inventories. Defaults to False.
+
+        Returns:
+            dict: Dict of variables. Key is variable name. Value is variable value.
+        """
+        _host = self.get_inv_host(hostname, strict=strict)
+        if not _host:
+            return {}
+        return self.vm.get_vars(host=_host)
+
+    def get_host_visible_var(self, hostname, var, strict=False):
+        """Tool for getting visible variable value of specified host. Variable may be defined in inventory files, any
+        group_vars and host_vars files. Both ansible inventory manager and variable managers are used under the hood.
+
+        Args:
+            hostname (str): Hostname.
+            var (str): Variable name.
+            strict (bool, optional): If strict==True, only get visible variable value of host with hostname from hosts
+                matching self.host_pattern in self.inventories. If strict=False, get visible variable value of any host
+                with hostname from self.inventories. Defaults to False.
+
+        Returns:
+            Any: Variable value, possible types: str, int, bool, list, dict.
+        """
+        return self.get_host_visible_vars(hostname, strict=strict).get(var, None)
+
+
+class AnsibleHosts(AnsibleHostsBase):
+
     def __init__(
             self,
             inventories,
             host_pattern,
+            loader=None,
+            inventory_manager=None,
+            variable_manager=None,
             options={},
             hostvars={}):
-        super(AnsibleHost, self).__init__(inventories, host_pattern, options=options, hostvars=hostvars)
-        if self.hosts_count > 1:
-            raise MultipleAnsibleHostsError("'{}' matches more than 1 host in '{}'".format(host_pattern, inventories))
-        self.host = self.hosts[0]
-        self.hostvars = self.host.get_vars()
-        self.hostname = self.hostvars.get("inventory_hostname")
-        self.ipaddr = self.hostvars.get("ansible_host")
-        self.host_visible_vars = self.vm.get_vars(host=self.host)
+
+        super(AnsibleHosts, self).__init__(
+            inventories,
+            host_pattern,
+            loader=loader,
+            inventory_manager=inventory_manager,
+            variable_manager=variable_manager,
+            options=options,
+            hostvars=hostvars
+        )
+
+        self.ans_hosts = [
+            AnsibleHost(
+                inventories,
+                hostname,
+                self.loader,
+                self.im,
+                self.vm,
+                self.options,
+                hostvars,
+            ) for hostname in self.hostnames
+        ]
+
+    # implement a list like interface based on attribute self.ans_hosts
+    def __len__(self):
+        return len(self.ans_hosts)
+
+    def __iter__(self):
+        return iter(self.ans_hosts)
+
+    def __getitem__(self, index):
+
+        if isinstance(index, int):
+            if index < 0:
+                index = len(self.ans_hosts) + index
+            if index < 0 or index >= len(self.ans_hosts):
+                raise IndexError("AnsibleHosts index out of range")
+            return self.ans_hosts[index]
+        elif isinstance(index, str):
+            for ans_host in self.ans_hosts:
+                if ans_host.hostname == index:
+                    return ans_host
+            raise KeyError("AnsibleHost with hostname '{}' not found".format(index))
+        else:
+            raise TypeError("AnsibleHosts indices must be integers or strings, not {}".format(type(index)))
+
+    def __str__(self):
+        return "<AnsibleHosts {} in {}>".format(self.hostnames, self.inventories)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class AnsibleHost(AnsibleHostsBase):
+
+    def __init__(
+            self,
+            inventories,
+            host_pattern,
+            loader=None,
+            inventory_manager=None,
+            variable_manager=None,
+            options={},
+            hostvars={}):
+
+        super(AnsibleHost, self).__init__(
+            inventories,
+            host_pattern,
+            loader=loader,
+            inventory_manager=inventory_manager,
+            variable_manager=variable_manager,
+            options=options,
+            hostvars=hostvars
+        )
+
+        if len(self.ans_inv_hosts) > 1:
+            raise MultipleAnsibleHostsError(
+                "More than one host match '{}' in inventory files '{}'".format(self.host_pattern, self.inventories)
+            )
+        self.ans_inv_host = self.ans_inv_hosts[0]
+        self.hostname = self.ans_inv_host.name
+        self.ip = self.ans_inv_host.get_vars().get("ansible_host", None)
+
+    def __str__(self):
+        return "<AnsibleHost {} in {}>".format(self.hostname, self.inventories)
+
+    def __repr__(self):
+        return self.__str__()

--- a/ansible/devutil/devices.py
+++ b/ansible/devutil/devices.py
@@ -1,0 +1,197 @@
+import json
+import logging
+import os
+import yaml
+
+from ansible_hosts import AnsibleHosts, AnsibleHost
+from devutil.ansible_hosts import NoAnsibleHostError, MultipleAnsibleHostsError, RunAnsibleModuleFailed
+
+logger = logging.getLogger(__name__)
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../"))
+
+
+class SonicHosts(AnsibleHosts):
+    SUPPORTED_UPGRADE_TYPES = ["onie", "sonic"]
+
+    def __init__(self, inventories, hosts_pattern, options={}, hostvars={}):
+        super(SonicHosts, self).__init__(inventories, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
+
+    def _upgrade_by_sonic(self, image_url, disk_used_percent):
+        try:
+            self.reduce_and_add_sonic_images(
+                disk_used_pcent=disk_used_percent,
+                new_image_url=image_url,
+                module_attrs={"become": True}
+            )
+            self.shell("reboot", module_attrs={"become": True, "async": 300, "poll": 0})
+            return True
+        except RunAnsibleModuleFailed as e:
+            logger.error(
+                "SONiC upgrade image failed, devices: {}, url: {}, error: {}".format(
+                    str(self.hostnames), image_url, repr(e)
+                )
+            )
+            return False
+
+    def _upgrade_by_onie(self, localhost, image_url, pause_time):
+        try:
+            self.shell("grub-editenv /host/grub/grubenv set next_entry=ONIE", module_attrs={"become": True})
+            self.shell(
+                'sleep 2 && shutdown -r now "Boot into onie."',
+                module_attrs={"become": True, "async": 5, "poll": 0}
+            )
+
+            for i in range(len(self.ipaddrs)):
+                localhost.wait_for(
+                    host=self.ipaddrs[i],
+                    port=22,
+                    state="started",
+                    search_regex="OpenSSH",
+                    delay=60 if i == 0 else 0,
+                    timeout=300,
+                    module_attrs={"changed_when": False}
+                )
+            if pause_time > 0:
+                localhost.pause(
+                    seconds=pause_time, prompt="Pause {} seconds for ONIE initialization".format(str(pause_time))
+                )
+            self.onie(
+                install="yes",
+                url=image_url,
+                module_attrs={"connection": "onie"}
+            )
+            return True
+        except RunAnsibleModuleFailed as e:
+            logger.error(
+                "ONIE upgrade image failed, devices: {}, url: {}, error: {}".format(
+                    str(self.hostnames), image_url, repr(e)
+                )
+            )
+            return False
+
+    def _post_upgrade_actions(self, localhost, disk_used_percent):
+        try:
+            for i in range(len(self.ipaddrs)):
+                localhost.wait_for(
+                    host=self.ipaddrs[i],
+                    port=22,
+                    state="started",
+                    search_regex="OpenSSH",
+                    delay=180 if i == 0 else 0,
+                    timeout=600,
+                    module_attrs={"changed_when": False}
+                )
+            localhost.pause(seconds=60, prompt="Wait for SONiC initialization")
+
+            # PR https://github.com/sonic-net/sonic-buildimage/pull/12109 decreased the sshd timeout
+            # This change may cause timeout when executing `generate_dump -s yesterday`.
+            # Increase this time after image upgrade
+            self.shell(
+                'sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config '
+                '&& systemctl restart sshd',
+                module_attrs={"become": True}
+            )
+
+            self.command("config bgp startup all", module_attrs={"become": True})
+            self.command("config save -y", module_attrs={"become": True})
+            self.reduce_and_add_sonic_images(
+                disk_used_pcent=disk_used_percent,
+                module_attrs={"become": True}
+            )
+            return True
+        except RunAnsibleModuleFailed as e:
+            logger.error(
+                "Post upgrade actions failed, devices: {}, error: {}".format(str(self.hostnames), repr(e))
+            )
+            return False
+
+    def upgrade_image(self, localhost, image_url, upgrade_type="sonic", disk_used_percent=50, onie_pause_time=0):
+        if upgrade_type not in self.SUPPORTED_UPGRADE_TYPES:
+            logger.error(
+                "Upgrade type '{}' is not in SUPPORTED_UPGRADE_TYPES={}".format(
+                    upgrade_type, self.SUPPORTED_UPGRADE_TYPES
+                )
+            )
+            return False
+
+        if upgrade_type == "sonic":
+            upgrade_result = self._upgrade_by_sonic(image_url, disk_used_percent)
+        elif upgrade_type == "onie":
+            upgrade_result = self._upgrade_by_onie(localhost, image_url, onie_pause_time)
+        if not upgrade_result:
+            return False
+
+        return self._post_upgrade_actions(localhost, disk_used_percent)
+
+    @property
+    def sonic_version(self):
+        try:
+            output = self.command("cat /etc/sonic/sonic_version.yml")
+            versions = {}
+            for hostname in self.hostnames:
+                versions[hostname] = yaml.safe_load(output[hostname]["stdout"])
+            return versions
+        except Exception as e:
+            logger.error("Failed to run `cat /etc/sonic/sonic_version.yml`: {}".format(repr(e)))
+            return {}
+
+
+def init_localhost(inventory, options={}, hostvars={}):
+    try:
+        return AnsibleHost(inventory, "localhost", options=options.copy(), hostvars=hostvars.copy())
+    except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:
+        logger.error(
+            "Failed to initialize localhost from inventory '{}', exception: {}".format(str(inventory), repr(e))
+        )
+        return None
+
+
+def init_hosts(inventory, hosts_pattern, options={}, hostvars={}):
+    try:
+        return AnsibleHosts(inventory, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
+    except NoAnsibleHostError as e:
+        logger.error(
+            "No hosts '{}' in inventory '{}', exception: {}".format(hosts_pattern, inventory, repr(e))
+        )
+        return None
+
+
+def init_sonichosts(inventory, hosts_pattern, options={}, hostvars={}):
+    try:
+        return SonicHosts(inventory, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
+    except NoAnsibleHostError as e:
+        logger.error(
+            "No hosts '{}' in inventory '{}', exception: {}".format(hosts_pattern, inventory, repr(e))
+        )
+        return None
+
+
+def init_testbed_sonichosts(inventory, testbed_name, testbed_file="testbed.yaml", options={}, hostvars={}):
+    testbed_file_path = os.path.join(ansible_path, testbed_file)
+    with open(testbed_file_path) as f:
+        testbeds = yaml.safe_load(f.read())
+
+    duts = None
+    for testbed in testbeds:
+        if testbed["conf-name"] == testbed_name:
+            duts = testbed["dut"]   # Type is list, historic reason.
+            break
+
+    if not duts:
+        logger.error("No testbed with name '{}' in testbed file {}".format(testbed_name, testbed_file_path))
+        return None
+
+    sonichosts = init_sonichosts(inventory, duts, options=options.copy(), hostvars=hostvars.copy())
+    if sonichosts and sonichosts.hosts_count != len(duts):
+        logger.error(
+            "Unmatched testbed duts: '{}', inventory: '{}', found hostnames: '{}'".format(
+                json.dumps(duts),
+                inventory,
+                json.dumps(sonichosts.hostnames)
+            )
+        )
+        return None
+
+    return sonichosts

--- a/ansible/devutil/devices.py
+++ b/ansible/devutil/devices.py
@@ -4,7 +4,7 @@ import os
 import yaml
 
 from ansible_hosts import AnsibleHosts, AnsibleHost
-from devutil.ansible_hosts import NoAnsibleHostError, MultipleAnsibleHostsError, RunAnsibleModuleFailed
+from devutil.ansible_hosts import NoAnsibleHostError, MultipleAnsibleHostsError
 
 logger = logging.getLogger(__name__)
 
@@ -15,115 +15,8 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../"))
 class SonicHosts(AnsibleHosts):
     SUPPORTED_UPGRADE_TYPES = ["onie", "sonic"]
 
-    def __init__(self, inventories, hosts_pattern, options={}, hostvars={}):
-        super(SonicHosts, self).__init__(inventories, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
-
-    def _upgrade_by_sonic(self, image_url, disk_used_percent):
-        try:
-            self.reduce_and_add_sonic_images(
-                disk_used_pcent=disk_used_percent,
-                new_image_url=image_url,
-                module_attrs={"become": True}
-            )
-            self.shell("reboot", module_attrs={"become": True, "async": 300, "poll": 0})
-            return True
-        except RunAnsibleModuleFailed as e:
-            logger.error(
-                "SONiC upgrade image failed, devices: {}, url: {}, error: {}".format(
-                    str(self.hostnames), image_url, repr(e)
-                )
-            )
-            return False
-
-    def _upgrade_by_onie(self, localhost, image_url, pause_time):
-        try:
-            self.shell("grub-editenv /host/grub/grubenv set next_entry=ONIE", module_attrs={"become": True})
-            self.shell(
-                'sleep 2 && shutdown -r now "Boot into onie."',
-                module_attrs={"become": True, "async": 5, "poll": 0}
-            )
-
-            for i in range(len(self.ipaddrs)):
-                localhost.wait_for(
-                    host=self.ipaddrs[i],
-                    port=22,
-                    state="started",
-                    search_regex="OpenSSH",
-                    delay=60 if i == 0 else 0,
-                    timeout=300,
-                    module_attrs={"changed_when": False}
-                )
-            if pause_time > 0:
-                localhost.pause(
-                    seconds=pause_time, prompt="Pause {} seconds for ONIE initialization".format(str(pause_time))
-                )
-            self.onie(
-                install="yes",
-                url=image_url,
-                module_attrs={"connection": "onie"}
-            )
-            return True
-        except RunAnsibleModuleFailed as e:
-            logger.error(
-                "ONIE upgrade image failed, devices: {}, url: {}, error: {}".format(
-                    str(self.hostnames), image_url, repr(e)
-                )
-            )
-            return False
-
-    def _post_upgrade_actions(self, localhost, disk_used_percent):
-        try:
-            for i in range(len(self.ipaddrs)):
-                localhost.wait_for(
-                    host=self.ipaddrs[i],
-                    port=22,
-                    state="started",
-                    search_regex="OpenSSH",
-                    delay=180 if i == 0 else 0,
-                    timeout=600,
-                    module_attrs={"changed_when": False}
-                )
-            localhost.pause(seconds=60, prompt="Wait for SONiC initialization")
-
-            # PR https://github.com/sonic-net/sonic-buildimage/pull/12109 decreased the sshd timeout
-            # This change may cause timeout when executing `generate_dump -s yesterday`.
-            # Increase this time after image upgrade
-            self.shell(
-                'sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config '
-                '&& systemctl restart sshd',
-                module_attrs={"become": True}
-            )
-
-            self.command("config bgp startup all", module_attrs={"become": True})
-            self.command("config save -y", module_attrs={"become": True})
-            self.reduce_and_add_sonic_images(
-                disk_used_pcent=disk_used_percent,
-                module_attrs={"become": True}
-            )
-            return True
-        except RunAnsibleModuleFailed as e:
-            logger.error(
-                "Post upgrade actions failed, devices: {}, error: {}".format(str(self.hostnames), repr(e))
-            )
-            return False
-
-    def upgrade_image(self, localhost, image_url, upgrade_type="sonic", disk_used_percent=50, onie_pause_time=0):
-        if upgrade_type not in self.SUPPORTED_UPGRADE_TYPES:
-            logger.error(
-                "Upgrade type '{}' is not in SUPPORTED_UPGRADE_TYPES={}".format(
-                    upgrade_type, self.SUPPORTED_UPGRADE_TYPES
-                )
-            )
-            return False
-
-        if upgrade_type == "sonic":
-            upgrade_result = self._upgrade_by_sonic(image_url, disk_used_percent)
-        elif upgrade_type == "onie":
-            upgrade_result = self._upgrade_by_onie(localhost, image_url, onie_pause_time)
-        if not upgrade_result:
-            return False
-
-        return self._post_upgrade_actions(localhost, disk_used_percent)
+    def __init__(self, inventories, host_pattern, options={}, hostvars={}):
+        super(SonicHosts, self).__init__(inventories, host_pattern, options=options.copy(), hostvars=hostvars.copy())
 
     @property
     def sonic_version(self):
@@ -138,37 +31,37 @@ class SonicHosts(AnsibleHosts):
             return {}
 
 
-def init_localhost(inventory, options={}, hostvars={}):
+def init_localhost(inventories, options={}, hostvars={}):
     try:
-        return AnsibleHost(inventory, "localhost", options=options.copy(), hostvars=hostvars.copy())
+        return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:
         logger.error(
-            "Failed to initialize localhost from inventory '{}', exception: {}".format(str(inventory), repr(e))
+            "Failed to initialize localhost from inventories '{}', exception: {}".format(str(inventories), repr(e))
         )
         return None
 
 
-def init_hosts(inventory, hosts_pattern, options={}, hostvars={}):
+def init_hosts(inventories, host_pattern, options={}, hostvars={}):
     try:
-        return AnsibleHosts(inventory, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
+        return AnsibleHosts(inventories, host_pattern, options=options.copy(), hostvars=hostvars.copy())
     except NoAnsibleHostError as e:
         logger.error(
-            "No hosts '{}' in inventory '{}', exception: {}".format(hosts_pattern, inventory, repr(e))
+            "No hosts '{}' in inventories '{}', exception: {}".format(host_pattern, inventories, repr(e))
         )
         return None
 
 
-def init_sonichosts(inventory, hosts_pattern, options={}, hostvars={}):
+def init_sonichosts(inventories, host_pattern, options={}, hostvars={}):
     try:
-        return SonicHosts(inventory, hosts_pattern, options=options.copy(), hostvars=hostvars.copy())
+        return SonicHosts(inventories, host_pattern, options=options.copy(), hostvars=hostvars.copy())
     except NoAnsibleHostError as e:
         logger.error(
-            "No hosts '{}' in inventory '{}', exception: {}".format(hosts_pattern, inventory, repr(e))
+            "No hosts '{}' in inventories '{}', exception: {}".format(host_pattern, inventories, repr(e))
         )
         return None
 
 
-def init_testbed_sonichosts(inventory, testbed_name, testbed_file="testbed.yaml", options={}, hostvars={}):
+def init_testbed_sonichosts(inventories, testbed_name, testbed_file="testbed.yaml", options={}, hostvars={}):
     testbed_file_path = os.path.join(ansible_path, testbed_file)
     with open(testbed_file_path) as f:
         testbeds = yaml.safe_load(f.read())
@@ -183,12 +76,12 @@ def init_testbed_sonichosts(inventory, testbed_name, testbed_file="testbed.yaml"
         logger.error("No testbed with name '{}' in testbed file {}".format(testbed_name, testbed_file_path))
         return None
 
-    sonichosts = init_sonichosts(inventory, duts, options=options.copy(), hostvars=hostvars.copy())
+    sonichosts = init_sonichosts(inventories, duts, options=options.copy(), hostvars=hostvars.copy())
     if sonichosts and sonichosts.hosts_count != len(duts):
         logger.error(
             "Unmatched testbed duts: '{}', inventory: '{}', found hostnames: '{}'".format(
                 json.dumps(duts),
-                inventory,
+                inventories,
                 json.dumps(sonichosts.hostnames)
             )
         )

--- a/ansible/devutil/sonic_helpers.py
+++ b/ansible/devutil/sonic_helpers.py
@@ -1,0 +1,196 @@
+import logging
+import os
+
+from devutil.ansible_hosts import RunAnsibleModuleFailed
+
+logger = logging.getLogger(__name__)
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../"))
+
+
+def upgrade_by_sonic(sonichosts, image_url, disk_used_percent):
+    try:
+        sonichosts.reduce_and_add_sonic_images(
+            disk_used_pcent=disk_used_percent,
+            new_image_url=image_url,
+            module_attrs={"become": True}
+        )
+        sonichosts.shell("reboot", module_attrs={"become": True, "async": 300, "poll": 0})
+        return True
+    except RunAnsibleModuleFailed as e:
+        logger.error(
+            "SONiC upgrade image failed, devices: {}, url: {}, error: {}".format(
+                str(sonichosts.hostnames), image_url, repr(e)
+            )
+        )
+        return False
+
+
+def upgrade_by_onie(sonichosts, localhost, image_url, pause_time):
+    try:
+        sonichosts.shell("grub-editenv /host/grub/grubenv set next_entry=ONIE", module_attrs={"become": True})
+        sonichosts.shell(
+            'sleep 2 && shutdown -r now "Boot into onie."',
+            module_attrs={"become": True, "async": 5, "poll": 0}
+        )
+
+        for i in range(len(sonichosts.ips)):
+            localhost.wait_for(
+                host=sonichosts.ips[i],
+                port=22,
+                state="started",
+                search_regex="OpenSSH",
+                delay=60 if i == 0 else 0,
+                timeout=300,
+                module_attrs={"changed_when": False}
+            )
+        if pause_time > 0:
+            localhost.pause(
+                seconds=pause_time, prompt="Pause {} seconds for ONIE initialization".format(str(pause_time))
+            )
+        sonichosts.onie(
+            install="yes",
+            url=image_url,
+            module_attrs={"connection": "onie"}
+        )
+        return True
+    except RunAnsibleModuleFailed as e:
+        logger.error(
+            "ONIE upgrade image failed, devices: {}, url: {}, error: {}".format(
+                str(sonichosts.hostnames), image_url, repr(e)
+            )
+        )
+        return False
+
+
+def patch_rsyslog(sonichosts):
+    rsyslog_conf_files = [
+        "/usr/share/sonic/templates/rsyslog.conf.j2",
+        "/etc/rsyslog.conf"
+    ]
+
+    # Get sonic version, use version of the first host
+    sonic_build_version = sonichosts.shell(
+        "sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version"
+    ).values()[0]["stdout"]
+
+    # Patch rsyslog to stop sending syslog to production and use new template for remote syslog
+    for conf_file in rsyslog_conf_files:
+        sonichosts.lineinfile(
+            path=conf_file,
+            state="present",
+            backrefs=True,
+            regexp=r"(^[^#]*@\[10\.20\.6\.16\]:514)",
+            line=r"# \g<1>",
+            module_attrs={"become": True}
+        )
+        sonichosts.lineinfile(
+            path=conf_file,
+            state="present",
+            insertafter="# Define a custom template",
+            line='$template RemoteSONiCFileFormat,"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% '
+                 '%PROCID% %MSGID% [origin swVersion="{}"] %msg%\n"'.format(sonic_build_version),
+            module_attrs={"become": True}
+        )
+
+    # Patch rsyslog.conf.j2 to use new template for remote syslog
+    sonichosts.lineinfile(
+        path="/usr/share/sonic/templates/rsyslog.conf.j2",
+        state="present",
+        backrefs=True,
+        regex=r"(\*\.\* @\[\{\{ server \}\}\]:514)",
+        line=r'\g<1>;RemoteSONiCFileFormat',
+        module_attrs={"become": True}
+    )
+
+    # Patch rsyslog.conf to use new template for remote syslog
+    sonichosts.shell(
+        r"sed -E -i 's/(^[^#]*@\[[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\]:514).*$/\1;RemoteSONiCFileFormat/g' "
+        "/etc/rsyslog.conf",
+        module_attrs={"become": True}
+    )
+
+    # Workaround for PR https://msazure.visualstudio.com/One/_git/Networking-acs-buildimage/pullrequest/6631568
+    # This PR updated the rsyslog.conf to use a new method for sending out syslog. Need to configure the new method
+    # to use RemoteSONiCFileFormat too.
+    remote_template = sonichosts.shell(
+        "echo `grep -c 'template=\".*SONiCFileFormat\"' /usr/share/sonic/templates/rsyslog.conf.j2`"
+    ).values()[0]["stdout"]
+    if remote_template == "0":
+        for conf_file in rsyslog_conf_files:
+            sonichosts.lineinfile(
+                path=conf_file,
+                state="present",
+                backrefs=True,
+                regex=r'^(\*\.\* action\(type="omfwd") target=(.*)$',
+                line=r'\g<1> template="RemoteSONiCFileFormat" target=\g<2>',
+                module_attrs={"become": True}
+            )
+    elif remote_template != "0":
+        for conf_file in rsyslog_conf_files:
+            sonichosts.replace(
+                dest=conf_file,
+                regexp='template=".*SONiCFileFormat"',
+                replace='template="RemoteSONiCFileFormat"',
+                module_attrs={"become": True}
+            )
+    sonichosts.shell("systemctl restart rsyslog", module_attrs={"become": True})
+
+
+def post_upgrade_actions(sonichosts, localhost, disk_used_percent):
+    try:
+        for i in range(len(sonichosts.ips)):
+            localhost.wait_for(
+                host=sonichosts.ips[i],
+                port=22,
+                state="started",
+                search_regex="OpenSSH",
+                delay=180 if i == 0 else 0,
+                timeout=600,
+                module_attrs={"changed_when": False}
+            )
+        localhost.pause(seconds=60, prompt="Wait for SONiC initialization")
+
+        # PR https://github.com/sonic-net/sonic-buildimage/pull/12109 decreased the sshd timeout
+        # This change may cause timeout when executing `generate_dump -s yesterday`.
+        # Increase this time after image upgrade
+        sonichosts.shell(
+            'sed -i "s/^ClientAliveInterval [0-9].*/ClientAliveInterval 900/g" /etc/ssh/sshd_config '
+            '&& systemctl restart sshd',
+            module_attrs={"become": True}
+        )
+
+        patch_rsyslog(sonichosts)
+
+        sonichosts.command("config bgp startup all", module_attrs={"become": True})
+        sonichosts.command("config save -y", module_attrs={"become": True})
+        sonichosts.reduce_and_add_sonic_images(
+            disk_used_pcent=disk_used_percent,
+            module_attrs={"become": True}
+        )
+        return True
+    except RunAnsibleModuleFailed as e:
+        logger.error(
+            "Post upgrade actions failed, devices: {}, error: {}".format(str(sonichosts.hostnames), repr(e))
+        )
+        return False
+
+
+def upgrade_image(sonichosts, localhost, image_url, upgrade_type="sonic", disk_used_percent=50, onie_pause_time=0):
+    if upgrade_type not in sonichosts.SUPPORTED_UPGRADE_TYPES:
+        logger.error(
+            "Upgrade type '{}' is not in SUPPORTED_UPGRADE_TYPES={}".format(
+                upgrade_type, sonichosts.SUPPORTED_UPGRADE_TYPES
+            )
+        )
+        return False
+
+    if upgrade_type == "sonic":
+        upgrade_result = upgrade_by_sonic(sonichosts, image_url, disk_used_percent)
+    elif upgrade_type == "onie":
+        upgrade_result = upgrade_by_onie(sonichosts, localhost, image_url, onie_pause_time)
+    if not upgrade_result:
+        return False
+
+    return post_upgrade_actions(sonichosts, localhost, disk_used_percent)

--- a/ansible/upgrade_sonic.py
+++ b/ansible/upgrade_sonic.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 from devutil.devices import init_localhost, init_sonichosts, init_testbed_sonichosts
+from devutil.sonic_helpers import upgrade_image
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -20,7 +21,7 @@ RC_INVALID_ARGS = 5
 
 def main(args):
 
-    localhost = init_localhost(args.inventory, args.verbosity)
+    localhost = init_localhost(args.inventory, options={"verbosity": args.verbosity})
     if not localhost:
         sys.exit(RC_INIT_FAILED)
 
@@ -31,7 +32,8 @@ def main(args):
     if not sonichosts:
         sys.exit(RC_INIT_FAILED)
 
-    result = sonichosts.upgrade_image(
+    result = upgrade_image(
+        sonichosts,
         localhost,
         args.image_url,
         upgrade_type=args.upgrade_type,
@@ -108,11 +110,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--disk-usage-percent",
+        "--disk-used-percent",
         type=int,
-        dest="disk_usage_percent",
+        dest="disk_used_percent",
         default=50,
-        help="Disk usage percent."
+        help="Disk used percent."
     )
 
     parser.add_argument(

--- a/ansible/upgrade_sonic.py
+++ b/ansible/upgrade_sonic.py
@@ -1,0 +1,133 @@
+import argparse
+import logging
+import sys
+
+from devutil.devices import init_localhost, init_sonichosts, init_testbed_sonichosts
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.DEBUG,
+    format="%(asctime)s %(filename)s#%(lineno)d %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+DISK_USED_PERCENT = 50
+
+RC_INIT_FAILED = 1
+RC_UPGRADE_FAILED = 3
+RC_INVALID_ARGS = 5
+
+
+def main(args):
+
+    localhost = init_localhost(args.inventory, args.verbosity)
+    if not localhost:
+        sys.exit(RC_INIT_FAILED)
+
+    if args.testbed_name:
+        sonichosts = init_testbed_sonichosts(args.inventory, args.testbed_name, options={"verbosity": args.verbosity})
+    else:
+        sonichosts = init_sonichosts(args.inventory, args.devices, options={"verbosity": args.verbosity})
+    if not sonichosts:
+        sys.exit(RC_INIT_FAILED)
+
+    result = sonichosts.upgrade_image(
+        localhost,
+        args.image_url,
+        upgrade_type=args.upgrade_type,
+        disk_used_percent=args.disk_used_percent,
+        onie_pause_time=args.pause_time
+    )
+    if not result:
+        sys.exit(RC_UPGRADE_FAILED)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Tool for SONiC image upgrade.")
+
+    parser.add_argument(
+        "-i", "--inventory",
+        type=str,
+        dest="inventory",
+        required=True,
+        help="Ansible inventory file")
+
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument(
+        "-d", "--device",
+        type=str,
+        dest="devices",
+        help="Name of the device to be upgraded."
+             "Mutually exclusive with testbed name argument."
+    )
+
+    group.add_argument(
+        "-t", "--testbed-name",
+        type=str,
+        dest="testbed_name",
+        help="Testbed name. DUTs of the specified testbed will be upgraded."
+             "This argument is mutually exclusive with device name argument '-d' or '--device'."
+    )
+
+    parser.add_argument(
+        "-u", "--url",
+        type=str,
+        dest="image_url",
+        required=True,
+        help="SONiC image url."
+    )
+
+    parser.add_argument(
+        "-y", "--type",
+        type=str,
+        choices=["sonic", "onie"],
+        dest="upgrade_type",
+        required=False,
+        default="sonic",
+        help="Upgrade type."
+    )
+
+    parser.add_argument(
+        "-f", "--tbfile",
+        type=str,
+        dest="tbfile",
+        default="testbed.yaml",
+        help="Testbed definition file."
+    )
+
+    parser.add_argument(
+        "-p", "--pause-time",
+        type=int,
+        dest="pause_time",
+        default=0,
+        help="Seconds to pause after ONIE upgrade."
+    )
+
+    parser.add_argument(
+        "--disk-usage-percent",
+        type=int,
+        dest="disk_usage_percent",
+        default=50,
+        help="Disk usage percent."
+    )
+
+    parser.add_argument(
+        "-v", "--verbosity",
+        type=int,
+        dest="verbosity",
+        default=2,
+        help="Log verbosity."
+    )
+
+    args = parser.parse_args()
+
+    if not args.testbed_name and not args.devices:
+        logger.error("Either testbed name or dut devices must be specified.")
+        parser.print_help()
+        sys.exit(RC_INVALID_ARGS)
+
+    main(args)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This change experimented the idea of running ansible in pure python. With the classes and functions defined in `ansible_hosts.py` and `devices.py`, we can use pure python to run any ansible module on any hosts. The required inputs are ansible inventory file and optional variable files. We can view it as a python version of playbook. Comparing with ansible playbook, we can take advantage of a real programming language. The drawback is that python programming experience is required.

Comparing with pytest-ansible, we do not need pytest. This design supports some ansible features not supported by pytest-ansible:
* fork: Pytest-ansible does not support running ansible modules in parallel. This design uses ansible's builtin forking capability to run modules in parallel.
* module attributes: Ansible supports additional module attributes that can be specified for each task in playbook. These module attributes can affect execution of the modules, for example "become", "async", etc. Pytest-ansible does not support these attributes. With this design, we can use keyword argument `module_attrs` to specify module attributes while calling an ansible module.

Not all ansible's builtin features are supported by this design. For example:
* Notify and event handler. (We can use python's libs to support that)

This idea is still new. I haven't figured out all of its potentials and limitations. Feedbacks, suggestions and contributions are more than welcome!

#### How did you do it?
* Added basic class `AnsibleHosts` and `AnsibleHost`
* Added class `SonicHosts`
* Added helper functions like `init_xxx_hosts`
* Added script `ansible/upgrade_sonic.py` as replacement of `ansible/upgrade_sonic.yml`
* Added script `.azure-pipelines/upgrade_image.py` which can be called in nightly test.

#### How did you verify/test it?
Test run the upgrade_sonic.py and upgrade_image.py scripts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
