### PR TITLE
Use wait_until in the checks in route flow counters test

### DIFF
--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -1,11 +1,13 @@
-import allure
 import logging
 import pytest
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.flow_counter import flow_counter_utils
 from tests.flow_counter.flow_counter_utils import is_route_flow_counter_supported   # noqa F401
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
+allure.logger = logger
 
 test_update_route_pattern_para = [
     {
@@ -32,7 +34,7 @@ def skip_if_not_supported(is_route_flow_counter_supported):     # noqa F811
     """Skip the test if route flow counter is not supported on this platform
 
     Args:
-        rand_selected_dut (object): DUT object
+        is_route_flow_counter_supported: fixture
     """
     pytest_require(is_route_flow_counter_supported,
                    'route flow counter is not supported')
@@ -96,6 +98,9 @@ class TestRouteCounter:
             route_flow_counter_params (list): A list contains the test parameter.
             [ipv6, pattern_a, pattern_b, prefix_a, prefix_b]
         """
+        def _check_route_flow_counter_state(dut, prefix, exist=True):
+            stats = flow_counter_utils.parse_route_flow_counter_stats(dut)
+            return exist == (prefix in stats)
         duthost = rand_selected_dut
         ipv6 = route_flow_counter_params['is_ipv6']
         route_pattern_a = route_flow_counter_params['route_pattern_a']
@@ -107,7 +112,6 @@ class TestRouteCounter:
             flow_counter_utils.set_route_flow_counter_pattern(
                 duthost, route_pattern_a)
 
-        logger.info('Adding static route {} and {}'.format(prefix_a, prefix_b))
         with allure.step('Adding static route {} and {}'.format(prefix_a, prefix_b)):
             nexthop_addr = self._get_nexthop(duthost, ipv6=ipv6)
             add_route(rand_selected_dut, prefix_a, nexthop_addr)
@@ -115,21 +119,19 @@ class TestRouteCounter:
 
         with allure.step('Route pattern is {}, verify route flow counter is bound to {}'.format(
                 route_pattern_a, prefix_a)):
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(
-                prefix_a in stats, 'Route flow counter for {} is not created'.format(prefix_a))
-            pytest_assert(prefix_b not in stats,
+            pytest_assert(wait_until(5, 1, 0, _check_route_flow_counter_state, duthost, prefix_a, True),
+                          'Route flow counter for {} is not created'.format(prefix_a))
+            pytest_assert(wait_until(5, 1, 0, _check_route_flow_counter_state, duthost, prefix_b, False),
                           'Route flow counter for {} should not be created'.format(prefix_b))
 
         with allure.step('Change route flow pattern to {}, verify route flow counter is bound to {}'.format(
                 route_pattern_b, prefix_b)):
             flow_counter_utils.set_route_flow_counter_pattern(
                 duthost, route_pattern_b)
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(prefix_a not in stats,
+            pytest_assert(wait_until(5, 1, 0, _check_route_flow_counter_state, duthost, prefix_a, False),
                           'Route flow counter for {} is not removed'.format(prefix_a))
-            pytest_assert(
-                prefix_b in stats, 'Route flow counter for {} is not created'.format(prefix_b))
+            pytest_assert(wait_until(5, 1, 0, _check_route_flow_counter_state, duthost, prefix_b, True),
+                          'Route flow counter for {} is not created'.format(prefix_b))
 
     def test_max_match_count(self, rand_selected_dut):
         """Test steps:
@@ -143,6 +145,9 @@ class TestRouteCounter:
         Args:
             rand_selected_dut (object): DUT object
         """
+        def _check_route_flow_counter_number(dut, expected_number):
+            stats = flow_counter_utils.parse_route_flow_counter_stats(dut)
+            return expected_number == len(stats)
         duthost = rand_selected_dut
         route_pattern = '1.1.0.0/16'
         prefix_list = ['1.1.1.0/24', '1.1.2.0/24', '1.1.3.0/24']
@@ -155,53 +160,40 @@ class TestRouteCounter:
             flow_counter_utils.set_route_flow_counter_pattern(
                 duthost, route_pattern, max_match_count=expect_route_flow_counter)
 
-        logger.info('Adding {} static routes while max allowed match count is {}'.format(
-            len(prefix_list), expect_route_flow_counter))
-        with allure.step('Adding static routes'):
+        with allure.step('Adding {} static routes while max allowed match count is {}'.format(
+                len(prefix_list), expect_route_flow_counter)):
             for prefix in prefix_list:
                 add_route(rand_selected_dut, prefix, nexthop_addr)
 
-        logger.info('Verify there are {} route flow counters'.format(
-            expect_route_flow_counter))
         with allure.step('Verify there are {} route flow counters'.format(expect_route_flow_counter)):
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(len(stats) == expect_route_flow_counter,
-                          'Expecetd {} route flow counters, but got {} counters'
-                          .format(expect_route_flow_counter, len(stats)))
+            pytest_assert(
+                wait_until(5, 1, 0, _check_route_flow_counter_number, duthost, expect_route_flow_counter),
+                'Expected {} route flow counters, but the actual is different'.format(expect_route_flow_counter))
 
-        logger.info('Removing a route, verify there are still {} route flow counters'.format(
-            expect_route_flow_counter))
-        with allure.step('Removing a route, verify there are still {} route flow counters'.format(
-                expect_route_flow_counter)):
+        with allure.step(
+                'Removing a route, verify there are still {} route flow counters'.format(expect_route_flow_counter)):
             del_route(rand_selected_dut, prefix_list[0], nexthop_addr)
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(len(stats) == expect_route_flow_counter,
-                          'Max allowed match counter is {}, but got {} counters'
-                          .format(expect_route_flow_counter, len(stats)))
+            pytest_assert(
+                wait_until(5, 1, 0, _check_route_flow_counter_number, duthost, expect_route_flow_counter),
+                'Expected {} route flow counters, but the actual is different'.format(expect_route_flow_counter))
 
         expect_route_flow_counter -= 1
-        logger.info('Set max_match_count to {}, verify there are {} route flow counters'.format(
-            expect_route_flow_counter, expect_route_flow_counter))
         with allure.step('Set max_match_count to {}, verify there are {} route flow counters'.format(
                 expect_route_flow_counter, expect_route_flow_counter)):
             flow_counter_utils.set_route_flow_counter_pattern(
                 duthost, route_pattern, max_match_count=expect_route_flow_counter)
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(len(stats) == expect_route_flow_counter,
-                          'Max allowed match counter is {}, but got {} counters'
-                          .format(expect_route_flow_counter, len(stats)))
+            pytest_assert(
+                wait_until(5, 1, 0, _check_route_flow_counter_number, duthost, expect_route_flow_counter),
+                'Expected {} route flow counters, but the actual is different'.format(expect_route_flow_counter))
 
         expect_route_flow_counter += 1
-        logger.info('Set max_match_count to {}, verify there are {} route flow counters'.format(
-            expect_route_flow_counter, expect_route_flow_counter))
         with allure.step('Set max_match_count to {}, verify there are {} route flow counters'.format(
                 expect_route_flow_counter, expect_route_flow_counter)):
             flow_counter_utils.set_route_flow_counter_pattern(
                 duthost, route_pattern, max_match_count=expect_route_flow_counter)
-            stats = flow_counter_utils.parse_route_flow_counter_stats(duthost)
-            pytest_assert(len(stats) == expect_route_flow_counter,
-                          'Max allowed match counter is {}, but got {} counters'
-                          .format(expect_route_flow_counter, len(stats)))
+            pytest_assert(
+                wait_until(5, 1, 0, _check_route_flow_counter_number, duthost, expect_route_flow_counter),
+                'Expected {} route flow counters, but the actual is different'.format(expect_route_flow_counter))
 
     def _get_nexthop(self, duthost, ipv6):
         """Get next hop from BGP neighbors


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test statistically failed on some of our platforms with 202211 image, and the cause was that there was a small delay between the static route is added/deleted and the output of route flow counters were updated. The delay was very small(less than 1s) but it may cause the test to fail sometimes.
So, it would be better to use wait_until with the checks to improve the stability of the test.
And I've replaced the logger.info with allure.step in tests.common.plugins.allure_wrapper to clean up the redundant text in the test script. It also prints entries in the test log.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To improve the stability of the test.
#### How did you do it?
1. Use wait_until with the checks
2. Use allure wrapper and remove the logger info
#### How did you verify/test it?
By automation, all cases passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
