### PR TITLE
[container_autorestart] Fix config enable feature autorestart before each container test

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -447,7 +447,8 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     return critical_proceses, bgp_check
 
 
-def run_test_on_single_container(duthosts, selected_rand_one_per_hwsku_hostname, duthost, container_name, service_name, tbinfo):
+def run_test_on_single_container(duthosts, selected_rand_one_per_hwsku_hostname, duthost, container_name, service_name,
+                                 tbinfo):
     feature_autorestart_states = duthost.get_container_autorestart_states()
     disabled_containers = get_disabled_container_list(duthost)
 
@@ -555,4 +556,5 @@ def test_containers_autorestart(duthosts, enum_rand_one_per_hwsku_hostname, enum
     asic = duthost.asic_instance(enum_rand_one_asic_index)
     service_name = asic.get_service_name(enum_dut_feature)
     container_name = asic.get_docker_name(enum_dut_feature)
-    run_test_on_single_container(duthosts, selected_rand_one_per_hwsku_hostname, duthost, container_name, service_name, tbinfo)
+    run_test_on_single_container(duthosts, selected_rand_one_per_hwsku_hostname, duthost, container_name, service_name,
+                                 tbinfo)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -29,13 +29,9 @@ POST_CHECK_THRESHOLD_SECS = 360
 
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
-    # # Enable autorestart for all features before the test begins
-    # for hostname in selected_rand_one_per_hwsku_hostname:
-    #     duthost = duthosts[hostname]
-    #     feature_list, _ = duthost.get_feature_status()
-    #     for feature, status in list(feature_list.items()):
-    #         if status == 'enabled':
-    #             duthost.shell("sudo config feature autorestart {} enabled".format(feature))
+    # Enable autorestart for all features before the test begins
+    enable_autorestart(duthosts, selected_rand_one_per_hwsku_hostname)
+
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
@@ -44,7 +40,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
 
 
 def enable_autorestart(duthosts, selected_rand_one_per_hwsku_hostname):
-    # Enable autorestart for all features before the test begins
+    # Enable autorestart for all features
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
         feature_list, _ = duthost.get_feature_status()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

If **post-check after one container autorestart failed**, this case will trigger **config reload**. The reload operation will **reset features autorestart config**. So, the next test may be affected. Actually, if the current testing container's **autorestart is disabled**, even kill its' critical process, it will not autorestart. And then raised `failed to stop container` failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

If **post-check after one container autorestart failed**, this case will trigger **config reload**. The reload operation will **reset autorestart config**. So, the next test may be affected. Actually, if the current testing container's **autorestart is disabled**, even kill its' critical process, it will not autorestart. And then raised `failed to stop container` failure.

#### How did you do it?

After config reload, enable autorestart for all containers to test.

#### How did you verify/test it?

Run TC in simulate scenario, if origin code, then raise failure `failed to stop container`, if fix code, passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
