### PR TITLE
[test_critical_process_monitor]Prolong wait time to 90s

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -586,7 +586,7 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
 
     stop_critical_processes(duthost, containers_in_namespaces)
 
-    # Wait for 70 seconds such that Supervisord/Monit has a chance to write alerting message into syslog.
+    # Wait for 90 seconds such that Supervisord/Monit has a chance to write alerting message into syslog.
     logger.info("Sleep 90 seconds to wait for the alerting messages in syslog...")
     time.sleep(90)
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -587,8 +587,8 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     stop_critical_processes(duthost, containers_in_namespaces)
 
     # Wait for 70 seconds such that Supervisord/Monit has a chance to write alerting message into syslog.
-    logger.info("Sleep 70 seconds to wait for the alerting messages in syslog...")
-    time.sleep(70)
+    logger.info("Sleep 90 seconds to wait for the alerting messages in syslog...")
+    time.sleep(90)
 
     logger.info("Checking the alerting messages from syslog...")
     loganalyzer.analyze(marker)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the flaky failure of  test_critical_process_monitor:

Expected Messages that are missing:
.*Process 'syncd' is not running in namespace 'host'.*

In the test module,  it waits 70s for the process exit logs, but the syncd exit log sometimes arrives around 70-90s,  then the test module fails.
Prolong the wait time to 90s to fix the flaky issue

details:

On dut:
admin@vlab-03:~$ date && docker exec syncd kill -SIGKILL 20
Wed Apr 19 12:09:49 UTC 2023
Syslog:
Apr 19 12:10:15.473993 vlab-03 INFO syncd#supervisord 2023-04-19 12:10:15,472 INFO exited: syncd (terminated by SIGKILL; not expected)

It spends 25s the supervisor detects syncd process exited, and 1 minute later,  supervisor-proc-exit-listener print the expected log, 85s totally.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixes the flaky failure of  test_critical_process_monitor:

Expected Messages that are missing:
.*Process 'syncd' is not running in namespace 'host'.*

In the test module,  it waits 70s for the process exit logs, but the syncd exit log sometimes arrives around 70-80s,  then the test module fails.
Prolong the wait time to 90s to fix the flaky issue

#### How did you do it?
Prolong the wait time to 90s from 70s.

#### How did you verify/test it?
On local t1-lag KVM testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
