### PR TITLE
[tests] consider tacacs in pytest accessing fanout

### DIFF
--- a/docs/testbed/README.testbed.Config.md
+++ b/docs/testbed/README.testbed.Config.md
@@ -12,6 +12,12 @@
 
 - [```ansible/files/sonic_lab_links.csv```](/ansible/files/sonic_lab_links.csv): Helper file helps you to create lab_connection_graph.xml, list all physical links between DUT, Fanoutleaf and Fanout root switches, servers and vlan configurations for each link
 
+- [```ansible/files/sonic_lab_pdu_links.csv```](/ansible/files/sonic_lab_pdu_links.csv): Helper file helps you to create lab_connection_graph.xml, list all pdu links between devices and pdu devices. For details about pdu configuraions, check doc [pdu wiring](./README.testbed.PDUWiring.md)
+
+- [```ansible/files/sonic_lab_bmc_links.csv```](/ansible/files/sonic_lab_bmc_links.csv): Helper file helps you to create lab_connection_graph.xml, list all bmc links between devices and management devices.
+
+- [```ansible/files/sonic_lab_console_links.csv```](/ansible/files/sonic_lab_console_links.csv): Helper file helps you to create lab_connection_graph.xml, list all console links between devices and management devices.
+
 - [```ansible/files/lab_connection_graph.xml```](/ansible/files/lab_connection_graph.xml): This is the lab graph file for library/conn_graph_facts.py to parse and get all lab fanout switch connections information. If you have only one fanout switch, you may go head manually modify the sample lab_connection_graph.xml file to set bot your fanout leaf and fanout root switch management IP point to the same fanout switch management IP and make sure all DUT and Fanout name and IP are matching your testbed.
 
 - [```ansible/files/creategraph.py```](/ansible/files/creategraph.py): Helper file helps you generate a lab_connection_graph.xml based on the device file and link file specified above.

--- a/docs/testbed/README.testbed.Fanout.md
+++ b/docs/testbed/README.testbed.Fanout.md
@@ -1,0 +1,11 @@
+# Fanout Credentials
+
+To deploy fanout, use the ansible playbook [fanout playbook](ansible/fanout.yml), during the execution, credentials will be read as group variables and used. 
+
+To define its passwords, there are several ways. When tacacs is enabled and all fanout devices use the same credential, set fanout_tacacs_user/password (it will override everything). When tacacs is enabled but different type of devices use different credentials, do not set fanout_tacacs_user/password but fanout_tacacs_{OS}_user/password. When instead tacacs is not enabled and fanout uses local authentication, do not set tacacs password for that type of device and set its local user name and passwords.
+
+Local credential names have been set arbitrarily and is listed below. Sonic devices use fanout_sonic_user/password, eos devices and mlnx devices use fanout_mlnx_user/password. Eos devices are special and will be discussed below.
+
+Eos devices are different in that we want it to have 2 sets of credentials, one for accessing eos network configurations and one for accessing eos shell. Ansible playbook will have both network and shell accounts setup before running setup, but the shell credential is transient, and the playbook will make it persistent. Shell credential is read from fanout_admin_user/password to login to eos shell, and a template is put in place to make fanout_admin_user/password persistent shell account on eos. Network related credentials are not used in fanout playbook so far, but if it is, it should be tacacs credentials like the others or local credential fanout_network_user/password.
+
+Pytest is another place where group variables are read to access fanout. Credential setup are similar for sonic and mlnx devices but different for eos. When test is run, we expect eos to have 2 sets of credentials already. Pytest will read fanout_network_user/password as network credential and fanout_shell_user/password as shell credential. When tacacs credential is set, it overrides local network credential but not shell credential.

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -16,7 +16,7 @@ class FanoutHost(object):
     For running ansible module on the Fanout switch
     """
 
-    def __init__(self, ansible_adhoc, os, hostname, device_type, user, passwd, shell_user=None, shell_passwd=None):
+    def __init__(self, ansible_adhoc, os, hostname, device_type, user, passwd, eos_shell_user=None, eos_shell_passwd=None):
         self.hostname = hostname
         self.type = device_type
         self.host_to_fanout_port_map = {}
@@ -25,8 +25,8 @@ class FanoutHost(object):
             self.os = os
             self.fanout_port_alias_to_name = {}
             self.host = SonicHost(ansible_adhoc, hostname,
-                                  shell_user=shell_user,
-                                  shell_passwd=shell_passwd)
+                                  ssh_user=user,
+                                  ssh_passwd=passwd)
         elif os == 'onyx':
             self.os = os
             self.host = OnyxHost(ansible_adhoc, hostname, user, passwd)
@@ -40,7 +40,7 @@ class FanoutHost(object):
         else:
             # Use eos host if the os type is unknown
             self.os = 'eos'
-            self.host = EosHost(ansible_adhoc, hostname, user, passwd, shell_user=shell_user, shell_passwd=shell_passwd)
+            self.host = EosHost(ansible_adhoc, hostname, user, passwd, shell_user=eos_shell_user, shell_passwd=eos_shell_passwd)
 
     def __getattr__(self, module_name):
         return getattr(self.host, module_name)

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -37,6 +37,9 @@ class SonicHost(AnsibleHostBase):
     """
     DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
+    """
+    setting either one of shell_user/shell_pw or ssh_user/ssh_passwd pair should yield the same result.
+    """
     def __init__(self, ansible_adhoc, hostname,
                  shell_user=None, shell_passwd=None,
                  ssh_user=None, ssh_passwd=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -578,7 +578,7 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa F
                     fanout_user = creds.get('fanout_network_user', None)
                     fanout_password = creds.get('fanout_network_password', None)
                 else:
-                    #TODO: support mlnx
+                    # when os is mellanox, not supported
                     pytest.fail("os other than sonic and eos not supported")
 
                 eos_shell_user = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -565,29 +565,38 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa F
                 host_vars = ansible_adhoc().options[
                     'inventory_manager'].get_host(fanout_host).vars
                 os_type = host_vars.get('os', 'eos')
-                admin_user = creds['fanout_admin_user']
-                admin_password = creds['fanout_admin_password']
-                # `fanout_network_user` and `fanout_network_password` are for
-                # accessing the non-shell CLI of fanout.
-                # Ansible will use this set of credentail for establishing
-                # `network_cli` connection with device when applicable.
-                network_user = creds.get('fanout_network_user', admin_user)
-                network_password = creds.get('fanout_network_password',
-                                             admin_password)
-                shell_user = creds.get('fanout_shell_user', admin_user)
-                shell_password = creds.get('fanout_shell_pass', admin_password)
-                if os_type == 'sonic':
-                    shell_user = creds.get('fanout_sonic_user', None)
-                    shell_password = creds.get('fanout_sonic_password', None)
+                if 'fanout_tacacs_user' in creds:
+                    fanout_user = creds['fanout_tacacs_user']
+                    fanout_password = creds['fanout_tacacs_password']
+                elif 'fanout_tacacs_{}_user'.format(os_type) in creds:
+                    fanout_user = creds['fanout_tacacs_{}_user'.format(os_type)]
+                    fanout_password = creds['fanout_tacacs_{}_password'.format(os_type)]
+                elif os_type == 'sonic':
+                    fanout_user = creds.get('fanout_sonic_user', None)
+                    fanout_password = creds.get('fanout_sonic_password', None)
+                elif os_type == 'eos':
+                    fanout_user = creds.get('fanout_network_user', None)
+                    fanout_password = creds.get('fanout_network_password', None)
+                else:
+                    #TODO: support mlnx
+                    pytest.fail("os other than sonic and eos not supported")
+
+                eos_shell_user = None
+                eos_shell_password = None
+                if os_type == "eos":
+                    admin_user = creds['fanout_admin_user']
+                    admin_password = creds['fanout_admin_password']
+                    eos_shell_user = creds.get('fanout_shell_user', admin_user)
+                    eos_shell_password = creds.get('fanout_shell_password', admin_password)
 
                 fanout = FanoutHost(ansible_adhoc,
                                     os_type,
                                     fanout_host,
                                     'FanoutLeaf',
-                                    network_user,
-                                    network_password,
-                                    shell_user=shell_user,
-                                    shell_passwd=shell_password)
+                                    fanout_user,
+                                    fanout_password,
+                                    eos_shell_user=eos_shell_user,
+                                    eos_shell_passwd=eos_shell_password)
                 fanout.dut_hostnames = [dut_host]
                 fanout_hosts[fanout_host] = fanout
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Ansible playbook for fanout has been setup to check variable fanout_tacacs_user/password and fanout_tacacs_{OS}_user/password as credentials. Now this pr modifies pytest conftest to check it. Variables have been renamed for clearity as well.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Same as summary.

#### How did you do it?
Check tacacs related variables first in conftest.

#### How did you verify/test it?
Run test in lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
