### PR TITLE
[Python3 migration]Fix test failure in ecmp

### DIFF
--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -152,7 +152,7 @@ def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
     po = config_facts.get('PORTCHANNEL_MEMBER', {})
     ports = config_facts.get('PORT', {})
 
-    tmp_fib_info = tempfile.NamedTemporaryFile()
+    tmp_fib_info = tempfile.NamedTemporaryFile(mode="w+")
     with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, timestamp)) as fp:
         fib = json.load(fp)
         for k, v in list(fib.items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [ecmp/inner_hashing] | TypeError: a bytes-like object is required, not 'str' #7902

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed after Python3 migration in tests/ecmp.
Traceback:
                if not skip:
                   tmp_fib_info.write("{}".format(prefix))

prefix     = '0.0.0.0/0'

ecmp/inner_hashing/conftest.py:179: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = ('0.0.0.0/0',), kwargs = {}

    @_functools.wraps(func)
    def func_wrapper(*args, **kwargs):
       return func(*args, **kwargs)
E      TypeError: a bytes-like object is required, not 'str'

args       = ('0.0.0.0/0',)
func       = <built-in method write of _io.BufferedRandom object at 0x7f7069f2b1a0>
kwargs     = {}

/usr/lib/python3.8/tempfile.py:612: TypeError

#### How did you do it?
When creating NamedTemporaryFile object, add mode argument and set to 'w+', which indicates that the file should be opened in text mode for reading and writing. The write method is then called with the string.

#### How did you verify/test it?
Manually run the test cases and got 100% pass.
ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv4-ipv6]
ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv4-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv4]
ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv4]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
