### PR TITLE
Skipping test_drop_counters.py::test_dst_ip_absent for cisco platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -32,9 +32,9 @@ drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop:
 
 drop_packets/test_drop_counters.py::test_dst_ip_absent:
   skip:
-    reason: "Test case not supported on Broadcom DNX platform"
+    reason: "Test case not supported on Broadcom DNX platform and Cisco 8000 platform"
     conditions:
-      "asic_subtype in ['broadcom-dnx']"
+      - "asic_subtype in ['broadcom-dnx'] or asic_type in ['cisco-8000']"
 
 drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
   skip:


### PR DESCRIPTION

### Description of PR
Adding skip to drop_packets/test_drop_counters.py::test_dst_ip_absent

Scapy will add dest ip as 127.0.0.1 when dest ip field is set to None

DUT will forward  destination IP address 127.0.0.1 through default route, Hence this test can't be tested in Cisco platform

Hence skipping the test


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added skip for drop_packets/test_drop_counters.py::test_dst_ip_absent

#### How did you verify/test it?
------------------------------------------------------------------------ live log sessionfinish ------------------------------------------------------------------------
08:58:52 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
======================================================================= short test summary info ========================================================================
SKIPPED [3] drop_packets/drop_packets.py: Test case not supported on Broadcom DNX platform and Cisco 8000 platform
====================================================================== 3 skipped in 9.63 seconds ================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
