### PR TITLE
Probe mux cable when sanity check fails in show mux status

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -531,10 +531,17 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
 
     for row in upper_tor_mux_config:
         port_name = row["port"]
+        port_idx = str(duts_minigraph_facts[dut_upper_tor.hostname][0][1]['minigraph_port_indices'][port_name])
         if "cable_type" in row:
             if row["cable_type"] and row["cable_type"] not in (CableType.active_active, CableType.active_standby):
                 err_msg = "Unsupported cable type %s for %s" % (row["cable_type"], port_name)
                 return False, err_msg, {}
+            elif row["cable_type"]:
+                port_cable_types[port_idx] = row["cable_type"]
+            else:
+                port_cable_types[port_idx] = CableType.default_type
+        else:
+            port_cable_types[port_idx] = CableType.default_type
 
     duts_parsed_mux_status = {}
     err_msg_from_mux_status = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Without icmp_responder, linkmgrd is stuck in wait state and it has
larger mux probe interval. So the mux status sync between linkmgrd and
the mux simulator takes longer time, and sanity check may fail in "show mux status"
#### How did you do it?
Probe mux for unchanged ports to reduce wait time
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
