### PR TITLE
To skip dual mock testcase for common tor device in 202012

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -4,39 +4,39 @@
 ##############################################################
 
 dualtor/test_ipinip.py::test_decap_standby_tor:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
+  skip:
+    reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "'dualtor' not in topo_name"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
 
 dualtor/test_orchagent_active_tor_downstream.py:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
+  skip:
+    reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "'7260' in platform"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
 
 dualtor/test_orchagent_mac_move.py:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
+  skip:
+    reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "'dualtor' not in topo_name"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
 
 dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
+  skip:
+    reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "'dualtor' not in topo_name"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
 
 dualtor/test_standby_tor_upstream_mux_toggle.py:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
+  skip:
+    reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "'dualtor' not in topo_name"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
 
 
 dualtor_io/test_normal_op.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -8,35 +8,35 @@ dualtor/test_ipinip.py::test_decap_standby_tor:
     reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orchagent_active_tor_downstream.py:
   skip:
     reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orchagent_mac_move.py:
   skip:
     reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby:
   skip:
     reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_standby_tor_upstream_mux_toggle.py:
   skip:
     reason: "dual tor mock test only support on 7050cx3"
     conditions:
       - "release in ['202012']"
-      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower())"
+      - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 
 dualtor_io/test_normal_op.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202012.yaml
@@ -5,35 +5,35 @@
 
 dualtor/test_ipinip.py::test_decap_standby_tor:
   skip:
-    reason: "dual tor mock test only support on 7050cx3"
+    reason: "dual tor mock test only support on 7050cx3 and 7260"
     conditions:
       - "release in ['202012']"
       - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orchagent_active_tor_downstream.py:
   skip:
-    reason: "dual tor mock test only support on 7050cx3"
+    reason: "dual tor mock test only support on 7050cx3 and 7260"
     conditions:
       - "release in ['202012']"
       - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orchagent_mac_move.py:
   skip:
-    reason: "dual tor mock test only support on 7050cx3"
+    reason: "dual tor mock test only support on 7050cx3 and 7260"
     conditions:
       - "release in ['202012']"
       - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby:
   skip:
-    reason: "dual tor mock test only support on 7050cx3"
+    reason: "dual tor mock test only support on 7050cx3 and 7260"
     conditions:
       - "release in ['202012']"
       - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"
 
 dualtor/test_standby_tor_upstream_mux_toggle.py:
   skip:
-    reason: "dual tor mock test only support on 7050cx3"
+    reason: "dual tor mock test only support on 7050cx3 and 7260"
     conditions:
       - "release in ['202012']"
       - "('dualtor' in topo_name) or ('7050cx3' not in platform.lower() and '7260' not in platform.lower())"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
skip other than xfail dual mock test case for common ToR device.

#### How did you do it?
modify the conditional mark file of 202012 to change from xfail to skip and limited the case only to specified HWSKU

#### How did you verify/test it?
manually run test to verify the skip logic. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
