### PR TITLE
Fix fanout SSH authentication failed issue

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -1,11 +1,11 @@
 - name: set login to tacacs if tacacs is defined
-  set_fact: ansible_ssh_user={{ fanout_tacacs_eos_user }} ansible_ssh_password={{ fanout_tacacs_eos_password }}
+  set_fact: ansible_ssh_user={{ fanout_tacacs_eos_user }} ansible_ssh_pass={{ fanout_tacacs_eos_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_eos_user is defined and fanout_tacacs_eos_password is defined
 
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_password={{ fanout_admin_password }}
+  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_pass={{ fanout_admin_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_eos_user is not defined and fanout_tacacs_eos_password is not defined

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -7,7 +7,7 @@
 ### playbook
 ################################################################################################
 - name: set login to tacacs if tacacs is defined
-  set_fact: ansible_ssh_user={{ fanout_tacacs_mlnx_user }} ansible_ssh_password={{ fanout_tacacs_mlnx_password }}
+  set_fact: ansible_ssh_user={{ fanout_tacacs_mlnx_user }} ansible_ssh_pass={{ fanout_tacacs_mlnx_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_mlnx_user is defined and fanout_tacacs_mlnx_password is defined

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,13 +1,13 @@
 - debug: msg="{{ device_info[inventory_hostname] }}"
 
 - name: set login to tacacs if tacacs is defined
-  set_fact: ansible_ssh_user={{ fanout_tacacs_sonic_user }} ansible_ssh_password={{ fanout_tacacs_sonic_password }}
+  set_fact: ansible_ssh_user={{ fanout_tacacs_sonic_user }} ansible_ssh_pass={{ fanout_tacacs_sonic_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_sonic_user is defined and fanout_tacacs_sonic_password is defined
 
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
+  set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_pass={{ fanout_sonic_password }}
   when: >
     fanout_tacacs_user is not defined and fanout_tacacs_user is not defined and
     fanout_tacacs_sonic_user is not defined and fanout_tacacs_sonic_password is not defined

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -13,10 +13,10 @@
 
 - set_fact: sw_type="{{ device_info[inventory_hostname]['Type'] }}"
 
-# fanout_tacacs_user can override fanout_tacacs_sonic_user, 
+# fanout_tacacs_user can override fanout_tacacs_sonic_user,
 # fanout_tacacs_sonic_user can override fanout_sonic_user
 - name: set login info if fanout_tacacs_user and fanout_tacacs_password is defined
-  set_fact: ansible_ssh_user={{ fanout_tacacs_user }} ansible_ssh_password={{ fanout_tacacs_password }}
+  set_fact: ansible_ssh_user={{ fanout_tacacs_user }} ansible_ssh_pass={{ fanout_tacacs_password }}
   when: fanout_tacacs_user is defined and fanout_tacacs_password is defined
   tags: always
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #7778 added support of SSH to fanout switch using TACACS account. However, this PR introduced an issue. It mistakenly set SSH password to variable  `ansible_ssh_password` instead of expected `ansible_ssh_pass`. Consequently, deploy fanout switch failed with authentication failure.

#### How did you do it?
This change corrected variable name `ansible_ssh_password` to `ansible_ssh_pass` in the touched files.

#### How did you verify/test it?
Run playbook fanout.yml.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
