### PR TITLE
Fix LogAnalyzer in test_announce_withdraw_route

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -6,7 +6,6 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from utils import get_crm_resources, check_queue_status, sleep_to_wait, LOOP_TIMES_LEVEL_MAP
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 ALLOW_ROUTES_CHANGE_NUMS = 5
 CRM_POLLING_INTERVAL = 1

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -41,7 +41,6 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
                                  withdraw_and_announce_existing_routes, loganalyzer):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
-    
     if loganalyzer:
         ignoreRegex = [
             ".*ERR route_check.py:.*",

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -39,16 +39,16 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 
 
 def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conpleteness_level,
-                                 withdraw_and_announce_existing_routes):
+                                 withdraw_and_announce_existing_routes, loganalyzer):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
-
-    ignoreRegex = [
-        ".*ERR route_check.py:.*",
-        ".*ERR.* \'routeCheck\' status failed.*"
-    ]
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="stress_routes_helper")
-    loganalyzer.ignore_regex.extend(ignoreRegex)
+    
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR route_check.py:.*",
+            ".*ERR.* \'routeCheck\' status failed.*"
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix `LogAnalyzer` in `test_announce_withdraw_route`.
The existing code to ignore expected error patterns is not working, we are still seeing test error caused by routeCheck error logs.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix `LogAnalyzer` in `test_announce_withdraw_route`.

#### How did you do it?
Update the LogAnalyzer fixture.

#### How did you verify/test it?
Verified on a  Mellanox platform. The error logs are ignored with this change.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
