### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/spytest/containers/keysight-ubuntu18/Dockerfile
+++ b/spytest/containers/keysight-ubuntu18/Dockerfile
@@ -3,38 +3,31 @@ FROM ubuntu:bionic
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=US/Pacific
 
-RUN apt -y update
-RUN apt -y upgrade
-
-RUN apt -y install build-essential
-RUN apt -y install git
-RUN apt -y install wget
-
-RUN apt -y install python
-RUN apt -y install python-setuptools
-RUN apt -y install python-pip
-RUN apt -y install python-tk
-RUN apt -y install tk
-RUN apt -y install tcl
-RUN apt -y install tclx8.4
-RUN apt -y install tcllib
-RUN apt -y install tcl-tls
-
-
-RUN apt -y install iputils-ping
-RUN apt -y install snmp
-RUN apt -y install snmptrapd
-
+RUN apt -y update \
+    && apt -y upgrade \
+    && apt -y install build-essential \
+    && apt -y install git \
+    && apt -y install wget \
+    && apt -y install python \
+    && apt -y install python-setuptools \
+    && apt -y install python-pip \
+    && apt -y install python-tk \
+    && apt -y install tk \
+    && apt -y install tcl \
+    && apt -y install tclx8.4 \
+    && apt -y install tcllib \
+    && apt -y install tcl-tls \
+    && apt -y install iputils-ping \
+    && apt -y install snmp \
+    && apt -y install snmptrapd
 COPY . /keysight
 WORKDIR /keysight
 
 RUN pip install --no-cache-dir -r ./spytest.txt
 
 # https://downloads.ixiacom.com/support/downloads_and_updates/public/ixnetwork/9.20-Update2/IxNetworkAPI9.20.2201.70Linux64.bin.tgz
-RUN bash ./IxNetworkAPI9.20.2201.71Linux64.bin -i silent
-
-RUN pip install --no-cache-dir -r /opt/ixia/ixnetwork/9.20.2201.71/lib/PythonApi/requirements.txt
-
+RUN bash ./IxNetworkAPI9.20.2201.71Linux64.bin -i silent \
+    && pip install --no-cache-dir -r /opt/ixia/ixnetwork/9.20.2201.71/lib/PythonApi/requirements.txt
 ENV SCID_TGEN_PATH=/opt
 ENV SCID_TCL85_BIN=/opt
 ENV IXNETWORK_VERSION=9.20.2201.71


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Hi!
The Dockerfile placed at "spytest/containers/keysight-ubuntu18/Dockerfile" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
- [x] Style change

### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
see description

#### How did you do it?
see description

#### How did you verify/test it?
manual validation

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
None

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
None

