### PR TITLE
Update conftest of crm test

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -7,7 +7,8 @@ import re
 from test_crm import RESTORE_CMDS
 from tests.common.helpers.crm import CRM_POLLING_INTERVAL
 from tests.common.errors import RunAnsibleModuleFail
-from tests.common.utilities import recover_acl_rule
+from tests.common.utilities import wait_until, recover_acl_rule
+from tests.common.platform.interface_utils import parse_intf_status
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +160,52 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("crm config polling interval {}".format(original_crm_polling_interval))["stdout"]
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
+
+
+def get_intf_list(duthost, tbinfo, enum_frontend_asic_index):
+    """ Return the interface list which would influence fdb entry by mac learning """
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
+    mg_facts = asichost.get_extended_minigraph_facts(tbinfo)
+    intf_connect_with_ptf = []
+    for intf, intf_desc in mg_facts["minigraph_neighbors"].items():
+        if "Server" in intf_desc['name']:
+            intf_connect_with_ptf.append(intf)
+    return intf_connect_with_ptf
+
+
+def check_interface_status(duthost, intf_list, expected_oper='up'):
+    """ Check interface status """
+    output = duthost.command("show interface description")
+    intf_status = parse_intf_status(output["stdout_lines"][2:])
+    for intf in intf_list:
+        if intf not in intf_status:
+            logging.info("Missing status for interface %s" % intf)
+            return False
+        if intf_status[intf]["oper"] != expected_oper:
+            logging.info("Oper status of interface {} is {}, expected {}".format(intf, intf_status[intf]["oper"],
+                                                                                 expected_oper))
+            return False
+    return True
+
+
+@pytest.fixture(scope="module", autouse=True)
+def shutdown_unnecessary_intf(duthosts, tbinfo, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname):
+    """ Shutdown unused interfaces to avoid fdb entry influenced by mac learning """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    intfs_connect_with_ptf = get_intf_list(duthost, tbinfo, enum_frontend_asic_index)
+    if intfs_connect_with_ptf:
+        logger.info("Shutdown interfaces: {}".format(intfs_connect_with_ptf))
+        duthost.shutdown_multiple(intfs_connect_with_ptf)
+        assert wait_until(300, 20, 0, check_interface_status, duthost, intfs_connect_with_ptf, 'down'), \
+            "All interfaces should be down!"
+
+    yield
+
+    if intfs_connect_with_ptf:
+        logger.info("Startup interfaces: {}".format(intfs_connect_with_ptf))
+        duthost.no_shutdown_multiple(intfs_connect_with_ptf)
+        assert wait_until(300, 20, 0, check_interface_status, duthost, intfs_connect_with_ptf), \
+            "All interfaces should be up!"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The port macs that connected with PTF directly(not Arista VMs) would be learned by swich from time to time.
And they would ocupy the FDB resources. It would affect the ipv4 route tests.
This PR would add a fixture to shutdown the unused ports before test, and restore them after test.

Summary:
Fixes 
Expected message “IPV4_ROUTE THRESHOLD_CLEAR for TH_FREE” not found issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Expected message “IPV4_ROUTE THRESHOLD_CLEAR for TH_FREE” not found from time to time.
#### How did you do it?
Add a fixture to shutdown the ports connect direcly with PTF(not the ports connect with Arista VMs) before test, and restore them after test.
#### How did you verify/test it?
Verified the modification by run it over community setups.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
