### PR TITLE
Fix&skip extremely long run time issue of test_stress_arp.py

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -64,7 +64,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
     """
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:
-        normalized_level = "basic"
+        normalized_level = "debug"
 
     ipv4_avaliable = get_crm_resources(duthost, "ipv4_neighbor", "available") - \
         get_crm_resources(duthost, "ipv4_neighbor", "used")
@@ -141,8 +141,7 @@ def add_nd(duthost, ptfhost, ptfadapter, config_facts, tbinfo, ip_and_intf_info,
 
         ptfadapter.dataplane.flush()
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
-        get_ipv6_entries_status(duthost, fake_src_addr)
-        wait_until(20, 1, 0, lambda: get_ipv6_entries_status is True)
+        wait_until(20, 1, 0, get_ipv6_entries_status, duthost, fake_src_addr)
         ptfhost.shell("ip -6 addr del {}/64 dev eth1".format(fake_src_addr))
 
 
@@ -155,7 +154,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
 
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:
-        normalized_level = "basic"
+        normalized_level = "debug"
 
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
     ipv6_avaliable = get_crm_resources(duthost, "ipv6_neighbor", "available") - \

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -33,6 +33,12 @@ arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
     conditions:
       - "release not in ['202012']"
 
+arp/test_stress_arp.py:
+  skip:
+    resason: "Extremely long long run time."
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/7874
+
 #######################################
 #####            bfd              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The `arp/test_stress_arp.py` script needs over 30k seconds to run.

The reason is that the scripts may repeatedly add/remove ipv6 neighbors for over 10k times. This operation takes time by itself.

Each time after adding/removing ipv6 neighbors, the script will check if the neighbor is added/removed successfully using wait_until.

The original wait_until check was like below:
```
    get_ipv6_entries_status(duthost, fake_src_addr)
    wait_until(20, 1, 0, lambda: get_ipv6_entries_status == True)
```
The lambda function checks if function `get_ipv6_entries_status` equals to True. This is a false positive. A function itself should always equals to True. Anyway, the wait_until function here won't timeout after 20 seconds.

After PR #6694 was merged, it changed the check to code like below:
```python
    get_ipv6_entries_status(duthost, fake_src_addr)
    wait_until(20, 1, 0, get_ipv6_entries_status is True)
```
This make it worse because express `get_ipv6_entries_status is True` will always be False.

The issue was not observed because the script does not have topology mark. It was always skipped, and the issue was not exposed.

After PR #7789 was merged, the script can be executed by nightly test and the issue was exposed.

#### How did you do it?
This change partly fixed the issue by:
1. Use correct wait_until check like below:
```python
    wait_until(20, 1, 0, get_ipv6_entries_status, duthost, fake_src_addr)
```
2. Change default completeness level to basic. The test will reduce default test iterations from 10 to 1.
3. Created issue and skip this test for now.

After the above fixes, this test still takes too long. A better solution is still needed to cover this test. Probably run a PTF script to generate massive arp requests to DUT and then check on DUT? Using ptfadapter to send packets one by one is too time consuming.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
