### PR TITLE
[ipfwd] Fix failed in test_dir_bcast due to topo type

### DIFF
--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 
 
-def get_ptf_src_ports(topo_type, tbinfo, duthost):
+def get_ptf_src_ports(tbinfo, duthost):
     # Source ports are upstream ports
-    upstream_neightbor_name = UPSTREAM_NEIGHBOR_MAP[topo_type]
+    upstream_neightbor_name = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]]
     ptf_src_ports = get_neighbor_ptf_port_list(duthost, upstream_neightbor_name, tbinfo)
     return ptf_src_ports
 
@@ -54,7 +54,7 @@ def get_ptf_dst_ports(duthost, mg_facts, testbed_type):
 
 def ptf_test_port_map(duthost, ptfhost, mg_facts, testbed_type, tbinfo):
     ptf_test_port_map = {}
-    ptf_src_ports = get_ptf_src_ports(testbed_type, tbinfo, duthost)
+    ptf_src_ports = get_ptf_src_ports(tbinfo, duthost)
     vlan_ip_port_pair = get_ptf_dst_ports(duthost, mg_facts, testbed_type)
 
     ptf_test_port_map = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Func get_ptf_src_ports requests topo_type to get neighbor port, but in previous code uses topo_name.

#### How did you do it?
Use topo_type

#### How did you verify/test it?
Run test
```
ipfwd/test_dir_bcast.py::test_dir_bcast PASSED                           [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
