### PR TITLE
Multi-asic support for Cisco QoS param generator

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -997,17 +997,22 @@ class QosSaiBase(QosBase):
                 logger.info('ARP proxy is {} on {}'.format(
                     value['proxy_arp'], key))
 
-    def dutBufferConfig(self, duthost):
+    def dutBufferConfig(self, duthost, dut_asic):
         bufferConfig = {}
         try:
+            ns_spec = ""
+            ns = dut_asic.get_asic_namespace()
+            if ns is not None:
+                # multi-asic support
+                ns_spec = " -n " + ns
             bufferConfig['BUFFER_POOL'] = json.loads(duthost.shell(
-                'sonic-cfggen -d --var-json "BUFFER_POOL"')['stdout'])
+                'sonic-cfggen -d --var-json "BUFFER_POOL"' + ns_spec)['stdout'])
             bufferConfig['BUFFER_PROFILE'] = json.loads(duthost.shell(
-                'sonic-cfggen -d --var-json "BUFFER_PROFILE"')['stdout'])
+                'sonic-cfggen -d --var-json "BUFFER_PROFILE"' + ns_spec)['stdout'])
             bufferConfig['BUFFER_QUEUE'] = json.loads(duthost.shell(
-                'sonic-cfggen -d --var-json "BUFFER_QUEUE"')['stdout'])
+                'sonic-cfggen -d --var-json "BUFFER_QUEUE"' + ns_spec)['stdout'])
             bufferConfig['BUFFER_PG'] = json.loads(duthost.shell(
-                'sonic-cfggen -d --var-json "BUFFER_PG"')['stdout'])
+                'sonic-cfggen -d --var-json "BUFFER_PG"' + ns_spec)['stdout'])
         except Exception as err:
             logger.info(err)
         return bufferConfig
@@ -1082,7 +1087,7 @@ class QosSaiBase(QosBase):
                     "THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
                 qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
             else:
-                bufferConfig = self.dutBufferConfig(duthost)
+                bufferConfig = self.dutBufferConfig(duthost, dut_asic)
                 pytest_assert(len(bufferConfig) == 4,
                               "buffer config is incompleted")
                 pytest_assert('BUFFER_POOL' in bufferConfig,
@@ -1115,7 +1120,7 @@ class QosSaiBase(QosBase):
                                                            tbinfo["topo"]["name"])
                 qosParams = qpm.run()
         elif is_cisco_device(duthost):
-            bufferConfig = self.dutBufferConfig(duthost)
+            bufferConfig = self.dutBufferConfig(duthost, dut_asic)
             pytest_assert('BUFFER_POOL' in bufferConfig,
                           'BUFFER_POOL does not exist in bufferConfig')
             pytest_assert('BUFFER_PROFILE' in bufferConfig,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes missing multi-asic support for Cisco QoS parameter generator. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Add "-n <asicname>" if asicname is present. 

#### How did you verify/test it?
Verified on T2.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
