### PR TITLE
[advanced-reboot] Fix issue that prevented device shutdown and full r…

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1433,7 +1433,7 @@ class ReloadTest(BaseTest):
 
             # Check sonic version after reboot
             self.check_sonic_version_after_reboot()
-        except Exception as e:
+        except Exception:
             traceback_msg = traceback.format_exc()
             self.fails['dut'].add(traceback_msg)
         finally:

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -60,6 +60,7 @@ import time
 import json
 import subprocess
 import threading
+import traceback
 import multiprocessing
 import itertools
 import ast
@@ -404,10 +405,11 @@ class ReloadTest(BaseTest):
         try:
             res = async_res.get(timeout=seconds)
         except Exception as err:
+            traceback_msg = traceback.format_exc()
             # TimeoutError and Exception's from func
             # captured here
             signal.set()
-            raise type(err)(message)
+            raise type(err)("{}: {}".format(message, traceback_msg))
         return res
 
     def generate_vlan_servers(self):
@@ -927,7 +929,7 @@ class ReloadTest(BaseTest):
     def put_nowait(self, queue, data):
         try:
             queue.put_nowait(data)
-        except queue.Full:
+        except Queue.Full:
             pass
 
     def pre_reboot_test_setup(self):
@@ -1432,7 +1434,8 @@ class ReloadTest(BaseTest):
             # Check sonic version after reboot
             self.check_sonic_version_after_reboot()
         except Exception as e:
-            self.fails['dut'].add(e)
+            traceback_msg = traceback.format_exc()
+            self.fails['dut'].add(traceback_msg)
         finally:
             self.handle_post_reboot_test_reports()
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -329,18 +329,9 @@ def analyze_sairedis_rec(messages, result, offset_from_kexec):
 def get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper):
     report = {"controlplane": {"arp_ping": "", "downtime": ""},
               "dataplane": {"lost_packets": "", "downtime": ""}}
-    # escaping, as glob utility does not work well with "[","]"
-    reboot_report_path = re.sub('([\[\]])', '[\\1]', log_dir)
-    if reboot_oper:
-        reboot_report_file_name = "{}-reboot-{}-report.json".format(
-            reboot_type, reboot_oper)
-    else:
-        reboot_report_file_name = "{}-reboot-report.json".format(reboot_type)
-    reboot_report_file = "{}/{}".format(reboot_report_path,
-                                        reboot_report_file_name)
-    files = glob.glob(reboot_report_file)
+    files = glob.glob1(log_dir,'*reboot*-report.json')
     if files:
-        filepath = files[0]
+        filepath = "{}/{}".format(log_dir, files[0])
         with open(filepath) as json_file:
             report = json.load(json_file)
     analyze_result.update(report)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -330,7 +330,7 @@ def get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper):
     report = {"controlplane": {"arp_ping": "", "downtime": ""},
               "dataplane": {"lost_packets": "", "downtime": ""}}
     # escaping, as glob utility does not work well with "[","]"
-    reboot_report_path = re.sub(r'([\[\]])', r'[\\1]', log_dir)
+    reboot_report_path = re.sub('([\[\]])','[\\1]',log_dir)
     if reboot_oper:
         reboot_report_file_name = "{}-reboot-{}-report.json".format(
             reboot_type, reboot_oper)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -330,7 +330,7 @@ def get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper):
     report = {"controlplane": {"arp_ping": "", "downtime": ""},
               "dataplane": {"lost_packets": "", "downtime": ""}}
     # escaping, as glob utility does not work well with "[","]"
-    reboot_report_path = re.sub('([\[\]])','[\\1]',log_dir)
+    reboot_report_path = re.sub('([\[\]])', '[\\1]', log_dir)
     if reboot_oper:
         reboot_report_file_name = "{}-reboot-{}-report.json".format(
             reboot_type, reboot_oper)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -329,7 +329,7 @@ def analyze_sairedis_rec(messages, result, offset_from_kexec):
 def get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper):
     report = {"controlplane": {"arp_ping": "", "downtime": ""},
               "dataplane": {"lost_packets": "", "downtime": ""}}
-    files = glob.glob1(log_dir,'*reboot*-report.json')
+    files = glob.glob1(log_dir, '*reboot*-report.json')
     if files:
         filepath = "{}/{}".format(log_dir, files[0])
         with open(filepath) as json_file:


### PR DESCRIPTION
…eport generation

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

The test_advanced_reboot fails on master branch when it fails to reboot the device, and fails w/ incorrect error: `DUT hasn't shutdown in 300 seconds`.
In reality the device is not rebooted at all as the test library crashes while doing so. The error is apparent when traceback is enabled in the code.

This PR fixes the error (introduced after change in https://github.com/sonic-net/sonic-mgmt/pull/7817), added traceback for better debug support.
Also, this fixes a part where reboot timing data is not printed entirely as the logs path can't be parsed due to a change in 
https://github.com/sonic-net/sonic-mgmt/pull/7049

```
2023-04-21T12:37:34.6364256Z 2023-04-21 12:37:15 : Schedule to reboot the remote switch in 10 sec
2023-04-21T12:37:34.6365498Z 2023-04-21 12:37:15 : Wait until Control plane is down
2023-04-21T12:37:34.6366843Z 2023-04-21 12:37:16 : SSH thread VM=172.16.140.81: BGP routing for ipv4 OK: True
2023-04-21T12:37:34.6368196Z 2023-04-21 12:37:16 : SSH thread VM=172.16.140.80: BGP routing for ipv4 OK: True
2023-04-21T12:37:34.6369551Z 2023-04-21 12:37:16 : SSH thread VM=172.16.140.81: BGP routing for ipv6 OK: True
2023-04-21T12:37:34.6371177Z 2023-04-21 12:37:16 : SSH thread VM=172.16.140.80: BGP routing for ipv6 OK: True
2023-04-21T12:37:34.6372523Z 2023-04-21 12:37:16 : ==================================================
2023-04-21T12:37:34.6373784Z 2023-04-21 12:37:16 : Report:
2023-04-21T12:37:34.6374984Z 2023-04-21 12:37:16 : ==================================================
2023-04-21T12:37:34.6376282Z 2023-04-21 12:37:16 : LACP/BGP were down for (extracted from cli):
2023-04-21T12:37:34.6377600Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6378933Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6380183Z 2023-04-21 12:37:16 : Extracted from VM logs:
2023-04-21T12:37:34.6381452Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6382721Z 2023-04-21 12:37:16 : Summary:
2023-04-21T12:37:34.6383857Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6385127Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6386287Z 2023-04-21 12:37:16 : Fails:
2023-04-21T12:37:34.6387433Z 2023-04-21 12:37:16 : --------------------------------------------------
2023-04-21T12:37:34.6388727Z 2023-04-21 12:37:16 : FAILED:dut:DUT hasn't shutdown in 300 seconds
2023-04-21T12:37:34.6389983Z 2023-04-21 12:37:16 : ==================================================
```

The reason for failure remained unclear until traceback from Exception is captured and printed along w/ failure:

```
        "======================================================================", 
        "FAIL: advanced-reboot.ReloadTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"ptftests/advanced-reboot.py\", line 1440, in runTest", 
        "    self.handle_post_reboot_test_reports()", 
        "  File \"ptftests/advanced-reboot.py\", line 1376, in handle_post_reboot_test_reports", 
        "    self.assertTrue(is_good, errors)", 
        "AssertionError: ", 
        "", 
        "Something went wrong. Please check output below:", 
        "", 
        "FAILED:dut:Traceback (most recent call last):", 
        "  File \"ptftests/advanced-reboot.py\", line 1393, in runTest", 
        "    self.wait_until_control_plane_down()", 
        "  File \"ptftests/advanced-reboot.py\", line 1041, in wait_until_control_plane_down", 
        "    \"DUT hasn't shutdown in {} seconds\".format(self.task_timeout))", 
        "  File \"ptftests/advanced-reboot.py\", line 412, in timeout", 
        "    raise type(err)(\"{}: {}\".format(message, traceback_msg))", 
        "AttributeError: DUT hasn't shutdown in 300 seconds: Traceback (most recent call last):", 
        "  File \"ptftests/advanced-reboot.py\", line 406, in timeout", 
        "    res = async_res.get(timeout=seconds)", 
        "  File \"/usr/lib/python2.7/multiprocessing/pool.py\", line 572, in get", 
        "    raise self._value", 
        "AttributeError: Queue instance has no attribute 'Full'", 
        "",
```


#### How did you do it?

#### How did you verify/test it?

Tested on a physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
