### PR TITLE
[python3] json.dumps() not support bytes string as input

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -96,6 +96,8 @@ class AnsibleHostBase(object):
             result = pool.apply_async(run_module, (module_args, complex_args))
             return pool, result
 
+        module_args = json.loads(json.dumps(module_args, cls=AnsibleHostBase.CustomEncoder))
+        complex_args = json.loads(json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder))
         res = self.module(*module_args, **complex_args)[self.hostname]
 
         if verbose:

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -32,6 +32,12 @@ class AnsibleHostBase(object):
     on the host.
     """
 
+    class CustomEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, bytes):
+                return obj.decode('utf-8')
+            return super().default(obj)
+
     def __init__(self, ansible_adhoc, hostname, *args, **kwargs):
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
@@ -65,8 +71,8 @@ class AnsibleHostBase(object):
                     line_number,
                     self.hostname,
                     self.module_name,
-                    json.dumps(module_args),
-                    json.dumps(complex_args)
+                    json.dumps(module_args, cls=AnsibleHostBase.CustomEncoder),
+                    json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder)
                 )
             )
         else:
@@ -99,7 +105,7 @@ class AnsibleHostBase(object):
                     function_name,
                     line_number,
                     self.hostname,
-                    self.module_name, json.dumps(res)
+                    self.module_name, json.dumps(res, cls=AnsibleHostBase.CustomEncoder)
                 )
             )
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

hit below error in nightly test, after upgrade to python3
```
qos/test_qos_sai.py::TestQosSai::testParameter[testbed-None] 
-------------------------------- live log setup --------------------------------
05:50:57 __init__._fixture_generator_decorator    L0088 ERROR  | 
TypeError("Object of type 'bytes' is not JSON serializable",)
Traceback (most recent call last):
  File "sonic-mgmt/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "sonic-mgmt/tests/qos/qos_sai_base.py", line 1294, in ingressLosslessProfile
    pgs
  File "sonic-mgmt/tests/qos/qos_sai_base.py", line 266, in __getBufferProfile
    self.__updateVoidRoidParams(dut_asic, bufferProfile)
  File "sonic-mgmt/tests/qos/qos_sai_base.py", line 197, in __updateVoidRoidParams
    "COUNTERS_BUFFER_POOL_NAME_MAP", bufferPoolName
  File "sonic-mgmt/tests/common/devices/sonic_asic.py", line 413, in run_redis_cmd
    result = self.sonichost.shell(argv=argv)
  File "sonic-mgmt/tests/common/devices/base.py", line 70, in _run
    json.dumps(complex_args)
  File "/usr/lib/python3.6/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'bytes' is not JSON serializable
ERROR                                                                    [100%]
```

RCA：
In Python 3, json.dumps() expects a string object as input, not a bytes object. To make your code work in Python 3, 

#### How did you do it?

since input is not a simple bytes string, it's a dict  and contain a bytes string. like below:
```
complex_args type <class 'dict'> value {'argv': ['redis-cli', '-n', '2', 'HGET', 'COUNTERS_BUFFER_POOL_NAME_MAP', b'ingress_lossless_pool']}
```

so override default method of json library, to support convert bytes string to normal string.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
