### PR TITLE
[qos] remove swich mac change behavior in qos sai test

### DIFF
--- a/tests/saitests/switch.py
+++ b/tests/saitests/switch.py
@@ -74,12 +74,6 @@ def switch_init(client):
         else:
             print("unknown switch attribute")
 
-    # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
-    # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
-    attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
-    attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
-    client.sai_thrift_set_switch_attribute(attr)
-
     # wait till the port are up
     time.sleep(10)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

saw test teardown error in nightly test, as below:
SAI_API_SWITCH:brcm_sai_set_switch_attribute:3435 updating switch mac addr failed with error -2.

RCA:
error was introduced by switch mac modify behavior in "tests/saitests/switch.py", as below:
```
def switch_init(client):
   ... omitted ...
    # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
    # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
    attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
    attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
    client.sai_thrift_set_switch_attribute(attr)
   ... omitted ...
```

#### How did you do it?

don't need to update switch mac address in qos sai test, remove this code snippet which is introduced 8 years ago.
and list reasons below:
- in sonic image, no command to change switch mac addr. just set swtich mac once, when create switch vai sai API. So dynamically changing switch mac is not valid usecase.
- in mgmt test script set,  only qos sai will try to change value of swich attribute SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, and do not see new mac address '00:77:66:55:44:33' is used in qos test. So looks like this mac address change is not necceary.

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
