### PR TITLE
Fix the testQosSaiDwrr and testQosSaiDwrrWeightChange case failures on T0/T0-Dualtor

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2911,6 +2911,28 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
+                wrr:
+                    ecn: 1
+                    q0_num_of_pkts: 70
+                    q1_num_of_pkts: 70
+                    q2_num_of_pkts: 70
+                    q3_num_of_pkts: 75
+                    q4_num_of_pkts: 75
+                    q5_num_of_pkts: 70
+                    q6_num_of_pkts: 70
+                    limit: 40
+                wrr_chg:
+                    ecn: 1
+                    q0_num_of_pkts: 40
+                    q1_num_of_pkts: 40
+                    q2_num_of_pkts: 40
+                    q3_num_of_pkts: 150
+                    q4_num_of_pkts: 150
+                    q5_num_of_pkts: 40
+                    q6_num_of_pkts: 40
+                    limit: 40
+                    lossy_weight: 8
+                    lossless_weight: 30
             400000_40m:
                 pkts_num_leak_out: 0
                 pg_drop:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the testQosSaiDwrr and testQosSaiDwrrWeightChange cases failures on T0/T0-Dualtor

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the testQosSaiDwrr and testQosSaiDwrrWeightChange case failures on T0/T0-Dualtor

#### How did you do it?
The common WRR parameter doesn't work on cisco-8000, add the platform specific WRR parameters.

#### How did you verify/test it?
the cases passed.

#### Any platform specific information?
cisco-8000

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
