### PR TITLE
[Platform API] Fix PsuTest::test_get_presence when a psu is in the skip list

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -109,11 +109,11 @@ class TestPsuApi(PlatformApiTestBase):
             name = psu.get_name(platform_api_conn, i)
             if self.expect(presence is not None, "Unable to retrieve PSU {} presence".format(i)):
                 if self.expect(isinstance(presence, bool), "PSU {} presence appears incorrect".format(i)):
-                    if name in self.psu_skip_list:
-                        self.expect(presence is False,
-                                    "PSU {} in skip_modules inventory got presence True expected False".format(i))
-                    else:
+                    if name not in self.psu_skip_list:
                         self.expect(presence is True, "PSU {} is not present".format(i))
+                    # NOTE: It is possible for a PSU to be populated but not being
+                    #       connected to external power, we therefore cannot assert
+                    #       that the psu is not present when in the skip list
         self.assert_expectations()
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
A power supply can be skipped because it does not have any input power but still be inserted into its slot. Therefore we should not assert that the power supply is not present if it is in the skip list.

#### How did you do it?
Update logic in test_get_presence according to above

#### How did you verify/test it?
Tested on Arista device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
