### PR TITLE
[Python3 migration]Fix test failure in everflow_test_utilities.py

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -8,6 +8,7 @@ import ipaddr
 import binascii
 import pytest
 import yaml
+import six
 
 import ptf.testutils as testutils
 import ptf.packet as packet
@@ -842,11 +843,17 @@ class BaseEverflowTest(object):
 
         # Add vendor specific padding to the packet
         if duthost.facts["asic_type"] in ["mellanox"]:
-            payload = binascii.unhexlify("0" * 44) + str(payload)
+            if six.PY2:
+                payload = binascii.unhexlify("0" * 44) + str(payload)
+            else:
+                payload = binascii.unhexlify("0" * 44) + str(payload).encode('utf-8')
 
         if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get(
                 "platform_asic") in ["broadcom-dnx"]:
-            payload = binascii.unhexlify("0" * 24) + str(payload)
+            if six.PY2:
+                payload = binascii.unhexlify("0" * 24) + str(payload)
+            else:
+                payload = binascii.unhexlify("0" * 24) + str(payload).encode('utf-8')
 
         expected_packet = testutils.simple_gre_packet(
             eth_src=setup[direction]["egress_router_mac"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure after Python3 migration in everflow_test_utilities.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Everflow tests fail after Python3 migration.
In Python2 binascii.unhexlify() returns a string while it returns bytes in Python3. Howerver, bytes cannot concatenate to a string in Python3.

#### How did you do it?
Encode string to bytes.

#### How did you verify/test it?
Manually run test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
