### PR TITLE
Fix name 'time' is not defined in test_pfcwd_all_port_storm.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pytest
+import time
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.pfc_storm import PFCMultiStorm


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes NameError: name 'time' is not defined in test_all_port_storm_restore in test_pfcwd_all_port_storm.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Found in Python3 migration smoke test. 
Failure is: [pfcwd/test_pfcwd_all_port_storm.py:140: NameError] - NameError: name 'time' is not defined

#### How did you do it?
Add import time

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
