### PR TITLE
[QoS] fix FDB aging in dualtor's qos sai test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1058,7 +1058,7 @@ class QosSaiBase(QosBase):
             "portSpeedCableLength": portSpeedCableLength,
         }
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope='function')
     def releaseAllPorts(
             self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, dutTestParams,
             updateIptables, ssh_tunnel_to_syncd_rpc
@@ -1148,7 +1148,7 @@ class QosSaiBase(QosBase):
             self.__loadSwssConfig(duthost)
         self.__deleteTmpSwitchConfig(duthost)
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope='function', autouse=True)
     def populateArpEntries(
             self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
             ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1058,7 +1058,7 @@ class QosSaiBase(QosBase):
             "portSpeedCableLength": portSpeedCableLength,
         }
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope='class')
     def releaseAllPorts(
             self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, dutTestParams,
             updateIptables, ssh_tunnel_to_syncd_rpc
@@ -1148,7 +1148,7 @@ class QosSaiBase(QosBase):
             self.__loadSwssConfig(duthost)
         self.__deleteTmpSwitchConfig(duthost)
 
-    @pytest.fixture(scope='function', autouse=True)
+    @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
             self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
             ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1112,7 +1112,7 @@ class QosSaiBase(QosBase):
             duthost.file(path=file["path"], state="absent")
 
     @pytest.fixture(scope='class', autouse=True)
-    def handleFdbAging(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    def handleFdbAging(self, tbinfo, duthosts, lower_tor_host, enum_rand_one_per_hwsku_frontend_hostname):
         """
             Disable FDB aging and reenable at the end of tests
 
@@ -1125,7 +1125,10 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        if 'dualtor' in tbinfo['topo']['name']:
+            duthost = lower_tor_host
+        else:
+            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         fdbAgingTime = 0
 
         self.__deleteTmpSwitchConfig(duthost)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1179,6 +1179,10 @@ class QosSaiBase(QosBase):
             duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+
+        dut_asic.command('sonic-clear fdb all')
+        dut_asic.command('sonic-clear arp')
+
         saiQosTest = None
         if dutTestParams["topo"] in self.SUPPORTED_T0_TOPOS:
             saiQosTest = "sai_qos_tests.ARPpopulate"

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -154,7 +154,7 @@ class TestQosSai(QosSaiBase):
 
     def testParameter(
         self, duthost, dutConfig, dutQosConfig, ingressLosslessProfile,
-        ingressLossyProfile, egressLosslessProfile, dualtor_ports
+        ingressLossyProfile, egressLosslessProfile, dualtor_ports, releaseAllPorts, populateArpEntries
     ):
         logger.info("asictype {}".format(duthost.facts["asic_type"]))
         logger.info("config {}".format(dutConfig))
@@ -164,7 +164,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
         self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLosslessProfile
+        ingressLosslessProfile, egressLosslessProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI XOFF limits
@@ -240,7 +240,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testPfcStormWithSharedHeadroomOccupancy(
         self, xonProfile, ptfhost, fanouthosts, conn_graph_facts,  fanout_graph_facts,
-        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile
+        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link.
@@ -411,7 +411,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
         self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile
+        ingressLosslessProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI XON limits
@@ -504,7 +504,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LosslessVoqProfile", ["lossless_voq_1", "lossless_voq_2",
                              "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
-            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts
+            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -567,7 +567,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile
+        ingressLosslessProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Headroom pool size
@@ -651,7 +651,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("sharedResSizeKey", ["shared_res_size_1", "shared_res_size_2"])
     def testQosSaiSharedReservationSize(
-        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig
+        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI shared reservation size
@@ -721,7 +721,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark
+        resetWatermark, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Headroom pool watermark
@@ -802,7 +802,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
         self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLossyProfile, resetWatermark,
+        ingressLosslessProfile, egressLossyProfile, resetWatermark, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -878,7 +878,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiLossyQueue(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLossyProfile
+        ingressLossyProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Lossy queue, shared buffer dynamic allocation
@@ -948,7 +948,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute
+            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -1018,7 +1018,7 @@ class TestQosSai(QosSaiBase):
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
-        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps
+        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1065,7 +1065,7 @@ class TestQosSai(QosSaiBase):
         )
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
-    def testQosSaiSeparatedDscpQueueMapping(self, duthost, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps):
+    def testQosSaiSeparatedDscpQueueMapping(self, duthost, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps, releaseAllPorts, populateArpEntries):
         """
             Test QoS SAI DSCP to queue mapping.
             We will have separated DSCP_TO_TC_MAP for uplink/downlink ports on T1 if PCBB enabled.
@@ -1125,7 +1125,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDot1pQueueMapping(
-        self, ptfhost, dutTestParams, dutConfig
+        self, ptfhost, dutTestParams, dutConfig, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Dot1p to queue mapping
@@ -1163,7 +1163,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDot1pPgMapping(
-        self, ptfhost, dutTestParams, dutConfig
+        self, ptfhost, dutTestParams, dutConfig, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Dot1p to PG mapping
@@ -1201,7 +1201,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDwrr(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
+        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI DWRR
@@ -1270,7 +1270,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic
@@ -1349,7 +1349,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPgHeadroomWatermark(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI PG headroom watermark test
@@ -1414,7 +1414,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPGDrop(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI PG drop counter
@@ -1468,7 +1468,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -1543,7 +1543,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDscpToPgMapping(
-        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
+        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -1592,7 +1592,7 @@ class TestQosSai(QosSaiBase):
         )
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
-    def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps):
+    def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps, releaseAllPorts, populateArpEntries):
         """
             Test QoS SAI DSCP to PG mapping ptf test.
             Since we are using different DSCP_TO_TC_MAP on uplink/downlink port, the test case also need to 
@@ -1651,7 +1651,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDwrrWeightChange(
         self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
-        updateSchedProfile
+        updateSchedProfile, releaseAllPorts, populateArpEntries
     ):
         """
             Test QoS SAI DWRR runtime weight change

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -154,7 +154,7 @@ class TestQosSai(QosSaiBase):
 
     def testParameter(
         self, duthost, dutConfig, dutQosConfig, ingressLosslessProfile,
-        ingressLossyProfile, egressLosslessProfile, dualtor_ports, releaseAllPorts, populateArpEntries
+        ingressLossyProfile, egressLosslessProfile, dualtor_ports
     ):
         logger.info("asictype {}".format(duthost.facts["asic_type"]))
         logger.info("config {}".format(dutConfig))
@@ -164,7 +164,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
         self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLosslessProfile, releaseAllPorts, populateArpEntries
+        ingressLosslessProfile, egressLosslessProfile
     ):
         """
             Test QoS SAI XOFF limits
@@ -240,7 +240,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testPfcStormWithSharedHeadroomOccupancy(
         self, xonProfile, ptfhost, fanouthosts, conn_graph_facts,  fanout_graph_facts,
-        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile, releaseAllPorts, populateArpEntries
+        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile
     ):
         """
             Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link.
@@ -411,7 +411,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
         self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, releaseAllPorts, populateArpEntries
+        ingressLosslessProfile
     ):
         """
             Test QoS SAI XON limits
@@ -504,7 +504,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LosslessVoqProfile", ["lossless_voq_1", "lossless_voq_2",
                              "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
-            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts, releaseAllPorts, populateArpEntries
+            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -567,7 +567,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, releaseAllPorts, populateArpEntries
+        ingressLosslessProfile
     ):
         """
             Test QoS SAI Headroom pool size
@@ -651,7 +651,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("sharedResSizeKey", ["shared_res_size_1", "shared_res_size_2"])
     def testQosSaiSharedReservationSize(
-        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
+        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig
     ):
         """
             Test QoS SAI shared reservation size
@@ -721,7 +721,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark, releaseAllPorts, populateArpEntries
+        resetWatermark
     ):
         """
             Test QoS SAI Headroom pool watermark
@@ -802,7 +802,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
         self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLossyProfile, resetWatermark, releaseAllPorts, populateArpEntries
+        ingressLosslessProfile, egressLossyProfile, resetWatermark,
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -878,7 +878,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiLossyQueue(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLossyProfile, releaseAllPorts, populateArpEntries
+        ingressLossyProfile
     ):
         """
             Test QoS SAI Lossy queue, shared buffer dynamic allocation
@@ -948,7 +948,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute, releaseAllPorts, populateArpEntries
+            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -1018,7 +1018,7 @@ class TestQosSai(QosSaiBase):
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
-        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps, releaseAllPorts, populateArpEntries
+        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1065,7 +1065,7 @@ class TestQosSai(QosSaiBase):
         )
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
-    def testQosSaiSeparatedDscpQueueMapping(self, duthost, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps, releaseAllPorts, populateArpEntries):
+    def testQosSaiSeparatedDscpQueueMapping(self, duthost, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps):
         """
             Test QoS SAI DSCP to queue mapping.
             We will have separated DSCP_TO_TC_MAP for uplink/downlink ports on T1 if PCBB enabled.
@@ -1125,7 +1125,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDot1pQueueMapping(
-        self, ptfhost, dutTestParams, dutConfig, releaseAllPorts, populateArpEntries
+        self, ptfhost, dutTestParams, dutConfig
     ):
         """
             Test QoS SAI Dot1p to queue mapping
@@ -1163,7 +1163,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDot1pPgMapping(
-        self, ptfhost, dutTestParams, dutConfig, releaseAllPorts, populateArpEntries
+        self, ptfhost, dutTestParams, dutConfig
     ):
         """
             Test QoS SAI Dot1p to PG mapping
@@ -1201,7 +1201,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDwrr(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
+        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
     ):
         """
             Test QoS SAI DWRR
@@ -1270,7 +1270,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, releaseAllPorts, populateArpEntries
+        resetWatermark
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic
@@ -1349,7 +1349,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPgHeadroomWatermark(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark, releaseAllPorts, populateArpEntries
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
     ):
         """
             Test QoS SAI PG headroom watermark test
@@ -1414,7 +1414,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPGDrop(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, releaseAllPorts, populateArpEntries
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig
     ):
         """
             Test QoS SAI PG drop counter
@@ -1468,7 +1468,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, releaseAllPorts, populateArpEntries
+        resetWatermark
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -1543,7 +1543,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDscpToPgMapping(
-        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps, releaseAllPorts, populateArpEntries
+        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -1592,7 +1592,7 @@ class TestQosSai(QosSaiBase):
         )
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
-    def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps, releaseAllPorts, populateArpEntries):
+    def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost, dutTestParams, dutConfig, direction, dut_qos_maps):
         """
             Test QoS SAI DSCP to PG mapping ptf test.
             Since we are using different DSCP_TO_TC_MAP on uplink/downlink port, the test case also need to 
@@ -1651,7 +1651,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDwrrWeightChange(
         self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
-        updateSchedProfile, releaseAllPorts, populateArpEntries
+        updateSchedProfile
     ):
         """
             Test QoS SAI DWRR runtime weight change


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

During Qos Sai test, saw unexpected drop caused by ARP entry miss or incorrect ARP entry.

#### How did you do it?

- enhance disable fdb aging for dualtor case: 
    qos sai test always toggle mux cable to lower tor, so also force lower tor as target dut in fdb aging disable function.
- clear fdb/arp before populate arp entries

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
