### PR TITLE
Fix test_everflow_dscp_with_policer for mellanox vendor

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -525,6 +525,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
         if vendor == "marvell":
             rate_limit = rate_limit * 1.25
 
+        send_time = "10"
+        if vendor == "mellanox":
+            send_time = "75"
+
         for asic in self.MIRROR_POLICER_UNSUPPORTED_ASIC_LIST:
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
             if vendorAsic in list(hostvars.keys()) and everflow_dut.facts['hwsku'] in hostvars[vendorAsic]:
@@ -594,7 +598,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                meter_type="packets",
                                cir=rate_limit,
                                cbs=rate_limit,
-                               send_time="10",
+                               send_time=send_time,
                                tolerance=everflow_tolerance)
         finally:
             # Clean up ACL rules and routes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The policer can confirm test deviation for mellanox vendor, only with min number of packets of 50,000.
As the number of packets is determined in ptftest/test only as a result of test send_time,
after testing on our platforms minimal send_time which was stable and achieved send packets in 50k range was 75 sec.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x ] 202205

### Approach
#### What is the motivation for this PR?
stabilize the test_everflow_dscp_with_policer for mellanox vendor
previously test was unstable on mellanox switches, and failed from time to time with error:

“FAIL: everflow_policer_test.EverflowPolicerTest”,

“-—————————————————————————————————-”,

“Traceback (most recent call last):”,

" File \“acstests/everflow_policer_test.py\”, line 333, in runTest",

" assert rx_pps >= self.min_rx_pps and rx_pps <= self.max_rx_pps, assert_str",

“AssertionError: min(90.0) <= pps(87) <= max(110.0)”,

"",

“-—————————————————————————————————-”,

“Ran 1 test in 28.337s”,

"",

“FAILED (failures=1)”
#### How did you do it?
tested several send_time values to get the test to send ~50k packets

#### How did you verify/test it?
run it several times on each SPC/SPC2/SPC3, to check the stability

#### Any platform specific information?
no

