### PR TITLE
Delay 20 seconds at the end of test_ntp

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -58,6 +58,11 @@ def setup_ntp(ptfhost, duthosts, rand_one_dut_hostname):
     duthost.command("config ntp del %s" % ptfhost.mgmt_ip)
     for ntp_server in ntp_servers:
         duthost.command("config ntp add %s" % ntp_server)
+    # The time jump leads to exception in lldp_syncd. The exception has been handled by lldp_syncd,
+    # but it will leave error messages in syslog, which will cause subsequent test cases to fail.
+    # So we need to wait for a while to make sure the error messages are flushed.
+    # The default update interval of lldp_syncd is 10 seconds, so we wait for 20 seconds here.
+    time.sleep(20)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add 20 seconds delay at the end of `test_ntp`.
Because of the time jump in `test_ntp`, we see  exception in lldp_syncd. 
```
ERR lldp#lldp-syncd message repeated 7 times: [ [lldp_syncd] ERROR: Failed to parse lldp age 0 day, 00:-53:-54 -- #012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/lldp_syncd/daemon.py", line 49, in parse_time#012    struct_time = time.strptime(hour_min_secs, LLDPD_TIME_FORMAT)#012  File "/usr/lib/python3.9/_strptime.py", line 562, in _strptime_time#012    tt = _strptime(data_string, format)[0]#012  File "/usr/lib/python3.9/_strptime.py", line 349, in _strptime#012    raise ValueError("time data %r does not match format %r" %#012ValueError: time data '00:-53:-54' does not match format '%H:%M:%S']
```
The exception has been handled by lldp_syncd, and `test_ntp` has disabled LogAnalyzer, hence no error is caught in `test_ntp`.
However, the error message in the next interval (each 10 seconds) will cause subsequent test cases to fail.
So we need to wait for a while to make sure the error messages are flushed.
The default update interval of lldp_syncd is 10 seconds, so we wait for 20 seconds here.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to add 20 seconds delay at the end of `test_ntp` to avoid the potential impact to subsequent test cases.

#### How did you do it?
Sleep 20 seconds at a module level fixture.

#### How did you verify/test it?
Verified on a SN4600 testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
