### PR TITLE
Fix sfp cable tech check

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -262,7 +262,7 @@ class TestSfpApi(PlatformApiTestBase):
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
             if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
-                if compliance_code == "Passive Cable":
+                if compliance_code == "Passive Cable" or compliance_code == "Unknown":
                    return False
             else:
                 compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some SFP-10G-T xcvrs (SFF8472) do not properly implement the "SFP Cable Technology" EEPROM field; this should normally either be "Active Cable" or "Passive Cable" but for these xcvrs it is neither and so it is effectively "Unknown". Need to fix logic in is_xcvr_optical to handle this appropriately.

#### How did you do it?
Update logic in is_xcvr_optical to handle "Unknown" value for "SFP+CableTechnology"

#### How did you verify/test it?
Tested on Arista device using SFP-10G-T xcvr

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
