### PR TITLE
[voq][chassis] Use system port name for BUFFER_QUEUE_TABLE in a voq chassis.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -209,6 +209,13 @@ class QosSaiBase(QosBase):
                 bufferProfile (dict): Map of buffer profile attributes
         """
 
+        if table == "BUFFER_QUEUE_TABLE" and dut_asic.sonichost.facts['switch_type'] == 'voq':
+            # For VoQ chassis, the buffer queues config is based on system port
+            if dut_asic.sonichost.is_multi_asic:
+                port = "{}:{}:{}".format(dut_asic.sonichost.hostname, dut_asic.namespace, port)
+            else:
+                port = "{}:Asic0:{}".format(dut_asic.sonichost.hostname, port)
+
         if self.isBufferInApplDb(dut_asic):
             db = "0"
             keystr = "{0}:{1}:{2}".format(table, port, priorityGroup)


### PR DESCRIPTION






<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PR# 14173 (https://github.com/sonic-net/sonic-buildimage/pull/14173) updates to set buffer_queue_config on system ports on a VoQ chassis. 

This broke the QoS tests in _getBufferProfile for BUFFER_QUEUE_TABLE

#### How did you do it?
Fix was to use system port name (derived from hostname and asic instance) when dealing with voq chassis and BUFFER_QUEUE_TABLE

#### How did you verify/test it?
Ran QoS tests against latest 202205 based image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
