### PR TITLE
[Python3 migration]Fix test failure in test_nhop_group.py

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -114,7 +114,7 @@ class Arp:
 
         # create a list of IP-MAC bindings
         for i in range(11, count + 11):
-            moff1 = "{0:x}".format(i / 255)
+            moff1 = "{0:x}".format(i // 255)
             moff2 = "{0:x}".format(i % 255)
 
             self.ip_mac_list.append(IP_MAC(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure after Python3 migration in test_nhop_group.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed with following error:
  File "/azp/_work/15/s/tests/ipfwd/test_nhop_group.py", line 117, in __init__
    moff1 = "{0:x}".format(i / 255)
ValueError: Unknown format code 'x' for object of type 'float'

#### How did you do it?
Use "//" instead of "/"
Search the whole code base and only find this one.

#### How did you verify/test it?
Manually run the testcase.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
