### PR TITLE
[Nvidia] Fix test_check_sfp_eeprom_with_option_dom issue due to some keys are not supported for OSFP 8X Pluggable Transceiver

### DIFF
--- a/tests/platform_tests/mellanox/util.py
+++ b/tests/platform_tests/mellanox/util.py
@@ -215,7 +215,8 @@ def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_
                 ["Application Advertisement", "ChannelThresholdValues", "ModuleThresholdValues"])
             expected_keys = expected_keys - excluded_keys
 
-    if "Identifier" in sfp_eeprom_info and sfp_eeprom_info["Identifier"] == "SFP/SFP+/SFP28":
+    sfp_type_for_excluded_monitor_threshold_key = ["SFP/SFP+/SFP28", "OSFP 8X Pluggable Transceiver"]
+    if "Identifier" in sfp_eeprom_info and sfp_eeprom_info["Identifier"] in sfp_type_for_excluded_monitor_threshold_key:
         excluded_keys = excluded_keys | {"ChannelMonitorValues", "ChannelThresholdValues", "ModuleMonitorValues",
                                          "ModuleThresholdValues"}
         expected_keys = (expected_keys | {


### PR DESCRIPTION
Because OSFP 8X Pluggable Transceiver does not support keys: "ChannelMonitorValues", "ChannelThresholdValues", "ModuleMonitorValues", "ModuleThresholdValues", So skip checking them.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_check_sfp_eeprom_with_option_dom issue

#### How did you do it?
Sikp checking keys: "ChannelMonitorValues", "ChannelThresholdValues", "ModuleMonitorValues", when Transceiver  is OSFP 8X Pluggable 

#### How did you verify/test it?
run test_check_sfp_eeprom_with_option_dom

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
