### PR TITLE
Temporarily skip test_static_route on 202205

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -38,7 +38,7 @@ t0:
   - process_monitoring/test_critical_process_monitoring.py
   - radv/test_radv_ipv6_ra.py
   - route/test_default_route.py
-  - route/test_static_route.py
+#  - route/test_static_route.py
   - show_techsupport/test_techsupport_no_secret.py
   - snmp/test_snmp_cpu.py
   - snmp/test_snmp_default_route.py


### PR DESCRIPTION
Summary:
Temp skip test_static_route.py in 202205 PR test to unblock PR test.
Will re-enable after it's stable. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
