### PR TITLE
[qos master/202205] Refresh ARP entry with mac address of PTF port instead of DUT VLAN interface

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1981,6 +1981,9 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116']:
             # populate ARP
+            # sender's MAC address is corresponding PTF port's MAC address
+            # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()
+            # for dualtor: sender_IP_address = DUT_default_VLAN_interface_IP_address + portIndex + 1
             for idx, ptid in enumerate(self.src_port_ids):
 
                 arpreq_pkt = simple_arp_packet(
@@ -2003,6 +2006,9 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.dst_port_id, arpreq_pkt)
         time.sleep(8)
 
+        # for dualtor, need to change test traffic's dest MAC address to point DUT's default VLAN interface
+        # and then DUT is able to correctly forward test traffic to dest PORT on PTF
+        # Reminder: need to change this dest MAC address after above ARP population to avoid corrupt ARP packet
         is_dualtor = self.test_params.get('is_dualtor', False)
         def_vlan_mac = self.test_params.get('def_vlan_mac', None)
         if is_dualtor and def_vlan_mac != None:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1979,11 +1979,6 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        is_dualtor = self.test_params.get('is_dualtor', False)
-        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
-        if is_dualtor and def_vlan_mac != None:
-            self.dst_port_mac = def_vlan_mac
-
         if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116']:
             # populate ARP
             for idx, ptid in enumerate(self.src_port_ids):
@@ -2007,6 +2002,11 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                           hw_tgt='00:00:00:00:00:00')
             send_packet(self, self.dst_port_id, arpreq_pkt)
         time.sleep(8)
+
+        is_dualtor = self.test_params.get('is_dualtor', False)
+        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
+        if is_dualtor and def_vlan_mac != None:
+            self.dst_port_mac = def_vlan_mac
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)


### PR DESCRIPTION
…fault vlan

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

In testcase sai_qos_tests.HdrmPoolSizeTest:

Test traffic's destination port is one of PTF port.
To correctly forward test traffic to dest PTF port, we should populate a correct ARP entry on DUT before test.
But in HdrmPoolSizeTest case, build a incorrect ARP packet, as below:
```
Ethernet II
    Destination: Broadcast (ff:ff:ff:ff:ff:ff)
    Source: 00:aa:bb:cc:dd:ee (00:aa:bb:cc:dd:ee)    >>>> incorrect address, it's mac addr of default vlan interface on dut
    Type: ARP (0x0806)
Address Resolution Protocol (request)
    Sender MAC address: 00:aa:bb:cc:dd:ee (00:aa:bb:cc:dd:ee)   >>>>  incorrect address, it's mac addr of default vlan interface on dut
    Sender IP address: 192.168.0.12
    Target MAC address: 00:00:00_00:00:00 (00:00:00:00:00:00)
    Target IP address: 192.168.0.1
```

RCA:
improperly use self.dst_port_mac to fill both ARP request sender address and test traffice's dest address:
We want to set test traffic's dest address to default vlan interface mac adress, so we change self.dst_port_mac to defalut vlan mac address before populate ARP. This address changing occured too early, and cuased incorrect ARP packet.


#### How did you do it?

When populate ARP, should use PTF port's mac address instead of DUT's default VLAN interface.
and then change traffca's dest mac address to default vlan interface during test.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
