### PR TITLE
Fix python3 compatibility issue of the switch connection plugin

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -61,7 +61,7 @@ class Connection(ConnectionBase):
         self._ssh_command += ['-o', 'ConnectTimeout=' + str(self.timeout)]
 
     def _remove_unprintable(self, buff):
-        return filter(lambda x: x in string.printable, buff)
+        return ''.join([x for x in buff if x in string.printable])
 
     def _spawn_connect(self):
         last_user = None
@@ -106,7 +106,7 @@ class Connection(ConnectionBase):
         if attempt == len(self.login['user']):
             raise AnsibleError("none of the passwords in the book works")
 
-        self.before_backup = client.before.split()
+        self.before_backup = client.before.decode().split()
 
         # determine the sku
         client.sendline('show version')
@@ -115,6 +115,7 @@ class Connection(ConnectionBase):
             # It may be that right after fanout starts
             # the OS on fanout sends few promts which may not
             # include 'show version' output
+            client.before = client.before.decode()
             if 'show version' in client.before:
                 if 'Arista' in client.before:
                     self.sku = 'eos'
@@ -241,7 +242,7 @@ class Connection(ConnectionBase):
             self._display.vvv('> %s' % (cmd), host=self.host)
             client.sendline(cmd)
             client.expect(prompts)
-            before = self._remove_unprintable(client.before)
+            before = self._remove_unprintable(client.before.decode())
             stdout += before
             self._display.vvv('< %s' % (before), host=self.host)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The switch connection plugin uses pexpect to interact with devices. By default, the text captured by pexpect is in format of bytes. It works in python2. In python3, default string type is unicode, this plugin may raise issue like below:
```
    File "/home/user/sonic-mgmt/ansible/plugins/connection/switch.py", line 118, in _spawn_connect
        if 'show version' in client.before:
```
#### How did you do it?
This change fixed the compatibility issue by converting bytes captured by pexpect to string.

#### How did you verify/test it?
Created ansible playbook to run a task using the `apswitch` action and the `switch` connection plugin.
Executed the playbook using both python2 and python3.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
