### PR TITLE
Splitting the PR:7911 into 2 parts, Part 2.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -885,6 +885,18 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions:
       - "asic_type not in ['cisco-8000']"
 
+qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
+  skip:
+    reason: "Lossless Voq test is supported only in Cisco-8000."
+    conditions:
+      - "asic_type not in ['cisco-8000']"
+
+qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
+  skip:
+    reason: "Lossy Voq test is supported only in Cisco-8000."
+    conditions:
+      - "asic_type not in ['cisco-8000']"
+
 #######################################
 #####         restapi             #####
 #######################################

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3409,23 +3409,23 @@ qos_params:
                     lossless_weight: 30
             wrr:
                 ecn: 1
-                q0_num_of_pkts: 140
-                q1_num_of_pkts: 140
-                q2_num_of_pkts: 140
-                q3_num_of_pkts: 150
-                q4_num_of_pkts: 150
-                q5_num_of_pkts: 140
-                q6_num_of_pkts: 140
+                q0_num_of_pkts: 70
+                q1_num_of_pkts: 70
+                q2_num_of_pkts: 70
+                q3_num_of_pkts: 75
+                q4_num_of_pkts: 75
+                q5_num_of_pkts: 70
+                q6_num_of_pkts: 70
                 limit: 80
             wrr_chg:
                 ecn: 1
-                q0_num_of_pkts: 80
-                q1_num_of_pkts: 80
-                q2_num_of_pkts: 80
-                q3_num_of_pkts: 300
-                q4_num_of_pkts: 300
-                q5_num_of_pkts: 80
-                q6_num_of_pkts: 80
+                q0_num_of_pkts: 40
+                q1_num_of_pkts: 40
+                q2_num_of_pkts: 40
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 40
+                q6_num_of_pkts: 40
                 limit: 80
                 lossy_weight: 8
                 lossless_weight: 30

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -97,7 +97,9 @@ class TestQosSai(QosSaiBase):
                 portIds: [0, 2, 16, 4, 18, 6, 20, 8, 22]
         '''
         if len(portIds) > len(availablePortIds):
-            logger.info('no enough ports for test')
+            logger.info(
+                'no enough ports for test: portIds:"{}" <'
+                ' availablePortIds:"{}"'.format(portIds, availablePortIds))
             return False
 
         # cache available as free port pool
@@ -531,7 +533,7 @@ class TestQosSai(QosSaiBase):
                              "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
             self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig,
-            dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts
+            dutQosConfig, static_route_for_splitvoq
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -547,8 +549,6 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000":
-            pytest.skip("Lossless Voq test is not supported")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and 'backend' not in dutTestParams['topo']:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
@@ -556,8 +556,12 @@ class TestQosSai(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
         self.updateTestPortIdIp(dutConfig, qosConfig[LosslessVoqProfile])
 
-        dst_port_id, dst_port_ip = singleMemberPortStaticRoute
-        src_port_1_id, src_port_2_id = nearbySourcePorts
+        available_port_ids = dutConfig['testPortIps'].keys()
+        available_port_ids.remove(dutConfig["testPorts"]["dst_port_id"])
+
+        available_port_ids.remove(dutConfig["testPorts"]["src_port_id"])
+        if len(available_port_ids) < 2:
+            raise RuntimeError("This test needs atleast 3 SRC port ids, and we are left with only ids:{}".format(available_port_ids))
 
         testPortIps = dutConfig["testPortIps"]
         testParams = dict()
@@ -566,12 +570,12 @@ class TestQosSai(QosSaiBase):
             "dscp": qosConfig[LosslessVoqProfile]["dscp"],
             "ecn": qosConfig[LosslessVoqProfile]["ecn"],
             "pg": qosConfig[LosslessVoqProfile]["pg"],
-            "dst_port_id": dst_port_id,
-            "dst_port_ip": dst_port_ip,
-            "src_port_1_id": src_port_1_id,
-            "src_port_1_ip": testPortIps[src_port_1_id]['peer_addr'],
-            "src_port_2_id": src_port_2_id,
-            "src_port_2_ip": testPortIps[src_port_2_id]['peer_addr'],
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": static_route_for_splitvoq,
+            "src_port_1_id": available_port_ids[0],
+            "src_port_1_ip": testPortIps[available_port_ids[0]]['peer_addr'],
+            "src_port_2_id":  available_port_ids[1],
+            "src_port_2_ip": testPortIps[available_port_ids[1]]['peer_addr'],
             "num_of_flows": qosConfig[LosslessVoqProfile]["num_of_flows"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[LosslessVoqProfile]["pkts_num_trig_pfc"]
@@ -839,7 +843,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
         self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLossyProfile, resetWatermark,
+        ingressLosslessProfile, egressLossyProfile, resetWatermark
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -982,10 +986,38 @@ class TestQosSai(QosSaiBase):
             testParams=testParams
         )
 
-    @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
+    @pytest.fixture(scope="function", autouse=False)
+    def fixture_reboot_dut(self, LossyVoq, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+            swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status, dutQosConfig,
+            dutConfig, tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports, localhost):  # noqa F811
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        flow_config = qosConfig[LossyVoq]["flow_config"]
+
+        if flow_config == "shared":
+            duthost = dutConfig['dutInstance']
+            # Need to save the new static route as well.
+            duthost.shell("config save -y")
+            original_voq_markings = get_markings_dut(duthost)
+            setup_markings_dut(duthost, localhost, voq_allocation_mode="default")
+            time.sleep(60)
+            self.stopServices(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status,
+                tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports) # noqa F811
+
+        yield
+        if flow_config == "shared":
+            setup_markings_dut(duthost, localhost, **original_voq_markings)
+            time.sleep(60)
+            self.stopServices(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                swapSyncd, enable_container_autorestart, disable_container_autorestart, get_mux_status,
+                tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports) # noqa F811
+
+    @pytest.mark.parametrize('LossyVoq', ['lossy_queue_voq_1', 'lossy_queue_voq_2'])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute
+            ingressLossyProfile, localhost, static_route_for_splitvoq,
+            fixture_reboot_dut
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -997,29 +1029,22 @@ class TestQosSai(QosSaiBase):
                     and test ports
                 dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
                 ingressLossyProfile (Fxiture): Map of ingress lossy buffer profile attributes
-                duthost : DUT host params
                 localhost : local host params
             Returns:
                 None
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000":
-            pytest.skip("Lossy Queue Voq test is not supported")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         flow_config = qosConfig[LossyVoq]["flow_config"]
+        duthost = dutConfig['dutInstance']
         assert flow_config in [
             "shared", "separate"], "Invalid flow config '{}'".format(flow_config)
-        if flow_config == "shared":
-            original_voq_markings = get_markings_dut(duthost)
-            setup_markings_dut(duthost, localhost,
-                               voq_allocation_mode="default")
-
         self.updateTestPortIdIp(dutConfig, qosConfig[LossyVoq])
 
         try:
-            dst_port_id, dst_port_ip = singleMemberPortStaticRoute
+            dst_port_ip = static_route_for_splitvoq
             testParams = dict()
             testParams.update(dutTestParams["basicParams"])
             testParams.update({
@@ -1028,7 +1053,7 @@ class TestQosSai(QosSaiBase):
                 "pg": qosConfig[LossyVoq]["pg"],
                 "src_port_id": dutConfig["testPorts"]["src_port_id"],
                 "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-                "dst_port_id": dst_port_id,
+                "dst_port_id": dutConfig["testPorts"]['dst_port_id'],
                 "dst_port_ip": dst_port_ip,
                 "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
                 "flow_config": flow_config,
@@ -1052,9 +1077,8 @@ class TestQosSai(QosSaiBase):
                 testParams=testParams
             )
 
-        finally:
-            if flow_config == "shared":
-                setup_markings_dut(duthost, localhost, **original_voq_markings)
+        except:
+            raise
 
     def testQosSaiDscpQueueMapping(
         self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps      # noqa F811

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -92,6 +92,13 @@ RELEASE_PORT_MAX_RATE = 0
 ECN_INDEX_IN_HEADER = 53  # Fits the ptf hex_dump_buffer() parse function
 DSCP_INDEX_IN_HEADER = 52  # Fits the ptf hex_dump_buffer() parse function
 
+def get_udp_port():
+    val = 1234
+    while True:
+        if val == 65535:
+            raise RuntimeError("We ran out of udp ports!")
+        val = max(1234, (val+10)%65535)
+        yield val
 
 def check_leackout_compensation_support(asic, hwsku):
     if 'broadcom' in asic.lower():
@@ -162,6 +169,52 @@ def construct_ip_pkt(pkt_len, dst_mac, src_mac, src_ip, dst_ip, dscp, src_vlan, 
         return pkt
 
 
+def construct_udp_pkt(pkt_len, dst_mac, src_mac, src_ip, dst_ip, dscp, src_vlan, udp_sport, udp_dport, **kwargs):
+    ecn = kwargs.get('ecn', 1)
+    ip_id = kwargs.get('ip_id', None)
+    ttl = kwargs.get('ttl', None)
+    exp_pkt = kwargs.get('exp_pkt', False)
+
+    tos = (dscp << 2) | ecn
+    pkt_args = {
+        'pktlen': pkt_len,
+        'eth_dst': dst_mac,
+        'eth_src': src_mac,
+        'ip_src': src_ip,
+        'ip_dst': dst_ip,
+        'ip_tos': tos,
+        'udp_sport':udp_sport,
+        'udp_dport':udp_dport
+    }
+    if ip_id is not None:
+        pkt_args['ip_id'] = ip_id
+
+    if ttl is not None:
+        pkt_args['ip_ttl'] = ttl
+
+    if src_vlan is not None:
+        pkt_args['dl_vlan_enable'] = True
+        pkt_args['vlan_vid'] = int(src_vlan)
+        pkt_args['vlan_pcp'] = dscp
+
+    pkt = simple_udp_packet(**pkt_args)
+
+    if exp_pkt:
+        masked_exp_pkt = Mask(pkt, ignore_extra_bytes=True)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
+        if src_vlan is not None:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
+        return masked_exp_pkt
+    else:
+        return pkt
+
+
+
 def construct_arp_pkt(eth_dst, eth_src, arp_op, src_ip, dst_ip, hw_dst, src_vlan):
     pkt_args = {
         'eth_dst': eth_dst,
@@ -226,7 +279,49 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
                 print("fill_leakout_plus_one: Success, sent %d packets, queue occupancy bytes rose from %d to %d" % (
                     packet_i + 1, queue_counters_base[queue], queue_counters[queue]), file=sys.stderr)
                 return True
+    print("fill_leakout_plus_one: Fail, sent %d packets, queue occupancy bytes remained %d" % (500, queue_counters_base[queue]), file=sys.stderr)
     return False
+
+
+def get_multiple_flows_udp(dp, dst_mac, dst_id, dst_ip, src_vlan, dscp, ecn, ttl, pkt_len, src_details, packets_per_port=1):
+    '''
+        Returns a dict of format:
+        src_id : [list of (pkt, exp_pkt) pairs that go to the given dst_id]
+    '''
+
+    def get_rx_port_udp(dp, src_port_id, pkt, exp_pkt):
+        send_packet(dp, src_port_id, pkt, 1)
+
+        result = dp.dataplane.poll(
+            device_number=0, exp_pkt=exp_pkt, timeout=3)
+        if isinstance(result, dp.dataplane.PollFailure):
+            dp.fail("Expected packet was not received. Received on port:{} {}".format(
+                result.port, result.format()))
+
+        return result.port
+
+    udp_port_gen = get_udp_port()
+    all_pkts = {}
+    for src_tuple in src_details:
+        num_of_pkts = 0
+        print("Trying {} => {}, dstip:{}".format(src_tuple[0], dst_id, dst_ip), file=sys.stderr)
+        while (num_of_pkts < packets_per_port):
+            pkt_args = {
+                'ip_ecn':ecn,
+                'ip_ttl':ttl}
+            pkt_args = [pkt_len, dst_mac, src_tuple[2], src_tuple[1], dst_ip, dscp, src_vlan, 1234, next(udp_port_gen)]
+            pkt = construct_udp_pkt(*pkt_args, ip_ecn=ecn, ip_ttl=ttl)
+            exp_pkt = construct_udp_pkt(*pkt_args, ip_ecn=ecn, ip_ttl=ttl-1, exp_pkt=True)
+
+            if get_rx_port_udp(dp, src_tuple[0], pkt, exp_pkt) == dst_id:
+                try:
+                    all_pkts[src_tuple[0]].append((pkt, exp_pkt))
+                    num_of_pkts+=1
+                except KeyError:
+                    all_pkts[src_tuple[0]] = []
+                    all_pkts[src_tuple[0]].append((pkt, exp_pkt))
+                    num_of_pkts+=1
+    return all_pkts
 
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
@@ -875,7 +970,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for pg, dot1ps in list(pg_dot1p_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.client, src_port_id)
 
                 # send pkts with dot1ps that map to the same pg
                 for dot1p in dot1ps:
@@ -1009,15 +1104,18 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         if is_dualtor and def_vlan_mac is not None:
             pkt_dst_mac = def_vlan_mac
 
-        pkt = construct_ip_pkt(packet_length,
-                               pkt_dst_mac,
-                               src_port_mac,
-                               src_port_ip,
-                               dst_port_ip,
-                               dscp,
-                               src_port_vlan,
-                               ecn=ecn,
-                               ttl=ttl)
+        pkt = get_multiple_flows_udp(
+                self,
+                router_mac,
+                dst_port_id,
+                dst_port_ip,
+                src_port_vlan,
+                dscp,
+                ecn,
+                ttl,
+                packet_length,
+                [(src_port_id, src_port_ip, self.dataplane.get_mac(0, src_port_id))],
+                packets_per_port=1)[src_port_id][0][0]
 
         print("test dst_port_id: {}, src_port_id: {}, src_vlan: {}".format(
             dst_port_id, src_port_id, src_port_vlan
@@ -1230,12 +1328,13 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_id = int(self.test_params['dst_port_id'])
         dst_port_ip = self.test_params['dst_port_ip']
         dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
-        src_port_1_id = int(self.test_params['src_port_1_id'])
-        src_port_1_ip = self.test_params['src_port_1_ip']
-        src_port_1_mac = self.dataplane.get_mac(0, src_port_1_id)
-        src_port_2_id = int(self.test_params['src_port_2_id'])
-        src_port_2_ip = self.test_params['src_port_2_ip']
-        src_port_2_mac = self.dataplane.get_mac(0, src_port_2_id)
+        src_details = []
+        src_details.append((int(self.test_params['src_port_1_id']),
+            self.test_params['src_port_1_ip'],
+            self.dataplane.get_mac(0, int(self.test_params['src_port_1_id']))))
+        src_details.append((int(self.test_params['src_port_2_id']),
+            self.test_params['src_port_2_ip'],
+            self.dataplane.get_mac(0, int(self.test_params['src_port_2_id']))))
         num_of_flows = self.test_params['num_of_flows']
         asic_type = self.test_params['sonic_asic_type']
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
@@ -2697,6 +2796,7 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         attr = sai_thrift_attribute_t(
             id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
         self.client.sai_thrift_set_port_attribute(port_list[dst_port_id], attr)
+        self.asic_type = self.test_params['asic_type']
 
         # Clear Counters
         sai_thrift_clear_all_counters(self.client)
@@ -3475,15 +3575,18 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # Prepare TCP packet data
         ttl = 64
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
-        pkt = construct_ip_pkt(packet_length,
-                               pkt_dst_mac,
-                               src_port_mac,
-                               src_port_ip,
-                               dst_port_ip,
-                               dscp,
-                               src_port_vlan,
-                               ecn=ecn,
-                               ttl=ttl)
+        pkt = get_multiple_flows_udp(
+                self,
+                pkt_dst_mac,
+                dst_port_id,
+                dst_port_ip,
+                src_port_vlan,
+                dscp,
+                ecn,
+                ttl,
+                packet_length,
+                [(src_port_id, src_port_ip, self.dataplane.get_mac(0, src_port_id))],
+                packets_per_port=1)[src_port_id][0][0]
 
         print("dst_port_id: %d, src_port_id: %d src_port_vlan: %s" %
               (dst_port_id, src_port_id, src_port_vlan), file=sys.stderr)


### PR DESCRIPTION
Pls see the description in PR:#7911.
The changes in this PR are:

**tests/qos/test_qos_sai.py**
1. Moved the skip conditions for cisco-8000 specific losslessVoQ and lossyVoq tests to the conditional marker file.
2. Reduced the number of packets for SharedResSize - The current number was too high for the PTF to handle. It dropped the packets, and the test fails.
3. Updated the splitVoq(cisco specific) testcases to use the new dutConfig values.
4. Added a new fixture for reboot, that will call the stop_services after reboot. This is used by the LossyVoq testcase.

**saitests/py3/sai_qos_tests.py:**
1. Implemented a brute-force function, get_multiple_flows_udp(), that gives us a list of packets that are switched to given dest port. This guarantees that we have the right set of packets that will always take the given dest port from the given src port. This is useful when we have dst ports that are members of a portchannel. There is no way to force a packet to take a particular dst port, so this function iterates over a set of udp ports to find all viable packets that are sent out only in the required dst port.
2. Adjusted the testcases to use the new function, there is no change in the logic/procedure.
