### PR TITLE
[202205][m0][acl] Add two scenarios support for M0 in ipv4 acl test (#7921)

### DIFF
--- a/tests/acl/templates/acltb_test_rules.j2
+++ b/tests/acl/templates/acltb_test_rules.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.66/32"
+                                    }
+                                }
+                            },
+                            "31": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 31
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.67/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.66/32"
+                                    }
+                                }
+                            },
+                            "31": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 31
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.67/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -492,6 +492,36 @@
                                         "code": "0"
                                     }
                                 }
+                            },
+                            "32": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 32
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::1/128"
+                                    }
+                                }
+                            },
+                            "33": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 33
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "32": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 32
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::1/128"
+                                    }
+                                }
+                            },
+                            "33": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 33
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -21,6 +21,7 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,34 @@ DOWNSTREAM_IP_TO_ALLOW = {
     "ipv6": "20c0:a800::1"
 }
 DOWNSTREAM_IP_TO_BLOCK = {
+    "ipv4": "192.168.0.251",
+    "ipv6": "20c0:a800::9"
+}
+
+# Below M0_L3 IPs are announced to DUT by annouce_route.py, it point to neighbor mx
+DOWNSTREAM_DST_IP_M0_L3 = {
+    "ipv4": "192.168.1.65",
+    "ipv6": "20c0:a800:0:1::14"
+}
+DOWNSTREAM_IP_TO_ALLOW_M0_L3 = {
+    "ipv4": "192.168.1.66",
+    "ipv6": "20c0:a800:0:1::1"
+}
+DOWNSTREAM_IP_TO_BLOCK_M0_L3 = {
+    "ipv4": "192.168.1.67",
+    "ipv6": "20c0:a800:0:1::9"
+}
+
+# Below M0_VLAN IPs are ip in vlan range
+DOWNSTREAM_DST_IP_M0_VLAN = {
+    "ipv4": "192.168.0.253",
+    "ipv6": "20c0:a800::14"
+}
+DOWNSTREAM_IP_TO_ALLOW_M0_VLAN = {
+    "ipv4": "192.168.0.252",
+    "ipv6": "20c0:a800::1"
+}
+DOWNSTREAM_IP_TO_BLOCK_M0_VLAN = {
     "ipv4": "192.168.0.251",
     "ipv6": "20c0:a800::9"
 }
@@ -204,7 +233,7 @@ def get_t2_info(duthosts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
+def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario):
     """Gather all required test information from DUT and tbinfo.
 
     Args:
@@ -222,8 +251,21 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
 
     vlan_ports = []
     vlan_mac = None
+    # Need to refresh below constants for two scenarios of M0
+    global DOWNSTREAM_DST_IP, DOWNSTREAM_IP_TO_ALLOW, DOWNSTREAM_IP_TO_BLOCK
 
-    if topo in ["t0", "m0", "mx"]:
+    # Announce routes for m0 is something different from t1/t0
+    if topo_scenario == "m0_vlan_scenario":
+        topo = "m0_vlan"
+        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_VLAN
+        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_M0_VLAN
+        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_VLAN
+    elif topo_scenario == "m0_l3_scenario":
+        topo = "m0_l3"
+        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_L3
+        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_M0_L3
+        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_L3
+    if topo in ["t0", "mx", "m0_vlan"]:
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
                       for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
 
@@ -241,8 +283,8 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     upstream_port_id_to_router_mac_map = {}
     downstream_port_id_to_router_mac_map = {}
 
-    # For M0/T0/dual ToR testbeds, we need to use the VLAN MAC to interact with downstream ports
-    # For T1 testbeds, no VLANs are present so using the router MAC is acceptable
+    # For M0_VLAN/MX/T0/dual ToR scenario, we need to use the VLAN MAC to interact with downstream ports
+    # For T1/M0_L3 scenario, no VLANs are present so using the router MAC is acceptable
     downlink_dst_mac = vlan_mac if vlan_mac is not None else rand_selected_dut.facts["router_mac"]
 
     if topo == "t2":
@@ -252,15 +294,17 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         downstream_port_id_to_router_mac_map = t2_info['downstream_port_id_to_router_mac_map']
         upstream_port_id_to_router_mac_map = t2_info['upstream_port_id_to_router_mac_map']
     else:
+        upstream_neigh_type = get_upstream_neigh_type(topo)
+        downstream_neigh_type = get_downstream_neigh_type(topo)
+        pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
+                       "Cannot get neighbor type for unsupported topo: {}".format(topo))
         for interface, neighbor in mg_facts["minigraph_neighbors"].items():
             port_id = mg_facts["minigraph_ptf_indices"][interface]
-            if (topo == "t1" and "T0" in neighbor["name"]) or \
-               (topo in ["t0", "m0", "mx"] and "Server" in neighbor["name"]):
+            if downstream_neigh_type in neighbor["name"].upper():
                 downstream_ports[neighbor['namespace']].append(interface)
                 downstream_port_ids.append(port_id)
                 downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
-            elif (topo == "t1" and "T2" in neighbor["name"]) or (topo == "t0" and "T1" in neighbor["name"]) or \
-                 (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]):
+            elif upstream_neigh_type in neighbor["name"].upper():
                 upstream_ports[neighbor['namespace']].append(interface)
                 upstream_port_ids.append(port_id)
                 upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
@@ -287,14 +331,15 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     # TODO: We should make this more robust (i.e. bind all active front-panel ports)
     acl_table_ports = defaultdict(list)
 
-    if topo in ["t0", "m0", "mx"] or tbinfo["topo"]["name"] in ("t1", "t1-lag"):
+    if topo in ["t0", "mx", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1", "t1-lag"):
         for namespace, port in downstream_ports.iteritems():
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.
             if namespace:
                 acl_table_ports[''] += port
 
-    if topo in ["t0", "m0"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet", "t1-56-lag"):
+    if topo in ["t0", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet",
+                                                                        "t1-56-lag"):
         for k, v in port_channels.iteritems():
             acl_table_ports[v['namespace']].append(k)
             # In multi-asic we need config both in host and namespace.
@@ -338,9 +383,11 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
 
 
 @pytest.fixture(scope="module", params=["ipv4", "ipv6"])
-def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
-    if tbinfo["topo"]["type"] in ["t0", "m0", "mx"] and request.param == "ipv6":
-        pytest.skip("IPV6 ACL test not currently supported on t0/m0 testbeds")
+def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname, topo_scenario):
+    if tbinfo["topo"]["type"] in ["t0", "mx"] and request.param == "ipv6":
+        pytest.skip("IPV6 ACL test not currently supported on t0/mx testbeds")
+    if topo_scenario == "m0_vlan_scenario" and request.param == "ipv6":
+        pytest.skip("IPV6 ACL test not currently supported on m0_vlan")
 
     return request.param
 
@@ -348,14 +395,17 @@ def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
 @pytest.fixture(scope="module")
 def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, ip_version):
     """Set up the ARP responder utility in the PTF container."""
+    global DOWNSTREAM_IP_PORT_MAP
+    # For m0 topo, need to refresh this constant for two different scenario
+    DOWNSTREAM_IP_PORT_MAP = {}
     duthost = duthosts[rand_one_dut_hostname]
-    if setup["topo"] not in ["t0", "m0", "mx"]:
+    if setup["topo"] not in ["t0", "mx", "m0_vlan"]:
         def noop():
             pass
 
         yield noop
 
-        return  # Don't fall through to t0/m0 case
+        return  # Don't fall through to t0/mx/m0_vlan case
 
     addr_list = [DOWNSTREAM_DST_IP[ip_version], DOWNSTREAM_IP_TO_ALLOW[ip_version], DOWNSTREAM_IP_TO_BLOCK[ip_version]]
 
@@ -866,23 +916,47 @@ class BaseAclTest(object):
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(7)
 
-    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version,
+                                     topo_scenario):
         """Verify that we can match and forward a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
-        counters_sanity_check.append(2 if direction == "uplink->downlink" else 3)
+        # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
+        if direction == "uplink->downlink":
+            if topo_scenario == "m0_l3_scenario":
+                if ip_version == "ipv6":
+                    rule_id = 32
+                else:
+                    rule_id = 30
+            else:
+                rule_id = 2
+        else:
+            rule_id = 3
+        counters_sanity_check.append(rule_id)
 
-    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version,
+                                   topo_scenario):
         """Verify that we can match and drop a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
-        counters_sanity_check.append(15 if direction == "uplink->downlink" else 16)
+        # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
+        if direction == "uplink->downlink":
+            if topo_scenario == "m0_l3_scenario":
+                if ip_version == "ipv6":
+                    rule_id = 33
+                else:
+                    rule_id = 31
+            else:
+                rule_id = 15
+        else:
+            rule_id = 16
+        counters_sanity_check.append(rule_id)
 
     def test_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop a packet on source IP."""

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -24,7 +24,7 @@ from ansible.vars.manager import VariableManager
 from tests.common import constants
 from tests.common.cache import cached
 from tests.common.cache import FactsCache
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
@@ -784,5 +784,18 @@ def get_upstream_neigh_type(topo_type, is_upper=True):
     """
     if topo_type in UPSTREAM_NEIGHBOR_MAP:
         return UPSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_type]
+
+    return None
+
+def get_downstream_neigh_type(topo_type, is_upper=True):
+    """
+    @summary: Get neighbor type by topo type
+    @param topo_type: topo type
+    @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
+    @return a str
+        Sample output: "mx"
+    """
+    if topo_type in DOWNSTREAM_NEIGHBOR_MAP:
+        return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
 
     return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/7921
In previous acl test, m0 only performs like t0, this PR is to add support to simulate both t0 and t1 scenario.

#### How did you do it?
1. IPv4 test
For m0_vlan_scenario, it is more likely t0, so just performs like t0.
For m0_l3_scenario tested downstream IPs for t1 is in vlan of m0 because m0 has a vlan but t1 doesn't have. So I added new tested IPs and add support for it. Because tested IPs has been changed, so I changed verify rule id for m0 in counters_sanity_check while in teardown period.
2. IPv6 test
Add support for m0_l3_scenario, not support m0_vlan_scenario for now.

#### How did you verify/test it?
Run test on M0/T0/T1 testbeds, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
