### PR TITLE
Added a fixture to disable xcvrd during sfputils reset

### DIFF
--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 import logging
 import os
+import json
+from tests.common.utilities import wait_until
 
 ans_host = None
 
@@ -11,23 +13,52 @@ def teardown_module():
     ans_host.file(path=file_path, state='absent')
 
 
-@pytest.fixture(autouse=True)
-def update_la_ignore_errors_list_for_mlnx(duthost, loganalyzer):
-    extended_ignore_list = []
+def check_pmon_service(duthost):
+    pmon_service_state = duthost.get_service_props("pmon")
+    return pmon_service_state["ActiveState"] == "active"
 
-    if loganalyzer:
-        if duthost.facts["asic_type"] in ["mellanox"]:
-            extended_ignore_list.append("kernel.*Eeprom query failed*")
-            # Ignore PMPE error https://github.com/sonic-net/sonic-buildimage/issues/7163
-            extended_ignore_list.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
 
-            for host in loganalyzer:
-                loganalyzer[host].ignore_regex.extend(extended_ignore_list)
+def restart_pmon(duthost):
+    duthost.shell("service pmon restart")
+    if not wait_until(1, 60, 0, check_pmon_service, duthost):
+        pytest.fail('pmon service is not up after 60 seconds. Test failed')
+
+
+def modify_daemon_file(daemon_dict):
+    daemon_dict["skip_xcvrd"] = True
+    daemon_dict.pop("delay_xcvrd", None)
+    daemon_dict.pop("skip_xcvrd_cmis_mgr", None)
+    return daemon_dict
+
+
+def create_json_file(temp_path, pmon_daemon_dict):
+    with open(temp_path, 'w') as pmon_daemon_json:
+        json.dump(pmon_daemon_dict, pmon_daemon_json, indent=4)
+        pmon_daemon_json.write("\n")
+
+
+def backup_original_daemon_file(duthost, pmon_daemon_file_path):
+    duthost.shell("cp {} /tmp/pmon_daemon_control.json".format(pmon_daemon_file_path))
+    original_file_path = os.path.join("/tmp", "pmon_daemon_control.json")
+    return original_file_path
+
+
+@pytest.fixture(autouse=False)
+def stop_xcvrd(duthost):
+    dut_platfrom = duthost.facts['platform']
+    pmon_daemon_path = os.path.join("/usr/share/sonic/device", dut_platfrom)
+    pmon_daemon_file_path = os.path.join(pmon_daemon_path, "pmon_daemon_control.json")
+    original_file_path = backup_original_daemon_file(duthost, pmon_daemon_file_path)
+    cmd = duthost.shell('cat {}'.format(pmon_daemon_file_path))
+    daemon_control_dict = json.loads(cmd['stdout'])
+    modified_dict = modify_daemon_file(daemon_control_dict)
+    temp_path = os.path.join("/tmp", "pmon_daemon_control.json")
+    create_json_file(temp_path, modified_dict)
+    duthost.copy(src=temp_path, dest=pmon_daemon_file_path)
+    restart_pmon(duthost)
 
     yield
+    # return the original daemon control file to the path
+    duthost.shell("mv {} {}".format(original_file_path, pmon_daemon_file_path))
+    restart_pmon(duthost)
 
-    if loganalyzer:
-        if duthost.facts["asic_type"] in ["mellanox"]:
-            for host in loganalyzer:
-                for ignore_regexp in extended_ignore_list:
-                    loganalyzer[host].ignore_regex.remove(ignore_regexp)

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -95,7 +95,7 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
 
 def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                              enum_frontend_asic_index, conn_graph_facts,
-                             tbinfo, xcvr_skip_list, shutdown_ebgp):    # noqa F811
+                             tbinfo, xcvr_skip_list, shutdown_ebgp, stop_xcvrd):    # noqa F811
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Added a fixture to disable xcvrd

Summary:
During SFP reset, cable EEPROM is not accessible, and kernel always return errno -5. Therefore an error message may appear:
`
ERR pmon#xcvrd: Failed to read sfp=8 EEPROM page=/sys/module/sx_core/asic0/module8/eeprom/pages/0/i2c-0x50/data, page_offset=14, size=2, offset=14, error = [Errno 5] Input/output error
`
In order to fix this unwanted message, I added a fixture to stop xcvrd in pmon service during the test,
to avoid race condition when accessing the transceiver. After the test the fixture enables xcvrd again.
This fixture replaces the LogAnalyzer skips to error messages that currently appear becuase the cable EEPROM is not accessible
In the suggested flow, these error messages won't appear.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Avoiding unnecessary error messages and test failures, as the error is expected.

#### How did you do it?
Added a fixture to disable xcvrd during the test, and restart it again after the test session ends.
#### How did you verify/test it?
Ran the mentioned test with this new fixture and checked that the error message doesn't appear.

#### Any platform specific information?
There are few attributes in pmon_daemon_control.json file aren't common to all platforms:
"delay_xcvrd"
"skip_xcvrd_cmis_mgr"
the "pop" method will remove them only if they exist.
