### PR TITLE
Fix the code for stopping exabgp in cleanup.sh.j2

### DIFF
--- a/ansible/roles/vm_set/templates/cleanup.sh.j2
+++ b/ansible/roles/vm_set/templates/cleanup.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # stop rynning VMs
 test -z "$(virsh list --state-running --name)" || virsh list --state-running --name | xargs -I % virsh destroy %
@@ -18,13 +18,11 @@ rm -f {{ root_path }}/disks/*
 test -z "$(ovs-vsctl list-br)" || ovs-vsctl list-br | xargs -I % ovs-vsctl del-br %
 
 # stop exabgp process before stopping ptf container
-test -z "$(docker ps | grep ptf | awk '{print $NF}')"
-ptf_container_name=$(docker ps | grep ptf | awk '{print $NF}')
-for ptf in  $ptf_container_name;
+ptf_container_names=$(docker ps | grep ptf | awk '{print $NF}')
+for ptf in $ptf_container_names;
 do
-  test -z "$(docker exec $ptf supervisorctl status | grep exabgp | awk '{print $1}')"
-  exabgp_process_name="$(docker exec $ptf supervisorctl status | grep exabgp | awk '{print $1}')"
-  docker exec $ptf supervisorctl stop $exabgp_process_name
+  docker exec $ptf supervisorctl stop exabgpv4:*
+  docker exec $ptf supervisorctl stop exabgpv6:*
 done
 
 # stop all running docker containers


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
After the exabgp processes are grouped to exabgpv4 and exabgpv6 in ptf container, the existing code for stopping exabgp processes in cleanup.sh.j2 was broken.

The exabgp processes cannot be stopped before stopping the PTF containers. Then, there is a chance that the server got stuck if we run the cleanup.sh script.

#### How did you do it?
This change updated the cleanup.sh.j2 template to stop the exabgp processes by group names.

#### How did you verify/test it?
Test run the rendered cleanup.sh script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
