### PR TITLE
Support to set max execute seconds of a test plan

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -98,6 +98,9 @@ parameters:
   type: string
   default: ""
 
+- name: MAX_EXECUTE_SECONDS
+  type: string
+  default: ""
 
 - name: SPECIFIED_PARAMS
   type: string
@@ -131,7 +134,8 @@ steps:
       --stop-on-failure ${{ parameters.STOP_ON_FAILURE }} \
       --retry-times ${{ parameters.RETRY_TIMES }} \
       --dump-kvm-if-fail ${{ parameters.DUMP_KVM_IF_FAIL }} \
-      --requester ${{ parameters.REQUESTER }}
+      --requester "${{ parameters.REQUESTER }}" \
+      --max-execute-seconds ${{ parameters.MAX_EXECUTE_SECONDS }}
 
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -141,6 +141,7 @@ class TestPlanManager(object):
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.client_secret = client_secret
+        self.token = None
         if self.tenant_id and self.client_id and self.client_secret:
             self._get_token(url)
 
@@ -293,6 +294,8 @@ class TestPlanManager(object):
         headers = {
             "Content-Type": "application/json"
         }
+        if self.token:
+            headers["Authorization"] = "Bearer {}".format(self.token)
         start_time = time.time()
         http_exception_times = 0
         while (timeout < 0 or (time.time() - start_time) < timeout):

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -215,6 +215,7 @@ class TestPlanManager(object):
                 "build_id": build_id,
                 "source_repo": kwargs.get("source_repo"),
                 "kvm_build_id": kvm_build_id,
+                "max_execute_seconds": kwargs.get("max_execute_seconds", None),
                 "dump_kvm_if_fail": kwargs.get("dump_kvm_if_fail", 2),
                 "mgmt_branch": kwargs["mgmt_branch"],
                 "testbed": {
@@ -637,6 +638,16 @@ if __name__ == "__main__":
         required=False,
         help="Requester of the test plan."
     )
+    parser_create.add_argument(
+        "--max-execute-seconds",
+        type=int,
+        dest="max_execute_seconds",
+        nargs='?',
+        const=None,
+        default=None,
+        required=False,
+        help="Max execute seconds of the test plan."
+    )
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
     parser_cancel = subparsers.add_parser("cancel", help="Cancel running test plan.")
@@ -764,6 +775,7 @@ if __name__ == "__main__":
                 retry_times=args.retry_times,
                 dump_kvm_if_fail=args.dump_kvm_if_fail,
                 requester=args.requester,
+                max_execute_seconds=args.max_execute_seconds,
             )
         elif args.action == "poll":
             tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_state)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support to set max execute seconds of a test plan

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Support to set max execute seconds of a test plan
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
