### PR TITLE
Updated conditional marks for ip_packet TC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -449,15 +449,16 @@ ip/test_ip_packet.py:
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
   skip:
-    reason: "Broadcom, Cisco and Marvell Asic will tolorate IP packets with 0xffff checksum"
+    reason: "Broadcom, Cisco, Marvell, Barefoot and Mellanox Asic will tolorate IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot'] and asic_subtype not in ['broadcom-dnx']"
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot', 'mellanox'] and asic_subtype not in ['broadcom-dnx']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:
-    reason: "Mellanox and Broadcom DNX Asic will drop IP packets with 0xffff checksum"
+    reason: "Arista-7280CR3-C40' and Broadcom DNX Asic will drop IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
+      - "asic_subtype in ['broadcom-dnx']"
+      - "hwsku in ['Arista-7280CR3-C40']"
 
 #######################################
 #####            ipfwd            #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
By default Mellanox asic will tolerate IP packets with 0xffff checksum.
PR reflects changes introduces in https://github.com/sonic-net/sonic-mgmt/pull/7400/files

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Moved skip condition for Mellanox asic from test_forward_ip_packet_with_0xffff_chksum_tolerant to test_forward_ip_packet_with_0xffff_chksum_drop
#### How did you verify/test it?
Run the test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
