### PR TITLE
[qos] update comparison for queue 7, since lacp traffic go throug queue7 instead of queue 0

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -436,8 +436,8 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # queue 3/4  1                 1               1                                                1                                         1                         # noqa E501
             # queue 5    1                 1               1                                                1                                         1                         # noqa E501
             # queue 7    0                 1               1                                                1                                         1                         # noqa E501
-            # LAG ports can have LACP packets on queue 0, hence using >= comparison
-            assert (queue_results[QUEUE_0] >= 1 + queue_results_base[QUEUE_0])
+            # LAG ports can have LACP packets on queue 7, hence using >= comparison
+            assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
             assert (queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
             assert (queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
             assert (queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
@@ -456,12 +456,12 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
                 else:
                     assert (queue_results[QUEUE_1] ==
                             57 + queue_results_base[QUEUE_1])
-                assert (queue_results[QUEUE_7] == 1 +
+                assert (queue_results[QUEUE_7] >= 1 +
                         queue_results_base[QUEUE_7])
             else:
                 assert (queue_results[QUEUE_1] == 58 +
                         queue_results_base[QUEUE_1])
-                assert (queue_results[QUEUE_7] == queue_results_base[QUEUE_7])
+                assert (queue_results[QUEUE_7] >= queue_results_base[QUEUE_7])
 
         finally:
             print("END OF TEST", file=sys.stderr)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -436,7 +436,6 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # queue 3/4  1                 1               1                                                1                                         1                         # noqa E501
             # queue 5    1                 1               1                                                1                                         1                         # noqa E501
             # queue 7    0                 1               1                                                1                                         1                         # noqa E501
-            # LAG ports can have LACP packets on queue 7, hence using >= comparison
             assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
             assert (queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
             assert (queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
@@ -456,11 +455,13 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
                 else:
                     assert (queue_results[QUEUE_1] ==
                             57 + queue_results_base[QUEUE_1])
+                # LAG ports can have LACP packets on queue 7, hence using >= comparison
                 assert (queue_results[QUEUE_7] >= 1 +
                         queue_results_base[QUEUE_7])
             else:
                 assert (queue_results[QUEUE_1] == 58 +
                         queue_results_base[QUEUE_1])
+                # LAG ports can have LACP packets on queue 7, hence using >= comparison
                 assert (queue_results[QUEUE_7] >= queue_results_base[QUEUE_7])
 
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

in testQosSaiSeparatedDscpQueueMapping, 
occasionally failed, because recevied 2 packets in queue 7, but expected received pkt number is 1.
so failed like below:
```
dscp: 63, total received: 1
last
queue_results_base [18, 1059, 19, 19, 19, 18, 19, 362]
queue_results      [19, 1116, 20, 20, 20, 19, 20, 364]
                   [1, 57, 1, 1, 1, 1, 1, 2]
END OF TEST
FAIL

======================================================================
FAIL: sai_qos_tests.DscpMappingPB
----------------------------------------------------------------------
Traceback (most recent call last):
  File "saitests/py3/sai_qos_tests.py", line 486, in runTest
    queue_results_base[QUEUE_7])
AssertionError
```

RCA:
This additional 1 packet is the lacp background traffic. we should ignore it non queue 7.

#### How did you do it?

ignore lacp background traffic on queue 7

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
