### PR TITLE
Fix type mismatch error

### DIFF
--- a/tests/common/dualtor/server_traffic_utils.py
+++ b/tests/common/dualtor/server_traffic_utils.py
@@ -5,7 +5,7 @@ import tempfile
 import sys
 import time
 
-from io import BytesIO
+from io import StringIO
 from ptf.dataplane import match_exp_pkt
 from scapy.all import sniff
 from scapy.packet import ls
@@ -97,7 +97,7 @@ class ServerTrafficMonitor(object):
     @staticmethod
     def _list_layer_str(packet):
         """Return list layer output string."""
-        _stdout, sys.stdout = sys.stdout, BytesIO()
+        _stdout, sys.stdout = sys.stdout, StringIO()
         try:
             ls(packet)
             return sys.stdout.getvalue()

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 import traceback
-from io import BytesIO
+from io import StringIO
 from ast import literal_eval
 
 import pytest
@@ -502,7 +502,7 @@ def compare_crm_facts(left, right):
 
 def dump_scapy_packet_show_output(packet):
     """Dump packet show output to string."""
-    _stdout, sys.stdout = sys.stdout, BytesIO()
+    _stdout, sys.stdout = sys.stdout, StringIO()
     try:
         packet.show()
         return sys.stdout.getvalue()
@@ -800,6 +800,7 @@ def get_upstream_neigh_type(topo_type, is_upper=True):
         return UPSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_type]
 
     return None
+
 
 def get_downstream_neigh_type(topo_type, is_upper=True):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Fix type mismatch error.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To fix the TypeError raised in dualtor/test_tor_ecn.py.
packet.show() method returns Unicode strings, which cannot be written to a BytesIO object in Python3. Therefore, the TypeError is raised. 

#### How did you do it?
To fix this issue, we need to use StringIO instead of BytesIO to capture the output of the packet.show() method as strings.

#### How did you verify/test it?
Run the test locally.

#### Any platform-specific information?
None.

Signed-off-by: zitingguo <zitingguo@microsoft.com>

