### PR TITLE
Add check to see if it's vendor test to improve wan test

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -331,33 +331,35 @@ def load_basic_facts(session):
         inv_name = tbinfo['inv_name']
     else:
         inv_name = 'lab'
+    # Since internal repo add vendor test support, add check to see if it's sonic-os, other wise skip load facts.
+    vendor = session.config.getoption("--dut_vendor", "sonic")
+    if vendor == "sonic":
+        # Load DUT basic facts
+        _facts = load_dut_basic_facts(inv_name, dut_name)
+        if _facts:
+            results.update(_facts)
 
-    # Load DUT basic facts
-    _facts = load_dut_basic_facts(inv_name, dut_name)
-    if _facts:
-        results.update(_facts)
+        # Load minigraph basic facts
+        _facts = load_minigraph_facts(inv_name, dut_name)
+        if _facts:
+            results.update(_facts)
 
-    # Load minigraph basic facts
-    _facts = load_minigraph_facts(inv_name, dut_name)
-    if _facts:
-        results.update(_facts)
+        # Load config basic facts
+        _facts = load_config_facts(inv_name, dut_name)
+        if _facts:
+            results.update(_facts)
 
-    # Load config basic facts
-    _facts = load_config_facts(inv_name, dut_name)
-    if _facts:
-        results.update(_facts)
+        # Load switch capabilities basic facts
+        _facts = load_switch_capabilities_facts(inv_name, dut_name)
+        if _facts:
+            results.update(_facts)
 
-    # Load switch capabilities basic facts
-    _facts = load_switch_capabilities_facts(inv_name, dut_name)
-    if _facts:
-        results.update(_facts)
+        # Load console basic facts
+        _facts = load_config_facts(inv_name, dut_name)
+        if _facts:
+            results.update(_facts)
 
-    # Load console basic facts
-    _facts = load_config_facts(inv_name, dut_name)
-    if _facts:
-        results.update(_facts)
-
-    # Load possible other facts here
+        # Load possible other facts here
 
     return results
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
As the internal repo has added wan vendor test feature, and vendor os test does not support load fects. when run the test with vendor os, it keeps throwing the following errors.

19:47:52 __init__.load_dut_basic_facts            L0155 ERROR  | Failed to load dut basic facts, exception: CalledProcessError(2, ['ansible', '-m', 'dut_basic_facts', '-i', '/var/src/sonic-mgmt-int/tests/common/plugins/conditional_mark/../../../../ansible/wan_interop_tb', 'rwa01.str01', '-o'])
19:47:54 __init__.load_minigraph_facts            L0210 ERROR  | Failed to load minigraph basic facts, exception: CalledProcessError(2, ['ansible', '-m', 'minigraph_facts', '-i', '../ansible/wan_interop_tb', 'rwa01.str01', '-a', 'host=rwa01.str01'])
19:47:55 __init__.load_config_facts               L0242 ERROR  | Failed to load config basic facts, exception: CalledProcessError(2, ['ansible', '-m', 'config_facts', '-i', '../ansible/wan_interop_tb', 'rwa01.str01', '-a', "host=rwa01.str01 source='persistent'"])
19:47:56 __init__.load_switch_capabilities_facts  L0271 ERROR  | Failed to load switch capabilities basic facts, exception: CalledProcessError(2, ['ansible', '-m', 'switch_capabilities_facts', '-i', '../ansible/wan_interop_tb', 'rwa01.str01'])
19:47:57 __init__.load_config_facts               L0242 ERROR  | Failed to load config basic facts, exception: CalledProcessError(2, ['ansible', '-m', 'config_facts', '-i', '../ansible/wan_interop_tb', 'rwa01.str01', '-a', "host=rwa01.str01 source='persistent'"])
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Improve the WAN vendor OS test.

#### How did you do it?
Before run the load fact, add check to see if it's running vendor OS test, if so, skip load facts as it's not supported.
Considering the sonic OS test may not add vendor option, it put the default value as "sonic", it will continue load facts if no vendor added as it's a default value.

#### How did you verify/test it?
Manually run test with wan test case in lab, the error logs goes away.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
