### PR TITLE
fix connection issue in test_bgp_bbr

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -312,7 +312,8 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
     pytest_assert(wait_until(5, 1, 0, check_dut, duthost, other_vms, bgp_neighbors,
                   setup, route, accepted=accepted), 'DUT check failed')
 
-    results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted}, other_vms, timeout=120)
+    results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted},
+                           other_vms, timeout=120, concurrent_tasks=6)
 
     failed_results = {}
     for node, result in list(results.items()):


### PR DESCRIPTION
Summary:
Fix ansibal connection issue when try to get route info on VMs.

```
Failed: Processes "['check_other_vms--ARISTA03T2', 'check_other_vms--ARISTA05T0', 'check_other_vms--ARISTA04T0', 'check_other_vms--ARISTA05T2', 'check_other_vms--ARISTA07T2', 'check_other_vms--ARISTA07T0', 'check_other_vms--ARISTA14T0', 'check_other_vms--ARISTA13T0']" failed with exit code "1" Exception: run module eos_command failed, Ansible Results => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible-local-2183899_UytQd/ansible-tmp-1675232139.68-2183953-131930942655767/AnsiballZ_eos_command.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/tmp/ansible-local-2183899_UytQd/ansible-tmp-1675232139.68-2183953-131930942655767/AnsiballZ_eos_command.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/tmp/ansible-local-2183899_UytQd/ansible-tmp-1675232139.68-2183953-131930942655767/AnsiballZ_eos_command.py\",
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Random failure when running test_bgp_bbr.py, always failed when try to get route info on remote VMs.
The root cause is during the test, we use parallel_run to check VMs route. On some T1 DUT, there is 24 VMs.
And we also have a loop to check all v4 and v6 routes, thus too many python thread try to connect VMs, which would cause temp connection failure.
 
#### How did you do it?
Limit number of threads by parallel_run from default value 24 to 6.

#### How did you verify/test it?
Keep running failure test case for more than 20 times. no failure happened again.
![image](https://user-images.githubusercontent.com/111116206/228459712-d502dfd4-fe6d-46bf-be5f-1a3ee5ecb112.png)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
