### PR TITLE
[Mellanox] Skip ttl expired drop counters test on new Nvidia platforms

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -856,7 +856,7 @@ def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_por
     """
     @summary: Create an IP packet with TTL=0.
     """
-    if "x86_64-mlnx_msn" in duthost.facts["platform"]:
+    if "x86_64-mlnx_msn" in duthost.facts["platform"] or "x86_64-nvidia_sn" in duthost.facts["platform"]:
         pytest.skip("Not supported on Mellanox devices")
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Nvidia(Mellanox) platforms doesn't support the ttl expired drop counters, the test case has been skipped by the keyword "x86_64-mlnx_msn" in platform name. But for the new Nvidia platforms, the name will be changed to "x86_64-nvidia_snXXXX", so need to add this keyword in the skip condition.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Skip ttl expired drop counters test on new Nvidia platforms
#### How did you do it?
Skip the test case by the keyword "x86_64-nvidia_sn" in platform name.
#### How did you verify/test it?
By automation, test case is skipped.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
