### PR TITLE
[Test case] Fix test_authorization does not wait long enough before running 'show aaa'

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -132,6 +132,9 @@ def check_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, 
         Verify TACACS+ user run command in server side whitelist:
             If command have local permission, user can run command.
     """
+    # The "config tacacs add" commands will trigger hostcfgd to regenerate tacacs config.
+    # If we immediately run "show aaa" command, the client may still be using the first invalid tacacs server.
+    # The second valid tacacs may not take effect yet. Wait some time for the valid tacacs server to take effect.
     succeeded = wait_until(10, 1, 0, verify_show_aaa, remote_user_client)
     pytest_assert(succeeded)
 
@@ -174,11 +177,6 @@ def test_authorization_tacacs_only_some_server_down(
 
     duthost.shell("sudo config tacacs add %s" % invalid_tacacs_server_ip)
     duthost.shell("sudo config tacacs add %s" % tacacs_server_ip)
-
-    # The above "config tacacs add" commands will trigger hostcfgd to regenerate tacacs config.
-    # If we immediately run "show aaa" command, the client may still be using the first invalid tacacs server.
-    # The second valid tacacs may not take effect yet. Wait some time for the valid tacacs server to take effect.
-    time.sleep(2)
 
     """
         Verify TACACS+ user run command in server side whitelist:

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -2,11 +2,12 @@ import logging
 import paramiko
 import time
 import pytest
+from _pytest.outcomes import Failed
 
 from tests.tacacs.utils import stop_tacacs_server, start_tacacs_server
 from tests.tacacs.utils import per_command_check_skip_versions, remove_all_tacacs_server, get_ld_path
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import skip_release
+from tests.common.utilities import skip_release, wait_until
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -113,15 +114,26 @@ def setup_authorization_tacacs_local(duthosts, enum_rand_one_per_hwsku_hostname)
     duthost.shell("sudo config aaa authorization local")    # Default authorization method is local
 
 
+def verify_show_aaa(remote_user_client):
+    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "show aaa")
+    if exit_code != 0:
+        return False
+
+    try:
+        check_ssh_output(stdout, 'AAA authentication')
+        return True
+    except Failed:
+        return False
+
+
 def check_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, remote_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     """
         Verify TACACS+ user run command in server side whitelist:
             If command have local permission, user can run command.
     """
-    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "show aaa")
-    pytest_assert(exit_code == 0)
-    check_ssh_output(stdout, 'AAA authentication')
+    succeeded = wait_until(10, 1, 0, verify_show_aaa, remote_user_client)
+    pytest_assert(succeeded)
 
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "config aaa")
     pytest_assert(exit_code == 1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fix test_authorization does not wait long enough before running `show aaa`.
Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_authorization does not wait long enough before running `show aaa`.

#### How did you do it?
Use `wait_until` to run `show aaa`, remove `time.sleep` before checking it. 

#### How did you verify/test it?
Run TC and TC passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
