### PR TITLE
skip test_loopback_action_basic on T1 topo testbed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -417,10 +417,11 @@ http/test_http_copy.py:
 #######################################
 iface_loopback_action/test_iface_loopback_action.py:
   skip:
-    reason: "Not working on non-mellanox platform"
+    reason: "Not working on non-mellanox platform or T1 topo"
+    conditions_logical_operator: "OR"
     conditions:
-      - "asic_type not in ['mellanox']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/7704
+      - "asic_type not in ['mellanox'] and https://github.com/sonic-net/sonic-mgmt/issues/7704"
+      - "'t1' in topo_name"
 
 #######################################
 #####      iface_namingmode       #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
skip test_loopback_action_basic on T1 topo testbed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_loopback_action_basic failed on Mellanox platform T1 topo testbed.
Failure reason was CMD "config vlan add 56" return failure.
ERR message "Failed to reset failed state of unit dhcp_relay.service: Unit dhcp_relay.service not loaded."
T1 testbed should be no dhcp_relay.service

#### How did you do it?
Skip this case on T1 testbed

#### How did you verify/test it?
Run this case on T1 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
