### PR TITLE
Fix the qos/test_qos_sai.py testQosSaiSharedReservationSize case failures on T0/T0-Dualtor

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2322,7 +2322,6 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116']:
                 # Send a packet from each ptf dst port to make DUT generate FDB for the destination ports
-                ttl = 64
                 pkt = construct_ip_pkt(64,
                                        src_port_mac,
                                        dst_port_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes testQosSaiSharedReservationSize case failures on Cisco T0/T0-Dualtor

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Fix the qos/test_qos_sai.py testQosSaiSharedReservationSize test cases failure on T0/dualtor.

#### How did you do it?
the case totally needs 12 ports to consume the shared memory. On T1, there are many port channels interfaces so the members of port channels are used for the test ports. While on the T0, there are just 4 port channels with 8 members in total, which is not enough. So on T0, the vlan trunk ports have to be used.
With the vlan trunk ports, the packets can be forwarded to multiple ports in vlan due to lacking of FDB entry for destination ports, that can be resolved by making the ptf send a packet from each destination port

#### How did you verify/test it?
test a few times, cases passed on T0/dualtor 
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[tor40-2-None-shared_res_size_1] PASSED [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[tor40-2-None-shared_res_size_2] PASSED [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
