### PR TITLE
fix FDB aging issue after config reload

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -244,9 +244,9 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             # config reload on active tor
             duthost.shell('config save -y')
             if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
-                config_reload(duthost, wait=400)
+                config_reload(duthost, wait=500)
             else:
-                config_reload(duthost, wait=350)
+                config_reload(duthost, wait=450)
             # FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)


### PR DESCRIPTION
Summary:
After config reload, FDB not recover after config reload, arp_update recover FDB may need 5 ~ 6 minutes. 
In current test script, we will wait for 350s, if swss restart time became longer, FDB may not recover by arp_update in 350s.
And would cause traffic broadcasted, and finally test case failure. 

```
E       AssertionError: Received expected packet on port 24 for device 0, but it should have arrived on one of these ports: [3, 14, 6].
E       ========== RECEIVED ==========
E       0000  FE 54 00 45 96 06 52 54 00 91 D3 27 08 00 45 00  .T.E..RT...&apos;..E.
E       0010  00 56 00 01 00 00 3F 06 75 9D 01 01 01 01 02 02  .V....?.u.......
E       0020  02 01 04 D2 10 E1 00 00 00 00 00 00 00 00 50 02  ..............P.
E       0030  20 00 5B 72 00 00 74 65 73 74 73 2E 72 6F 75 74   .[r..tests.rout
E       0040  65 2E 74 65 73 74 5F 73 74 61 74 69 63 5F 72 6F  e.test_static_ro
E       0050  75 74 65 20 74 65 73 74 73 2E 72 6F 75 74 65 2E  ute tests.route.
E       0060  74 65 73 74                                      test
E       ==============================
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Increase wait time, at this moment, for feature improvement.
We may need replace ping with arpping. 

#### How did you verify/test it?
run test_static_route.py on KVM DUT and physical DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
