### PR TITLE
[dualtor_io] add admin down config reload tests for active-active topology

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -414,7 +414,7 @@ def test_active_link_admin_down_config_reload_downstream(
                 allowed_disruption=0,
                 allow_disruption_before_traffic=True
             )
-            
+
         finally:
             config_interface_admin_status(upper_tor_host, active_active_ports, "up")
             upper_tor_host.shell("config save -y")

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -398,11 +398,7 @@ def test_active_link_admin_down_config_reload_downstream(
             config_interface_admin_status(upper_tor_host, active_active_ports, "down")
 
             upper_tor_host.shell("config save -y")
-
-            send_t1_to_server_with_action(
-                upper_tor_host, verify=True, allowed_disruption=0,
-                action=lambda: config_reload(upper_tor_host, wait=0)
-            )
+            config_reload(upper_tor_host, wait=60)
 
             verify_tor_states(
                 expected_active_host=lower_tor_host,
@@ -410,6 +406,11 @@ def test_active_link_admin_down_config_reload_downstream(
                 expected_standby_health='unhealthy',
                 cable_type=cable_type,
                 skip_state_db=True
+            )
+
+            send_t1_to_server_with_action(
+                upper_tor_host, verify=True,
+                allowed_disruption=0,
             )
             
         finally:

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -390,7 +390,7 @@ def test_active_link_admin_down_config_reload_upstream(
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_downstream(
-    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
     cable_type, active_active_ports
 ):
     if cable_type == CableType.active_active:

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -410,7 +410,9 @@ def test_active_link_admin_down_config_reload_downstream(
 
             send_t1_to_server_with_action(
                 upper_tor_host, verify=True,
+                stop_after=180,
                 allowed_disruption=0,
+                allow_disruption_before_traffic=True
             )
             
         finally:

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -359,6 +359,66 @@ def config_interface_admin_status(duthost, ports, admin_status="up"):
 
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
+def test_active_link_admin_down_config_reload_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    cable_type, active_active_ports
+):
+    if cable_type == CableType.active_active:
+        try:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "down")
+
+            upper_tor_host.shell("config save -y")
+
+            send_server_to_t1_with_action(
+                lower_tor_host, verify=True, allowed_disruption=0,
+                action=lambda: config_reload(upper_tor_host, wait=0)
+            )
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True  #state db will be 'unknown'
+            )
+
+        finally:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+            upper_tor_host.shell("config save -y")
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_active_link_admin_down_config_reload_downstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    cable_type, active_active_ports
+):
+    if cable_type == CableType.active_active:
+        try:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "down")
+
+            upper_tor_host.shell("config save -y")
+
+            send_t1_to_server_with_action(
+                upper_tor_host, verify=True, allowed_disruption=0,
+                action=lambda: config_reload(upper_tor_host, wait=0)
+            )
+
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host,
+                expected_standby_health='unhealthy',
+                cable_type=cable_type,
+                skip_state_db=True
+            )
+            
+        finally:
+            config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+            upper_tor_host.shell("config save -y")
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     cable_type, active_active_ports                                     # noqa F811

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -360,8 +360,8 @@ def config_interface_admin_status(duthost, ports, admin_status="up"):
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_upstream(
-    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    cable_type, active_active_ports
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,       # noqa F811
+    cable_type, active_active_ports                                      # noqa F811
 ):
     if cable_type == CableType.active_active:
         try:
@@ -379,7 +379,7 @@ def test_active_link_admin_down_config_reload_upstream(
                 expected_standby_host=upper_tor_host,
                 expected_standby_health='unhealthy',
                 cable_type=cable_type,
-                skip_state_db=True  #state db will be 'unknown'
+                skip_state_db=True  # state db will be 'unknown'
             )
 
         finally:
@@ -390,8 +390,8 @@ def test_active_link_admin_down_config_reload_upstream(
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_downstream(
-    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    cable_type, active_active_ports
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,       # noqa F811
+    cable_type, active_active_ports                                      # noqa F811
 ):
     if cable_type == CableType.active_active:
         try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fixing test gaps: 

https://github.com/sonic-net/sonic-mgmt/issues/7688
https://github.com/sonic-net/sonic-mgmt/issues/7687

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on active-active topology dualtor DUT, tests passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
