### PR TITLE
[Nvidia]Fix test_sfps in test_chassis.py for Nvidia 5600 platform

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -435,6 +435,9 @@ class TestChassisApi(PlatformApiTestBase):
                 for port,data in list(interface_facts.items()):
                     if data['type'] == 'RJ45':
                         expected_num_sfps += 1
+            elif 'sn5600' in duthost.facts.get("platform"):
+                # 5600 platform has an extra service port which is also counted in SFP object lists
+                expected_num_sfps += 1
             pytest_assert(num_sfps == expected_num_sfps,
                           "Number of sfps ({}) does not match expected number ({})"
                           .format(num_sfps, expected_num_sfps))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The Nvidia 5600 platform has an extra service port which is also counted in SFP object list. Need to update the case test_sfps in test_chassis.py.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_sfps in test_chassis.py for 5600 platform
#### How did you do it?
Add expected_num_sfps by 1 if the platform is Nvidia 5600.
#### How did you verify/test it?
By automation, test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
