### PR TITLE
[chassis] [single-asic] Generate correct minigraph for single-asic card

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -172,9 +172,10 @@ class SonicPortAliasMap():
                         aliasmap[alias] = name
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
-                            if multi_asic.num_asics > 1:
+                            # we only want following ASIC info in minigraph for multi-asic
+                            if asic_id:
                                 front_panel_asic_ifnames[alias] = asicifname
-                                front_panel_asic_id[alias] = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
+                                front_panel_asic_id[alias] = "ASIC" + str(asic_id)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):
                         asicifname = mapping[asic_name_index]
                         asic_if_names.append(asicifname)

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -173,7 +173,7 @@ class SonicPortAliasMap():
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
                             # we only want following ASIC info in minigraph for multi-asic
-                            if asic_id:
+                            if asic_id is not None:
                                 front_panel_asic_ifnames[alias] = asicifname
                                 front_panel_asic_id[alias] = "ASIC" + str(asic_id)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -172,8 +172,9 @@ class SonicPortAliasMap():
                         aliasmap[alias] = name
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
-                            front_panel_asic_ifnames[alias] = asicifname
-                            front_panel_asic_id[alias] = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
+                            if multi_asic.num_asics > 1:
+                                front_panel_asic_ifnames[alias] = asicifname
+                                front_panel_asic_id[alias] = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):
                         asicifname = mapping[asic_name_index]
                         asic_if_names.append(asicifname)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/pull/7312 changed minigraph for multi-asic, but single-asic scenario is not working
e.g. with this change, minigraph has following info -- same card same startport has different endDevice, which `xxx33T1` is the only one we want, the `ASIC0` should only appear for multi-asic, this will impact the config_db parsed from minigraph, as `ASIC0` will overwrite `xxx33T1` in the neighbor dictionary.
```
 <PngDec>
    <DeviceInterfaceLinks>
      <DeviceLinkBase>
        <ElementType>DeviceInterfaceLink</ElementType>
        <EndDevice>xxx33T1</EndDevice>
        <EndPort>Ethernet1</EndPort>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
...

 <DeviceLinkBase i:type="DeviceInterfaceLink">
        <ElementType>DeviceInterfaceLink</ElementType>
...
        <ChassisInternal>true</ChassisInternal>
        <EndDevice>ASIC0</EndDevice>
        <EndPort>Eth0</EndPort>
        <FlowControl>true</FlowControl>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
        <Validate>true</Validate>
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Single-asic card:
Before, minigraph:
```
 <PngDec>
    <DeviceInterfaceLinks>
      <DeviceLinkBase>
        <ElementType>DeviceInterfaceLink</ElementType>
        <EndDevice>xxx33T1</EndDevice>
        <EndPort>Ethernet1</EndPort>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
...

 <DeviceLinkBase i:type="DeviceInterfaceLink">
        <ElementType>DeviceInterfaceLink</ElementType>
...
        <ChassisInternal>true</ChassisInternal>
        <EndDevice>ASIC0</EndDevice>
        <EndPort>Eth0</EndPort>
        <FlowControl>true</FlowControl>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
        <Validate>true</Validate>
```

After, no `ASIC0` printed in `DeviceInterfaceLinks` section:
```
 <PngDec>
    <DeviceInterfaceLinks>
      <DeviceLinkBase>
        <ElementType>DeviceInterfaceLink</ElementType>
        <EndDevice>xxx33T1</EndDevice>
        <EndPort>Ethernet1</EndPort>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
...
      </DeviceLinkBase>
      <DeviceLinkBase>
        <ElementType>DeviceInterfaceLink</ElementType>
        <EndDevice>xxx64T1</EndDevice>
        <EndPort>Ethernet1</EndPort>
        <StartDevice>xxx-lc7-1</StartDevice>
        <StartPort>Ethernet32/1</StartPort>
      </DeviceLinkBase>
    </DeviceInterfaceLinks>
```

Multi-asic card minigraph remains as is -- has both T1 neighbors(for T2 dut) as well as Ethxx-ASICxx in `DeviceInterfaceLinks` section:
```
   <DeviceInterfaceLinks>
      <DeviceLinkBase>
        <ElementType>DeviceInterfaceLink</ElementType>
        <EndDevice>xxx01T1</EndDevice>
        <EndPort>Ethernet1</EndPort>
        <StartDevice>masic-card-1</StartDevice>
        <StartPort>Ethernet1/1</StartPort>
...
      </DeviceLinkBase>
      <DeviceLinkBase i:type="DeviceInterfaceLink">
        <ElementType>DeviceInterfaceLink</ElementType>
        <ChassisInternal>true</ChassisInternal>
        <EndDevice>ASIC1</EndDevice>
        <EndPort>Eth136-ASIC1</EndPort>
        <FlowControl>true</FlowControl>
        <StartDevice>masic-card-1</StartDevice>
        <StartPort>Ethernet36/1</StartPort>
        <Validate>true</Validate>
      </DeviceLinkBase>
    </DeviceInterfaceLinks>
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
