### PR TITLE
skip test_memory_exhaustion on Celestica-E1031

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -752,6 +752,17 @@ platform_tests/mellanox/test_reboot_cause.py:
       - "platform in ['x86_64-mlnx_msn2010-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2100-r0', 'x86_64-mlnx_msn2410-r0', 'x86_64-nvidia_sn2201-r0']"
 
 #######################################
+####  test_memory_exhaustion.py   #####
+#######################################
+platform_tests/test_memory_exhaustion.py:
+  skip:
+    reason: "Unsupported release or platforms"
+    conditions_logical_operator: 'OR'
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+      - "hwsku in ['Celestica-E1031-T48S4']"
+
+#######################################
 #####    test_platform_info.py    #####
 #######################################
 platform_tests/test_platform_info.py::test_thermal_control_fan_status:
@@ -867,12 +878,3 @@ platform_tests/test_reload_config.py:
 platform_tests/test_sequential_restart.py::test_restart_syncd:
   skip:
     reason: "Restarting syncd is not supported yet"
-
-#######################################
-####  test_memory_exhaustion.py   #####
-#######################################
-platform_tests/test_memory_exhaustion.py:
-  skip:
-    reason: "Unsupported release 20191130"
-    conditions:
-      - "is_multi_asic==True and release in ['201911']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -757,10 +757,8 @@ platform_tests/mellanox/test_reboot_cause.py:
 platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Unsupported release or platforms"
-    conditions_logical_operator: 'OR'
     conditions:
-      - "is_multi_asic==True and release in ['201911']"
-      - "hwsku in ['Celestica-E1031-T48S4']"
+      - "(is_multi_asic==True and release in ['201911']) or (hwsku in ['Celestica-E1031-T48S4'])"
 
 #######################################
 #####    test_platform_info.py    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Skip testcase `test_memory_exhaustion` on Celestica-E1031 platform. `tail /dev/zero` cannot always trigger an OOM kernal panic on this platform.
2. Keep the keys in `tests_mark_conditions_platform_tests.yaml` in alphabetical order.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip testcase `test_memory_exhaustion` on Celestica-E1031 platform.

#### How did you do it?
Use conditional mark to skip the testcase on Celestica-E1031 platform.

#### How did you verify/test it?
Verified on Celestica-E1031 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
