### PR TITLE
Add 'any' topology mark to pre and post test

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.posttest,
-    pytest.mark.topology('util'),
+    pytest.mark.topology('util', 'any'),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.skip_check_dut_health

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.pretest,
-    pytest.mark.topology('util'),
+    pytest.mark.topology('util', 'any'),
     pytest.mark.disable_loganalyzer,
     pytest.mark.skip_check_dut_health
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In TestbedV2, pre and post test are run in module mode, need to add 'any' mark otherwise it will be wrongly skipped

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
In TestbedV2, pre and post test are run in module mode, need to add 'any' mark otherwise it will be wrongly skipped
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
