### PR TITLE
[Python3 migration]Fix test failure in dualtor and revert bad fixes during Python3 migration

### DIFF
--- a/ansible/module_utils/dualtor_utils.py
+++ b/ansible/module_utils/dualtor_utils.py
@@ -1,6 +1,7 @@
 """Common dualtor related utilities."""
 import ipaddress
 import re
+import six
 
 
 def get_intf_index(intf):
@@ -26,8 +27,8 @@ def generate_mux_cable_facts(topology):
     vlan_prefix_v6 = vlan_config["prefix_v6"]
     vlan_address_v4, netmask_v4 = vlan_prefix_v4.split("/")
     vlan_address_v6, netmask_v6 = vlan_prefix_v6.split("/")
-    vlan_address_v4 = ipaddress.ip_address(vlan_address_v4.decode())
-    vlan_address_v6 = ipaddress.ip_address(vlan_address_v6.decode())
+    vlan_address_v4 = ipaddress.ip_address(six.text_type(vlan_address_v4))
+    vlan_address_v6 = ipaddress.ip_address(six.text_type(vlan_address_v6))
     for index, intf in enumerate(enabled_interfaces):
         if host_interfaces_active_active:
             is_active_active = intf in host_interfaces_active_active

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -11,6 +11,7 @@ import ptf
 import re
 import string
 import sys
+import six
 
 from collections import defaultdict
 from datetime import datetime
@@ -929,7 +930,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
     if len(generate_hashed_packet_to_server.packets_cache[call_signature]) < count:
         pkt_num = count - len(generate_hashed_packet_to_server.packets_cache[call_signature])
         for _ in range(pkt_num):
-            if ipaddress.ip_address(target_server_ip.decode()).version == 4:
+            if ipaddress.ip_address(six.text_type(target_server_ip)).version == 4:
                 pkt_t = _generate_hashed_ipv4_packet(src_mac, dst_mac, target_server_ip, hash_key)
             else:
                 pkt_t = _generate_hashed_ipv6_packet(src_mac, dst_mac, target_server_ip, hash_key)
@@ -1327,7 +1328,7 @@ def add_nexthop_routes(standby_tor, route_dst, nexthops=None):
     logging.info("Applying route on {} to dst {}".format(standby_tor.hostname, route_dst))
     bgp_neighbors = list(standby_tor.bgp_facts()['ansible_facts']['bgp_neighbors'].keys())
 
-    route_dst = ipaddress.ip_address(route_dst.decode())
+    route_dst = ipaddress.ip_address(six.text_type(route_dst))
     ip_neighbors = []
     for neighbor in bgp_neighbors:
         if ipaddress.ip_address(neighbor).version == route_dst.version:
@@ -1353,7 +1354,7 @@ def remove_static_routes(duthost, route_dst):
     """
     Remove static routes for duthost
     """
-    route_dst = ipaddress.ip_address(route_dst.decode())
+    route_dst = ipaddress.ip_address(six.text_type(route_dst))
     subnet_mask_len = 32 if route_dst.version == 4 else 128
 
     logger.info("Removing dual ToR peer switch static route:  {}/{}".format(str(route_dst), subnet_mask_len))

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -504,7 +504,10 @@ def dump_scapy_packet_show_output(packet):
     """Dump packet show output to string."""
     _stdout, sys.stdout = sys.stdout, StringIO()
     try:
-        packet.show()
+        if six.PY2:
+            packet.show()
+        else:
+            packet.show2()
         return sys.stdout.getvalue()
     finally:
         sys.stdout = _stdout

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -11,6 +11,7 @@ import random
 import time
 import contextlib
 import scapy
+import six
 
 from ptf import mask
 from ptf import testutils
@@ -141,8 +142,12 @@ def test_decap_standby_tor(
         """Verify packet is passed downstream to server."""
         packets = ptfadapter.dataplane.packet_queues[(0, port)]
         for packet in packets:
-            if exp_pkt.pkt_match(packet):
-                return True
+            if six.PY2:
+                if exp_pkt.pkt_match(packet):
+                    return True
+            else:
+                if exp_pkt.pkt_match(packet[0]):
+                    return True
         return False
 
     if is_t0_mocked_dualtor(tbinfo):        # noqa F405

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -4,6 +4,7 @@ import time
 import logging
 import ipaddress
 import json
+import six
 from collections import defaultdict
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
@@ -116,7 +117,7 @@ def setup_neighbors(duthost, ptfhost, ip_to_port):
 
     for ip, port in list(ip_to_port.items()):
 
-        if isinstance(ipaddress.ip_address(ip.decode('utf8')), ipaddress.IPv4Address):
+        if isinstance(ipaddress.ip_address(six.text_type(ip)), ipaddress.IPv4Address):
             neigh_entries['NEIGH'][vlan_name + "|" + ip] = {
                 "neigh": ptfhost.shell("cat /sys/class/net/eth" + str(port) + "/address")["stdout_lines"][0],
                 "family": "IPv4"

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -16,10 +16,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -10,10 +10,10 @@ from tests.platform_tests.thermal_control_test_helper import start_thermal_contr
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -9,10 +9,10 @@ from tests.common.utilities import skip_release_for_platform
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -9,10 +9,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -11,10 +11,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -11,10 +11,10 @@ from tests.common.helpers.assertions import pytest_assert
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -12,10 +12,10 @@ from tests.common.utilities import skip_release_for_platform
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -11,10 +11,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -16,10 +16,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -9,10 +9,10 @@ from platform_api_test_base import PlatformApiTestBase
 ###################################################
 # TODO: Remove this after we transition to Python 3
 import sys
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     STRING_TYPE = str
 else:
-    STRING_TYPE = str
+    STRING_TYPE = basestring
 # END Remove this after we transition to Python 3
 ###################################################
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failures after Python3 migration in tests/dualtor directory.
dualtor.test_ipinip
dualtor.test_tor_ecn

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failures after Python3 migration in tests/dualtor directory.
dualtor.test_ipinip
dualtor.test_tor_ecn

#### How did you do it?
1. Use six.text_type()
2. Use packet.show2() instead of packet.show() in Python3
3. Use pkt_match(packet[0]) instead of pkt_match(packet) in Python3
4. Search the code base, fix possible issue with ip_address() and decode().
5. Fix bad fix in first batch Python3 migration(#7748 )

#### How did you verify/test it?
Manually run test cases and got 100% pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
