### PR TITLE
Adding missing asic_type param to sai_thrift_read_port_counters in LosslessVoq test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1289,11 +1289,12 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         recv_counters_base1, queue_counters = sai_thrift_read_port_counters(
-            self.src_client, port_list['src'][src_port_1_id])
+            self.src_client, asic_type, port_list['src'][src_port_1_id])
         recv_counters_base2, queue_counters = sai_thrift_read_port_counters(
-            self.src_client, port_list['src'][src_port_2_id])
+            self.src_client, asic_type, port_list['src'][src_port_2_id])
         xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.dst_client, port_list['dst'][dst_port_id])
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
+
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1327,11 +1328,11 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters1, queue_counters = sai_thrift_read_port_counters(
-                self.src_client, port_list['src'][src_port_1_id])
+                self.src_client, asic_type, port_list['src'][src_port_1_id])
             recv_counters2, queue_counters = sai_thrift_read_port_counters(
-                self.src_client, port_list['src'][src_port_2_id])
+                self.src_client, asic_type, port_list['src'][src_port_2_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.dst_client, port_list['dst'][dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             pfc_txd = recv_counters1[pg] - recv_counters_base1[pg]
             assert pfc_txd == 0, "Unexpected PFC TX {} on port {}".format(pfc_txd, src_port_1_id)
@@ -1368,11 +1369,11 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters_base1 = recv_counters1
             recv_counters_base2 = recv_counters2
             recv_counters1, queue_counters = sai_thrift_read_port_counters(
-                self.src_client, port_list['src'][src_port_1_id])
+                self.src_client, asic_type, port_list['src'][src_port_1_id])
             recv_counters2, queue_counters = sai_thrift_read_port_counters(
-                self.src_client, port_list['src'][src_port_2_id])
+                self.src_client, asic_type, port_list['src'][src_port_2_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.dst_client, port_list['dst'][dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port pfc
             assert recv_counters1[pg] > recv_counters_base1[pg], "PFC TX counters did not increase for port {}".format(src_port_1_id)
             assert recv_counters2[pg] > recv_counters_base2[pg], "PFC TX counters did not increase for port {}".format(src_port_2_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR[# 7556](https://github.com/sonic-net/sonic-mgmt/pull/7556) to support multi-asic, mulit-dut scenarios for QoS tests, missed adding asic_type param to the sai_thrift_read_port_counters in LosslessVoq test
#### How did you do it?
Added asic_type param to the sai_thrift_read_port_counters call in LosslessVoq  tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
