### PR TITLE
Fix AnsibleUndefinedVariable seen while generating fanout configuration

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -18,7 +18,7 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if 'broadcom' in fanout_sonic_version["asic_type"] and device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] and port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
             "tpid": "0x9100",
     {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
While configuring sonic fanout using 
```
ansible-playbook fanout.yml -i <inv> --limit <sonic fanout device> -b --vault-password-file <>
```
Hitting this error:
```
TASK [fanout : build fanout startup config] ****************************************************************************************************************************************************************
task path: /data/sonic-mgmt/sonic-mgmt-int/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml:8
fatal: [device]: FAILED! => {
    "changed": false, 
    "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute u'Ethernet256'"
}
```
#### How did you do it?
Check if port_name is present in device links graph before trying to access the dictionary.
Issue is seen when some port on fanout is not being used in connection graph.

#### How did you verify/test it?
Able to configure sonic fanout after this fix.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
