### PR TITLE
[Chassis Support] TestMemoryExhaustion testcase always execute on fir…

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -24,10 +24,11 @@ class TestMemoryExhaustion:
     """
 
     @pytest.fixture(autouse=True)
-    def tearDown(self, duthost, localhost, pdu_controller):
+    def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, pdu_controller):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         dut_ip = duthost.mgmt_ip
         hostname = duthost.hostname
         if not self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED):

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -41,7 +41,8 @@ class TestMemoryExhaustion:
             # Wait until all critical processes are healthy.
             wait_critical_processes(duthost)
 
-    def test_memory_exhaustion(self, duthost, localhost):
+    def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         dut_ip = duthost.mgmt_ip
         hostname = duthost.hostname
         dut_datetime = duthost.get_now_time()


### PR DESCRIPTION
…st module specified in testbed.yaml instead of one  per HWSKU

### Description of PR
When running the testcase TestMemoryExhaustion.test_memory_exhaustion for a chassis noticed that although it was suppose to be executing on each HWSKU of the Chassis modules, due to the way the parameter was specified it ended up always executing on the same first module specified in tesbed.yaml file. 

For example the testbed info for the chassis lists the following DUTs:

  dut:
    - SONiC-lc4-1
    - SONiC-lc2-1
    - SONiC-lc3-1
    - SONiC-sup-2

And if you execute the test:
The parameter specified will always point to "SONiC-lc4-1" and the same module gets executed multiple times instead of testing on other DUTs of the specified chassis.

Here is one sample test run that was suppose to be executing on LC4, LC3, and SUP but it ended up executing 3 times on LC4:
```
2023-04-13T13:21:19.9318243Z ============================= test session starts ==============================
2023-04-13T13:21:19.9320412Z platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
2023-04-13T13:21:19.9399952Z ansible: 2.8.12
2023-04-13T13:21:19.9401234Z rootdir: /azp/_work/33/s/tests, inifile: pytest.ini
2023-04-13T13:21:19.9403443Z plugins: ansible-2.2.4, metadata-1.11.0, celery-4.4.7, forked-1.3.0, allure-pytest-2.8.22, xdist-1.28.0, repeat-0.9.1, html-1.22.1
2023-04-13T13:21:21.2276804Z collected 3 items
2023-04-13T13:21:21.2283536Z 
2023-04-13T13:31:48.7102648Z platform_tests/test_memory_exhaustion.py::TestMemoryExhaustion::test_memory_exhaustion[SONiC-lc4-1] PASSED [ 33%]
2023-04-13T13:38:19.3830358Z platform_tests/test_memory_exhaustion.py::TestMemoryExhaustion::test_memory_exhaustion[SONiC-lc3-1] FAILED [ 66%]
2023-04-13T13:46:14.1617450Z platform_tests/test_memory_exhaustion.py::TestMemoryExhaustion::test_memory_exhaustion[SONiC-sup-2] FAILED [100%]
2023-04-13T13:46:14.1618732Z 
2023-04-13T13:46:14.1620994Z =================================== FAILURES ===================================
2023-04-13T13:46:14.1622979Z _________ TestMemoryExhaustion.test_memory_exhaustion[SONiC-lc3-1] _________
2023-04-13T13:46:14.1623709Z 
2023-04-13T13:46:14.1625408Z self = <tests.platform_tests.test_memory_exhaustion.TestMemoryExhaustion instance at 0x7fe720c47eb0>
2023-04-13T13:46:14.1627248Z duthost = <MultiAsicSonicHost SONiC-lc4-1>
2023-04-13T13:46:14.1628793Z localhost = <tests.common.devices.local.Localhost object at 0x7fe75cc8fc50>
2023-04-13T13:46:14.1629447Z 
2023-04-13T13:46:14.1630754Z     def test_memory_exhaustion(self, duthost, localhost):
2023-04-13T13:46:14.1632196Z         dut_ip = duthost.mgmt_ip
2023-04-13T13:46:14.1633615Z         hostname = duthost.hostname
2023-04-13T13:46:14.1635048Z         dut_datetime = duthost.get_now_time()
2023-04-13T13:46:14.1636346Z     
2023-04-13T13:46:14.1637841Z         # Our shell command is designed as 'nohup bash -c "sleep 5 && tail /dev/zero" &' because of:
2023-04-13T13:46:14.1639263Z         #  * `tail /dev/zero` is used to run out of memory completely.
2023-04-13T13:46:14.1640644Z         #  * Since `tail /dev/zero` will cause the DUT reboot, we need to run it in the background
2023-04-13T13:46:14.1642064Z         #    (using &) to avoid pytest getting stuck. `nohup` is also necessary to protect the
2023-04-13T13:46:14.1643318Z         #    background process.
2023-04-13T13:46:14.1644566Z         #  * Some DUTs with few free memory may reboot before ansible receive the result of shell
2023-04-13T13:46:14.1646069Z         #    command, so we add `sleep 5` to ensure ansible receive the result first.
2023-04-13T13:46:14.1647526Z         cmd = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
2023-04-13T13:46:14.1648736Z         res = duthost.shell(cmd)
2023-04-13T13:46:14.1649838Z         if not res.is_successful:
2023-04-13T13:46:14.1651222Z             pytest.fail('DUT {} run command {} failed'.format(hostname, cmd))
2023-04-13T13:46:14.1652497Z     
2023-04-13T13:46:14.1653582Z         # Waiting for SSH connection shutdown
2023-04-13T13:46:14.1654900Z         pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_ABSENT, SSH_SHUTDOWN_TIMEOUT),
2023-04-13T13:46:14.1656397Z                       'DUT {} did not shutdown'.format(hostname))
2023-04-13T13:46:14.1657641Z         # Waiting for SSH connection startup
2023-04-13T13:46:14.1658959Z         pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
2023-04-13T13:46:14.1660441Z >                     'DUT {} did not startup'.format(hostname))
2023-04-13T13:46:14.1661825Z E       Failed: DUT SONiC-lc4-1 did not startup
2023-04-13T13:46:14.1662322Z 
2023-04-13T13:46:14.1663784Z cmd        = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
2023-04-13T13:46:14.1665045Z dut_datetime = datetime.datetime(2023, 4, 13, 13, 31, 49)
2023-04-13T13:46:14.1666283Z dut_ip     = u'10.1.2.3'
2023-04-13T13:46:14.1667444Z duthost    = <MultiAsicSonicHost SONiC-lc4-1>
2023-04-13T13:46:14.1668678Z hostname   = 'SONiC-lc4-1'
2023-04-13T13:46:14.1669883Z localhost  = <tests.common.devices.local.Localhost object at 0x7fe75cc8fc50>
2023-04-13T13:46:14.1671575Z res        = {'stderr_lines': [], u'cmd': u'nohup bash -c "sleep 5 && tail /dev/zero" &', u...tdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [], 'failed': False}
2023-04-13T13:46:14.1673232Z self       = <tests.platform_tests.test_memory_exhaustion.TestMemoryExhaustion instance at 0x7fe720c47eb0>
2023-04-13T13:46:14.1673796Z 
2023-04-13T13:46:14.1674839Z platform_tests/test_memory_exhaustion.py:66: Failed
2023-04-13T13:46:14.1676237Z _________ TestMemoryExhaustion.test_memory_exhaustion[SONiC-sup-2] _________
2023-04-13T13:46:14.1676784Z 
2023-04-13T13:46:14.1677941Z self = <tests.platform_tests.test_memory_exhaustion.TestMemoryExhaustion instance at 0x7fe71e497550>
2023-04-13T13:46:14.1679318Z duthost = <MultiAsicSonicHost SONiC-lc4-1>
2023-04-13T13:46:14.1680505Z localhost = <tests.common.devices.local.Localhost object at 0x7fe75cc8fc50>
2023-04-13T13:46:14.1681024Z 
2023-04-13T13:46:14.1682076Z     def test_memory_exhaustion(self, duthost, localhost):
2023-04-13T13:46:14.1683207Z         dut_ip = duthost.mgmt_ip
2023-04-13T13:46:14.1684309Z         hostname = duthost.hostname
2023-04-13T13:46:14.1685390Z         dut_datetime = duthost.get_now_time()
2023-04-13T13:46:14.1686454Z     
2023-04-13T13:46:14.1687796Z         # Our shell command is designed as 'nohup bash -c "sleep 5 && tail /dev/zero" &' because of:
2023-04-13T13:46:14.1689071Z         #  * `tail /dev/zero` is used to run out of memory completely.
2023-04-13T13:46:14.1690417Z         #  * Since `tail /dev/zero` will cause the DUT reboot, we need to run it in the background
2023-04-13T13:46:14.1692099Z         #    (using &) to avoid pytest getting stuck. `nohup` is also necessary to protect the
2023-04-13T13:46:14.1693391Z         #    background process.
2023-04-13T13:46:14.1694755Z         #  * Some DUTs with few free memory may reboot before ansible receive the result of shell
2023-04-13T13:46:14.1696287Z         #    command, so we add `sleep 5` to ensure ansible receive the result first.
2023-04-13T13:46:14.1697830Z         cmd = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
2023-04-13T13:46:14.1699169Z         res = duthost.shell(cmd)
2023-04-13T13:46:14.1700422Z         if not res.is_successful:
2023-04-13T13:46:14.1701837Z             pytest.fail('DUT {} run command {} failed'.format(hostname, cmd))
2023-04-13T13:46:14.1703311Z     
2023-04-13T13:46:14.1704612Z         # Waiting for SSH connection shutdown
2023-04-13T13:46:14.1705973Z         pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_ABSENT, SSH_SHUTDOWN_TIMEOUT),
2023-04-13T13:46:14.1707399Z                       'DUT {} did not shutdown'.format(hostname))
2023-04-13T13:46:14.1708720Z         # Waiting for SSH connection startup
2023-04-13T13:46:14.1710070Z         pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
2023-04-13T13:46:14.1711563Z >                     'DUT {} did not startup'.format(hostname))
2023-04-13T13:46:14.1712988Z E       Failed: DUT SONiC-lc4-1 did not startup
2023-04-13T13:46:14.1713496Z 
2023-04-13T13:46:14.1714766Z cmd        = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
2023-04-13T13:46:14.1716163Z dut_datetime = datetime.datetime(2023, 4, 13, 13, 38, 20)
2023-04-13T13:46:14.1742400Z dut_ip     = u'10.1.2.3'
2023-04-13T13:46:14.1744857Z duthost    = <MultiAsicSonicHost SONiC-lc4-1>
2023-04-13T13:46:14.1746988Z hostname   = 'SONiC-lc4-1'
2023-04-13T13:46:14.1749046Z localhost  = <tests.common.devices.local.Localhost object at 0x7fe75cc8fc50>
2023-04-13T13:46:14.1752025Z res        = {'stderr_lines': [], u'cmd': u'nohup bash -c "sleep 5 && tail /dev/zero" &', u...tdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [], 'failed': False}
2023-04-13T13:46:14.1754379Z self       = <tests.platform_tests.test_memory_exhaustion.TestMemoryExhaustion instance at 0x7fe71e497550>
2023-04-13T13:46:14.1755319Z 
2023-04-13T13:46:14.1757096Z platform_tests/test_memory_exhaustion.py:66: Failed
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To support Chassis testing 

#### How did you do it?

#### How did you verify/test it?
Verified that after my change the tests are done on the correct intended modules (LC4, LC3, and SUP)

#### Any platform specific information?
Tested on Chassis as well as pizzabox HWSKU to ensure no regression on pizzabox for this added support.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
