### PR TITLE
[TACACS] Remove unsupported command from TACACS RO user test case.

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -96,7 +96,7 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
 
     # Run as RO and use the commands allowed by the sudoers file
     commands = {
-        "cat": ["sudo cat /var/log/syslog", "sudo cat /var/log/syslog.1", "sudo cat /var/log/syslog.2.gz"],
+        "cat": ["sudo cat /var/log/syslog", "sudo cat /var/log/syslog.1"],
         "brctl": ["sudo brctl show"],
         "docker": [
             "sudo docker exec snmp cat /etc/snmp/snmpd.conf",


### PR DESCRIPTION
**What I did**
Remove unsupported command from test_ro_user_allowed_command test case.

**Why I did it**
For RO user, cat command should only show syslog and syslog.1

**How I verified it**
Pass all UT.

**Details if related**
