### PR TITLE
Ignore pmon errors in syncd auto restart test

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -173,6 +173,10 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_host
         'teamd': swss_syncd_teamd_regex,
     }
 
+    # During syncd restart, the pmon container is also restarted,
+    # and we noticed some errors in the pmon container
+    ignore_regex_dict['syncd'].extend(ignore_regex_dict['pmon'])
+
     feature = enum_dut_feature
 
     impacted_duts = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix error in `test_containers_autorestart[syncd]`. 
The test result was error because of error logs from xcvrd in pmon container.
```
Apr 17 02:27:14.699740 str-msn4600c-acs-02 ERR pmon#xcvrd: sx_api_host_ifc_trap_id_register_set exited with error, rc 4
Apr 17 02:27:14.699740 str-msn4600c-acs-02 ERR pmon#xcvrd: sx_api_host_ifc_close exited with error, rc 3
```
Actually, this errors have been ignored in the pmon restart test. Since pmon is going to restart with syncd, we should also ignore these log patterns in syncd restart test.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix error in `test_containers_autorestart[syncd]`. 

#### How did you do it?
Ignore the error logs from pmon in syncd restart test.

#### How did you verify/test it?
Verified on a SN2700 testbed.
```
collected 13 items                                                                                                                                                                          

autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-lldp] PASSED                                                                               [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-acms] SKIPPED                                                                              [ 15%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-pmon]  PASSED                                                                               [ 23%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-snmp]  PASSED                                                                               [ 30%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-macsec] SKIPPED                                                                            [ 38%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-telemetry] PASSED                                                                          [ 46%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-mux] SKIPPED                                                                               [ 53%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-bgp]  PASSED                                                                                [ 61%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-radv] PASSED                                                                               [ 69%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-teamd]  PASSED                                                                              [ 76%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-dhcp_relay]  PASSED                                                                         [ 84%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-swss]  PASSED                                                                               [ 92%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-msn2700-01-None-syncd]  PASSED                                                                              [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
