### PR TITLE
[202012][everflow][m0] Backport m0 support for everflow test

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -379,17 +379,24 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 pytest.fail("ipv4 lo interface not found")
 
             for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces + vlan_sub_interfaces, peer_count), subnets):
+                def _get_namespace(minigraph_config, intf):
+                    namespace = DEFAULT_NAMESPACE
+                    if intf in minigraph_config and 'namespace' in minigraph_config[intf] and \
+                            minigraph_config[intf]['namespace']:
+                        namespace = minigraph_config[intf]['namespace']
+                    return namespace
                 conn = {}
                 local_addr, neighbor_addr = [_ for _ in subnet][:2]
                 conn["local_intf"] = "%s" % intf
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
                 conn["loopback_ip"] = loopback_ip
-                conn["namespace"] = DEFAULT_NAMESPACE
+                conn["namespace"] = _get_namespace(mg_facts['minigraph_neighbors'], intf)
+
                 if intf.startswith("PortChannel"):
                     member_intf = mg_facts["minigraph_portchannels"][intf]["members"][0]
                     conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_ptf_indices"][member_intf]
-                    conn["namespace"] = mg_facts["minigraph_portchannels"][intf]["namespace"]
+                    conn["namespace"] = _get_namespace(mg_facts["minigraph_portchannels"], intf)
                 elif constants.VLAN_SUB_INTERFACE_SEPARATOR in intf:
                     orig_intf, vlan_id = intf.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
                     ptf_port_index = str(mg_facts["minigraph_port_indices"][orig_intf])

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -445,7 +445,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     elif tbinfo["topo"]["type"] in set(["t1", "t2"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
-        if topo_scenario == "m0_t1_scenario":
+        if topo_scenario == "m0_l3_scenario":
             setup_func = _setup_interfaces_t1_or_t2
         else:
             setup_func = _setup_interfaces_t0

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -10,12 +10,16 @@ UPSTREAM_NEIGHBOR_MAP = {
     "t0": "t1",
     "t1": "t2",
     "m0": "m1",
-    "t2": "t3"
+    "t2": "t3",
+    "m0_vlan": "m1",
+    "m0_l3": "m1"
 }
 # Describe downstream neighbor of dut in different topos
 DOWNSTREAM_NEIGHBOR_MAP = {
     "t0": "server",
     "t1": "t0",
     "m0": "mx",
-    "t2": "t1"
+    "t2": "t1",
+    "m0_vlan": "server",
+    "m0_l3": "mx"
 }

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -4,3 +4,18 @@ DEFAULT_NAMESPACE = None
 NAMESPACE_PREFIX = 'asic'
 ASIC_PARAM_TYPE_ALL = 'num_asics'
 ASIC_PARAM_TYPE_FRONTEND = 'frontend_asics'
+
+# Describe upstream neighbor of dut in different topos
+UPSTREAM_NEIGHBOR_MAP = {
+    "t0": "t1",
+    "t1": "t2",
+    "m0": "m1",
+    "t2": "t3"
+}
+# Describe downstream neighbor of dut in different topos
+DOWNSTREAM_NEIGHBOR_MAP = {
+    "t0": "server",
+    "t1": "t0",
+    "m0": "mx",
+    "t2": "t1"
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1290,7 +1290,7 @@ def pytest_generate_tests(metafunc):
 
     if 'topo_scenario' in metafunc.fixturenames:
         if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
-            metafunc.parametrize('topo_scenario', ['m0_t0_scenario', 'm0_t1_scenario'], scope='module')
+            metafunc.parametrize('topo_scenario', ['m0_vlan_scenario', 'm0_l3_scenario'], scope='module')
         else:
             metafunc.parametrize('topo_scenario', ['default'], scope='module')
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -45,10 +45,10 @@ VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
 # Topo that downstream neighbor of DUT are servers
-DOWNSTREAM_SERVER_TOPO = ["t0"]
+DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
 @pytest.fixture(scope="module")
-def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
+def setup_info(duthosts, rand_one_dut_hostname, tbinfo, topo_scenario):
     """
     Gather all required test information.
 
@@ -74,6 +74,8 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     acl_capability_facts = duthost.acl_capabilities_facts()["ansible_facts"]
 
     topo_type = tbinfo["topo"]["type"]
+    if topo_type == "m0":
+        topo_type = "m0_vlan" if "m0_vlan_scenario" in topo_scenario else "m0_l3"
     # Get the list of T0/T2 ports
     for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
         pytest_assert(topo_type in UPSTREAM_NEIGHBOR_MAP and topo_type in DOWNSTREAM_NEIGHBOR_MAP, "Unsupported topo")
@@ -274,7 +276,7 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_arp_responder(duthost, ptfhost, setup_info):
-    if setup_info['topo'] != 't0':
+    if setup_info['topo'] not in ['t0', 'm0_vlan']:
         yield
         return
     ip_list = [TARGET_SERVER_IP, DEFAULT_SERVER_IP]

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -15,6 +15,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 import json
 
 # TODO: Add suport for CONFIGLET mode
@@ -43,18 +44,6 @@ DEFAULT_SERVER_IP = "192.168.0.3"
 VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
-# Describe upstream neighbor of dut in different topos
-UPSTREAM_NEIGHBOR_MAP = {
-    "t0": "t1",
-    "t1": "t2",
-    "m0": "m1"
-}
-# Describe downstream neighbor of dut in different topos
-DOWNSTREAM_NEIGHBOR_MAP = {
-    "t0": "server",
-    "t1": "t0",
-    "m0": "mx"
-}
 # Topo that downstream neighbor of DUT are servers
 DOWNSTREAM_SERVER_TOPO = ["t0"]
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -43,6 +43,20 @@ DEFAULT_SERVER_IP = "192.168.0.3"
 VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
+# Describe upstream neighbor of dut in different topos
+UPSTREAM_NEIGHBOR_MAP = {
+    "t0": "t1",
+    "t1": "t2",
+    "m0": "m1"
+}
+# Describe downstream neighbor of dut in different topos
+DOWNSTREAM_NEIGHBOR_MAP = {
+    "t0": "server",
+    "t1": "t0",
+    "m0": "mx"
+}
+# Topo that downstream neighbor of DUT are servers
+DOWNSTREAM_SERVER_TOPO = ["t0"]
 
 @pytest.fixture(scope="module")
 def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
@@ -60,74 +74,45 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     topo = tbinfo['topo']['name']
 
-    # {namespace: [server ports]}
-    server_ports_namespace_map = defaultdict(list)
-    # {namespace: [T1 ports]}
-    t1_ports_namespace_map = defaultdict(list)
-    # { namespace : [tor ports] }
-    tor_ports_namespace_map = defaultdict(list)
-    # { namespace : [spine ports] }
-    spine_ports_namespace_map = defaultdict(list)
-
-    # { set of namespace server ports belong }
-    server_ports_namespace = set()
-    # { set of namespace t1 ports belong}
-    t1_ports_namespace = set()
-    # { set of namespace tor ports belongs }
-    tor_ports_namespace = set()
-    # { set of namespace spine ports belongs }
-    spine_ports_namespace = set()
-
+    upstream_ports_namespace_map = defaultdict(list)
+    downstream_ports_namespace_map = defaultdict(list)
+    upstream_ports_namespace = set()
+    downstream_ports_namespace = set()
 
     # Gather test facts
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     switch_capability_facts = duthost.switch_capabilities_facts()["ansible_facts"]
     acl_capability_facts = duthost.acl_capabilities_facts()["ansible_facts"]
 
+    topo_type = tbinfo["topo"]["type"]
     # Get the list of T0/T2 ports
     for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
-        if "t1" in topo:
-            # Get the list of T0/T2 ports
-            if "t0" in neigh["name"].lower():
-                # Add Tor ports to namespace
-                tor_ports_namespace_map[neigh['namespace']].append(dut_port)
-                tor_ports_namespace.add(neigh['namespace'])
-            elif "t2" in neigh["name"].lower():
-                # Add Spine ports to namespace
-                spine_ports_namespace_map[neigh['namespace']].append(dut_port)
-                spine_ports_namespace.add(neigh['namespace'])
-        elif "t0" in topo:
-            # Get the list of Server/T1 ports
-            if "server" in neigh["name"].lower():
-                # Add Server ports to namespace
-                server_ports_namespace_map[neigh['namespace']].append(dut_port)
-                server_ports_namespace.add(neigh['namespace'])
-            elif "t1" in neigh["name"].lower():
-                # Add T1 ports to namespace
-                t1_ports_namespace_map[neigh['namespace']].append(dut_port)
-                t1_ports_namespace.add(neigh['namespace'])
-        else:
-            # Todo: Support dualtor testbed
-            pytest.skip("Unsupported topo")
+        pytest_assert(topo_type in UPSTREAM_NEIGHBOR_MAP and topo_type in DOWNSTREAM_NEIGHBOR_MAP, "Unsupported topo")
+        if UPSTREAM_NEIGHBOR_MAP[topo_type] in neigh["name"].lower():
+            upstream_ports_namespace_map[neigh['namespace']].append(dut_port)
+            upstream_ports_namespace.add(neigh['namespace'])
+        elif DOWNSTREAM_NEIGHBOR_MAP[topo_type] in neigh["name"].lower():
+            downstream_ports_namespace_map[neigh['namespace']].append(dut_port)
+            downstream_ports_namespace.add(neigh['namespace'])
 
     if 't1' in topo:
-        # Set of TOR ports only Namespace 
-        tor_only_namespace = tor_ports_namespace.difference(spine_ports_namespace)
-        # Set of Spine ports only Namespace 
-        spine_only_namespace = spine_ports_namespace.difference(tor_ports_namespace)
-        # Randomly choose from TOR_only Namespace if present else just use first one 
-        tor_namespace = random.choice(tuple(tor_only_namespace)) if tor_only_namespace else tuple(tor_ports_namespace)[0]
-        # Randomly choose from Spine_only Namespace if present else just use first one 
-        spine_namespace = random.choice(tuple(spine_only_namespace)) if spine_only_namespace else tuple(spine_ports_namespace)[0]
-        tor_ports = tor_ports_namespace_map[tor_namespace]
-        spine_ports = spine_ports_namespace_map[spine_namespace]
-
+        # Set of downstream ports only Namespace
+        downstream_only_namespace = downstream_ports_namespace.difference(upstream_ports_namespace)
+        # Set of upstream ports only Namespace
+        upstream_only_namespace = upstream_ports_namespace.difference(downstream_ports_namespace)
+        # Randomly choose from downstream_only Namespace if present else just use first one
+        downstream_namespace = random.choice(tuple(downstream_only_namespace)) \
+            if downstream_only_namespace else tuple(downstream_ports_namespace)[0]
+        # Randomly choose from upstream_only Namespace if present else just use first one
+        upstream_namespace = random.choice(tuple(upstream_only_namespace)) \
+            if upstream_only_namespace else tuple(upstream_ports_namespace)[0]
     else:
-        # Use the default namespace for Server and T1
-        server_namespace = tuple(server_ports_namespace)[0]
-        t1_namespace = tuple(t1_ports_namespace)[0]
-        server_ports = server_ports_namespace_map[server_namespace]
-        t1_ports = t1_ports_namespace_map[t1_namespace]
+        # Use the default namespace
+        downstream_namespace = tuple(downstream_ports_namespace)[0]
+        upstream_namespace = tuple(upstream_ports_namespace)[0]
+
+    downstream_ports = downstream_ports_namespace_map[downstream_namespace]
+    upstream_ports = upstream_ports_namespace_map[upstream_namespace]
 
     switch_capabilities = switch_capability_facts["switch_capabilities"]["switch"]
     acl_capabilities = acl_capability_facts["acl_capabilities"]
@@ -179,7 +164,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
                             out_port_exclude_list.append(lag_member)
 
                 out_port_ptf_id_list.append(ptf_port_id)
-    
+
     setup_information = {
         "router_mac": duthost.facts["router_mac"],
         "test_mirror_v4": test_mirror_v4,
@@ -198,89 +183,60 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
             if k in mg_facts["minigraph_ports"]
         },
         # { ptf_port_id : namespace }
-        "port_index_namespace_map" : {
+        "port_index_namespace_map": {
            v: mg_facts["minigraph_neighbors"][k]['namespace']
            for k, v in mg_facts["minigraph_ptf_indices"].items()
            if k in mg_facts["minigraph_ports"]
         }
     }
 
-    if 't0' in topo:
-        # Downstream traffic (T0 -> Server)
-        server_dest_ports = []
-        server_dest_ports_ptf_id = []
-        get_port_info(server_ports, server_dest_ports, server_dest_ports_ptf_id, None)
+    # Downstream traffic
+    downstream_dest_ports = []
+    downstream_dest_ports_ptf_id = []
+    downstream_dest_lag_name = None if topo_type in DOWNSTREAM_SERVER_TOPO else []
+    get_port_info(downstream_ports, downstream_dest_ports, downstream_dest_ports_ptf_id, downstream_dest_lag_name)
 
-        # Upstream traffic (Server -> T0)
-        t1_dest_ports = []
-        t1_dest_ports_ptf_id = []
-        t1_dest_lag_name = []
-        get_port_info(t1_ports, t1_dest_ports, t1_dest_ports_ptf_id, t1_dest_lag_name)
+    # Upstream traffic
+    upstream_dest_ports = []
+    upstream_dest_ports_ptf_id = []
+    upstream_dest_lag_name = []
+    get_port_info(upstream_ports, upstream_dest_ports, upstream_dest_ports_ptf_id, upstream_dest_lag_name)
 
+    setup_information.update(
+        {
+            "topo": topo_type,
+            DOWN_STREAM: {
+                "src_port": upstream_ports[0],
+                "src_port_lag_name": upstream_dest_lag_name[0],
+                "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][upstream_ports[0]]),
+                # For T0 topo, downstream traffic ingress from the first portchannel,
+                # and mirror packet egress from other portchannels
+                "dest_port": upstream_dest_ports[1:] \
+                if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_ports,
+                "dest_port_ptf_id": upstream_dest_ports_ptf_id[1:] \
+                if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_ports_ptf_id,
+                "dest_port_lag_name": upstream_dest_lag_name[1:] \
+                if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_lag_name,
+                "namespace": downstream_namespace
+            },
+            UP_STREAM: {
+                "src_port": downstream_ports[0],
+                # DUT whose downstream are servers doesn't have lag connect to server
+                "src_port_lag_name": "Not Applicable" \
+                if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_lag_name[0],
+                "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][downstream_ports[0]]),
+                "dest_port": upstream_dest_ports,
+                "dest_port_ptf_id": upstream_dest_ports_ptf_id,
+                "dest_port_lag_name": upstream_dest_lag_name,
+                "namespace": upstream_namespace
+            },
+        }
+    )
+
+    if topo_type in DOWNSTREAM_SERVER_TOPO:
         setup_information.update(
             {
-                "topo": "t0",
-                "server_ports": server_ports,
-                "server_dest_ports_ptf_id": server_dest_ports_ptf_id,
-                "t1_ports": t1_ports,
-                DOWN_STREAM: {
-                    "src_port": t1_ports[0],
-                    "src_port_lag_name":t1_dest_lag_name[0],
-                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][t1_ports[0]]),
-                    # Downstream traffic ingress from the first portchannel,
-                    # and mirror packet egress from other portchannels
-                    "dest_port": t1_dest_ports[1:],
-                    "dest_port_ptf_id": t1_dest_ports_ptf_id[1:],
-                    "dest_port_lag_name": t1_dest_lag_name[1:],
-                    "namespace": server_namespace
-                },
-                UP_STREAM: {
-                    "src_port": server_ports[0],
-                    "src_port_lag_name":"Not Applicable",
-                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][server_ports[0]]),
-                    "dest_port": t1_dest_ports,
-                    "dest_port_ptf_id": t1_dest_ports_ptf_id,
-                    "dest_port_lag_name": t1_dest_lag_name,
-                    "namespace": t1_namespace
-                },
-            }
-        )
-    elif 't1' in topo:
-        # Downstream traffic (T1 -> T0)
-        tor_dest_ports = []
-        tor_dest_ports_ptf_id = []
-        tor_dest_lag_name = []
-        get_port_info(tor_ports, tor_dest_ports, tor_dest_ports_ptf_id, tor_dest_lag_name)
-        
-        # Upstream traffic (T0 -> T1)
-        spine_dest_ports = []
-        spine_dest_ports_ptf_id = []
-        spine_dest_lag_name = []
-        get_port_info(spine_ports, spine_dest_ports, spine_dest_ports_ptf_id, spine_dest_lag_name)
-
-        setup_information.update(
-            {
-                "topo": "t1",
-                "tor_ports": tor_ports,
-                "spine_ports": spine_ports,
-                DOWN_STREAM: {
-                    "src_port": spine_ports[0],
-                    "src_port_lag_name":spine_dest_lag_name[0],
-                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][spine_ports[0]]),
-                    "dest_port": tor_dest_ports,
-                    "dest_port_ptf_id": tor_dest_ports_ptf_id,
-                    "dest_port_lag_name": tor_dest_lag_name,
-                    "namespace": tor_namespace
-                    },
-                UP_STREAM: {
-                    "src_port": tor_ports[0],
-                    "src_port_lag_name":tor_dest_lag_name[0],
-                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][tor_ports[0]]),
-                    "dest_port": spine_dest_ports,
-                    "dest_port_ptf_id": spine_dest_ports_ptf_id,
-                    "dest_port_lag_name": spine_dest_lag_name,
-                    "namespace": spine_namespace
-                }
+                "server_dest_ports_ptf_id": downstream_dest_ports_ptf_id
             }
         )
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -37,7 +37,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         Remove the route as part of cleanup.
         """
         duthost = duthosts[rand_one_dut_hostname]
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             # On T0 testbed, the collector IP is routed to T1
             namespace = setup_info[UP_STREAM]['namespace']
             tx_port = setup_info[UP_STREAM]["dest_port"][0]

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -9,7 +9,7 @@ from everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM
 from everflow_test_utilities import setup_info  # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1")
+    pytest.mark.topology("t0", "t1", "m0")
 ]
 
 EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -34,6 +34,8 @@ def build_candidate_ports(duthost, tbinfo):
     unselected_ports = {}
     if tbinfo['topo']['type'] == 't0':
         candidate_neigh_name = 'Server'
+    elif tbinfo['topo']['type'] == 'm0':
+        candidate_neigh_name = 'MX'
     else:
         candidate_neigh_name = 'T0'
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -146,6 +148,8 @@ def get_uplink_ports(duthost, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     if 't0' == tbinfo['topo']['type']:
         neigh_name = 'T1'
+    elif 'm0' == tbinfo['topo']['type']:
+        neigh_name = 'M1'
     else:
         neigh_name = 'T2'
     for dut_port, neigh in mg_facts["minigraph_neighbors"].items():

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -15,7 +15,7 @@ from everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DS
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1")
+    pytest.mark.topology("t0", "t1", "m0")
 ]
 
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -457,7 +457,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
             if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:
                 pytest.skip("Skipping test since mirror policing is not supported on {0} {1} platforms".format(vendor,asic))
-        if setup_info['topo'] == 't0':
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
             default_tarffic_port_type = dest_port_type
             # Use the second portchannel as missor session nexthop
             tx_port = setup_info[dest_port_type]["dest_port"][1]
@@ -480,7 +480,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             table_type = "MIRROR_DSCP"
             rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            if setup_info['topo'] == 't0' and self.acl_stage() == "egress":
+            if setup_info['topo'] in ['t0', 'm0_vlan'] and self.acl_stage() == "egress":
                 # For T0 upstream, the EVERFLOW_DSCP table is binded to one of portchannels
                 bind_interface = setup_info[dest_port_type]["dest_port_lag_name"][0]
                 mirror_port_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
@@ -534,7 +534,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         tx_port_ids = self._get_tx_port_id_list(tx_ports)
         target_ip = "30.0.0.10"
         default_ip = self.DEFAULT_DST_IP
-        if 't0' == setup['topo'] and direction == DOWN_STREAM:
+        if setup['topo'] in ['t0', 'm0_vlan'] and direction == DOWN_STREAM:
             target_ip = TARGET_SERVER_IP
             default_ip = DEFAULT_SERVER_IP
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of adding support for m0 to simulate both t0 and t1 in everflow and bgp test.
https://github.com/sonic-net/sonic-mgmt/pull/7389
https://github.com/sonic-net/sonic-mgmt/pull/7618
https://github.com/sonic-net/sonic-mgmt/pull/6900

#### How did you do it?

#### How did you verify/test it?
Run everflow and bgp test on m0/t0/t1 testbeds, no errors.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
