### PR TITLE
[202012][m0][acl] Add two scenarios support for M0 in ipv4 acl test (#7921)

### DIFF
--- a/tests/acl/templates/acltb_test_rules.j2
+++ b/tests/acl/templates/acltb_test_rules.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.66/32"
+                                    }
+                                }
+                            },
+                            "31": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 31
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.67/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.66/32"
+                                    }
+                                }
+                            },
+                            "31": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 31
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.1.67/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -492,6 +492,36 @@
                                         "code": "0"
                                     }
                                 }
+                            },
+                            "32": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 32
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::1/128"
+                                    }
+                                }
+                            },
+                            "33": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 33
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -450,6 +450,36 @@
                                         "code": 1
                                     }
                                 }
+                            },
+                            "32": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 32
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::1/128"
+                                    }
+                                }
+                            },
+                            "33": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 33
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800:0:1::9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -21,6 +21,7 @@ from ansible.vars.manager import VariableManager
 from tests.common import constants
 from tests.common.cache import cached
 from tests.common.cache import FactsCache
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -566,3 +567,30 @@ def safe_filename(filename, replacement_char='_'):
     """
     illegal_chars_pattern = re.compile("[#%&{}\\<>\*\?/ \$!'\":@\+`|=]")
     return re.sub(illegal_chars_pattern, replacement_char, filename)
+
+
+def get_upstream_neigh_type(topo_type, is_upper=True):
+    """
+    @summary: Get neighbor type by topo type
+    @param topo_type: topo type
+    @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
+    @return a str
+        Sample output: "mx"
+    """
+    if topo_type in UPSTREAM_NEIGHBOR_MAP:
+        return UPSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_type]
+
+    return None
+
+def get_downstream_neigh_type(topo_type, is_upper=True):
+    """
+    @summary: Get neighbor type by topo type
+    @param topo_type: topo type
+    @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
+    @return a str
+        Sample output: "mx"
+    """
+    if topo_type in DOWNSTREAM_NEIGHBOR_MAP:
+        return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
+
+    return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/7921
In previous acl test, m0 only performs like t0, this PR is to add support to simulate both t0 and t1 scenario.

#### How did you do it?
**1. IPv4 test**
- For m0_vlan_scenario, it is more likely t0, so just performs like t0.
- For m0_l3_scenario
  - tested downstream IPs for t1 is in vlan of m0 because m0 has a vlan but t1 doesn't have. So I added new tested IPs and add support for it.
  - Because tested IPs has been changed, so I changed verify rule id for m0 in `counters_sanity_check` while in teardown period.

**2. IPv6 test**
Add support for m0_l3_scenario, **not** support m0_vlan_scenario for now.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
