### PR TITLE
[Python3 migration]Fix test failure in test_pfcwd_function.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pytest
 import time
+import six
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.assertions import pytest_assert
@@ -88,12 +89,12 @@ class PfcCmd(object):
             counter value(string)
         """
         asic = dut.get_queue_oid_asic_instance(queue_oid)
-        return asic.run_redis_cmd(
+        return six.text_type(asic.run_redis_cmd(
             argv=[
                 "redis-cli", "-n", "2", "HGET",
                 "COUNTERS:{}".format(queue_oid), attr
             ]
-        )[0].encode("utf-8")
+        )[0])
 
     @staticmethod
     def set_storm_status(dut, queue_oid, storm_status):
@@ -162,22 +163,22 @@ class PfcCmd(object):
             db = "4"
             pg_pattern = "BUFFER_PG|{}|3-4"
 
-        pg_profile = asic.run_redis_cmd(
+        pg_profile = six.text_type(asic.run_redis_cmd(
             argv=[
                 "redis-cli", "-n", db, "HGET",
                 pg_pattern.format(port), "profile"
             ]
-        )[0].encode("utf-8")
+        )[0])
 
         if BF_PROFILE[:-2] in pg_profile or BF_PROFILE_TABLE[:-2] in pg_profile:
             pg_profile = pg_profile.split(DB_SEPARATORS[db])[-1][:-1]
         table_template = BF_PROFILE if db == "4" else BF_PROFILE_TABLE
 
-        alpha = asic.run_redis_cmd(
+        alpha = six.text_type(asic.run_redis_cmd(
             argv=[
                 "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "dynamic_th"
             ]
-        )[0].encode("utf-8")
+        )[0])
 
         return pg_profile, alpha
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in test_pfcwd_function.py after Python3 migraiton

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
After Python3 migration, the test failed with error: TypeError: a bytes-like object is required, not 'str'

#### How did you do it?
Use six.text_type() to replace encode(). six.text_type() return unicode in Python2 and string in Python3.

#### How did you verify/test it?
Manually run the test case.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
