### PR TITLE
Add a test case to check /etc/resolv.conf

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -12,6 +12,7 @@ t0:
   - cacl/test_cacl_function.py
   - dhcp_relay/test_dhcp_relay.py
   - dhcp_relay/test_dhcpv6_relay.py
+  - dns/test_dns_resolv_conf.py
   - generic_config_updater/test_aaa.py
   - generic_config_updater/test_bgpl.py
   - generic_config_updater/test_bgp_prefix.py

--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -12,3 +12,7 @@ DEFAULT_SSH_CONNECT_PARAMS = {
     "public": {"username": "admin",
                "password": "YourPaSsWoRd"}
 }
+# resolv.conf expected nameservers
+RESOLV_CONF_NAMESERVERS = {
+    "public": []
+}

--- a/tests/dns/test_dns_resolv_conf.py
+++ b/tests/dns/test_dns_resolv_conf.py
@@ -1,0 +1,38 @@
+import pytest
+import logging
+from tests.common.constants import RESOLV_CONF_NAMESERVERS
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import get_image_type
+
+pytestmark = [
+    pytest.mark.topology("any")
+]
+
+logger = logging.getLogger(__name__)
+
+def test_dns_resolv_conf(duthost):
+    """verify that /etc/resolv.conf contains the expected nameservers
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+    """
+    # Check SONiC image type and get expected nameservers in /etc/resolv.conf
+    expected_nameservers = set(RESOLV_CONF_NAMESERVERS[get_image_type(duthost=duthost)])
+
+    logger.info("expected nameservers: [{}]".format(" ".join(expected_nameservers)))
+
+    resolv_conf = duthost.shell("cat /etc/resolv.conf", module_ignore_errors=True)
+    pytest_assert(resolv_conf["rc"] == 0, "Failed to read /etc/resolf.conf!")
+    current_nameservers = []
+    for resolver_line in resolv_conf["stdout_lines"]:
+        if not resolver_line.startswith("nameserver"):
+            continue
+        current_nameservers.append(resolver_line.split()[1])
+
+    current_nameservers = set(current_nameservers)
+
+    logger.info("current nameservers: [{}]".format(" ".join(current_nameservers)))
+
+    pytest_assert(not(current_nameservers ^ expected_nameservers),
+            "Mismatch between expected and current nameservers! Expected: [{}]. Current: [{}].".format(
+                " ".join(expected_nameservers), " ".join(current_nameservers)))

--- a/tests/dns/test_dns_resolv_conf.py
+++ b/tests/dns/test_dns_resolv_conf.py
@@ -10,6 +10,7 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+
 def test_dns_resolv_conf(duthost):
     """verify that /etc/resolv.conf contains the expected nameservers
 
@@ -34,5 +35,5 @@ def test_dns_resolv_conf(duthost):
     logger.info("current nameservers: [{}]".format(" ".join(current_nameservers)))
 
     pytest_assert(not(current_nameservers ^ expected_nameservers),
-            "Mismatch between expected and current nameservers! Expected: [{}]. Current: [{}].".format(
-                " ".join(expected_nameservers), " ".join(current_nameservers)))
+                  "Mismatch between expected and current nameservers! Expected: [{}]. Current: [{}].".format(
+                  " ".join(expected_nameservers), " ".join(current_nameservers)))

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -154,6 +154,7 @@ test_t0() {
       popd
     else
       tests="\
+      dns/test_dns_resolv_conf.py \
       generic_config_updater/test_aaa.py \
       generic_config_updater/test_bgpl.py \
       generic_config_updater/test_bgp_prefix.py \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add a test case to verify that the expected nameservers are present (or not present) in /etc/resolv.conf.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

There have been cases where `/etc/resolv.conf` contained unexpected nameservers. Ideally, this file should be empty (unless otherwise configured during the image build in sonic-buildimage).

#### How did you do it?

This test case gets the nameservers specified in `/etc/resolv.conf` and compares them against the expected nameservers specified in `RESOLV_CONF_NAMESERVERS`. If there are nameservers missing, or if there are nameservers present that should not be present, then this test case fails.

#### How did you verify/test it?

1. Tested with a nameserver that's present in `/etc/resolv.conf`, but not in `RESOLV_CONF_NAMESERVERS`
2. Tested with an empty `/etc/resolv.conf` and empty list in `RESOLV_CONF_NAMESERVERS`.
3. Tested with one nameserver in `/etc/resolv.conf` and matching nameserver in `RESOLV_CONF_NAMESERVERS`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

Any topology

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
