### PR TITLE
[tunnel qos remap] download syncd rpc image from public_docker_registry

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -1,4 +1,5 @@
 
+import copy
 import ipaddress
 import pytest
 import logging

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -236,13 +236,22 @@ def _remove_ssh_tunnel_to_syncd_rpc(duthost):
 
 
 @pytest.fixture(scope='module')
-def swap_syncd(rand_selected_dut, creds):
+def swap_syncd(request, rand_selected_dut, creds):
+    public_docker_reg = request.config.getoption("--public_docker_registry")
+    new_creds = None
+    if public_docker_reg:
+        new_creds = copy.deepcopy(creds)
+        new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
+        new_creds['docker_registry_username'] = ''
+        new_creds['docker_registry_password'] = ''
+    else:
+        new_creds = creds
     # Swap syncd container
-    docker.swap_syncd(rand_selected_dut, creds)
+    docker.swap_syncd(rand_selected_dut, new_creds)
     _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
     yield
     # Restore syncd container
-    docker.restore_default_syncd(rand_selected_dut, creds)
+    docker.restore_default_syncd(rand_selected_dut, new_creds)
     _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
 
 


### PR DESCRIPTION
…egistry

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

Whne ran test_tunnel_qos_remap on master branch, saw below image download issue:
"Error response from daemon: manifest for soniccr1.azurecr.io/docker-syncd-brcm-rpc:master.234564-06d6dafcf not found: manifest unknown: manifest tagged by \"master.234564-06d6dafcf\" is not found"

RCA:
swap_syncd not support public_docker_registry

#### How did you do it?

implement swap_syncd public_docker_registry support similar to swapSyncd

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
