### PR TITLE
fix empty qos config processing to avoid exception

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -474,19 +474,24 @@ def dut_qos_maps(rand_selected_front_end_dut):
 
         # port_qos_map
         port_qos_map_data = rand_selected_front_end_dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['port_qos_map'] = json.loads(port_qos_map_data) if bool(port_qos_map_data) else None
+        maps['port_qos_map'] = json.loads(port_qos_map_data) if port_qos_map_data else None
         # dscp_to_tc_map
-        dscp_to_tc_map_data = rand_selected_front_end_dut.shell("{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map_data) if bool(dscp_to_tc_map_data) else None
+        dscp_to_tc_map_data = rand_selected_front_end_dut.shell(
+            "{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map_data) if dscp_to_tc_map_data else None
         # tc_to_queue_map
-        tc_to_queue_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map_data) if bool(tc_to_queue_map_data) else None
+        tc_to_queue_map_data = rand_selected_front_end_dut.shell(
+            "{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map_data) if tc_to_queue_map_data else None
         # tc_to_priority_group_map
-        tc_to_priority_group_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_priority_group_map'] = json.loads(tc_to_priority_group_map_data) if bool(tc_to_priority_group_map_data) else None
+        tc_to_priority_group_map_data = rand_selected_front_end_dut.shell(
+            "{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_priority_group_map'] = json.loads(
+            tc_to_priority_group_map_data) if tc_to_priority_group_map_data else None
         # tc_to_dscp_map
-        tc_to_dscp_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map_data) if bool(tc_to_dscp_map_data) else None
+        tc_to_dscp_map_data = rand_selected_front_end_dut.shell(
+            "{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map_data) if tc_to_dscp_map_data else None
     except Exception as e:
         logger.error("Got exception: " + repr(e))
     return maps

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -473,25 +473,20 @@ def dut_qos_maps(rand_selected_front_end_dut):
             sonic_cfggen_cmd = "sonic-cfggen -d --var-json"
 
         # port_qos_map
-        maps['port_qos_map'] = json.loads(
-            rand_selected_front_end_dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
-        )
+        port_qos_map_data = rand_selected_front_end_dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['port_qos_map'] = json.loads(port_qos_map_data) if bool(port_qos_map_data) else None
         # dscp_to_tc_map
-        maps['dscp_to_tc_map'] = json.loads(
-            rand_selected_front_end_dut.shell("{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
-        )
+        dscp_to_tc_map_data = rand_selected_front_end_dut.shell("{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map_data) if bool(dscp_to_tc_map_data) else None
         # tc_to_queue_map
-        maps['tc_to_queue_map'] = json.loads(
-            rand_selected_front_end_dut.shell("{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
-        )
+        tc_to_queue_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map_data) if bool(tc_to_queue_map_data) else None
         # tc_to_priority_group_map
-        maps['tc_to_priority_group_map'] = json.loads(
-            rand_selected_front_end_dut.shell("{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        )
+        tc_to_priority_group_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_priority_group_map'] = json.loads(tc_to_priority_group_map_data) if bool(tc_to_priority_group_map_data) else None
         # tc_to_dscp_map
-        maps['tc_to_dscp_map'] = json.loads(
-            rand_selected_front_end_dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        )
+        tc_to_dscp_map_data = rand_selected_front_end_dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map_data) if bool(tc_to_dscp_map_data) else None
     except Exception as e:
         logger.error("Got exception: " + repr(e))
     return maps


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

saw below exception message during qos sai test for 202205 branch

qos/test_qos_sai.py::TestQosSai::testParameter[str3-8101-02-None] 
-------------------------------- live log setup --------------------------------
02:48:14 duthost_utils.dut_qos_maps               L0482 ERROR  | Got exception: ValueError('No JSON object could be decoded',)
PASSED                                                                   [  2%]

RCA:
On 202205 testbed, TC_TO_DSCP_MAP field is empty in sonic configuration.
Json module try to load this empty config will cause above exception message. as below code snippet:
```
maps['tc_to_dscp_map'] = json.loads(
           rand_selected_front_end_dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
       )
```

#### How did you do it?

add empty check before execute json.loads()

#### How did you verify/test it?

pass local test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
