### PR TITLE
[chassis] [test_link_down] remove extra loop for linecards, wait for linecards to startup

### DIFF
--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -174,8 +174,11 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     # Also make sure fanout hosts' links are down
     link_status_on_all_fanouts(localhost, fanouts_and_ports, up=False)
 
-    # Wait for ssh port to open up on the DUT
+    # Wait for ssh port to open up on the SUP
     wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
+    # Wait for ssh port to open up on the linecards
+    for linecard in duthosts.frontend_nodes:
+        wait_for_startup(linecard, localhost, 0, MAX_TIME_TO_REBOOT)
 
     dut_uptime = duthost.get_up_time()
     logger.info('DUT {} up since {}'.format(hostname, dut_uptime))

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -127,7 +127,8 @@ def link_status_on_all_fanouts(localhost, fanouts_and_ports, up=True):
     """
     Return:
         True: if up=True, and all links on all fanout hosts are up
-        False: if up=False, and all link on all fanout hosts are down
+              or
+              if up=False, and all link on all fanout hosts are down
     """
     link_status_on_host(localhost, fanouts_and_ports, up)
     logger.info("All interfaces on all fanouts are {}!".format('up' if up else 'down'))

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -89,25 +89,25 @@ def fanout_hosts_and_ports(fanouthosts, duts_and_ports):
 
 def links_down(fanout, ports):
     """
-        Input:
-            ports: set of ports on this fanout
-        Returns:
-            True: if all ports are down
-            False: if any port is up
+    Input:
+        ports: set of ports on this fanout
+    Returns:
+        True: if all ports are down
+        False: if any port is up
     """
     return fanout.links_status_down(ports)
 
 
 def links_up(fanout, ports):
     """
-        Returns:
-            True: if all ports are up
-            False: if any port is down
+    Returns:
+        True: if all ports are up
+        False: if any port is down
     """
     return fanout.links_status_up(ports)
 
 
-def link_status_on_host(duthost, localhost, fanouts_and_ports, up=True):
+def link_status_on_host(localhost, fanouts_and_ports, up=True):
     for fanout, ports in list(fanouts_and_ports.items()):
         hostname = fanout.hostname
         # Assumption here is all fanouts are healthy.
@@ -123,14 +123,14 @@ def link_status_on_host(duthost, localhost, fanouts_and_ports, up=True):
     return True
 
 
-def link_status_on_all_LC(duthosts, localhost, fanouts_and_ports, up=True):
+def link_status_on_all_fanouts(localhost, fanouts_and_ports, up=True):
     """
     Return:
-        True: all links on all LCs are down
+        True: if up=True, and all links on all fanout hosts are up
+        False: if up=False, and all link on all fanout hosts are down
     """
-    for LC in duthosts.frontend_nodes:
-        link_status_on_host(LC, localhost, fanouts_and_ports, up)
-    logger.info("All interfaces on all linecards are {}!".format('up' if up else 'down'))
+    link_status_on_host(localhost, fanouts_and_ports, up)
+    logger.info("All interfaces on all fanouts are {}!".format('up' if up else 'down'))
     return True    
 
 
@@ -162,7 +162,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, duts_and_ports)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_all_LC(duthosts, localhost, fanouts_and_ports)
+    link_status_on_all_fanouts(localhost, fanouts_and_ports)
     
     # Get a dut uptime before reboot
     dut_uptime_before = duthost.get_up_time()
@@ -170,8 +170,8 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     # Reboot RP should reboot both RP&LC, should detect all links on all linecards go down
     reboot(duthost, localhost, wait_for_ssh=False)
 
-    # RP doesn't have any interfaces, check all LCs' interfaces
-    link_status_on_all_LC(duthosts, localhost, fanouts_and_ports, up=False)
+    # Also make sure fanout hosts' links are down
+    link_status_on_all_fanouts(localhost, fanouts_and_ports, up=False)
 
     # Wait for ssh port to open up on the DUT
     wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
@@ -185,7 +185,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_all_LC(duthosts, localhost, fanouts_and_ports)
+    link_status_on_all_fanouts(localhost, fanouts_and_ports)
 
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostname, 
@@ -201,7 +201,7 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostn
     fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, dut_ports)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_host(duthost, localhost, fanouts_and_ports)
+    link_status_on_host(localhost, fanouts_and_ports)
 
     # Get a dut uptime before reboot
     dut_uptime_before = duthost.get_up_time()
@@ -209,8 +209,8 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostn
     # Reboot dut, we should detect this host's fanout switches have all links down
     reboot(duthost, localhost, wait_for_ssh=False)
 
-    # After reboot, immediately check for links 'down' status
-    link_status_on_host(duthost, localhost, fanouts_and_ports, up=False)
+    # After reboot, immediately check if all links on all fanouts are down
+    link_status_on_host(localhost, fanouts_and_ports, up=False)
 
     # Wait for ssh port to open up on the DUT
     wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
@@ -224,4 +224,4 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostn
     check_interfaces_and_services(duthost, conn_graph_facts["device_conn"][hostname], xcvr_skip_list)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_host(duthost, localhost, fanouts_and_ports)
+    link_status_on_host(localhost, fanouts_and_ports)


### PR DESCRIPTION
1. Remove loop for linecards when checking fanouts' links status, as fanouts are already found and saved from all linecards earlier in `fanout_hosts_and_ports`
2. After sup reboot in `test_link_down_on_sup`, besides waiting for SUP to come back up, also wait for liencards to come back up, before checking linecards critical services/process/interfaces etc.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
```
        wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
    
        dut_uptime = duthost.get_up_time()
        logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
        rebooted = float(dut_uptime_before.strftime("%s")) != float(dut_uptime.strftime("%s"))
        assert rebooted, "Device {} did not reboot".format(hostname)
    
        # Verify that the links are all LCs are up
>       check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list)
        pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
>                     "Not all critical processes are healthy")
E       Failed: Not all critical processes are healthy

dut        = <MultiAsicSonicHost chassis-lc5-1>
```
After:
```
platform_tests/test_link_down.py::test_link_down_on_sup_reboot[chassis-sup-1] PASSED [ 25%]
platform_tests/test_link_down.py::test_link_status_on_host_reboot[chassis--lc5-1] PASSED [ 50%]
platform_tests/test_link_down.py::test_link_status_on_host_reboot[chassis--lc3-1] PASSED [ 75%]
platform_tests/test_link_down.py::test_link_status_on_host_reboot[chassis--lc7-1] PASSED [100%]

- generated xml file: /azp/_work/49/s/tests/logs/platform_tests/test_link_down.xml -
========================= 4 passed in 2977.17 seconds ==========================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
