### PR TITLE
[Python3 migration] Fix Python3 compatibility issue in test_syslog_rate_limit.py and test_show_platform.py

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import six
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.devices.sonic_asic import SonicAsic
 
@@ -87,7 +88,10 @@ class SonicDbCli(object):
         if result == {}:
             raise SonicDbKeyNotFound("Key: %s, field: %s not found in sonic-db cmd: %s" % (key, field, cmd))
         else:
-            return result['stdout'].decode('unicode-escape')
+            if six.PY2:
+                return result['stdout'].decode('unicode-escape')
+            else:
+                return result['stdout']
 
     def get_and_check_key_value(self, key, value, field=None):
         """

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -13,6 +13,7 @@ import json
 import logging
 import re
 import pytest
+import six
 from . import util
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
@@ -281,8 +282,12 @@ def verify_show_platform_fan_output(duthost, raw_output_lines):
     pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output on '{}'".
                   format(duthost.hostname))
     if len(raw_output_lines) == 1:
-        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Fan Not detected",
-                      "Unexpected fan status output on '{}'".format(duthost.hostname))
+        if six.PY2:
+            pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Fan Not detected",
+                          "Unexpected fan status output on '{}'".format(duthost.hostname))
+        else:
+            pytest_assert(raw_output_lines[0].strip() == "Fan Not detected",
+                          "Unexpected fan status output on '{}'".format(duthost.hostname))
     else:
         pytest_assert(len(raw_output_lines) > 2,
                       "There must be at least two lines of output if any fan is detected on '{}'".
@@ -340,8 +345,12 @@ def verify_show_platform_temperature_output(raw_output_lines, hostname):
 
     pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output on '{}'".format(hostname))
     if len(raw_output_lines) == 1:
-        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thermal Not detected",
-                      "Unexpected thermal status output on '{}'".format(hostname))
+        if six.PY2:
+            pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thermal Not detected",
+                          "Unexpected thermal status output on '{}'".format(hostname))
+        else:
+            pytest_assert(raw_output_lines[0].strip() == "Thermal Not detected",
+                          "Unexpected thermal status output on '{}'".format(hostname))
     else:
         pytest_assert(len(raw_output_lines) > 2,
                       "There must be at least two lines of output if any thermal is detected on '{}'".format(hostname))

--- a/tests/platform_tests/cli/util.py
+++ b/tests/platform_tests/cli/util.py
@@ -3,6 +3,7 @@ util.py
 
 Utility functions for testing SONiC CLI
 """
+import six
 
 
 def parse_colon_speparated_lines(lines):
@@ -58,7 +59,10 @@ def get_fields(line, field_ranges):
     """
     fields = []
     for field_range in field_ranges:
-        field = line[field_range[0]:field_range[1]].encode('utf-8')
+        if six.PY2:
+            field = line[field_range[0]:field_range[1]].encode('utf-8')
+        else:
+            field = line[field_range[0]:field_range[1]]
         fields.append(field.strip())
 
     return fields

--- a/tests/python3_test_files.txt
+++ b/tests/python3_test_files.txt
@@ -359,6 +359,7 @@ syslog/__init__.py
 syslog/conftest.py
 syslog/syslog_utils.py
 syslog/test_syslog.py
+syslog/test_syslog_rate_limit.py
 crm/conftest.py
 crm/test_crm.py
 mpls/test_mpls.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add test_syslog_rate_limit.py to Python3 running list

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Python3 compatibility issue found in smoke test and reported by @nhe-NV 

#### How did you do it?
1. Add test_syslog_rate_limit.py to Python3 running list file: tests/python3_test_files.txt
2. Fix string compatibility issue in tests/common/helpers/sonic_db.py
3. Fix string compatibility issue in test_show_platform.py

#### How did you verify/test it?
Manually the test case

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A