### PR TITLE
[advanced-reboot] Check IO threads have started before joining

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -272,6 +272,9 @@ class ReloadTest(BaseTest):
             alt_password=self.test_params.get('alt_password')
         )
 
+        self.sender_thr = threading.Thread(target=self.send_in_background)
+        self.sniff_thr = threading.Thread(target=self.sniff_in_background)
+
         # Check if platform type is kvm
         stdout, stderr, return_code = self.dut_connection.execCommand(
             "show platform summary | grep Platform | awk '{print $2}'")
@@ -1112,6 +1115,11 @@ class ReloadTest(BaseTest):
             self.no_routing_stop = self.reboot_start
 
     def handle_warm_reboot_health_check(self):
+        # wait until sniffer and sender threads have started
+        while not (self.sniff_thr.isAlive() and self.sender_thr.isAlive()):
+            time.sleep(1)
+
+        self.log("IO sender and sniffer threads have started, wait unitl completion")
         self.sniff_thr.join()
         self.sender_thr.join()
 
@@ -1478,8 +1486,6 @@ class ReloadTest(BaseTest):
         if not self.kvm_test and\
                 (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
                  self.reboot_type or 'service-warm-restart' in self.reboot_type):
-            self.sender_thr = threading.Thread(target=self.send_in_background)
-            self.sniff_thr = threading.Thread(target=self.sniff_in_background)
             # Event for the sniff_in_background status.
             self.sniffer_started = threading.Event()
             self.sniff_thr.start()
@@ -1796,20 +1802,6 @@ class ReloadTest(BaseTest):
         self.log('Pcapng file converted into pcap file')
         # Remove tmp pcapng file
         subprocess.call(['rm', '-f', pcapng_full_capture])
-
-    def send_and_sniff(self):
-        """
-        This method starts two background threads in parallel:
-        one for sending, another for collecting the sent packets.
-        """
-        self.sender_thr = threading.Thread(target=self.send_in_background)
-        self.sniff_thr = threading.Thread(target=self.sniff_in_background)
-        # Event for the sniff_in_background status.
-        self.sniffer_started = threading.Event()
-        self.sniff_thr.start()
-        self.sender_thr.start()
-        self.sniff_thr.join()
-        self.sender_thr.join()
 
     def check_tcp_payload(self, packet):
         """

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1119,7 +1119,7 @@ class ReloadTest(BaseTest):
         while not (self.sniff_thr.isAlive() and self.sender_thr.isAlive()):
             time.sleep(1)
 
-        self.log("IO sender and sniffer threads have started, wait unitl completion")
+        self.log("IO sender and sniffer threads have started, wait until completion")
         self.sniff_thr.join()
         self.sender_thr.join()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix a rare issue when IO threads are accessed before initialization
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

To fix a rare issue when control plane is detected to be down before reboot is issued. This happens if any out of 10 ping packets are dropped (cause unknown).
When this happens, the logic proceeds to wait (join) for sender and sniffer threads to complete.
Since the device never really rebooted, there is a chance sender and sniffer threads are not initialized and started.

Additonally, removed the unused method `send_and_sniff`

```
2023-03-30 12:26:59 : Schedule to reboot the remote switch in 10 sec
2023-03-30 12:26:59 : Wait until Control plane is down
2023-03-30 12:27:00 : Send   500 Received   500 t1->servers
2023-03-30 12:27:00 : SSH thread VM=172.16.143.127: BGP routing for ipv4 OK: True
2023-03-30 12:27:00 : SSH thread VM=172.16.143.126: BGP routing for ipv4 OK: True
2023-03-30 12:27:00 : SSH thread VM=172.16.143.127: BGP routing for ipv6 OK: True
2023-03-30 12:27:00 : SSH thread VM=172.16.143.126: BGP routing for ipv6 OK: True
2023-03-30 12:27:01 : Send    10 Received     7 ping DUT
2023-03-30 12:27:01 : Control plane state transition from up to down
2023-03-30 12:27:02 : Dut reboots: reboot start 2023-03-30 12:27:02.037546
2023-03-30 12:27:02 : Wait until Control plane is up
2023-03-30 12:27:02 : ==================================================
2023-03-30 12:27:02 : Report:
2023-03-30 12:27:02 : ==================================================
2023-03-30 12:27:02 : LACP/BGP were down for (extracted from cli):
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : Extracted from VM logs:
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : Summary:
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : Fails:
2023-03-30 12:27:02 : --------------------------------------------------
2023-03-30 12:27:02 : FAILED:dut:'ReloadTest' object has no attribute 'sniff_thr'
2023-03-30 12:27:02 : ==================================================
```

#### How did you do it?

Fix the issue by:
1. Initializing sender and sniffer threads in init.
2. Before joining the IO threads wait for them to start -- keep checking `isAlive()`

#### How did you verify/test it?
Tested on physical testbed and fix works.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
