### PR TITLE
Resolve test_tx_disable_channel failure for SFF-8472

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -685,6 +685,10 @@ class TestSfpApi(PlatformApiTestBase):
                 # Test all channels for a eight-channel transceiver
                 all_channel_mask = 0xFF
                 expected_mask = 0x80
+            elif info_dict["type_abbrv_name"] == "SFP":
+                # Test all channels for a single-channel transceiver
+                all_channel_mask = 0x1
+                expected_mask = 0x1
             else:
                 # Test all channels for a four-channel transceiver
                 all_channel_mask = 0XF


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
It seems that currently, test_tx_disable_channel testcase in sonic-mgmt is failing for SFF-8472. The failure is seen because we are trying to write to a read-only bit.
Since SFF-8472 has just 1 channel, the test_tx_disable_channel test needs to be modified accordingly to handle the same.
Also, this fix needs to be committed along with sonic-net/sonic-platform-common/pull/364 which has the change required to avoid writing to read-only bit.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
The test_tx_disable_channel has now been verified for SFF-8472 as well as QSFP-DD.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
