### PR TITLE
Update configlet with the missing port_channel config information used in add rack script

### DIFF
--- a/tests/configlet/util/configlet.py
+++ b/tests/configlet/util/configlet.py
@@ -68,6 +68,8 @@ def get_port_channel():
                 "admin_status": "up",
                 "min_links": "1",
                 "mtu": "9100",
+                "tpid": "0x8100",
+                "lacp_key": "auto",
                 "members": list(sonic_local_ports)
             }
         }


### PR DESCRIPTION


### Description of PR

     Config used to add rack via port channel there is missing the elements "tpid" and "lacp_key". These elements are generated as part of the original config but not part of the add_rack config.


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

#### What is the motivation for this PR?

   This PR is closing the gap in the config used to add T0 rack with T1 rack via port channel

#### How did you verify/test it?

   Added the missing config in configlet and re-ran the test script to verify the difference between the original config_db and the config_db post add rack process


