### PR TITLE
Fix "logging not defined" issue of some snappi tests

### DIFF
--- a/tests/snappi/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi/bgp/files/bgp_convergence_helper.py
@@ -1,3 +1,4 @@
+import logging
 from tabulate import tabulate
 from statistics import mean
 from tests.common.utilities import (wait, wait_until)
@@ -147,7 +148,7 @@ def run_rib_in_convergence_test(cvg_api,
                                         port_count,
                                         number_of_routes,
                                         route_type,
-                                        port_speed,) 
+                                        port_speed,)
 
     """
         Run the convergence test by withdrawing all routes at once and
@@ -362,7 +363,7 @@ def __tgen_bgp_config(cvg_api,
             bgpv4_peer.as_type = BGP_TYPE
             bgpv4_peer.peer_address = temp_tg_port[i-1]['peer_ip']
             bgpv4_peer.as_number = int(TGEN_AS_NUM)
-            route_range = bgpv4_peer.v4_routes.add(name=NG_LIST[-1]) 
+            route_range = bgpv4_peer.v4_routes.add(name=NG_LIST[-1])
             route_range.addresses.add(address='200.1.0.1', prefix=32, count=number_of_routes)
             as_path = route_range.as_path
             as_path_segment = as_path.segments.add()
@@ -397,7 +398,7 @@ def __tgen_bgp_config(cvg_api,
             ipv6_stack.address = temp_tg_port[i-1]['ipv6']
             ipv6_stack.gateway = temp_tg_port[i-1]['peer_ipv6']
             ipv6_stack.prefix = int(temp_tg_port[i-1]['ipv6_prefix'])
-            
+
             bgpv6 = config.devices[i-1].bgp
             bgpv6.router_id = temp_tg_port[i-1]['peer_ip']
             bgpv6_int = bgpv6.ipv6_interfaces.add()
@@ -791,7 +792,7 @@ def get_RIB_IN_capacity(cvg_api,
                 bgpv4_peer.as_type = BGP_TYPE
                 bgpv4_peer.peer_address = temp_tg_port[i-1]['peer_ip']
                 bgpv4_peer.as_number = int(TGEN_AS_NUM)
-                route_range = bgpv4_peer.v4_routes.add(name="Network_Group%d" % i) 
+                route_range = bgpv4_peer.v4_routes.add(name="Network_Group%d" % i)
                 route_range.addresses.add(address='200.1.0.1', prefix=32, count=number_of_routes)
                 as_path = route_range.as_path
                 as_path_segment = as_path.segments.add()
@@ -825,7 +826,7 @@ def get_RIB_IN_capacity(cvg_api,
                 ipv6_stack.address = temp_tg_port[i-1]['ipv6']
                 ipv6_stack.gateway = temp_tg_port[i-1]['peer_ipv6']
                 ipv6_stack.prefix = int(temp_tg_port[i-1]['ipv6_prefix'])
-                
+
                 bgpv6 = config.devices[i-1].bgp
                 bgpv6.router_id = temp_tg_port[i-1]['peer_ip']
                 bgpv6_int = bgpv6.ipv6_interfaces.add()

--- a/tests/snappi/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi/lacp/files/lacp_dut_helper.py
@@ -1,3 +1,4 @@
+import logging
 from tabulate import tabulate
 from tests.common.utilities import (wait, wait_until)
 from tests.common.helpers.assertions import pytest_assert
@@ -192,7 +193,7 @@ def __tgen_bgp_config(api,
     ipv6_2.address = temp_tg_port[1]['ipv6']
     ipv6_2.gateway = temp_tg_port[1]['peer_ipv6']
     ipv6_2.prefix = int(temp_tg_port[1]['ipv6_prefix'])
-    
+
     bgpv4 = config.devices[1].bgp
     bgpv4.router_id = temp_tg_port[1]['peer_ip']
     bgpv4_int = bgpv4.ipv4_interfaces.add()
@@ -202,7 +203,7 @@ def __tgen_bgp_config(api,
     bgpv4_peer.as_type = BGP_TYPE
     bgpv4_peer.peer_address = temp_tg_port[1]['peer_ip']
     bgpv4_peer.as_number = int(TGEN_AS_NUM)
-    route_range1 = bgpv4_peer.v4_routes.add(name="IPv4_Routes") 
+    route_range1 = bgpv4_peer.v4_routes.add(name="IPv4_Routes")
     route_range1.addresses.add(address='200.1.0.1', prefix=32, count=number_of_routes)
     as_path = route_range1.as_path
     as_path_segment = as_path.segments.add()
@@ -267,7 +268,7 @@ def print_port_stats(api,port_names):
         port_table.append(port_stats[0].frames_rx_rate)
         table1.append(port_table)
     columns = ['Dut Port', 'Tgen Port', 'Tx. Frame Rate', 'Rx. Frame Rate']
-    logger.info("\n%s" % 
+    logger.info("\n%s" %
     tabulate(table1, headers=columns, tablefmt="psql"))
 
 

--- a/tests/snappi/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi/lacp/files/lacp_physical_helper.py
@@ -1,3 +1,4 @@
+import logging
 from tabulate import tabulate
 from statistics import mean
 from tests.common.utilities import (wait, wait_until)
@@ -257,7 +258,7 @@ def __tgen_bgp_config(cvg_api,
     ipv6_2.address = temp_tg_port[1]['ipv6']
     ipv6_2.gateway = temp_tg_port[1]['peer_ipv6']
     ipv6_2.prefix = int(temp_tg_port[1]['ipv6_prefix'])
-    
+
     bgpv4 = config.devices[1].bgp
     bgpv4.router_id = temp_tg_port[1]['peer_ip']
     bgpv4_int = bgpv4.ipv4_interfaces.add()
@@ -267,7 +268,7 @@ def __tgen_bgp_config(cvg_api,
     bgpv4_peer.as_type = BGP_TYPE
     bgpv4_peer.peer_address = temp_tg_port[1]['peer_ip']
     bgpv4_peer.as_number = int(TGEN_AS_NUM)
-    route_range1 = bgpv4_peer.v4_routes.add(name="IPv4_Routes") 
+    route_range1 = bgpv4_peer.v4_routes.add(name="IPv4_Routes")
     route_range1.addresses.add(address='200.1.0.1', prefix=32, count=number_of_routes)
     as_path = route_range1.as_path
     as_path_segment = as_path.segments.add()

--- a/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The `logging` module is used by some files under `tests.snappi`. However, the module is not imported in the files. This caused error like below while collecting the snappi tests:
    `E NameError: name 'logging' is not defined`

#### How did you do it?
The fix is to import logging in those files.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
