### PR TITLE
Modified CRM ACL entry testcase according to Marvell Design

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -119,7 +119,7 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
             acl_entry_config[str(seq_id)] = copy.deepcopy(acl_entry_template)
             acl_entry_config[str(seq_id)]["config"]["sequence-id"] = seq_id
 
-        with tempfile.NamedTemporaryFile(suffix=".json", prefix="acl_config", mode="w") as fp:
+        with tempfile.NamedTemporaryFile(suffix=".json", prefix="acl_config") as fp:
             json.dump(acl_config, fp)
             fp.flush()
             logger.info("Generating config for ACL rule, ACL table - DATAACL")
@@ -173,7 +173,7 @@ def generate_fdb_config(duthost, entry_num, vlan_id, iface, op, dest):
                           }
         fdb_config_json.append(fdb_entry_json)
 
-    with tempfile.NamedTemporaryFile(suffix=".json", prefix="fdb_config", mode="w") as fp:
+    with tempfile.NamedTemporaryFile(suffix=".json", prefix="fdb_config") as fp:
         logger.info("Generating FDB config")
         json.dump(fdb_config_json, fp)
         fp.flush()
@@ -252,7 +252,7 @@ def verify_thresholds(duthost, asichost, **kwargs):
     Verifies the following threshold parameters: percentage, actual used, actual free
     """
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='crm_test')
-    for key, value in list(THR_VERIFY_CMDS.items()):
+    for key, value in THR_VERIFY_CMDS.items():
         logger.info("Verifying CRM threshold '{}'".format(key))
         template = Template(value)
         if "exceeded" in key:
@@ -319,9 +319,9 @@ def check_crm_stats(cmd, duthost, origin_crm_stats_used, origin_crm_stats_availa
 def generate_neighbors(amount, ip_ver):
     """ Generate list of IPv4 or IPv6 addresses """
     if ip_ver == "4":
-        ip_addr_list = list(ipaddress.IPv4Network("%s" % "2.0.0.0/8").hosts())[0:amount]
+        ip_addr_list = list(ipaddress.IPv4Network(u"%s" % "2.0.0.0/8").hosts())[0:amount]
     elif ip_ver == "6":
-        ip_addr_list = list(ipaddress.IPv6Network("%s" % "2001::/112").hosts())[0:amount]
+        ip_addr_list = list(ipaddress.IPv6Network(u"%s" % "2001::/112").hosts())[0:amount]
     else:
         pytest.fail("Incorrect IP version specified - {}".format(ip_ver))
     return ip_addr_list
@@ -438,7 +438,7 @@ def configure_neighbors(amount, interface, ip_ver, asichost, test_name):
 
 def get_entries_num(used, available):
     """ Get number of entries needed to be created that 'used' counter reached one percent """
-    return ((used + available) // 100) + 1
+    return ((used + available) / 100) + 1
 
 
 @pytest.mark.usefixtures('disable_route_checker')
@@ -543,10 +543,10 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     if used_percent < 1:
         routes_num = get_entries_num(new_crm_stats_route_used, new_crm_stats_route_available)
         if ip_ver == "4":
-            routes_list = " ".join([str(ipaddress.IPv4Address('2.0.0.1') + item) + "/32"
+            routes_list = " ".join([str(ipaddress.IPv4Address(u'2.0.0.1') + item) + "/32"
                                     for item in range(1, routes_num + 1)])
         elif ip_ver == "6":
-            routes_list = " ".join([str(ipaddress.IPv6Address('2001::') + item) + "/128"
+            routes_list = " ".join([str(ipaddress.IPv6Address(u'2001::') + item) + "/128"
                                     for item in range(1, routes_num + 1)])
         else:
             pytest.fail("Incorrect IP version specified - {}".format(ip_ver))
@@ -835,6 +835,7 @@ def recreate_acl_table(duthost, ports):
     duthost.shell_cmds(cmds=cmds)
 
 
+
 def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector):
     apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
     acl_tbl_key = asic_collector["acl_tbl_key"]
@@ -888,7 +889,6 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
                                     crm_stats_acl_entry_used,
                                     crm_stats_acl_entry_available,"==", ">=")
 
-
 def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, collector, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
@@ -896,11 +896,16 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
     if duthost.facts["asic_type"] == "marvell":
         # Remove DATA ACL Table and add it again with ports in same port group
-        logger.info("get testbed info")
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        if tbinfo["topo"]["type"] == "mx":
-            ports = ",".join(duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]["DATAACL"]["ports"])
-            logger.info("apply acl config to ports {}".format(ports))
+        tmp_ports = mg_facts["minigraph_ports"].keys()
+        tmp_ports.sort(key=lambda x: int(x[8:]))
+        for i in range(3):
+            if i == 0:
+                ports = ",".join(tmp_ports[17:19])
+            elif i == 1:
+                ports = ",".join(tmp_ports[24:26])
+            elif i == 2:
+                ports = ",".join([tmp_ports[20],tmp_ports[25]])
             recreate_acl_table(duthost, ports)
             verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector)
             # Rebind DATA ACL at end to recover original config
@@ -908,29 +913,12 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             recreate_acl_table(duthost, ports)
             apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
             duthost.command("acl-loader delete")
-        else:
-            tmp_ports = mg_facts["minigraph_ports"].keys()
-            tmp_ports.sort(key=lambda x: int(x[8:]))
-            for i in range(4):
-                if i == 0:
-                    ports = ",".join(tmp_ports[17:19])
-                elif i == 1:
-                    ports = ",".join(tmp_ports[24:26])
-                elif i == 2:
-                    ports = ",".join([tmp_ports[20],tmp_ports[25]])
-                logger.info("apply acl config to ports {}".format(ports))
-                recreate_acl_table(duthost, ports)
-                verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector)
-                # Rebind DATA ACL at end to recover original config
-                recreate_acl_table(duthost, ports)
-                apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
-                duthost.command("acl-loader delete")
     else:
         verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector)
 
     pytest_assert(crm_stats_checker,
-                                  "\"crm_stats_acl_entry_used\" counter was not decremented or "
-                                  "\"crm_stats_acl_entry_available\" counter was not incremented")
+                  "\"crm_stats_acl_entry_used\" counter was not decremented or "
+                  "\"crm_stats_acl_entry_available\" counter was not incremented")
 
 
 def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, collector):
@@ -1015,7 +1003,7 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     get_fdb_stats = "redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available"
     topology = tbinfo["topo"]["properties"]["topology"]
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-    port_dict = dict(list(zip(list(cfg_facts['port_index_map'].values()), list(cfg_facts['port_index_map'].keys()))))
+    port_dict = dict(zip(cfg_facts['port_index_map'].values(), cfg_facts['port_index_map'].keys()))
     # Use for test 1st in list hosts interface port to add into dummy VLAN
     host_port_id = [id for id in topology["host_interfaces"]][0]
     iface = port_dict[host_port_id]


### PR DESCRIPTION

### Description of PR
<!--
- Modified CRM ACL entry testcase according to Marvell Design
-This specific change is to align Marvell SAI design.
When an acl is bind to set of ports, there is a possibility that more than one rule is configured in ASIC for single user-configured rule.
This is because of mapping the ports to corresponding port bit-map in Marvell SAI.
For same user configrued acl rule, if port-number falls different port-bitmap, SAI will replicate the rule.
We ensure that the ports used in this TC will fall under same port-bitmap to have one-to-one mapping of CRM Used-count and available-count.
-->

Summary: Modified CRM ACL entry testcase according to Marvell Design Modified CRM ACL entry testcase according to Marvell Design
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ X] 202205

### Approach

#### How did you verify/test it?
Ran test case on sonic PTF testbed and test case is passing 
crm/test_crm.py::test_acl_entry[str-marvell-acs-1-None] PASSED 

#### Any platform specific information?
Yes

