### PR TITLE
To skip fast/warm reboot for non t0 device

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -734,7 +734,7 @@ platform_tests/fwutil/test_fwutil.py::test_fwutil_auto:
 #######################################
 platform_tests/mellanox:
   skip:
-    reason: "Mellanox platform tests only supported on Mellanox devices" 
+    reason: "Mellanox platform tests only supported on Mellanox devices"
     conditions:
       - "asic_type not in ['mellanox']"
 
@@ -804,7 +804,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
   skip:
     reason: "Skip test_fast_reboot for m0/mx"
     conditions:
-      - "topo_name in ['m0', 'mx', 't1', 't2']"
+      - "topo_type in ['m0', 'mx', 't1', 't2']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -821,7 +821,7 @@ platform_tests/test_reboot.py::test_soft_reboot:
   skip:
     reason: "Skip test_soft_reboot for m0/mx"
     conditions:
-      - "topo_name in ['m0', 'mx']"
+      - "topo_type in ['m0', 'mx']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -832,7 +832,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
   skip:
     reason: "Skip test_warm_reboot for m0/mx"
     conditions:
-      - "topo_name in ['m0', 'mx', 't1', 't2']"
+      - "topo_type in ['m0', 'mx', 't1', 't2']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To skip fast and warm reboot for non t1 topos

#### How did you do it?
To refine the mark conditional file, which use wrong variable for the skip.

#### How did you verify/test it?
Manually run test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
