### PR TITLE
Add a test case to verify that BGP packets use queue7

### DIFF
--- a/docs/testplan/BGP-queue-test-plan.md
+++ b/docs/testplan/BGP-queue-test-plan.md
@@ -1,0 +1,31 @@
+# BGP-queue test plan
+
+* [Overview](#Overview)
+   * [Scope](#Scope)
+   * [Testbed](#Testbed)
+* [Setup configuration](#Setup%20configuration)
+* [Test cases](#Test%20cases)
+
+## Overview
+The purpose is to make sure that BGP control packets use unicast queue 7 by default on all SONiC platforms.
+The test expects that basic BGP configuration for the test is pre-configured on SONiC device before test run.
+
+### Scope
+The test is targeting a running SONiC system with fully functioning configuration. The purpose of the test is to verify BGP control packets use egress queue 7 on SONiC platforms.
+
+### Testbed
+The test could run on any testbed.
+
+## Setup configuration
+This test requires BGP neighbors to be configured and established before the test run.
+
+## Test
+The test will verify that all BGP packets use unicast queue 7 by default. It is to be noted that if BGP sessions are established over PortChannels, LACP packets will also use the same unicast queue 7, but that does not impact the test functionality.
+
+## Test cases
+### Test case test_bgp_queue
+#### Test steps
+* Clear all queue counters using "sonic-clear counters" command
+* Generate a mapping of neighbors to the corresponding interfaces/ports using ARP/NDP entries
+* For all "established" BGP sessions, run "show queue counters" on the corresponding port
+* Verify that unicast queue 7 counters are non-zero and that unicast queue 0 counters are zero

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -25,7 +25,7 @@ def get_queue_counters(duthost, port, queue):
         fields = line.split()
         if fields[1] == txq:
             return int(fields[2])
-    return 0
+    return -1
 
 
 def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinfo):

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -1,0 +1,73 @@
+import time
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+
+def clear_queue_counters(duthost):
+    duthost.shell("sonic-clear queuecounters")
+
+
+def get_queue_counters(duthost, port, queue):
+    """
+    Return the counter for a given queue in given port
+    """
+    cmd = "show queue counters {}".format(port)
+    output = duthost.shell(cmd)['stdout_lines']
+    txq = "UC{}".format(queue)
+    for line in output:
+        fields = line.split()
+        if fields[1] == txq:
+            return int(fields[2])
+    return 0
+
+
+def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinfo):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    clear_queue_counters(duthost)
+    time.sleep(10)
+    bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    arp_dict = {}
+    ndp_dict = {}
+    show_arp = duthost.command('show arp')
+    show_ndp = duthost.command('show ndp')
+    for arp_entry in show_arp['stdout_lines']:
+        items = arp_entry.split()
+        if (len(items) != 4):
+            continue
+        ip = items[0]
+        iface = items[2]
+        arp_dict[ip] = iface
+    for ndp_entry in show_ndp['stdout_lines']:
+        items = ndp_entry.split()
+        if (len(items) != 5):
+            continue
+        ip = items[0]
+        iface = items[2]
+        ndp_dict[ip] = iface
+
+    for k, v in list(bgp_facts['bgp_neighbors'].items()):
+        # Only consider established bgp sessions
+        if v['state'] == 'established':
+            assert (k in arp_dict.keys() or k in ndp_dict.keys())
+            if k in arp_dict:
+                ifname = arp_dict[k]
+            else:
+                ifname = ndp_dict[k]
+            if (ifname.startswith("PortChannel")):
+                for port in mg_facts['minigraph_portchannels'][ifname]['members']:
+                    logger.info("PortChannel '{}' : port {}".format(ifname, port))
+                    assert(get_queue_counters(duthost, port, "0") == 0)
+                    assert(get_queue_counters(duthost, port, "7"))
+            else:
+                logger.info(ifname)
+                assert(get_queue_counters(duthost, ifname, "0") == 0)
+                assert(get_queue_counters(duthost, ifname, "7"))

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -59,9 +59,9 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         if v['state'] == 'established':
             assert (k in arp_dict.keys() or k in ndp_dict.keys())
             if k in arp_dict:
-                ifname = arp_dict[k]
+                ifname = arp_dict[k].split('.',1)[0]
             else:
-                ifname = ndp_dict[k]
+                ifname = ndp_dict[k].split('.',1)[0]
             if (ifname.startswith("PortChannel")):
                 for port in mg_facts['minigraph_portchannels'][ifname]['members']:
                     logger.info("PortChannel '{}' : port {}".format(ifname, port))

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -59,9 +59,9 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         if v['state'] == 'established':
             assert (k in arp_dict.keys() or k in ndp_dict.keys())
             if k in arp_dict:
-                ifname = arp_dict[k].split('.',1)[0]
+                ifname = arp_dict[k].split('.', 1)[0]
             else:
-                ifname = ndp_dict[k].split('.',1)[0]
+                ifname = ndp_dict[k].split('.', 1)[0]
             if (ifname.startswith("PortChannel")):
                 for port in mg_facts['minigraph_portchannels'][ifname]['members']:
                     logger.info("PortChannel '{}' : port {}".format(ifname, port))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

- Add a test case to verify that BGP packets use queue7 on all platforms
- All control packets including BGP are expected to use queue7, separate from data packet queues

Summary:
Fixes # (17647967)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [ ] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
It was observed that control packets use queue 0 in TD2 platforms which can lead to these packets being lost when link utilization becomes close to 100%. This can lead to critical issues in field like BGP keepalive failures. This management test is a way to make sure that this doesn't happen again in production.
#### How did you do it?
By bringing up BGP sessions with neighbors and making sure that BGP control traffic uses queue 7 by default using "show queue counters".
#### How did you verify/test it?
By running the test and making sure that it works as expected, reporting success or failure depending on which queues are used by control packets.
#### Any platform specific information?
This is applicable to all platforms.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
