### PR TITLE
[Nvidia] Fix test case test_show_platform_temperature_mocked for Nvidia SN5600 platform

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -44,7 +44,7 @@ SWITCH_MODELS = {
             },
             "module": {
                 "start": 1,
-                "number": 64
+                "number": 65
             },
             "psu": {
                 "start": 1,

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -55,7 +55,9 @@ SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument m
                                      '.*ERR pmon#thermalctld.*Failed to get minimum ambient temperature, use pessimistic instead.*',
                                      '.*ERR pmon#thermalctld.*Failed to read from file /run/hw-management/thermal.*',
                                      '.*ERR pmon#thermalctld.*Failed to read from file /var/run/hw-management/thermal.*',
-                                     '.*ERR pmon#thermalctld.*Failed to run thermal policy.*']
+                                     '.*ERR pmon#thermalctld.*Failed to run thermal policy.*',
+                                     '.*ERR pmon#psud:.*Failed to read from file \/var\/run\/hw-management\/thermal\/port_amb.*',
+                                     ".*ERR pmon#psud:.*Failed to read from file \/var\/run\/hw-management\/thermal\/fan_amb.*"]
 
 SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',
                               '.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. On Nvidia 5600 platform, there are 65 sfp, not 64
2. 5600 is using new thermal control algorithm in HW-mgmt, need to ignore 2 errors when doing the mock


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test case test_show_platform_temperature_mocked for Nvidia 5600 platform
#### How did you do it?
1. Update the module number in mellanox_data.py to 65
2. Add 2 errors to the ignore list of test_platform_info.py
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
