### PR TITLE
[snmp] Fix test_snmp_memory_load failed

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -110,7 +110,8 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     sysTotalFreeMemory_OID = "1.3.6.1.4.1.2021.4.11.0"
-    snmp_command = "snmpget -v 2c -c public {} {}".format(host_ip,sysTotalFreeMemory_OID) + "| awk '{print $4}'"
+    snmp_command = "snmpget -v 2c -c {} {} {}".format(creds_all_duts[duthost.hostname]["snmp_rocommunity"], host_ip,
+                                                      sysTotalFreeMemory_OID) + "| awk '{print $4}'"
     snmp_free_memory = localhost.shell(snmp_command)['stdout']
     mem_free = duthost.shell("grep MemFree /proc/meminfo | awk '{print $2}'")['stdout']
     mem_total = duthost.shell("grep MemTotal /proc/meminfo | awk '{print $2}'")['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR https://github.com/sonic-net/sonic-mgmt/pull/7570 changed the dynamic acquisition of snmp_rocommunity to a fixed value 'public', which would caused failed.

#### How did you do it?
Get value of snmp_rocommunity from customized creds_all_duts

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
