### PR TITLE
[container_autorestart] Disable loganalyzer when test container autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -529,6 +529,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     logger.info("End of testing the container '{}'".format(container_name))
 
 
+@pytest.mark.disable_loganalyzer
 def test_containers_autorestart(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index,
                                 enum_dut_feature, tbinfo):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Disable loganalyzer when test container autorestart. Ignore those error logs during container autorestart and mainly focus on the feature `autorestart`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Disable loganalyzer when test container autorestart. Ignore those error logs during container autorestart and mainly focus on the feature `autorestart`.

#### How did you do it?

add `@pytest.mark.disable_loganalyzer` on test method

#### How did you verify/test it?

Run test case and passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
