### PR TITLE
Fix exception in `show_counter` when ports is None

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -128,7 +128,7 @@ def show_counter(counter_name, ptftest, asic_type, ports, current=None, base=Non
                     'PgCnt'        : [[pg_counter_field_template.format(i) for i in range(PG_NUM)],        sai_thrift_read_pg_counters,      None, True],
                     'PgDrop'       : [[pg_drop_field_template.format(i) for i in range(PG_NUM)],           sai_thrift_read_pg_drop_counters, None, True],
                     'PtfCnt'       : [['rx', 'tx'],                                                        read_ptf_counters,                None, False]}
-    if counter_name not in counter_info:
+    if counter_name not in counter_info or ports == None:
         return None
 
     counter_fields = counter_info[counter_name][0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix exception in `show_counter` when `ports` is `None`.
```
ERROR\n\n======================================================================\error: sai_qos_tests.TunnelDscpToPgMapping\n
----------------------------------------------------------------------\n
Traceback (most recent call last):\n
  File "saitests/sai_qos_tests.py", line 788, in runTest\n
    stats = show_stats('just collect base data', self, self.test_params.get('sonic_asic_type', None), self.test_params.get('test_port_ids', None), silent=True)\n
  File "saitests/sai_qos_tests.py", line 172, in show_stats\n
    results. Append(show_counter('PtfCnt', ptftest, asic_type, ports, current=None, base=base, indexes=None, banner=banner, silent=silent)[0])\n
  File "saitests/sai_qos_tests.py", line 146, in show_counter\n
    for pidx, port in enumerate(ports):\nTypeError: 'NoneType' object is not iterable\n\n
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix exception in `show_counter` when `ports` is `None`..

#### How did you do it?
Return directly if `ports == None`.

#### How did you verify/test it?
Verified by running `sai_qos_tests.TunnelDscpToPgMapping`.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
