### PR TITLE
Update PFCXonTest for cisco-8000 multi-asic

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3431,6 +3431,51 @@ qos_params:
                 lossless_weight: 30
             hdrm_pool_wm_multiplier: 1
             cell_size: 384
+        topo-t2:
+            100000_300m:
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 10300
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 10
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 10300
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 10
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 3415
+                    pkts_num_dismiss_pfc: 23
+                    packet_size: 1350
+                    pkts_num_egr_mem: 6884
+            400000_300m:
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 9923
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 10
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 9923
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 10
     jr2:
         topo-any:
             100000_300m:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For cisco-8000 multi-asic, there are 3 queues to fill to trigger XOFF, 1st queue in ingress asic, 2nd queue in fabric card, 3rd queue in egress asic. 
Added a function fill_egress_plus_one to fill 2nd queue and 3rd queue.
Updated qos.yml for topo-t2 Xon case.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
It's for cisco-8000 only.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
