### PR TITLE
Fix pdu KeyError for pdu_controller fixture

### DIFF
--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from .pdu_manager import pdu_manager_factory
+from tests.common.utilities import get_host_visible_vars
 
 
 logger = logging.getLogger(__name__)
@@ -22,8 +23,15 @@ def get_pdu_hosts(duthost):
     return pdu_hosts
 
 
+def get_pdu_visible_vars(inventories, pdu_hostnames):
+    pdu_hosts_vars = {}
+    for pdu_hostname in pdu_hostnames:
+        pdu_hosts_vars[pdu_hostname] = get_host_visible_vars(inventories, pdu_hostname)
+    return pdu_hosts_vars
+
+
 @pytest.fixture(scope="module")
-def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts, pdu):
+def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts):
     """
     @summary: Fixture for controlling power supply to PSUs of DUT
     @param duthost: Fixture duthost defined in sonic-mgmt/tests/conftest.py
@@ -32,7 +40,15 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     pdu_hosts = get_pdu_hosts(duthost)
-    controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu)
+    pdu_hostnames = []
+    if pdu_hosts:
+        pdu_hostnames = pdu_hosts.keys()
+    else:
+        duthost_pdu_info = conn_graph_facts.get("device_pdu_info", {}).get(duthost.hostname, {})
+        pdu_hostnames = [pdu["Hostname"] for pdu in duthost_pdu_info.values()]
+
+    pdu_vars = get_pdu_visible_vars(duthost.host.options["inventory_manager"]._sources, pdu_hostnames)
+    controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu_vars)
 
     yield controller
 
@@ -43,13 +59,21 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
 
 
 @pytest.fixture(scope="module")
-def get_pdu_controller(conn_graph_facts, pdu):
+def get_pdu_controller(conn_graph_facts):
     controller_map = {}
 
     def pdu_controller_helper(duthost):
         if duthost.hostname not in controller_map:
             pdu_hosts = get_pdu_hosts(duthost)
-            controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu)
+            pdu_hostnames = []
+            if pdu_hosts:
+                pdu_hostnames = pdu_hosts.keys()
+            else:
+
+                duthost_pdu_info = conn_graph_facts.get("device_pdu_info", {}).get(duthost.hostname, {})
+                pdu_hostnames = [pdu["Hostname"] for pdu in duthost_pdu_info.values()]
+            pdu_vars = get_pdu_visible_vars(duthost.host.options["inventory_manager"]._sources, pdu_hostnames)
+            controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu_vars)
             controller_map[duthost.hostname] = controller
 
         return controller_map[duthost.hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #7782 updated the pdu_manager_factory interface. Only devutils using this function was updated accordingly. Fixtures like pdu_controller using this function also need to be updated.

#### How did you do it?
This PR updated the pdu_controller and get_pdu_controller fixtures accordingly to pass correct PDU variables to the pdu_manager_factory function.

This change only can fix the issue under python2.
Under python3, the pysnmp package version 4.4.12
is much higher than the 4.2.5 package used in python2. The newer package has compatibility issues. The current snmp_pdu_controllers.py script needs to be updated for python3. This issue will be addressed in other PRs.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
