### PR TITLE
[dualtor][utilities] confirm neighbor entry exists before checking tunnel routes

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -11,15 +11,18 @@ logger = logging.getLogger(__name__)
 
 APP_DB = 0
 STATE_DB = 6
+CONFIG_DB = 4
 
 DB_NAME_MAP = {
     APP_DB: "APP_DB",
-    STATE_DB: "STATE_DB"
+    STATE_DB: "STATE_DB",
+    CONFIG_DB: "CONFIG_DB"
 }
 
 DB_SEPARATOR_MAP = {
     APP_DB: ":",
-    STATE_DB: "|"
+    STATE_DB: "|",
+    CONFIG_DB: "|"
 }
 
 APP_DB_MUX_STATE_FIELDS = {
@@ -167,6 +170,30 @@ class DBChecker:
 
         return not bool(mismatch_ports)
     
+    def _get_nbr_data(self, intf_name, dest_name):
+        """Fetch neighbor data"""
+        ipaddress = self._get_ipaddr(intf_name, dest_name)
+        if ipaddress == "":
+            logger.debug("Failed to fetch {}'s {} address in config db. ".format(intf_name, dest_name))
+
+            return False
+
+        cmd = "/bin/ip neigh show " + ipaddress
+        nbr_data = self.duthost.shell(cmd)['stdout']
+
+        logger.debug("Fetched neighbor entry data for {} {}: {}".format(intf_name, dest_name, nbr_data))
+        return len(nbr_data) > 0
+
+    def _get_ipaddr(self, intf_name, dest_name):
+        """Get IP address from mux cable table in config db"""
+        tbl_name = "MUX_CABLE" + DB_SEPARATOR_MAP[CONFIG_DB] + intf_name
+        db_dump = self._dump_db(CONFIG_DB, tbl_name)
+
+        if tbl_name in db_dump:
+            return db_dump[tbl_name]['value'].get(dest_name, "")
+        
+        return ""
+
     def _get_mux_tunnel_route(self):
         """Get output of show muxcable tunnel-route. """
         tunnel_route = json.loads(self.duthost.shell("show muxcable tunnel-route --json")['stdout'])
@@ -190,6 +217,9 @@ class DBChecker:
                     mismatch_ports[intf] = routes
             else:
                 for dest_name in expected.keys():
+                    if not self._get_nbr_data(intf, dest_name):
+                        continue
+
                     if dest_name in routes: 
                         if not (int(routes[dest_name]["asic"]) == expected[dest_name]["asic"] 
                                     and int(routes[dest_name]["kernel"]) == expected[dest_name]["kernel"]):

--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -182,7 +182,7 @@ class DBChecker:
         nbr_data = self.duthost.shell(cmd)['stdout']
 
         logger.debug("Fetched neighbor entry data for {} {}: {}".format(intf_name, dest_name, nbr_data))
-        return len(nbr_data) > 0
+        return nbr_data and nbr_data.startswith(ipaddress.split("/")[0])
 
     def _get_ipaddr(self, intf_name, dest_name):
         """Get IP address from mux cable table in config db"""

--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -198,6 +198,7 @@ class DBChecker:
         """Get output of show muxcable tunnel-route. """
         tunnel_route = json.loads(self.duthost.shell("show muxcable tunnel-route --json")['stdout'])
         
+        logger.debug(json.dumps(tunnel_route, indent=4))
         return tunnel_route
 
     def get_tunnel_route_mismatched_ports(self, stand_alone):
@@ -218,6 +219,7 @@ class DBChecker:
             else:
                 for dest_name in expected.keys():
                     if not self._get_nbr_data(intf, dest_name):
+                        logger.debug("Skipping tunnel_route check for {} {} due to non-existing neighbor entry. ".format(intf, dest_name))
                         continue
 
                     if dest_name in routes: 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to improve dualtor_io test utilities. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Checking tunnel routes when neighbor entry is missing is meaningless. 

#### How did you do it?
Fetch ip address from config db, then check the neighbor entry. 

#### How did you verify/test it?
Ran test_normal_op tests on dualtor testbeds. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
