### PR TITLE
Fix auto neg tests which failed with error list index out of range

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2304,7 +2304,10 @@ Totals               6450                 6449
     def get_port_fec(self, portname):
         out = self.shell('redis-cli -n 4 HGET "PORT|{}" "fec"'.format(portname))
         assert_exit_non_zero(out)
-        return out["stdout_lines"][0]
+        if out["stdout_lines"]:
+            return out["stdout_lines"][0]
+        else:
+            return None
 
     def set_port_fec(self, portname, state):
         if not state:

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -331,7 +331,8 @@ def prepare_autonegtest_params(duthosts, fanouthosts):
                 if len(selected_ports) == max_interfaces_per_dut:
                     break
                 auto_neg_mode = fanout.get_auto_negotiation_mode(fanout_port)
-                if auto_neg_mode is not None:
+                fec_mode = duthost.get_port_fec(dut_port)
+                if auto_neg_mode is not None and fec_mode is not None:
                     speeds = get_common_supported_speeds(duthost, dut_port, fanout, fanout_port)
                     selected_ports[dut_port] = {
                         'fanout': fanout.hostname,

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -281,14 +281,12 @@ def test_collect_pfc_pause_delay_params(duthosts, tbinfo):
 
     file_name = tbname + '.json'
     folder = 'pfc_headroom_test_params'
-
-    
     filepath = os.path.join(folder, file_name)
     try:
         if not os.path.exists(folder):
             os.mkdir(folder)
         with open(filepath, 'w') as yf:
-            json.dump({ tbname : pfc_pause_delay_params}, yf, indent=4)
+            json.dump({tbname: pfc_pause_delay_params}, yf, indent=4)
     except IOError as e:
         logger.warning('Unable to create file {}: {}'.format(filepath, e))
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -234,7 +234,7 @@ def collect_dut_pfc_pause_delay_params(dut):
         pfc_pause_delay_test_params[200] = False
     else:
         pfc_pause_delay_test_params = None
-    
+
     return pfc_pause_delay_test_params
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
get_port_fec will fail with an error IndexError: list index out of range,
when port FEC mode is N/A.
this will cause all the autoneg tests to fail when get_port_fec is called on the tested port which has no FEC mode.

### Type of change

- [ x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x ] 202205

### Approach
fix get_port_fec to not cause a runtime error in case port FEC mode is N/A
fix prepare_autonegtest_params to not choose ports for auto neg tests which have no FEC mode.

#### What is the motivation for this PR?
**check FEC in the table:**
redis-cli -n 4 hgetall "PORT|Ethernet0"

or 

check the FEC in "show interfaces status"
     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  ---------------  ----------
     Ethernet0              0,1      50G   9100    N/A    etp1a  PortChannel101      up       up  QSFP28 or later         off
     Ethernet2              2,3      50G   9100    N/A    etp1b  PortChannel101      up       up  QSFP28 or later         off
 

**Observed behavior**
Test failing with error msg:
 

    def get_port_fec(self, portname):
        out = self.shell('redis-cli -n 4 HGET "PORT|{}" "fec"'.format(portname))
        assert_exit_non_zero(out)
>       return out["stdout_lines"][0]
E       IndexError: list index out of range
 

**Why it's failed:**

In the default configuration, after running minigraph, the FEC is:

rs for interface with speed 100G and no split port
N/A for interface with speed 50G and split port
 

When the FEC is N/A, we can't see it in the output which the test expects from CLI:  redis-cli -n 4 HGET "PORT|{}" "fec"

root@r-tigon-04:/home/admin# redis-cli -n 4 HGET "PORT|Ethernet0" "fec"
(nil)
Because it doesn't exist:

root@r-tigon-04:/home/admin# redis-cli -n 4 hgetall "PORT|Ethernet0"
 1) "admin_status"
 2) "up"
 3) "alias"
 4) "etp1a"
 5) "description"
 6) "ARISTA01T1:Ethernet1"
 7) "index"
 8) "1"
 9) "lanes"
10) "0,1"
11) "mtu"
12) "9100"
13) "pfc_asym"
14) "off"
15) "speed"
16) "50000"
17) "tpid"
18) "0x8100"
 
**What needs to do:**
Update the test to take only the ports with configured FEC

#### How did you do it?
fixed the functions mention above, 
Run test_pretest -k test_update_testbed_metadata to create an updated 'autoneg-test-params.json' and run the autoneg tests on the new ports.

#### How did you verify/test it?
checked the tests passed on the new ports after changing the functions

#### Any platform specific information?
no
#### Supported testbed topology if it's a new test case?
any
