### PR TITLE
[Nvidia] Fix headroom size exceeds limit log error issue for test_auto_negotiation

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -15,6 +15,8 @@ from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import list_dut_fanout_connections
 from tests.common.utilities import skip_release
 from tests.common.helpers.port_utils import is_sfp_speed_supported
+from tests.conftest import get_autoneg_tests_data
+from tests.common.mellanox_data import is_mellanox_device
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -356,3 +358,35 @@ def test_force_speed(enum_speed_per_dutport_fixture):
         fanout_actual_speed == speed,
         'expect fanout speed: {}, but got {}'.format(speed, fanout_actual_speed)
     )
+
+
+@pytest.fixture(scope='module', autouse=True)
+def change_cable_length(duthost):
+    if is_mellanox_device(duthost):
+        """
+        For nvidia device, when buffer model is dynamic, the headroom size is related to the speed and cable length.
+        When speed is bigger or equal to 400G, we need change the cable length to one smaller one such as 50m, otherwise
+        there will be some log errors like: refreshPgsForPort: Update speed (400000) and cable length (300m) for port
+        Ethernet0 failed, accumulative headroom size exceeds the limit.
+        """
+        buffer_model = duthost.shell('redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
+        if buffer_model == "dynamic":
+            autoneg_test_data = get_autoneg_tests_data()
+            new_cable_length = '50m'
+            speed_threshold_for_change_cable_length = 400000
+            for autonego_item in autoneg_test_data:
+                dut_name = autonego_item['dutname']
+                if dut_name == "unknown":
+                    pytest_require(
+                        dut_name != 'unknown',
+                        'required datafile is missing at metadata/autoneg-test-params.json. '
+                        'To create it before the tests run: py.test test_pretest -k test_update_testbed_metadata'
+                    )
+                dut_port = autonego_item['port']
+                speeds = autonego_item['speeds']
+                for speed in speeds:
+                    if int(speed) >= speed_threshold_for_change_cable_length:
+                        logger.info("Port:{}, Speed {} >= {}, change cable length to {}".format(
+                            dut_port, speed, speed_threshold_for_change_cable_length, new_cable_length))
+                        duthost.shell("config interface cable-length {} {}".format(dut_port, new_cable_length))
+                        break


### PR DESCRIPTION
For nvidia device, when buffer model is dynamic, the headroom size is related to the speed and cable length. When speed is bigger or equal to 400G and cable length is bigger, due to the ASIC headroom limitation, there will be some log errors like below.
```
Jan 15 13:29:52.719869  ERR swss#buffermgrd: :- isHeadroomResourceValid: Unable to update profile for port Ethernet0. Accumulative headroom size exceeds limit
Jan 15 13:29:52.719869  ERR swss#buffermgrd: :- refreshPgsForPort: Update speed (400000) and cable length (300m) for port Ethernet0 failed, accumulative headroom size exceeds the limit
Jan 15 13:29:52.721416  ERR swss#buffermgrd: :- doTask: Failed to process table update
```
So we need to change the cable lentgh to one smaller value such as 50m




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Make case meet the the headroom limitation so that there are no related error logs.

#### How did you do it?
Change cable length to 50m for port with speed bigger or equal to 400G

#### How did you verify/test it?
run  test_auto_negotiation issue

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
