### PR TITLE
Let TBv2 PR checks depend on pre commit check

### DIFF
--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -58,10 +58,7 @@ steps:
     id:
     comment: |
       The [pre-commit](http://pre-commit.com/) check detected issues in the files touched by this pull request.
-      The detected issues may be old or new. For new issues, please try to fix them.
-
-      For old issues, it is not mandatory to fix them because they were not caused by this change. It is unfair to blame
-      author of this pull request. But if you can take extra effort to fix the old issues as well, that would be great!
+      The pre-commit check is a mandatory check, please fix detected issues.
 
       Detailed pre-commit check results:
       <samp>$(results)</samp>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ stages:
 
 - stage: Test
   dependsOn: Pre-test
-  condition: and(succeeded(), in(stageDependencies.Pre_test.result, 'Succeeded'))
+  condition: and(succeeded(), in(dependencies.Pre_test.result, 'Succeeded'))
   variables:
   - group: Testbed-Tools
   - name: inventory
@@ -44,19 +44,9 @@ stages:
   - group: GIT_SECRETS
 
   jobs:
-  # - job: pre_commit
-  #   displayName: "pre-commit-check"
-  #   timeoutInMinutes: 10
-  #   continueOnError: false
-  #   pool: ubuntu-20.04
-  #   steps:
-  #   - template: .azure-pipelines/pre-commit-check.yml
-
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -73,8 +63,6 @@ stages:
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -90,8 +78,6 @@ stages:
 
   - job: t0_testbedv2
     displayName: "kvmtest-t0 by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -105,8 +91,6 @@ stages:
 
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -123,8 +107,6 @@ stages:
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -139,8 +121,6 @@ stages:
 
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -155,8 +135,6 @@ stages:
   - job:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: true
@@ -171,8 +149,6 @@ stages:
 
   - job: sonic_t0_testbedv2
     displayName: "kvmtest-t0-sonic by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -192,8 +168,6 @@ stages:
   - job:
     pool: sonictest-dualtor
     displayName: "kvmtest-dualtor"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -208,8 +182,6 @@ stages:
 
   - job: dualtor_testbedv2
     displayName: "kvmtest-dualtor-t0 by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -225,8 +197,6 @@ stages:
   - job:
     pool: sonictest-ma
     displayName: "kvmtest-multi-asic-t1-lag"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -242,8 +212,6 @@ stages:
 
   - job: multi_asic_testbedv2
     displayName: "kvmtest-multi-asic-t1-lag by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -259,8 +227,6 @@ stages:
 
   - job: wan_testbedv2
     displayName: "kvmtest-wan by TestbedV2"
-    # dependsOn:
-    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
     pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
-
+    
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
     - template: .azure-pipelines/pre-commit-check.yml
 
 - stage: Test
-  dependsOn: Pre-test
+  dependsOn: Pre_test
   condition: and(succeeded(), in(dependencies.Pre_test.result, 'Succeeded'))
   variables:
   - group: Testbed-Tools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
         tbtype: t0
         vmtype: ceos
         section: part-1
-          
+
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,10 +31,9 @@ stages:
     pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
-    
+
 - stage: Test
   dependsOn: Pre-test
-  condition: and(succeeded())
   variables:
   - group: Testbed-Tools
   - name: inventory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ trigger: none
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 stages:
-- stage: Pre-test
+- stage: Pre_test
   variables:
   - group: Testbed-Tools
   - group: GIT_SECRETS
@@ -34,6 +34,7 @@ stages:
 
 - stage: Test
   dependsOn: Pre-test
+  condition: and(succeeded(), in(stageDependencies.Pre_test.result, 'Succeeded'))
   variables:
   - group: Testbed-Tools
   - name: inventory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,9 @@ name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd
 
 stages:
 - stage: Pre-test
+  variables:
+  - group: Testbed-Tools
+  - group: GIT_SECRETS
   jobs:
   - job: pre_commit
     displayName: "pre-commit-check"
@@ -28,7 +31,7 @@ stages:
     pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
-
+    
 - stage: Test
   dependsOn: Pre-test
   condition: and(succeeded())

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,16 +19,7 @@ trigger: none
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 stages:
-- stage: Test
-
-  variables:
-  - group: Testbed-Tools
-  - name: inventory
-    value: veos_vtb
-  - name: testbed_file
-    value: vtestbed.yaml
-  - group: GIT_SECRETS
-
+- stage: Pre-test
   jobs:
   - job: pre_commit
     displayName: "pre-commit-check"
@@ -38,11 +29,31 @@ stages:
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
+- stage: Test
+  dependsOn: Pre-test
+  condition: and(succeeded())
+  variables:
+  - group: Testbed-Tools
+  - name: inventory
+    value: veos_vtb
+  - name: testbed_file
+    value: vtestbed.yaml
+  - group: GIT_SECRETS
+
+  jobs:
+  # - job: pre_commit
+  #   displayName: "pre-commit-check"
+  #   timeoutInMinutes: 10
+  #   continueOnError: false
+  #   pool: ubuntu-20.04
+  #   steps:
+  #   - template: .azure-pipelines/pre-commit-check.yml
+
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -59,8 +70,8 @@ stages:
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -76,8 +87,8 @@ stages:
 
   - job: t0_testbedv2
     displayName: "kvmtest-t0 by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -91,8 +102,8 @@ stages:
 
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -109,8 +120,8 @@ stages:
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -125,8 +136,8 @@ stages:
 
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -141,8 +152,8 @@ stages:
   - job:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: true
@@ -157,8 +168,8 @@ stages:
 
   - job: sonic_t0_testbedv2
     displayName: "kvmtest-t0-sonic by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -178,8 +189,8 @@ stages:
   - job:
     pool: sonictest-dualtor
     displayName: "kvmtest-dualtor"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -194,8 +205,8 @@ stages:
 
   - job: dualtor_testbedv2
     displayName: "kvmtest-dualtor-t0 by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -211,8 +222,8 @@ stages:
   - job:
     pool: sonictest-ma
     displayName: "kvmtest-multi-asic-t1-lag"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -228,8 +239,8 @@ stages:
 
   - job: multi_asic_testbedv2
     displayName: "kvmtest-multi-asic-t1-lag by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -245,8 +256,8 @@ stages:
 
   - job: wan_testbedv2
     displayName: "kvmtest-wan by TestbedV2"
-    dependsOn:
-    - pre_commit
+    # dependsOn:
+    # - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
     pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
-    
+
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
@@ -106,38 +106,6 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
 
-  - job:
-    pool: ubuntu-20.04
-    displayName: "kvmtest-t0"
-    dependsOn:
-    - t0_part1
-    - t0_part2
-    - t0_testbedv2
-    - t0_2vlans_testbedv2
-    condition: always()
-    continueOnError: false
-    variables:
-      resultOfPart1: $[ dependencies.t0_part1.result ]
-      resultOfPart2: $[ dependencies.t0_part2.result ]
-      resultOfT0TestbedV2: $[ dependencies.t0_testbedv2.result ]
-      resultOfT02VlansTestbedV2: $[ dependencies.t0_2vlans_testbedv2.result ]
-
-    steps:
-    - script: |
-        if [ $(resultOfT0TestbedV2) == "Succeeded" ] && [ $(resultOfT02VlansTestbedV2) == "Succeeded" ]; then
-          echo "TestbedV2 t0 passed."
-          exit 0
-        fi
-
-        if [ $(resultOfPart1) == "Succeeded" ] && [ $(resultOfPart2) == "Succeeded" ]; then
-          echo "Classic t0 jobs(both part1 and part2) passed."
-          exit 0
-        fi
-
-        echo "Both classic and TestbedV2 t0 jobs failed! Please check the detailed information. (Any of them passed, t0 will be considered as passed)"
-        exit 1
-
-
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
@@ -169,27 +137,6 @@ stages:
         TOPOLOGY: t1-lag
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
-
-  - job:
-    displayName: "kvmtest-t1-lag"
-    dependsOn:
-    - t1_lag_classic
-    - t1_lag_testbedv2
-    condition: always()
-    continueOnError: false
-    pool: ubuntu-20.04
-    variables:
-      resultOfClassic: $[ dependencies.t1_lag_classic.result ]
-      resultOfTestbedV2: $[ dependencies.t1_lag_testbedv2.result ]
-    steps:
-    - script: |
-        if [ $(resultOfClassic) == "Succeeded" ] || [ $(resultOfTestbedV2) == "Succeeded" ]; then
-          echo "One or both of t1_lag_classic and t1_lag_testbedv2 passed."
-          exit 0
-        else
-          echo "Both t1_lag_classic and t1_lag_testbedv2 failed! Please check the detailed information."
-          exit 1
-        fi
 
   - job:
     pool: sonictest-sonic-t0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
         tbtype: t0
         vmtype: ceos
         section: part-1
-
+          
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,8 @@ stages:
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -57,6 +59,8 @@ stages:
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -72,6 +76,8 @@ stages:
 
   - job: t0_testbedv2
     displayName: "kvmtest-t0 by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -85,6 +91,8 @@ stages:
 
   - job: t0_2vlans_testbedv2
     displayName: "kvmtest-t0-2vlans by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -133,6 +141,8 @@ stages:
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -147,6 +157,8 @@ stages:
 
   - job: t1_lag_testbedv2
     displayName: "kvmtest-t1-lag by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -182,6 +194,8 @@ stages:
   - job:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: true
@@ -196,6 +210,8 @@ stages:
 
   - job: sonic_t0_testbedv2
     displayName: "kvmtest-t0-sonic by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -215,6 +231,8 @@ stages:
   - job:
     pool: sonictest-dualtor
     displayName: "kvmtest-dualtor"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -229,6 +247,8 @@ stages:
 
   - job: dualtor_testbedv2
     displayName: "kvmtest-dualtor-t0 by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -244,6 +264,8 @@ stages:
   - job:
     pool: sonictest-ma
     displayName: "kvmtest-multi-asic-t1-lag"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 400
     condition: and(succeeded(), eq(variables.RUN_CLASSICAL_TEST, 'YES'))
     continueOnError: false
@@ -259,6 +281,8 @@ stages:
 
   - job: multi_asic_testbedv2
     displayName: "kvmtest-multi-asic-t1-lag by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -274,6 +298,8 @@ stages:
 
   - job: wan_testbedv2
     displayName: "kvmtest-wan by TestbedV2"
+    dependsOn:
+    - pre_commit
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Pre-commit check has been set to a mandatory check, if pre-commit check fails, pr can't be merged.
So it will be more efficient if we can get a pr check failure result after pre-commit check fails.
#### How did you do it?
Let TBv2 PR checks depend on pre commit check
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
