### PR TITLE
skip test_bgp_session_flap.py for T1

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -88,6 +88,13 @@ bgp/test_bgp_multipath_relax.py:
     conditions:
       - "'backend' in topo_name"
 
+bgp/test_bgp_session_flap.py:
+  skip:
+    reason: "Skip t1 for now, there is some issue for this case."
+    conditions:
+      - "'t1' in topo_type"
+      - https://github.com/sonic-net/sonic-mgmt/issues/7963
+
 bgp/test_bgp_slb.py:
   skip:
     reason: "Skip over topologies which doesn't support slb."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
After running test_bgp_session_flap.py on T1, 'down_neighbor' error was thrown and caused failure on sanity check of next case.
Submit a issue:  https://github.com/sonic-net/sonic-mgmt/issues/7963
#### How did you do it?
Skip it on T1 for now until the issue is fixed.

#### How did you verify/test it?
Run test_bgp_session_flap.py and case after it.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
