### PR TITLE
[reboot] Remove INIT_VIEW from event check

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -623,7 +623,6 @@ class AdvancedReboot:
 
         event_counters = {
             "SAI_CREATE_SWITCH": 1,
-            "INIT_VIEW": 1,
             "APPLY_VIEW": 1,
             "LAG_READY": len(self.mgFacts["minigraph_portchannels"]),
             "PORT_READY": len(self.mgFacts["minigraph_ports"]) - down_ports,

--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -3,7 +3,6 @@ import re
 REQUIRED_PATTERNS = {
     "time_span": [
         "SAI_CREATE_SWITCH",
-        "INIT_VIEW",
         "APPLY_VIEW"
     ],
     "offset_from_kexec": [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [14444](https://github.com/sonic-net/sonic-buildimage/issues/14444)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Reboot TC failed with error "Event INIT_VIEW was found 0 times, when expected exactly 1 times"
#### How did you do it?
Remove INIT_VIEW check 
#### How did you verify/test it?
Run fast/warm reboot. TC passed
#### Any platform specific information?
SONiC Software Version: SONiC.202211_RC9.2-243f8ce9b
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
