### PR TITLE
Skip IPv6 everflow per interface test on unsupported ASICs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -359,6 +359,12 @@ everflow/test_everflow_per_interface.py:
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
 
+everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-default]:
+  skip:
+    reason: "Skip everflow per interface IPv6 test on unsupported platforms"
+    conditions:
+      - "asic_type in ['cisco-8000', 'marvell', 'mellanox']"
+
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:
     strict: True

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -28,19 +28,6 @@ EVERFLOW_SESSION_NAME = "everflow_session_per_interface"
 logger = logging.getLogger(__file__)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_if_not_supported(tbinfo, setup_info, ip_ver):      # noqa F811
-
-    asic_type = setup_info[UP_STREAM]['everflow_dut'].facts["asic_type"]
-    unsupported_platforms = ["mellanox", "cisco-8000"]
-    # Skip ipv6 test on Mellanox platform
-    is_mellanox_ipv4 = asic_type == 'mellanox' and ip_ver == 'ipv4'
-    # Skip ipv6 test on cisco-8000 platform
-    is_cisco_ipv4 = asic_type == 'cisco-8000' and ip_ver == 'ipv4'
-    pytest_require(asic_type not in unsupported_platforms or is_mellanox_ipv4 or is_cisco_ipv4,
-                   "Match 'IN_PORTS' is not supported on {} platform".format(asic_type))
-
-
 def build_candidate_ports(duthost, tbinfo, ns):
     """
     Build candidate ports for testing


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip IPv6 everflow per interface test on unsupported platforms, including `cisco`, `Marvell` and `Mellanox`.
The IPv4 everflow per interface test is running on all platforms.
The hardcoded skip logic is removed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip IPv6 everflow per interface test on unsupported platforms, including `Cisco`, `Marvell` and `Mellanox`.

#### How did you do it?
Add sko condition into `tests_mark_confitions.yml`, and remove the hardcoded skip logic.

#### How did you verify/test it?
Verified by running on testbed with `Cisco` or `Marvell` platform. Confirmed the test case is skipped.

#### Any platform specific information?
Only skip the IPv6 test on `Cisco`, `Marvell` and `Mellanox`
#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
