### PR TITLE
[Python3 migration]Fix test error in test_vnet_vxlan.py

### DIFF
--- a/tests/vxlan/templates/vnet_config.j2
+++ b/tests/vxlan/templates/vnet_config.j2
@@ -66,7 +66,7 @@ num_vnet_batch: {{ num_vnet_batch }}
   {% set num_routes_iterations = ((num_routes/num_routes_batch)/(num_vnet/num_vnet_batch))|round|int %}
   {% if num_routes_iterations == 0 %} {% set num_routes_iterations = 1 %} {% endif %}
 {% endif %}
-{% set topo_vlan = minigraph_vlans.keys()[0] %}
+{% set topo_vlan = minigraph_vlans.keys()|list|first %}
 
 {# Max RIFs support currently is 128 #}
 {% if num_vnet > 128 %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test error after Python3 migartion in test_vnet_vxlan.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
See following error:

        return yaml.safe_load(                                                                                                                             
           safe_open_template(                                                                                                                            
                join(TEMPLATE_DIR, "vnet_config.j2")).render(combined_args))

in vxlan/conftest.py:353:                                                                                                                                     
                                                                                                                                                       
    def getattr(self, obj, attribute):                                                                                                                     
        """Get an item or attribute of an object but prefer the attribute.                                                                                 
        Unlike :meth:`getitem` the attribute *must* be a bytestring.                                                                                       
        """                                                                                                                                                
        try:                                                                                                                                               
           return getattr(obj, attribute)                                                                                                                 
E           jinja2.exceptions.UndefinedError: dict object has no element Undefined                                                                         
                                                                                                                                                                                                                                                                         
in /var/AzDevOps/env-python3/lib/python3.8/site-packages/jinja2/environment.py:397: UndefinedError 

#### How did you do it?
The issue is due to the use of minigraph_vlans.keys()[0] and minigraph_vlans[topo_vlan].members[1:] in the Jinja2 template, which are not supported in Python 3.

In Python 3, dict.keys() returns a dictionary view object, which does not support indexing. Instead, you can convert it to a list and then access the element using indexing.

#### How did you verify/test it?
Manually run test_vnet_vxlan.py

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
