### PR TITLE
[console] Add console baud rate test

### DIFF
--- a/tests/common/helpers/console_helper.py
+++ b/tests/common/helpers/console_helper.py
@@ -1,0 +1,24 @@
+import pytest
+import pexpect
+
+
+def assert_expect_text(client, text, target_line, timeout_sec=0.1):
+    index = client.expect_exact([text, pexpect.EOF, pexpect.TIMEOUT], timeout=timeout_sec)
+    if index == 1:
+        pytest.fail("Encounter early EOF during testing line {}".format(target_line))
+    elif index == 2:
+        pytest.fail("Not able to get expected text in {}s".format(timeout_sec))
+
+
+def create_ssh_client(ip, user, pwd):
+    # Set 'echo=False' is very important since pexpect will echo back all inputs to buffer by default
+    client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'.format(user, ip),
+                           echo=False)
+    client.expect('[Pp]assword:')
+    client.sendline(pwd)
+    return client
+
+
+def ensure_console_session_up(client, line):
+    client.expect_exact('Successful connection to line [{}]'.format(line))
+    client.expect_exact('Press ^A ^X to disconnect')

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -1,7 +1,7 @@
 import pytest
-import pexpect
 import string
 import random
+from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -72,7 +72,7 @@ def test_console_loopback_pingpong(duthost, creds, src_line, dst_line):
         sender = create_ssh_client(dutip, "{}:{}".format(dutuser, src_line), dutpass)
         receiver = create_ssh_client(dutip, "{}:{}".format(dutuser, dst_line), dutpass)
 
-        ensure_console_session_up(sender,   src_line)
+        ensure_console_session_up(sender, src_line)
         ensure_console_session_up(receiver, dst_line)
 
         sender.sendline('ping')
@@ -81,28 +81,6 @@ def test_console_loopback_pingpong(duthost, creds, src_line, dst_line):
         assert_expect_text(sender, 'pong', src_line)
     except Exception:
         pytest.fail("Not able to communicate DUT via reverse SSH")
-
-
-def create_ssh_client(ip, user, pwd):
-    # Set 'echo=False' is very important since pexpect will echo back all inputs to buffer by default
-    client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-                           .format(user, ip), echo=False)
-    client.expect('[Pp]assword:')
-    client.sendline(pwd)
-    return client
-
-
-def ensure_console_session_up(client, line):
-    client.expect_exact('Successful connection to line [{}]'.format(line))
-    client.expect_exact('Press ^A ^X to disconnect')
-
-
-def assert_expect_text(client, text, target_line, timeout_sec=0.1):
-    index = client.expect_exact([text, pexpect.EOF, pexpect.TIMEOUT], timeout=timeout_sec)
-    if index == 1:
-        pytest.fail("Encounter early EOF during testing line {}".format(target_line))
-    elif index == 2:
-        pytest.fail("Not able to get expected text in {}s".format(timeout_sec))
 
 
 def generate_random_string(length):

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -1,0 +1,105 @@
+import pytest
+import time
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
+
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
+
+BAUD_RATE_MAP = {
+    "default": "9600"
+}
+BOOT_TYPE = {
+    "armhf-nokia_ixs7215_52x-r0": "UBoot-ONIE",
+    "x86_64-arista_720dt_48s": "ABoot"
+}
+pass_config_test = True
+
+
+def is_sonic_console(conn_graph_facts, dut_hostname):
+    return conn_graph_facts['device_console_info'][dut_hostname]["Os"] == "sonic"
+
+
+def test_console_baud_rate_config(duthost):
+    global pass_config_test
+    pass_config_test = False
+    platform = duthost.facts["platform"]
+    expected_baud_rate = BAUD_RATE_MAP[platform] if platform in BAUD_RATE_MAP else BAUD_RATE_MAP["default"]
+    res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2",
+                        module_ignore_errors=True)
+    pytest_assert(res["rc"] == 0 and res["stdout"] == expected_baud_rate, "Baud rate {} is unexpected!"
+                  .format(res["stdout"]))
+    pass_config_test = True
+
+
+@pytest.fixture(scope="module")
+def console_client_setup_teardown(duthost, conn_graph_facts, creds):
+    pytest_assert(pass_config_test, "Fail due to failure in test_console_baud_rate_config.")
+    dut_hostname = duthost.hostname
+    console_host = conn_graph_facts['device_console_info'][dut_hostname]['ManagementIp']
+    pytest_require(is_sonic_console(conn_graph_facts, dut_hostname), "Unsupport non-sonic console swith.")
+    console_port = conn_graph_facts['device_console_link'][dut_hostname]['ConsolePort']['peerport']
+    dutuser = creds['sonicadmin_user']
+    dutpass = creds['sonicadmin_password']
+
+    client = None
+    try:
+        client = create_ssh_client(console_host, "{}:{}".format(dutuser, console_port), dutpass)
+    except Exception as err:
+        pytest.fail("Not connect console ssh, error: {}".format(err))
+
+    ensure_console_session_up(client, console_port)
+    client.sendline()
+    assert_expect_text(client, "login:", console_port, timeout_sec=1)
+    client.sendline(dutuser)
+    client.sendline(dutpass)
+    yield client, console_port
+
+    if client is not None:
+        time.sleep(2)
+        client.terminate()
+
+
+@pytest.fixture(scope="module")
+def boot_connect_teardown(console_client_setup_teardown):
+    yield
+    client, _ = console_client_setup_teardown
+    if client is not None:
+        client.sendline("reboot")
+        # Wait DUT to reboot
+        time.sleep(120)
+
+
+def run_aboot_test(client, console_port):
+    assert_expect_text(client, "Press Control-C now to enter Aboot shell", console_port, timeout_sec=120)
+    client.sendcontrol("c")
+    assert_expect_text(client, "Aboot#", console_port, timeout_sec=2)
+
+
+def run_uboot_onie_test(client, console_port):
+    assert_expect_text(client, "Hit any key to stop autoboot", console_port, timeout_sec=180)
+    client.sendline()
+    assert_expect_text(client, "Marvell>>", console_port, timeout_sec=2)
+    client.sendline("run onie_bootcmd")
+    assert_expect_text(client, "Please press Enter to activate this console", console_port, timeout_sec=60)
+    client.sendline()
+    assert_expect_text(client, "ONIE:/ #", console_port, timeout_sec=60)
+
+
+def test_baud_rate_sonic_connect(console_client_setup_teardown):
+    client, console_port = console_client_setup_teardown
+    assert_expect_text(client, "Last login:", console_port, timeout_sec=5)
+
+
+def test_baud_rate_boot_connect(duthost, console_client_setup_teardown, boot_connect_teardown):
+    client, console_port = console_client_setup_teardown
+    platform = duthost.facts["platform"]
+    pytest_require(platform in BOOT_TYPE, "Unsupported platform: {}".format(platform))
+    client.sendline("sudo reboot")
+    if BOOT_TYPE[platform] == "ABoot":
+        run_aboot_test(client, console_port)
+    elif BOOT_TYPE[platform] == "UBoot-ONIE":
+        run_uboot_onie_test(client, console_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [# 5399](https://github.com/sonic-net/sonic-mgmt/issues/5399)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add test case to verify the console's baud rate is 9600

#### How did you do it?
1. Verify console baud rate in sonic by cmdfile.
2. Connect to DUT by console to verify the actual baud rate.
3. While connecting by console, reboot to aboot/onie to verify baud rate.

#### How did you verify/test it?
Run tests
```
collected 3 items

dut_console/test_console_baud_rate.py::test_console_baud_rate_config PASSED                                                                                                                  [ 33%]
dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect PASSED                                                                                                                   [ 66%]
dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect PASSED                                                                                                                    [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
