### PR TITLE
[snmp]: Use pgrep to kill memory hog process

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -46,7 +46,7 @@ def load_memory(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost.copy(src='snmp/memory.py', dest='/tmp/memory.py')
     duthost.shell("nohup python /tmp/memory.py > /dev/null 2>&1 &")
     yield
-    duthost.shell("killall python /tmp/memory.py", module_ignore_errors=True)
+    duthost.shell("pkill -SIGTERM -f 'python /tmp/memory.py'", module_ignore_errors=True)
 
 def collect_memory(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During the teardown for test_snmp_memory_load, `killall python` is run on the DUT which kills the procdockerstatsd process causing the database container to exit and putting the DUT in an unhealthy state for subsequent tests.

#### How did you do it?
Use `pgrep -f` so that only the process started by the test is killed during teardown.

#### How did you verify/test it?
Run `test_snmp_memory_load`. Verify that the device does not crash, and `show int status` outputs normally afterwards.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
