### PR TITLE
Fix `defaultdict` not imported issue of test_techsupport

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -7,6 +7,7 @@ import logging
 import tech_support_cmds as cmds
 import re
 from random import randint
+from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
@@ -287,7 +288,7 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
         While taking the fw dump, the fw is busy and doesn't respond to other calls.
         The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields
         every 60 seconds which fails during the fw dump.
-        This is a temporary issue and this log can be ignored. 
+        This is a temporary issue and this log can be ignored.
         Issue link: https://github.com/sonic-net/sonic-buildimage/issues/12621
     """
     ignoreRegex = [
@@ -393,9 +394,9 @@ def add_asic_arg(format_str, cmds_list, asic_num):
 @pytest.fixture(scope='function')
 def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
-    Prepare a list of commands to be expected in the 
-    show techsupport output. All the expected commands are 
-    categorized into groups. 
+    Prepare a list of commands to be expected in the
+    show techsupport output. All the expected commands are
+    categorized into groups.
 
     For multi ASIC platforms, command strings are generated based on
     the number of ASICs.
@@ -458,8 +459,8 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist, strbash_in_cmdlist):
-    """ 
-    Check commands within a group against the command list 
+    """
+    Check commands within a group against the command list
 
     Returns: list commands not found
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Script `test_techsupport.py` used `defaultdict`. However, `defaultdict` is not imported. This could result in error like below while running case `test_techsupport_commands`:
```
NameError: name 'defaultdict' is not defined.
```
This issue is only observed while run the test using python3.

#### How did you do it?
The fix is to import `defaultdict` from the collections module.

#### How did you verify/test it?
Test run `test_techsupport.py`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
