### PR TITLE
Updated QoS SAI tests PTF timeout from 600 to 1200 sec and revert PR#7364

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -130,7 +130,7 @@ class QosBase:
                   "--log-file",
                   "/tmp/{0}.log".format(testCase),
                   "--test-case-timeout",
-                  "600"
+                  "1200"
               ]
         result = ptfhost.shell(
                       argv=params,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -108,22 +108,35 @@ class QosBase:
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        custom_options = " --disable-ipv6 --disable-vxlan --disable-geneve" \
-                         " --disable-erspan --disable-mpls --disable-nvgre"
-        ptf_runner(
-            ptfhost,
-            "saitests",
-            testCase,
-            platform_dir="ptftests",
-            params=testParams,
-            log_file="/tmp/{0}.log".format(testCase),
-            qlen=10000,
-            is_python3=True,
-            relax=False,
-            timeout=1200,
-            custom_options=custom_options
-        )
-
+        params = [
+                  "/root/env-python3/bin/ptf",
+                  "--test-dir",
+                  "saitests/py3",
+                  testCase,
+                  "--platform-dir",
+                  "ptftests",
+                  "--platform",
+                  "remote",
+                  "-t",
+                  ";".join(["{}={}".format(k, repr(v)) for k, v in testParams.items()]),
+                  "--qlen",
+                  "10000",
+                  "--disable-ipv6",
+                  "--disable-vxlan",
+                  "--disable-geneve",
+                  "--disable-erspan",
+                  "--disable-mpls",
+                  "--disable-nvgre",
+                  "--log-file",
+                  "/tmp/{0}.log".format(testCase),
+                  "--test-case-timeout",
+                  "600"
+              ]
+        result = ptfhost.shell(
+                      argv=params,
+                      chdir="/root",
+                      )
+        pytest_assert(result["rc"] == 0, "Failed when running test '{0}'".format(testCase))
 
 class QosSaiBase(QosBase):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR# [7634](https://github.com/sonic-net/sonic-mgmt/pull/7364) was included in 20205 branch. 
This PR was to only change the timeout of ptf_runner for QoS tests from 600 to 1200.

However, this PR brought changes like passing 'custom_options' to ptf_runner.

The ptf_runner method in tests/ptf_runner.py in 202205 does not support this 'custom_options' - as it has not been updated to github master version. 

Thus, the QoS tests were failing in 202205 branch.

#### How did you do it?
- Revert the commit in 202205 that brought this PR in to go back to the original code.
- Changed timeout value from 600 to 1200

#### How did you verify/test it?
Ran QoS tests against chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
