### PR TITLE
[test_iface_namingmode] Fix test_show_interfaces_counter

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -279,11 +279,12 @@ class TestShowInterfaces():
 
         assert(len(interfaces) > 0)
 
-        for item in interfaces:
-            if mode == 'alias':
-                assert item in setup['port_alias']
-            elif mode == 'default':
-                assert item in setup['default_interfaces']
+        if mode == 'alias':
+            for item in setup['port_alias']:
+                assert item in interfaces
+        elif mode == 'default':
+            for item in setup['default_interfaces']:
+                assert item in interfaces
 
     def test_show_interfaces_description(self, setup_config_mode, sample_intf):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_show_interfaces_counter fails if the interfaces in the output of `show interfaces counter` do not align exactly with the known list of working interfaces corresponding to port_alias_facts, i.e. if some
interfaces are down. 

#### How did you do it?
Modified test to instead check that all working interfaces are indeed part of the command's output.

#### How did you verify/test it?
Ran the test and it passed on an Arista device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
