### PR TITLE
[dualtor] add test utilities for verifying tunnel routes 

### DIFF
--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -28,13 +28,15 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa F
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=upper_tor_host,
-                          expected_standby_host=lower_tor_host)
+                          expected_standby_host=lower_tor_host,
+                          skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
-                          cable_type=cable_type)
+                          cable_type=cable_type,
+                          skip_tunnel_route=False)
 
 
 @pytest.mark.enable_active_active


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Adding common test utilities for verifying dualtor tunnel routes. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. Add test utilities to check `show mux tunnel-route` output. 
2. Enable the checking in test_normal_op::test_normal_op_upstream

#### How did you verify/test it?
Test passed on mixed topology for active-active and active-standby interfaces. 
```
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor_io/test_normal_op.py::test_normal_op_upstream.xml -
---------------------------- live log sessionfinish ----------------------------
01:29:43 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 2 passed in 483.62 seconds ==========================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
