### PR TITLE
[Python3 migration]Fix test failure in test_sub_port_l2_forwarding.py

### DIFF
--- a/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
+++ b/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
@@ -110,9 +110,9 @@ def test_sub_port_l2_forwarding(apply_config_on_the_dut, duthosts, rand_one_dut_
     def verify_no_packet_received(ptfadapter, ports, packet_fingerprint):
         for port in ports:
             for packet, _ in ptfadapter.dataplane.packet_queues[(0, port)]:
-                if packet_fingerprint in packet:
+                if packet_fingerprint in str(packet):
                     logging.error("Received packet with fingerprint '%s' on port %s: %s\n", port, packet_fingerprint,
-                                  packet)
+                                  str(packet))
                     pytest.fail("Received packet on port %s" % port)
 
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7884 [test_sub_port_l2_forwarding] [test issue] TypeError: a bytes-like object is required, not 'str'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test sub_port_interfaces/test_sub_port_l2_forwarding.py fail over python3 issue:
TypeError: a bytes-like object is required, not 'str'

#### How did you do it?
In Python3, a string cannot work with bytes
Use str to convert bytes to string

#### How did you verify/test it?
The change can work both in Python2 and Python3.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
