### PR TITLE
[pre-commit] Fix style issues in test scripts under `test_reporting/*` folder

### DIFF
--- a/test_reporting/collect_azp_results.py
+++ b/test_reporting/collect_azp_results.py
@@ -26,7 +26,7 @@ def get_tasks_results(buildid):
         "cancelled_tasks": ""
     }
 
-    pipeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/"+ str(buildid)
+    pipeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid)
     print("Collect pipeline startTime from here:{}".format(pipeline_url))
     api_result = requests.get(pipeline_url, auth=AUTH)
     starttime_str = api_result.json()["startTime"]
@@ -37,7 +37,8 @@ def get_tasks_results(buildid):
     starttime_str = starttime_str.replace("Z", "")
     task_results["start_time"] = starttime_str
 
-    timeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid) + "/timeline?api-version=5.1"
+    timeline_url = \
+        "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid) + "/timeline?api-version=5.1"
     print("Collect task results from here:{}".format(timeline_url))
     api_result = requests.get(timeline_url, auth=AUTH)
     build_records = api_result.json()["records"]
@@ -55,6 +56,7 @@ def get_tasks_results(buildid):
     with open(TASK_RESULT_FILE, "w") as f:
         json.dump(task_results, f)
     return task_results
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -398,17 +398,17 @@ def _extract_test_summary(test_cases):
 
     test_result_summary = {k: str(v) for k, v in test_result_summary.items()}
     total = int(test_result_summary["failures"]) + int(test_result_summary["skipped"]) \
-          + int(test_result_summary["errors"]) + int(test_result_summary["xfails"])
+        + int(test_result_summary["errors"]) + int(test_result_summary["xfails"])
     passed = int(test_result_summary["tests"]) - int(total)
     passed = max(0, passed)
     if case is None:
         return test_result_summary
     name = case['file']
     REPORT_LIST.append("{}, {}, {}, {}, {}, {}, {}, {}".
-                         format(name, test_result_summary["tests"],
-                         passed, test_result_summary["failures"],
-                         test_result_summary["skipped"], test_result_summary["errors"],
-                         test_result_summary["xfails"], test_result_summary["time"]))
+                       format(name, test_result_summary["tests"],
+                              passed, test_result_summary["failures"],
+                              test_result_summary["skipped"], test_result_summary["errors"],
+                              test_result_summary["xfails"], test_result_summary["time"]))
     return test_result_summary
 
 

--- a/test_reporting/kusto/heat_maps.kql
+++ b/test_reporting/kusto/heat_maps.kql
@@ -4,7 +4,7 @@
 .create-or-alter function TestDefectRate(timeframe: timespan = 3d, asic: string = "", sku: string = "", topo: string = "", version: string = "201911")
 {
     FlatTestReportView
-    | where Timestamp >= ago(timeframe) 
+    | where Timestamp >= ago(timeframe)
             and (Result != "skipped" or Error)
             and AsicType contains asic
             and HardwareSku contains sku


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
pre-commit is a static analysis tool introduced recently. This tool is not able to do diff-only check. It checks the whole files touched by PR. We can't blame PR author for legacy issues. That's why currently the pre-commit check is only optional.

To ensure that we can make pre-commit a mandatory check for PRs submitted to this repository, we need to fix all the legacy issues complained by pre-commit.
#### How did you do it?
This change fixes the style issues of test scripts under `test_reporting/*` folder
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
