### PR TITLE
Update to loganalyzer_common_ignore.txt

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -167,6 +167,8 @@ r, ".* ERR kernel:.* Set it down before adding it as a team port.*"
 # https://msazure.visualstudio.com/One/_workitems/edit/16703529
 r, ".* ERR CCmisApi:.*system_service.*Broken pipe.*"
 
+r, ".* ERR CCmisApi:.*system_service_Map_base::at.*"
+
 r, ".*ERR kernel: \[.*\] AMD-Vi: Event logged \[IO_PAGE_FAULT device=00:13.1 domain=0x0009 address=0x0 flags=0x0000\].*"
 
 r, ".*WARNING kernel: .*linux_knet_cb.*linux_bcm_knet.*linux_user_bde.*linux_kernel_bde.*xt_TCPMSS.*8021q.*garp.*mrp.*dummy.*"


### PR DESCRIPTION
 ### Description of PR

Below error msg is reported from loganalyzer as part of dual-tor test cases.  
One of the test case raising this error is dualtor/test_tor_ecn.py

ERR CCmisApi: system_service_Map_base::at


Summary:
Fixes # (issue)

 But the error trace is not seen in any repo which is little wierd.  
Based on this observation and discussion with optics team, this error is added to the ignore list




### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205



#### How did you do it?

Added the error string to loganalyzer ignore list

#### How did you verify/test it?

Verified by rerunning the test cases with the error msg added to ignore list


