### PR TITLE
[qos 202012] add default value for public_docker_registry option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,12 @@ def pytest_addoption(parser):
     add_normal_reboot_args(parser)
 
     ############################
+    #   QoS options         #
+    ############################
+    parser.addoption("--public_docker_registry", action="store_true", default=False,
+                     help="To use public docker registry for syncd swap, by default is disabled (False)")
+
+    ############################
     #   loop_times options     #
     ############################
     parser.addoption("--loop_times", metavar="LOOP_TIMES", action="store", default=1, type=int,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

miss default value for public_docker_registry,  caused below error

```
request = <SubRequest 'swap_syncd' for <Function test_tunnel_decap_dscp_to_pg_mapping>>
rand_selected_dut = <MultiAsicSonicHost str2-7050cx3-acs-06>
creds = {'ad_domain': 'GME', 'ad_integration_enabled': True, 'ansible_become_pass': "{{ secret_group_vars['str']['ansible_become_pass'] }}", 'ansible_ssh_pass': "{{ secret_group_vars['str']['ansible_ssh_pass'] }}", ...}

    @pytest.fixture(scope='module')
    def swap_syncd(request, rand_selected_dut, creds):
>       public_docker_reg = request.config.getoption("--public_docker_registry")
E       ValueError: no option named '--public_docker_registry'

creds      = {'ad_domain': 'GME', 'ad_integration_enabled': True, 'ansible_become_pass': "{{ secret_group_vars['str']['ansible_become_pass'] }}", 'ansible_ssh_pass': "{{ secret_group_vars['str']['ansible_ssh_pass'] }}", ...}
rand_selected_dut = <MultiAsicSonicHost str2-7050cx3-acs-06>
request    = <SubRequest 'swap_syncd' for <Function test_tunnel_decap_dscp_to_pg_mapping>>

qos/tunnel_qos_remap_base.py:238: ValueError
```


#### How did you do it?

set default value to "false"

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
