### PR TITLE
[dualtor][active-active] Add link admin down config reload admin up cases

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -125,7 +125,8 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay, allow_disruption
 def verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic=False):
     # Wait for the IO to complete before doing checks
     if verify:
-        validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay, allow_disruption_before_traffic=allow_disruption_before_traffic)
+        validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay,
+                                 allow_disruption_before_traffic=allow_disruption_before_traffic)
     return tor_IO.get_test_results()
 
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -34,7 +34,7 @@ def arp_setup(ptfhost):
     ptfhost.shell("supervisorctl reread && supervisorctl update")
 
 
-def validate_traffic_results(tor_IO, allowed_disruption, delay):
+def validate_traffic_results(tor_IO, allowed_disruption, delay, allow_disruption_before_traffic=False):
     """
     Generates a report (dictionary) of I/O metrics that were calculated as part
     of the dataplane test. This report is to be used by testcases to verify the
@@ -109,7 +109,7 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay):
                             "Maximum allowed duplication: {}s"
                             .format(server_ip, longest_duplication, delay))
 
-        if bool(disruption_before_traffic):
+        if not allow_disruption_before_traffic and bool(disruption_before_traffic):
             failures.append("Traffic on server {} was disrupted prior to test start, "
                             "missing {} packets from the start of the packet flow"
                             .format(server_ip, disruption_before_traffic))
@@ -122,10 +122,10 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay):
     pytest_assert(len(failures) == 0, '\n' + '\n'.join(failures))
 
 
-def verify_and_report(tor_IO, verify, delay, allowed_disruption):
+def verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic=False):
     # Wait for the IO to complete before doing checks
     if verify:
-        validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay)
+        validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay, allow_disruption_before_traffic=allow_disruption_before_traffic)
     return tor_IO.get_test_results()
 
 
@@ -209,7 +209,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                             stop_after=None):
+                             stop_after=None, allow_disruption_before_traffic=False):
         """
         Helper method for `send_t1_to_server_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -244,7 +244,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        return verify_and_report(tor_IO, verify, delay, allowed_disruption)
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic)
 
     yield t1_to_server_io_test
 

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -11,8 +11,10 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
+from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.config_reload import config_reload
 
 
 pytestmark = [
@@ -338,3 +340,121 @@ def test_active_link_down_downstream_active_soc(
             cable_type=cable_type,
             skip_state_db=True
         )
+
+
+def config_interface_admin_status(duthost, ports, admin_status="up"):
+    """Config interface admin status."""
+    if admin_status == "up":
+        cmd = "config interface startup %s"
+    elif admin_status == "down":
+        cmd = "config interface shutdown %s"
+    else:
+        return
+
+    cmds = []
+    for port in ports:
+        cmds.append(cmd % port)
+    duthost.shell_cmds(cmds=cmds)
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_active_link_admin_down_config_reload_link_up_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
+    cable_type, active_active_ports                                     # noqa F811
+):
+    """
+    Send traffic from server to T1 and unshut the active-active mux ports.
+    Verify switchover and disruption.
+    """
+    if cable_type == CableType.active_active:
+        try:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "down")
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True
+            )
+
+            upper_tor_host.shell("config save -y")
+            config_reload(upper_tor_host, wait=60)
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True,
+                verify_db_timeout=60
+            )
+
+            send_server_to_t1_with_action(
+                upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+                allowed_disruption=1, action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+            )
+
+            verify_tor_states(
+                expected_active_host=[upper_tor_host, lower_tor_host],
+                expected_standby_host=None,
+                cable_type=cable_type,
+            )
+
+        finally:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+            upper_tor_host.shell("config save -y")
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_active_link_admin_down_config_reload_link_up_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
+    cable_type, active_active_ports                                     # noqa F811
+):
+    """
+    Send traffic from T1 to standby ToR and unshut the active-active mux ports.
+    Verify switchover and disruption.
+    """
+    if cable_type == CableType.active_active:
+        try:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "down")
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True
+            )
+
+            upper_tor_host.shell("config save -y")
+            config_reload(upper_tor_host, wait=60)
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True,
+                verify_db_timeout=60
+            )
+
+            # after config reload, it takes time to setup the zero-mac tunnel routes for
+            # the mux server ips, so there will be disruption before traffic.
+            send_t1_to_server_with_action(
+                upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+                allowed_disruption=1, action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
+                allow_disruption_before_traffic=True
+            )
+
+            verify_tor_states(
+                expected_active_host=[upper_tor_host, lower_tor_host],
+                expected_standby_host=None,
+                cable_type=cable_type,
+            )
+
+        finally:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+            upper_tor_host.shell("config save -y")

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -394,8 +394,7 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
             send_server_to_t1_with_action(
                 upper_tor_host,
                 verify=True,
-                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                allowed_disruption=1,
+                allowed_disruption=0,
                 action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up")
             )
 
@@ -449,8 +448,7 @@ def test_active_link_admin_down_config_reload_link_up_downstream_standby(
             send_t1_to_server_with_action(
                 upper_tor_host,
                 verify=True,
-                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                allowed_disruption=1,
+                allowed_disruption=0,
                 action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
                 allow_disruption_before_traffic=True
             )

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -392,14 +392,17 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
             )
 
             send_server_to_t1_with_action(
-                upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                allowed_disruption=1, action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+                upper_tor_host,
+                verify=True,
+                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+                allowed_disruption=1,
+                action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up")
             )
 
             verify_tor_states(
                 expected_active_host=[upper_tor_host, lower_tor_host],
                 expected_standby_host=None,
-                cable_type=cable_type,
+                cable_type=cable_type
             )
 
         finally:
@@ -444,15 +447,18 @@ def test_active_link_admin_down_config_reload_link_up_downstream_standby(
             # after config reload, it takes time to setup the zero-mac tunnel routes for
             # the mux server ips, so there will be disruption before traffic.
             send_t1_to_server_with_action(
-                upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                allowed_disruption=1, action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
+                upper_tor_host,
+                verify=True,
+                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+                allowed_disruption=1,
+                action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
                 allow_disruption_before_traffic=True
             )
 
             verify_tor_states(
                 expected_active_host=[upper_tor_host, lower_tor_host],
                 expected_standby_host=None,
-                cable_type=cable_type,
+                cable_type=cable_type
             )
 
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7689
Fixes #7690 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add testcases to cover upstream/downstream dualtor io of link admin down
config reload then lin up scenario.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add two cases:
* `test_active_link_admin_down_config_reload_link_up_upstream`
* `test_active_link_admin_down_config_reload_link_up_downstream_standby`

#### How did you verify/test it?
Run on `dualtor-mixed` testbed.
```
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_link_up_upstream[active-standby] SKIPPED                                                                                                                  [ 25%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_link_up_upstream[active-active] PASSED                                                                                                                    [ 50%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_link_up_downstream_standby[active-standby] SKIPPED                                                                                                        [ 75%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_link_up_downstream_standby[active-active] PASSED                                                                                                          [100%]

========================================================================================== 2 passed, 2 skipped, 28 deselected in 1369.22 seconds ===========================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
