### PR TITLE
[Python3 migration]Fix test failure in qos_sai_base.py

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -250,14 +250,11 @@ class QosSaiBase(QosBase):
             bufkeystr = "BUFFER_PROFILE|"
 
         if check_qos_db_fv_reference_with_table(dut_asic):
+            out = dut_asic.run_redis_cmd(argv=["redis-cli", "-n", db, "HGET", keystr, "profile"])[0]
             if six.PY2:
-                bufferProfileName = dut_asic.run_redis_cmd(
-                    argv=["redis-cli", "-n", db, "HGET", keystr, "profile"]
-                )[0].encode("utf-8").translate(None, "[]")
+                bufferProfileName = out.encode("utf-8").translate(None, "[]")
             else:
-                bufferProfileName = dut_asic.run_redis_cmd(
-                    argv=["redis-cli", "-n", db, "HGET", keystr, "profile"]
-                )[0].translate({ord(i): None for i in '[]'})
+                bufferProfileName = out.translate({ord(i): None for i in '[]'})
         else:
             bufferProfileName = bufkeystr + dut_asic.run_redis_cmd(
                 argv=["redis-cli", "-n", db, "HGET", keystr, "profile"])[0]
@@ -325,22 +322,17 @@ class QosSaiBase(QosBase):
                 wredProfile (dict): Map of ECN/WRED attributes
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
+            out = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
+                        "wred_profile"
+                    ]
+                )[0]
             if six.PY2:
-                wredProfileName = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
-                        "wred_profile"
-                    ]
-                )[0].encode("utf-8").translate(None, "[]")
+                wredProfileName = out.encode("utf-8").translate(None, "[]")
             else:
-                wredProfileName = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
-                        "wred_profile"
-                    ]
-                )[0].translate({ord(i): None for i in '[]'})
+                wredProfileName = out.translate({ord(i): None for i in '[]'})
         else:
             wredProfileName = "WRED_PROFILE|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
@@ -390,20 +382,16 @@ class QosSaiBase(QosBase):
                 SchedulerParam (dict): Map of scheduler parameters
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
+            out = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                    ]
+                )[0]
             if six.PY2:
-                schedProfile = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
-                    ]
-                )[0].encode("utf-8").translate(None, "[]")
+                schedProfile = out.encode("utf-8").translate(None, "[]")
             else:
-                schedProfile = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
-                    ]
-                )[0].translate({ord(i): None for i in '[]'})
+                schedProfile = out.translate({ord(i): None for i in '[]'})
         else:
             schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -7,6 +7,7 @@ import yaml
 import random
 import os
 import sys
+import six
 
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -156,7 +157,10 @@ class QosSaiBase(QosBase):
             db = "4"
             keystr = "BUFFER_POOL|"
         if check_qos_db_fv_reference_with_table(dut_asic):
-            pool = bufferProfile["pool"].encode("utf-8").translate(None, "[]")
+            if six.PY2:
+                pool = bufferProfile["pool"].encode("utf-8").translate(None, "[]")
+            else:
+                pool = bufferProfile["pool"].translate({ord(i): None for i in '[]'})
         else:
             pool = keystr + bufferProfile["pool"]
         bufferSize = int(
@@ -184,27 +188,33 @@ class QosSaiBase(QosBase):
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
             if self.isBufferInApplDb(dut_asic):
-                bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
-                    None, "[]").replace("BUFFER_POOL_TABLE:", ''
-                                        )
+                if six.PY2:
+                    bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
+                        None, "[]").replace("BUFFER_POOL_TABLE:", '')
+                else:
+                    bufferPoolName = bufferProfile["pool"].translate(
+                        {ord(i): None for i in '[]'}).replace("BUFFER_POOL_TABLE:", '')
             else:
-                bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
-                    None, "[]").replace("BUFFER_POOL|", ''
-                                        )
+                if six.PY2:
+                    bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
+                        None, "[]").replace("BUFFER_POOL|", '')
+                else:
+                    bufferPoolName = bufferProfile["pool"].translate(
+                        {ord(i): None for i in '[]'}).replace("BUFFER_POOL|", '')
         else:
-            bufferPoolName = bufferProfile["pool"].encode("utf-8")
+            bufferPoolName = six.text_type(bufferProfile["pool"])
 
-        bufferPoolVoid = dut_asic.run_redis_cmd(
+        bufferPoolVoid = six.text_type(dut_asic.run_redis_cmd(
             argv=[
                 "redis-cli", "-n", "2", "HGET",
                 "COUNTERS_BUFFER_POOL_NAME_MAP", bufferPoolName
             ]
-        )[0].encode("utf-8")
+        )[0])
         bufferProfile.update({"bufferPoolVoid": bufferPoolVoid})
 
-        bufferPoolRoid = dut_asic.run_redis_cmd(
+        bufferPoolRoid = six.text_type(dut_asic.run_redis_cmd(
             argv=["redis-cli", "-n", "1", "HGET", "VIDTORID", bufferPoolVoid]
-        )[0].encode("utf-8").replace("oid:", '')
+        )[0]).replace("oid:", '')
         bufferProfile.update({"bufferPoolRoid": bufferPoolRoid})
 
     def __getBufferProfile(self, request, dut_asic, os_version, table, port, priorityGroup):
@@ -240,9 +250,14 @@ class QosSaiBase(QosBase):
             bufkeystr = "BUFFER_PROFILE|"
 
         if check_qos_db_fv_reference_with_table(dut_asic):
-            bufferProfileName = dut_asic.run_redis_cmd(
-                argv=["redis-cli", "-n", db, "HGET", keystr, "profile"]
-            )[0].encode("utf-8").translate(None, "[]")
+            if six.PY2:
+                bufferProfileName = dut_asic.run_redis_cmd(
+                    argv=["redis-cli", "-n", db, "HGET", keystr, "profile"]
+                )[0].encode("utf-8").translate(None, "[]")
+            else:
+                bufferProfileName = dut_asic.run_redis_cmd(
+                    argv=["redis-cli", "-n", db, "HGET", keystr, "profile"]
+                )[0].translate({ord(i): None for i in '[]'})
         else:
             bufferProfileName = bufkeystr + dut_asic.run_redis_cmd(
                 argv=["redis-cli", "-n", db, "HGET", keystr, "profile"])[0]
@@ -310,21 +325,30 @@ class QosSaiBase(QosBase):
                 wredProfile (dict): Map of ECN/WRED attributes
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
-            wredProfileName = dut_asic.run_redis_cmd(
-                argv=[
-                    "redis-cli", "-n", "4", "HGET",
-                    "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
-                    "wred_profile"
-                ]
-            )[0].encode("utf-8").translate(None, "[]")
+            if six.PY2:
+                wredProfileName = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
+                        "wred_profile"
+                    ]
+                )[0].encode("utf-8").translate(None, "[]")
+            else:
+                wredProfileName = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
+                        "wred_profile"
+                    ]
+                )[0].translate({ord(i): None for i in '[]'})
         else:
-            wredProfileName = "WRED_PROFILE|" + dut_asic.run_redis_cmd(
+            wredProfileName = "WRED_PROFILE|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "HGET",
                     "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
                     "wred_profile"
                 ]
-            )[0].encode("utf-8")
+            )[0])
 
         result = dut_asic.run_redis_cmd(
             argv=["redis-cli", "-n", "4", "HGETALL", wredProfileName]
@@ -344,12 +368,12 @@ class QosSaiBase(QosBase):
             Returns:
                 watermarkStatus (str): Watermark status
         """
-        watermarkStatus = dut_asic.run_redis_cmd(
+        watermarkStatus = six.text_type(dut_asic.run_redis_cmd(
             argv=[
                 "redis-cli", "-n", "4", "HGET",
                 "FLEX_COUNTER_TABLE|QUEUE_WATERMARK", "FLEX_COUNTER_STATUS"
             ]
-        )[0].encode("utf-8")
+        )[0])
 
         return watermarkStatus
 
@@ -366,23 +390,31 @@ class QosSaiBase(QosBase):
                 SchedulerParam (dict): Map of scheduler parameters
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
-            schedProfile = dut_asic.run_redis_cmd(
-                argv=[
-                    "redis-cli", "-n", "4", "HGET",
-                    "QUEUE|{0}|{1}".format(port, queue), "scheduler"
-                ]
-            )[0].encode("utf-8").translate(None, "[]")
+            if six.PY2:
+                schedProfile = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                    ]
+                )[0].encode("utf-8").translate(None, "[]")
+            else:
+                schedProfile = dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                    ]
+                )[0].translate({ord(i): None for i in '[]'})
         else:
-            schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
+            schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "HGET",
                     "QUEUE|{0}|{1}".format(port, queue), "scheduler"
                 ]
-            )[0].encode("utf-8")
+            )[0])
 
-        schedWeight = dut_asic.run_redis_cmd(
+        schedWeight = six.text_type(dut_asic.run_redis_cmd(
             argv=["redis-cli", "-n", "4", "HGET", schedProfile, "weight"]
-        )[0].encode("utf-8")
+        )[0])
 
         return {"schedProfile": schedProfile, "schedWeight": schedWeight}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in qos_sai_base.py after Python3 migration

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test cases fail in qos_sai_base.py after Python3 migration.
There are a lot of encode()/replace()/translate() in tests/qos. These functions behave differently in Python3.

#### How did you do it?
1. In Python 2, the encode() function returns a string object, while in Python 3 it returns a bytes object. 
Use six.text_type() to replace encode() to make code compatible both in Python2 and Python3. six.text_type() returns Unicode in Python2 and string in Python3.

2. Make sure string and bytes object are used correctly in translate().
Python 3 changes translate() to require a mapping table to be passed as an argument. Use ord() function to convert each character in the string '[]' to its corresponding Unicode code point, and then passes the resulting dictionary comprehension as an argument to the translate() method.

#### How did you verify/test it?
Run testcase manually.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
