### PR TITLE
[Python3 migration]Fix oid issue in snmp_pdu_controllers.py

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -118,9 +118,10 @@ class snmpPduController(PduControllerBase):
             for varBinds in varTable:
                 for oid, val in varBinds:
                     oid = oid.getOid() if hasattr(oid, 'getoid') else oid
-                    current_oid = oid.prettyPrint()
+                    current_oid = str(oid)
                     port_oid = current_oid.replace(pdu_port_base, '')
                     label = val.prettyPrint().lower()
+                    logger.info("Found port {} with label {}".format(port_oid, label))
                     self._build_outlet_maps(port_oid, label)
 
     def _get_pdu_ports(self):
@@ -226,8 +227,8 @@ class snmpPduController(PduControllerBase):
 
         for oid, val in varBinds:
             oid = oid.getOid() if hasattr(oid, 'getoid') else oid
-            current_oid = oid.prettyPrint()
-            current_val = val.prettyPrint()
+            current_oid = str(oid)
+            current_val = str(val)
             port_oid = current_oid.replace(self.PORT_POWER_BASE_OID, '')
             if port_oid == port_id:
                 status['output_watts'] = current_val
@@ -245,8 +246,8 @@ class snmpPduController(PduControllerBase):
 
         for oid, val in varBinds:
             oid = oid.getOid() if hasattr(oid, 'getoid') else oid
-            current_oid = oid.prettyPrint()
-            current_val = val.prettyPrint()
+            current_oid = str(oid)
+            current_val = str(val)
             port_oid = current_oid.replace(self.PORT_STATUS_BASE_OID, '')
             if port_oid == port_id:
                 status = {"outlet_id": port_oid, "outlet_on": True if current_val == self.STATUS_ON else False}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes snmp_pdu_controllers.py issue in Python3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In Python2, oid.prettyPrint() prints 1.3.6.1.4.1.9.1.283
In Python3, oid.prettyPrint() prints SNMPv2-SMI::enterprises.9.1.283
This difference breaks port_label_dict in _build_outlet_maps() in snmp_pdu_controllers.py

#### How did you do it?
Change oid.prettyPrint() to str(oid). This will make code work both in Python2 and Python3.

#### How did you verify/test it?
PDU testcase can run manually both in Python2 and Python3.

