### PR TITLE
Handle MegaBits speed for show int status <interface> output in test_update_speed testcase

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -265,7 +265,8 @@ def test_update_speed(duthost, ensure_dut_readiness):
                 expect_op_success(duthost, output)
                 current_status_speed = check_interface_status(duthost, "Speed").replace("G", "000")
                 current_status_speed = current_status_speed.replace("M", "")
-                pytest_assert(current_status_speed == speed, "Failed to properly configure interface speed to requested value {}".format(speed))
+                pytest_assert(current_status_speed == speed,
+                              "Failed to properly configure interface speed to requested value {}".format(speed))
             else:
                 expect_op_failure(output)
         finally:

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -264,8 +264,8 @@ def test_update_speed(duthost, ensure_dut_readiness):
             if is_valid:
                 expect_op_success(duthost, output)
                 current_status_speed = check_interface_status(duthost, "Speed").replace("G", "000")
-                pytest_assert(current_status_speed == speed,
-                              "Failed to properly configure interface speed to requested value {}".format(speed))
+                current_status_speed = current_status_speed.replace("M", "")
+                pytest_assert(current_status_speed == speed, "Failed to properly configure interface speed to requested value {}".format(speed))
             else:
                 expect_op_failure(output)
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixes the issue when the supported selected speed to test for the interface is in _Mbps_ instead of _Gbps_.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test case '_test_update_speed_' in test_eth_interface.py fails, when the supported selected speed to apply on the interface is in '_Mbps_' speed instead of '_Gbps_'.

#### How did you do it?
If the current status speed after applying the patch is in '_Mbps_', handle it as it is done for '_Gbps_' speed.

#### How did you verify/test it?
Ran the 'test_update_speed' tests against a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
