### PR TITLE
[202205] fix script issue caused by cherry pick commit

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -4,6 +4,7 @@ import ipaddress
 import time
 import natsort
 import random
+import six
 import re
 from collections import defaultdict
 
@@ -228,7 +229,7 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
         check_static_route(duthost, prefix, nexthop_addrs, ipv6=ipv6)
 
         # Check traffic get forwarded to the nexthop
-        ip_dst = str(ipaddress.ip_network(str(prefix))[1])
+        ip_dst = ipaddress.ip_network(six.u(prefix))[1]
         # try to refresh arp entry before traffic testing to improve stability
         for nexthop_addr in nexthop_addrs:
             duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)


### PR DESCRIPTION
Summary:

```
AddressValueError: '1.1.1.0/24' does not appear to be an IPv4 or IPv6 network. Did you pass in a bytes (str in Python 2) instead of a unicode object?

-        ip_dst = str(ipaddress.ip_network(unicode(prefix))[1])
-        with RouteFlowCounterTestContext(is_route_flow_counter_supported, duthost, [prefix], {prefix: {'packets': '1'}}):
+        ip_dst = str(ipaddress.ip_network(str(prefix))[1])
+        # try to refresh arp entry before traffic testing to improve stability
```

Original commit
https://github.com/sonic-net/sonic-mgmt/pull/7898



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
re-run test_static_route.py

![image](https://user-images.githubusercontent.com/111116206/229399280-82363b94-87ae-415b-830c-9b11485fdc1a.png)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
