### PR TITLE
Added Cisco qos param generator

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -1,0 +1,69 @@
+class QosParamCisco(object):
+    def __init__(self, qos_params, bufferConfig):
+        '''
+        Initialize parameters all tests will use
+        '''
+        self.qos_params = qos_params
+        self.bufferConfig = bufferConfig
+        self.ingress_pool_size = None
+        self.ingress_pool_headroom = None
+        if "ingress_lossless_pool" in self.bufferConfig["BUFFER_POOL"]:
+            self.ingress_pool_size = self.bufferConfig["BUFFER_POOL"]["ingress_lossless_pool"]["size"]
+            self.ingress_pool_headroom = self.bufferConfig["BUFFER_POOL"]["ingress_lossless_pool"]["xoff"]
+        self.egress_pool_size = None
+        if "egress_lossy_pool" in self.bufferConfig["BUFFER_POOL"]:
+            self.egress_pool_size = self.bufferConfig["BUFFER_POOL"]["egress_lossy_pool"]["size"]
+        # Find SMS size
+        small_sms = 64 * (2 ** 20)
+        self.is_large_sms = self.ingress_pool_size + self.ingress_pool_headroom > small_sms
+
+    def run(self):
+        '''
+        Define parameters for each test.
+
+        Each function takes common parameters and outputs to the relevant section of the
+        self.qos_params structure.
+        '''
+        self.__define_shared_reservation_size()
+        return self.qos_params
+
+    def __mark_skip(self, testcase, reason):
+        self.qos_params[testcase]["skip"] = reason
+
+    def __define_shared_reservation_size(self):
+        if self.ingress_pool_size == None or self.ingress_pool_headroom == None:
+            skip_reason = "ingress_lossless_pool not defined, nothing to test"
+            self.__mark_skip("shared_res_size_1", skip_reason)
+            self.__mark_skip("shared_res_size_2", skip_reason)
+        elif self.is_large_sms:
+            res_1 = {"dscps": [8, 8, 8, 8, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "pgs": [0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "queues": [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "src_port_i": [0, 1, 2, 3, 0, 1, 2, 3, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+                     "dst_port_i": [6, 7, 8, 9, 6, 7, 8, 9, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11],
+                     "pkt_counts": [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595, 2038, 2038, 1014, 1014, 1014, 1014, 64, 1],
+                     "shared_limit_bytes": 75497472}
+            res_2 = {"dscps": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "pgs": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8],
+                     "dst_port_i": [9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+                     "pkt_counts": [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052, 1286, 1286, 1286, 238, 1],
+                     "shared_limit_bytes": 67109376}
+        else:
+            res_1 = {"dscps": [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "pgs": [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "queues": [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+                     "src_port_i": [0, 1, 2, 3, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+                     "dst_port_i": [6, 7, 8, 9, 10, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11],
+                     "pkt_counts": [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415, 415, 415, 415, 42, 1] ,
+                     "shared_limit_bytes": 46661760}
+            res_2 = {"dscps": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "pgs": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
+                     "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+                     "dst_port_i": [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
+                     "pkt_counts": [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1],
+                     "shared_limit_bytes": 41943552}
+        self.qos_params["shared_res_size_1"].update(res_1)
+        self.qos_params["shared_res_size_2"].update(res_2)

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -1,5 +1,7 @@
 class QosParamCisco(object):
-    def __init__(self, qos_params, bufferConfig):
+    SMALL_SMS_PLATFORMS = ["x86_64-8102_64h_o-r0"]
+
+    def __init__(self, qos_params, duthost, bufferConfig):
         '''
         Initialize parameters all tests will use
         '''
@@ -14,8 +16,7 @@ class QosParamCisco(object):
         if "egress_lossy_pool" in self.bufferConfig["BUFFER_POOL"]:
             self.egress_pool_size = self.bufferConfig["BUFFER_POOL"]["egress_lossy_pool"]["size"]
         # Find SMS size
-        small_sms = 64 * (2 ** 20)
-        self.is_large_sms = self.ingress_pool_size + self.ingress_pool_headroom > small_sms
+        self.is_large_sms = duthost.facts['platform'] not in self.SMALL_SMS_PLATFORMS
 
     def run(self):
         '''

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -31,7 +31,7 @@ class QosParamCisco(object):
         self.qos_params[testcase]["skip"] = reason
 
     def __define_shared_reservation_size(self):
-        if self.ingress_pool_size == None or self.ingress_pool_headroom == None:
+        if self.ingress_pool_size is None or self.ingress_pool_headroom is None:
             skip_reason = "ingress_lossless_pool not defined, nothing to test"
             self.__mark_skip("shared_res_size_1", skip_reason)
             self.__mark_skip("shared_res_size_2", skip_reason)
@@ -41,14 +41,16 @@ class QosParamCisco(object):
                      "queues": [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                      "src_port_i": [0, 1, 2, 3, 0, 1, 2, 3, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
                      "dst_port_i": [6, 7, 8, 9, 6, 7, 8, 9, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11],
-                     "pkt_counts": [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595, 2038, 2038, 1014, 1014, 1014, 1014, 64, 1],
+                     "pkt_counts": [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595,
+                                    2038, 2038, 1014, 1014, 1014, 1014, 64, 1],
                      "shared_limit_bytes": 75497472}
             res_2 = {"dscps": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
                      "pgs": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
                      "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
                      "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8],
                      "dst_port_i": [9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
-                     "pkt_counts": [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052, 1286, 1286, 1286, 238, 1],
+                     "pkt_counts": [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052,
+                                    1286, 1286, 1286, 238, 1],
                      "shared_limit_bytes": 67109376}
         else:
             res_1 = {"dscps": [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
@@ -56,7 +58,8 @@ class QosParamCisco(object):
                      "queues": [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                      "src_port_i": [0, 1, 2, 3, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
                      "dst_port_i": [6, 7, 8, 9, 10, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11],
-                     "pkt_counts": [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415, 415, 415, 415, 42, 1] ,
+                     "pkt_counts": [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415,
+                                    415, 415, 415, 42, 1],
                      "shared_limit_bytes": 46661760}
             res_2 = {"dscps": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],
                      "pgs": [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3],

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -35,7 +35,8 @@ class QosParamCisco(object):
             skip_reason = "ingress_lossless_pool not defined, nothing to test"
             self.__mark_skip("shared_res_size_1", skip_reason)
             self.__mark_skip("shared_res_size_2", skip_reason)
-        elif self.is_large_sms:
+            return
+        if self.is_large_sms:
             res_1 = {"dscps": [8, 8, 8, 8, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                      "pgs": [0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                      "queues": [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2526,6 +2526,16 @@ qos_params:
                 pkts_num_margin: 4
                 packet_size: 1350
                 cell_size: 384
+            shared_res_size_1:
+                ecn: 1
+                packet_size: 1350
+                cell_size: 384
+                pkts_num_margin: 1
+            shared_res_size_2:
+                ecn: 1
+                packet_size: 1350
+                cell_size: 384
+                pkts_num_margin: 1
             100000_300m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -2639,30 +2649,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 10, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415, 415, 415, 415, 42, 1] 
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 46661760
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6]
-                    dst_port_i: [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13]
-                    pkt_counts: [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 41943552
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -2794,30 +2780,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 10, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415, 415, 415, 415, 42, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 46661760
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6]
-                    dst_port_i: [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13]
-                    pkt_counts: [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 41943552
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -2940,30 +2902,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 8, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 4, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 10, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3413, 3413, 3413, 3413, 3413, 2389, 2389, 2389, 1526, 1526, 1392, 415, 415, 415, 415, 42, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 46661760
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6]
-                    dst_port_i: [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13]
-                    pkt_counts: [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 41943552
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -3082,30 +3020,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 0, 1, 2, 3, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 6, 7, 8, 9, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595, 2038, 2038, 1014, 1014, 1014, 1014, 64, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 75497472
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]
-                    dst_port_i: [8, 8, 9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
-                    pkt_counts: [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052, 1511, 1511, 1074, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 67109376
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -3264,30 +3178,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 0, 1, 2, 3, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 6, 7, 8, 9, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595, 2038, 2038, 1014, 1014, 1014, 1014, 64, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 75497472
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]
-                    dst_port_i: [8, 8, 9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
-                    pkt_counts: [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052, 1511, 1511, 1074, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 67109376
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -3446,30 +3336,6 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                shared_res_size_1:
-                    dscps: [8, 8, 8, 8, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [0, 0, 0, 0, 1, 1, 1, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 1, 2, 3, 0, 1, 2, 3, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
-                    dst_port_i: [6, 7, 8, 9, 6, 7, 8, 9, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]
-                    pkt_counts: [3822, 3822, 3822, 3822, 3822, 3822, 3822, 3822, 2595, 2595, 2595, 2595, 2038, 2038, 1014, 1014, 1014, 1014, 64, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 75497472
-                shared_res_size_2:
-                    dscps: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    ecn: 1
-                    pgs: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    queues: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4]
-                    src_port_i: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]
-                    dst_port_i: [8, 8, 9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
-                    pkt_counts: [3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 3549, 2052, 2052, 1511, 1511, 1074, 1]
-                    packet_size: 1350
-                    cell_size: 384
-                    pkts_num_margin: 1
-                    shared_limit_bytes: 67109376
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1084,6 +1084,7 @@ class QosSaiBase(QosBase):
                 sys.path.append(sub_folder_dir)
             import qos_param_generator
             qpm = qos_param_generator.QosParamCisco(qosConfigs['qos_params'][dutAsic][dutTopo],
+                                                    duthost,
                                                     bufferConfig)
             qosParams = qpm.run()
         else:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -11,6 +11,7 @@ import sys
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
+from tests.common.cisco_data import is_cisco_device
 #from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, dualtor_ports  # noqa F401
 from tests.common.dualtor.mux_simulator_control \
     import toggle_all_simulator_ports, get_mux_status, check_mux_status, validate_check_result  # noqa F401
@@ -1071,6 +1072,20 @@ class QosSaiBase(QosBase):
                                                            duthost,
                                                            tbinfo["topo"]["name"])
                 qosParams = qpm.run()
+        elif is_cisco_device(duthost):
+            bufferConfig = self.dutBufferConfig(duthost)
+            pytest_assert('BUFFER_POOL' in bufferConfig, 'BUFFER_POOL does not exist in bufferConfig')
+            pytest_assert('BUFFER_PROFILE' in bufferConfig, 'BUFFER_PROFILE does not exist in bufferConfig')
+            pytest_assert('BUFFER_QUEUE' in bufferConfig, 'BUFFER_QUEUE does not exist in bufferConfig')
+            pytest_assert('BUFFER_PG' in bufferConfig, 'BUFFER_PG does not exist in bufferConfig')
+            current_file_dir = os.path.dirname(os.path.realpath(__file__))
+            sub_folder_dir = os.path.join(current_file_dir, "files/cisco/")
+            if sub_folder_dir not in sys.path:
+                sys.path.append(sub_folder_dir)
+            import qos_param_generator
+            qpm = qos_param_generator.QosParamCisco(qosConfigs['qos_params'][dutAsic][dutTopo],
+                                                    bufferConfig)
+            qosParams = qpm.run()
         else:
             qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
         yield {

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -668,12 +668,15 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
 
-        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
-        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        qosConfig = dutQosConfig["param"]
         testPortIps = dutConfig["testPortIps"]
 
         if not sharedResSizeKey in list(qosConfig.keys()):
             pytest.skip("Shared reservation size parametrization '%s' is not enabled" % sharedResSizeKey)
+
+        if "skip" in qosConfig[sharedResSizeKey]:
+            # Skip if buffer pools and profiles are not be present, marked by qos param generator
+            pytest.skip(qosConfig[sharedResSizeKey]["skip"])
 
         self.updateTestPortIdIp(dutConfig, qosConfig[sharedResSizeKey])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enabled qos parameter generator for Cisco.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Improve reliability of qos.yml cross-platform test case execution by adding adaptable qos parameter generation. 

#### How did you do it?
- Added basic qos parameter generator
- Included basic buffer profiles/pools for future work improving automatic param generation
- Abstracted one test to start, shared_res_size test. Allows test to adapt it's tuning based on the detected buffer pool sizings.

#### How did you verify/test it?

Passed on O8C48 testbed. 

#### Any platform specific information?
shared_res_size is a Cisco-only testcase. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
