### PR TITLE
[dualtor] create dualtor default tunnel during presetup based on asic type

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1639,6 +1639,8 @@ Totals               6450                 6449
             asic = "td3"
         elif "Broadcom Limited Device b980" in output:
             asic = "th3"
+        elif "Cisco Systems Inc Device a001" in output:
+            asic = "gb"
 
         return asic
 

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -338,7 +338,7 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     peer_switch_key = 'PEER_SWITCH|{}'.format(peer_switch_hostname)
     device_meta_key = 'DEVICE_METADATA|localhost'
     restart_swss = False
-    if dut.get_asic_name() in ['th2', 'td3']:
+    if dut.get_asic_name() in ['th2', 'td3', 'gb']:
         restart_swss = True
     cmd = 'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR')
     dut.shell(cmd=cmd)


### PR DESCRIPTION
**Description**
In our lab environment, sonic dualTOR router will need to create tunnel before running the testcase.

**Steps to reproduce the issue**
"dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops"

**Describe the results you expected**
testcase Pass

**Additional information you deem important**
some of dualtor testcase will need to switch from downlink to uplink by mocking tunnel
so that testcase is able to default have tunnel on below
https://github.com/sonic-net/sonic-swss/blob/master/orchagent/muxorch.cpp#L932
https://github.com/sonic-net/sonic-swss/blob/master/orchagent/muxorch.cpp#L933

to avoid the failure on removing non-existing tunnel during pre-setup. 
Mar 6 22:59:58.293515 mth-t0-64 INFO swss#supervisord: tunnelmgrd Cannot find device "tun0"
Mar 6 22:59:52.922587 mth-t0-64 WARNING swss#tunnelmgrd: :- doTunnelRouteTask: Failed to del route 192.168.0.15/32, res
