### PR TITLE
Improvising pre_checks for test_reload config 

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -195,7 +195,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
 
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
-           reboot_helper=None, reboot_kwargs=None):
+           reboot_helper=None, reboot_kwargs=None, plt_reboot_ctrl_overwrite=True):
     """
     reboots DUT
     :param duthost: DUT host object
@@ -221,9 +221,10 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
             timeout = reboot_ctrl['timeout']
         if wait == 0:
             wait = reboot_ctrl['wait']
-            if plt_reboot_ctrl:
-                wait = plt_reboot_ctrl['wait']
-                timeout = plt_reboot_ctrl['timeout']
+        if plt_reboot_ctrl_overwrite and plt_reboot_ctrl:
+            # get 'wait' and 'timeout' from inventory if they are specified, otherwise use current values
+            wait = plt_reboot_ctrl.get('wait', wait)
+            timeout = plt_reboot_ctrl.get('timeout', timeout)
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
     except KeyError:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -221,9 +221,9 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
             timeout = reboot_ctrl['timeout']
         if wait == 0:
             wait = reboot_ctrl['wait']
-        if plt_reboot_ctrl:
-            wait = plt_reboot_ctrl['wait']
-            timeout = plt_reboot_ctrl['timeout']
+            if plt_reboot_ctrl:
+                wait = plt_reboot_ctrl['wait']
+                timeout = plt_reboot_ctrl['timeout']
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
     except KeyError:

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -88,7 +88,8 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname,
     if not config_force_option_supported(duthost):
         return
 
-    reboot(duthost, localhost, reboot_type="cold", wait=5)
+    reboot(duthost, localhost, reboot_type="cold", wait=5,
+           plt_reboot_ctrl_overwrite=False)
 
     # Check if all database containers have started
     wait_until(60, 1, 0, check_database_status, duthost)
@@ -114,7 +115,8 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname,
     wait_until(60, 1, 0, check_database_status, duthost)
     # Check if interfaces-config.service is exited
     wait_until(60, 1, 0, check_interfaces_config_service_status, duthost)
-    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
+    out = duthost.shell("sudo config reload -y",
+                        executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -23,11 +23,12 @@ pytestmark = [
 ]
 
 
-def test_reload_configuration(duthosts, rand_one_dut_hostname, conn_graph_facts, xcvr_skip_list):       # noqa F811
+def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
+                              conn_graph_facts, xcvr_skip_list):       # noqa F811
     """
     @summary: This test case is to reload the configuration and check platform status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     asic_type = duthost.facts["asic_type"]
 
@@ -78,12 +79,12 @@ def check_database_status(duthost):
     return True
 
 
-def test_reload_configuration_checks(duthosts, rand_one_dut_hostname,
+def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
                                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to test various system checks in config reload
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     if not config_force_option_supported(duthost):
         return

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -114,8 +114,7 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname,
     wait_until(60, 1, 0, check_database_status, duthost)
     # Check if interfaces-config.service is exited
     wait_until(60, 1, 0, check_interfaces_config_service_status, duthost)
-    out = duthost.shell("sudo config reload -y",
-			 executable="/bin/bash", module_ignore_errors=True)
+    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -110,8 +110,12 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname,
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
     logging.info("Checking config reload after system is up")
+    # Check if all database containers have started
+    wait_until(60, 1, 0, check_database_status, duthost)
+    # Check if interfaces-config.service is exited
+    wait_until(60, 1, 0, check_interfaces_config_service_status, duthost)
     out = duthost.shell("sudo config reload -y",
-                        executable="/bin/bash", module_ignore_errors=True)
+			 executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR is an add-on to the PR #7289.To resolve intermittent failures in test_reload_configuration_checks,

Summary:
Fixes # (issue)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

test_config_reload is failing intermittently at:
- [Line 97](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/test_reload_config.py#L97).  Even though wait parameter to reboot is being passed as 5, but if plt_reboot_dict is defined in the inventory, this wait time would be overwritten to value in plt_reboot_dict - [Line 220](https://github.com/sonic-net/sonic-mgmt/blob/34ce7e3c2cec20a7619af5b005dea21282bed8ef/tests/common/reboot.py#L220)

- [Line 108](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/test_reload_config.py#L108). After successful config reload, we are not checking for database service has started before executing config reload again. If database service has not started, we see the following exception:
```
"Traceback (most recent call last):File \"/usr/local/bin/config\", line 8, in <module>
    sys.exit(config())\n  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 764, in __call__
   return self.main(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 717, in main\n    rv = self.invoke(ctx)  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 1134, in invoke   Command.invoke(self, ctx) File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 956, in invoke    return ctx.invoke(self.callback, **ctx.params)  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 555, in invoke    return callback(*args, **kwargs)  File \"/usr/local/lib/python3.9/dist-packages/click/decorators.py\", line 17, in new_func    return f(get_current_context(), *args, **kwargs)  File \"/usr/local/lib/python3.9/dist-packages/config/main.py\", line 1104, in config    ctx.obj = Db()  File \"/usr/local/lib/python3.9/dist-packages/utilities_common/db.py\", line 12, in __init__    self.cfgdb.connect()  File \"/usr/lib/python3/dist-packages/swsscommon/swsscommon.py\", line 1862, in connect    return _swsscommon.ConfigDBConnector_Native_connect(self, wait_for_init, retry_on)\nRuntimeError: Unable to connect to redis: Cannot assign requested address"
```


#### How did you do it?
-the wait time should only be changed to value defined in plt_reboot_dict only when its value is 0. Else should pick the value sent in the function call.
-Check if interfaces-config.service is exited successfully & database containers has started before doing config reload for the second time

#### How did you verify/test it?
Ran the test against T2 chassis multiple times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
