### PR TITLE
Add UT for flush_unused_database

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -61,6 +61,7 @@ t0:
   - test_features.py
   - test_interfaces.py
   - test_procdockerstatsd.py
+  - database/test_db_scripts.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py

--- a/tests/database/test_db_scripts.py
+++ b/tests/database/test_db_scripts.py
@@ -1,0 +1,28 @@
+"""
+Test the database scripts
+"""
+import logging
+import pytest
+
+from tests.common.utilities import skip_release
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+def test_flush_unused_database(duthosts, rand_one_dut_hostname):
+    """
+    @summary: Test 'flush_unused_database' scripts can run correctly inside database container.
+     ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c database/test_db_scripts.py -f vtestbed.csv -i veos_vtb
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # the flush_unused_database exist after 202012 branch
+    skip_release(duthost, ["201811", "201911"])
+
+    result = duthost.shell("docker exec -t database flush_unused_database")
+    pytest_assert(result["rc"] == 0, "flush_unused_database script failed with {}".format(result["stdout"]))

--- a/tests/database/test_db_scripts.py
+++ b/tests/database/test_db_scripts.py
@@ -14,6 +14,7 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+
 def test_flush_unused_database(duthosts, rand_one_dut_hostname):
     """
     @summary: Test 'flush_unused_database' scripts can run correctly inside database container.

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -172,7 +172,8 @@ test_t0() {
       process_monitoring/test_critical_process_monitoring.py \
       show_techsupport/test_techsupport_no_secret.py \
       system_health/test_system_status.py \
-      radv/test_radv_ipv6_ra.py"
+      radv/test_radv_ipv6_ra.py \
+      database/test_db_scripts.py"
 
       pushd $SONIC_MGMT_DIR/tests
       ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname


### PR DESCRIPTION
**What I did**
Add new UT for flush_unused_database scripts.

**Why I did it**
The flush_unused_database script not cover by UT.

**How I verified it**
Pass all UT.

**Details if related**
This UT depends on PR: https://github.com/sonic-net/sonic-buildimage/pull/14632
