### PR TITLE
[202012][cherry-pick]Add test cases to verify hashing for IPinIP packet

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -22,6 +22,7 @@ from ptf.testutils import simple_tcp_packet
 from ptf.testutils import simple_tcpv6_packet
 from ptf.testutils import send_packet
 from ptf.testutils import verify_packet_any_port
+from ptf.testutils import simple_ipv4ip_packet
 
 import fib
 import lpm
@@ -81,6 +82,8 @@ class HashTest(BaseTest):
 
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
         self.single_fib = self.test_params.get('single_fib_for_duts', False)
+
+        self.ipver = self.test_params.get('ipver', 'ipv4')
 
         # set the base mac here to make it persistent across calls of check_ip_route
         self.base_mac = self.dataplane.get_mac(*random.choice(self.dataplane.ports.keys()))
@@ -389,7 +392,238 @@ class HashTest(BaseTest):
         @summary: Send packet for each range of both IPv4 and IPv6 spaces and
         expect the packet to be received from one of the expected ports
         """
+        for hash_key in self.hash_keys:
+            logging.info("hash test hash_key: {}".format(hash_key))
+            self.check_hash(hash_key)
 
+class IPinIPHashTest(HashTest):
+    '''
+    This test is to verify the hash key for IPinIP packet.
+    The src_ip, dst_ip, src_port and dst_port of inner frame are expected to be hash keys
+    for IPinIP packet.
+    '''
+
+    def check_ipv4_route(self, hash_key, src_port, dst_port_list, outer_src_ip, outer_dst_ip):
+        '''
+        @summary: Check IPv4 route works.
+        @param hash_key: hash key to build packet with.
+        @param src_port: index of port to use for sending packet to switch
+        @param dst_port_list: list of ports on which to expect packet to come back from the switch
+        '''
+        ip_src = self.src_ip_interval.get_random_ip() if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
+
+        inner_pkt_len = random.randrange(100, 1024) if hash_key == 'inner_length' else 100
+
+        pkt = simple_tcp_packet(pktlen=inner_pkt_len if vlan_id == 0 else inner_pkt_len + 4,
+                            dl_vlan_enable=False if vlan_id == 0 else True,
+                            vlan_vid=vlan_id,
+                            vlan_pcp=0,
+                            ip_src=ip_src,
+                            ip_dst=ip_dst,
+                            tcp_sport=sport,
+                            tcp_dport=dport,
+                            ip_ttl=64)
+        
+        ipinip_pkt = simple_ipv4ip_packet(
+                            eth_dst=router_mac,
+                            eth_src=src_mac,
+                            ip_src=outer_src_ip,
+                            ip_dst=outer_dst_ip,
+                            inner_frame=pkt['IP'])
+
+        exp_pkt = ipinip_pkt.copy()
+        exp_pkt['IP'].ttl -= 1
+
+        if hash_key == 'ip-proto':
+            ipinip_pkt['IP'].payload.proto = ip_proto
+            exp_pkt['IP'].payload.proto = ip_proto
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        # mask the chksum also if masking the ttl
+        if self.ignore_ttl:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
+       
+        send_packet(self, src_port, ipinip_pkt)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'\
+            .format(ipinip_pkt.src,
+                    ipinip_pkt.dst,
+                    ipinip_pkt['IP'].src,
+                    ipinip_pkt['IP'].dst,
+                    ipinip_pkt['IP'].proto,
+                    pkt['IP'].src,
+                    pkt['IP'].dst,
+                    pkt['IP'].proto,
+                    sport,
+                    dport,
+                    src_port))
+
+        rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+        actual_src_mac = Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+    
+    def check_ipv6_route(self, hash_key, src_port, dst_port_list, outer_src_ip, outer_dst_ip):
+        '''
+        @summary: Check IPv6 route works.
+        @param hash_key: hash key to build packet with.
+        @param in_port: index of port to use for sending packet to switch
+        @param dst_port_list: list of ports on which to expect packet to come back from the switch
+        @return Boolean
+        '''
+        ip_src = self.src_ip_interval.get_random_ip() if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
+
+        inner_pkt_len = random.randrange(100, 1024) if hash_key == 'inner_length' else 100
+
+        pkt = simple_tcpv6_packet(pktlen=inner_pkt_len if vlan_id == 0 else inner_pkt_len + 4,
+                                dl_vlan_enable=False if vlan_id == 0 else True,
+                                vlan_vid=vlan_id,
+                                vlan_pcp=0,
+                                ipv6_dst=ip_dst,
+                                ipv6_src=ip_src,
+                                tcp_sport=sport,
+                                tcp_dport=dport,
+                                ipv6_hlim=64)
+
+        ipinip_pkt = simple_ipv4ip_packet(
+                                eth_dst=router_mac,
+                                eth_src=src_mac,
+                                ip_src=outer_src_ip,
+                                ip_dst=outer_dst_ip,
+                                inner_frame=pkt['IPv6'])
+        
+        exp_pkt = ipinip_pkt.copy()
+        exp_pkt['IP'].ttl -= 1
+
+        if hash_key == 'ip-proto':
+            ipinip_pkt['IP'].payload['IPv6'].nh = ip_proto
+            exp_pkt['IP'].payload['IPv6'].nh = ip_proto
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
+        # mask the chksum also if masking the ttl
+        if self.ignore_ttl:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
+        
+        send_packet(self, src_port, ipinip_pkt)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'\
+            .format(ipinip_pkt.src,
+                    ipinip_pkt.dst,
+                    ipinip_pkt['IP'].src,
+                    ipinip_pkt['IP'].dst,
+                    ipinip_pkt['IP'].proto,
+                    pkt['IPv6'].src,
+                    pkt['IPv6'].dst,
+                    pkt['IPv6'].nh,
+                    sport,
+                    dport,
+                    src_port))
+
+        rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+        actual_src_mac = Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+    
+    def check_ip_route(self, hash_key, src_port, dst_port_list, outer_src_ip, outer_dst_ip):
+        if self.ipver == 'ipv4':
+            (matched_index, received) = self.check_ipv4_route(hash_key, src_port, dst_port_list, outer_src_ip, outer_dst_ip)
+        else:
+            (matched_index, received) = self.check_ipv6_route(hash_key, src_port, dst_port_list, outer_src_ip, outer_dst_ip)
+
+        assert received
+
+        matched_port = dst_port_list[matched_index]
+        logging.info("Received packet at " + str(matched_port))
+        time.sleep(0.02)
+
+        return (matched_port, received)
+    
+    def check_hash(self, hash_key):
+        # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
+        # We don't care the actually value as long as the outer_dst_ip is routed by default routed
+        # The outer_src_ip and outer_dst_ip are fixed
+        outer_src_ip = '80.1.0.31'
+        outer_dst_ip = '80.1.0.32'
+        src_port, exp_port_list, next_hop = self.get_src_and_exp_ports(outer_dst_ip)
+
+        logging.info("outer_src_ip={}, outer_dst_ip={}, src_port={}, exp_port_list={}".format(outer_src_ip, outer_dst_ip, src_port, exp_port_list))
+        if len(exp_port_list) <= 1:
+            logging.warning("{} has only {} nexthop".format(outer_dst_ip, exp_port_list))
+            assert False
+
+        hit_count_map = {}
+        if hash_key == 'ingress-port':
+            # The 'ingress-port' key is not used in hash by design. We are doing negative test for 'ingress-port'.
+            # When 'ingress-port' is included in HASH_KEYS, the PTF test will try to inject same packet to different
+            # ingress ports and expect that they are forwarded from same egress port.
+            for ingress_port in self.get_ingress_ports(exp_port_list, outer_dst_ip):
+                logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'\
+                    .format(hash_key, ingress_port, exp_port_list, outer_src_ip, outer_dst_ip))
+                (matched_index, _) = self.check_ip_route(hash_key, ingress_port, exp_port_list, outer_src_ip, outer_dst_ip)
+                hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
+            logging.info("hit count map: {}".format(hit_count_map))
+            assert True if len(hit_count_map.keys()) == 1 else False
+        elif hash_key == 'inner_length':
+            # The length of inner_frame is not used as hash key for IPinIP packet.
+            # The test generates IPinIP packets with random inner_frame_length, and then verify the egress path.
+            # The egress port should never change
+            for _ in range(0, self.balancing_test_times*len(exp_port_list)):
+                logging.info('Checking hash key {}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'\
+                         .format(hash_key, exp_port_list, outer_src_ip, outer_dst_ip))
+                (matched_index, _) = self.check_ip_route(hash_key, src_port, exp_port_list, outer_src_ip, outer_dst_ip)
+                hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
+            logging.info("hit count map: {}".format(hit_count_map))
+            assert True if len(hit_count_map.keys()) == 1 else False
+        else:
+            for _ in range(0, self.balancing_test_times*len(exp_port_list)):
+                logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'\
+                    .format(hash_key, src_port, exp_port_list, outer_src_ip, outer_dst_ip))
+                (matched_index, _) = self.check_ip_route(hash_key, src_port, exp_port_list, outer_src_ip, outer_dst_ip)
+                hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
+            logging.info("hash_key={}, hit count map: {}".format(hash_key, hit_count_map))
+
+            self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+
+    def runTest(self):
+        """
+        @summary: Send IPinIP packet for each range of both IPv4 and IPv6 spaces and
+        expect the packet to be received from one of the expected ports
+        """
         for hash_key in self.hash_keys:
             logging.info("hash test hash_key: {}".format(hash_key))
             self.check_hash(hash_key)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -19,6 +19,7 @@ from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.fib_utils import fib_info_files_per_function
 from tests.common.fixtures.fib_utils import single_fib_for_duts
 from tests.common.utilities import wait
+from tests.common.helpers.assertions import pytest_require
 
 logger = logging.getLogger(__name__)
 
@@ -206,7 +207,7 @@ def ipver(request):
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def add_default_route_to_dut(duts_running_config_facts, duthosts, tbinfo):
     """
     Add a default route to the device for storage backend testbed.
@@ -281,3 +282,73 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
             log_file=log_file,
             qlen=PTF_QLEN,
             socket_recv_size=16384)
+
+# The test case is to verify src-ip, dst-ip, src-port, dst-port and ip-proto of inner_frame in a IPinIP packet are
+# used as hash keys
+def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function, hash_keys, ptfhost, ipver,
+              tbinfo, mux_server_url, router_macs,
+              ignore_ttl, single_fib_for_duts):
+    # Skip test on none T1 testbed
+    pytest_require('t1' == tbinfo['topo']['type'], "The test case runs on T1 topology")
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(ipver, timestamp)
+    logging.info("PTF log file: %s" % log_file)
+    if ipver == "ipv4":
+        src_ip_range = SRC_IP_RANGE
+        dst_ip_range = DST_IP_RANGE
+    else:
+        src_ip_range = SRC_IPV6_RANGE
+        dst_ip_range = DST_IPV6_RANGE
+    ptf_runner(ptfhost,
+            "ptftests",
+            "hash_test.IPinIPHashTest",
+            platform_dir="ptftests",
+            params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url),
+                    "hash_keys": hash_keys,
+                    "src_ip_range": ",".join(src_ip_range),
+                    "dst_ip_range": ",".join(dst_ip_range),
+                    "router_macs": router_macs,
+                    "vlan_ids": VLANIDS,
+                    "ignore_ttl":ignore_ttl,
+                    "single_fib_for_duts": single_fib_for_duts,
+                    "ipver": ipver
+                   },
+            log_file=log_file,
+            qlen=PTF_QLEN,
+            socket_recv_size=16384)
+
+# The test is to verify the hashing logic is not using unexpected field as keys
+# Only inner frame length is tested at this moment
+def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files_per_function, ptfhost, ipver,
+              tbinfo, mux_server_url, router_macs,
+              ignore_ttl, single_fib_for_duts):
+    hash_keys = ['inner_length']
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(ipver, timestamp)
+    logging.info("PTF log file: %s" % log_file)
+    if ipver == "ipv4":
+        src_ip_range = SRC_IP_RANGE
+        dst_ip_range = DST_IP_RANGE
+    else:
+        src_ip_range = SRC_IPV6_RANGE
+        dst_ip_range = DST_IPV6_RANGE
+    ptf_runner(ptfhost,
+            "ptftests",
+            "hash_test.IPinIPHashTest",
+            platform_dir="ptftests",
+            params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url),
+                    "hash_keys": hash_keys,
+                    "src_ip_range": ",".join(src_ip_range),
+                    "dst_ip_range": ",".join(dst_ip_range),
+                    "router_macs": router_macs,
+                    "vlan_ids": VLANIDS,
+                    "ignore_ttl":ignore_ttl,
+                    "single_fib_for_duts": single_fib_for_duts,
+                    "ipver": ipver
+                   },
+            log_file=log_file,
+            qlen=PTF_QLEN,
+            socket_recv_size=16384)
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to backport the change in #7605 into `202012` branch.
This PR is to add a test case to verity the hashing for IPinIP packet.
It's expected that the `src_ip`, `dst_ip`, `src_port` and `dst_port` of inner packet are used as hash key.
This PR also adds a negative test case to verify the length of inner_frame is not used as hash key.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to add test cases to verify hashing for IPinIP packet.

#### How did you do it?
Added two test cases
1. test_ipinip_hash to verify the `src_ip`, `dst_ip`, `src_port` and `dst_port` of inner packet are used as hashing key.
2. test_ipinip_hash_negative to verify inner_frame length is not used as hashing key.

#### How did you verify/test it?
The change is verified on a Cisco T1 testbed and Arista T1 testbed.

#### Any platform specific information?
Test case `test_ipinip_hash` is running only on Cisco platform at this moment.
The negative test case `test_ipinip_hash_negative` should run on all platforms.

#### Supported testbed topology if it's a new test case?
Test case `test_ipinip_hash` runs only on T1 topology. 
Test case `test_ipinip_hash_negative` should run on all topologies.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
