### PR TITLE
[m0][everflow] Skip m0 everflow per intf ipv6 test on marvell

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -411,16 +411,16 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-defaul
       - "asic_type in ['cisco-8000', 'marvell', 'mellanox']"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_vlan_scenario]:
-skip:
-  reason: "Skip m0 everflow per interface IPv6 test on marvell"
-  conditions:
-    - "asic_type in ['marvell']"
+  skip:
+    reason: "Skip m0 everflow per interface IPv6 test on marvell"
+    conditions:
+      - "asic_type in ['marvell']"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_l3_scenario]:
-skip:
-  reason: "Skip m0 everflow per interface IPv6 test on marvell"
-  conditions:
-    - "asic_type in ['marvell']"
+  skip:
+    reason: "Skip m0 everflow per interface IPv6 test on marvell"
+    conditions:
+      - "asic_type in ['marvell']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -410,6 +410,18 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-defaul
     conditions:
       - "asic_type in ['cisco-8000', 'marvell', 'mellanox']"
 
+everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_vlan_scenario]:
+skip:
+  reason: "Skip m0 everflow per interface IPv6 test on marvell"
+  conditions:
+    - "asic_type in ['marvell']"
+
+everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_l3_scenario]:
+skip:
+  reason: "Skip m0 everflow per interface IPv6 test on marvell"
+  conditions:
+    - "asic_type in ['marvell']"
+
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   xfail:
     strict: True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip m0 IPv6 everflow per interface test on marvell.

#### How did you do it?
Add sko condition into tests_mark_confitions.yml.

#### How did you verify/test it?
Run test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
