### PR TITLE
[Python3 migration]Fix test failure in test_vlan_ping.py

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -63,10 +63,7 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
             break
 
     py_assert(vm_name is not None, "Can't get neighbor vm")
-    if six.PY2:
-        vm_ip_with_prefix = (vm_info['conf']['interfaces']['Port-Channel1']['ipv4']).decode('utf-8')
-    else:
-        vm_ip_with_prefix = vm_info['conf']['interfaces']['Port-Channel1']['ipv4']
+    vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Port-Channel1']['ipv4'])
     output = vm_info['host'].command("ip addr show dev po1")
     vm_host_info["mac"] = output['stdout_lines'][1].split()[1]
     vm_ip_intf = ipaddress.IPv4Interface(vm_ip_with_prefix).ip

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 import logging
 import ptf.testutils as testutils
+import six
 from tests.common.helpers.assertions import pytest_assert as py_assert
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,10 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
             break
 
     py_assert(vm_name is not None, "Can't get neighbor vm")
-    vm_ip_with_prefix = (vm_info['conf']['interfaces']['Port-Channel1']['ipv4']).decode('utf-8')
+    if six.PY2:
+        vm_ip_with_prefix = (vm_info['conf']['interfaces']['Port-Channel1']['ipv4']).decode('utf-8')
+    else:
+        vm_ip_with_prefix = vm_info['conf']['interfaces']['Port-Channel1']['ipv4']
     output = vm_info['host'].command("ip addr show dev po1")
     vm_host_info["mac"] = output['stdout_lines'][1].split()[1]
     vm_ip_intf = ipaddress.IPv4Interface(vm_ip_with_prefix).ip


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #7867 [test_vlan_ping] [ test issue ] | 'str' object has no attribute 'decode'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed after Python3 migration.
vm_ip_with_prefix = (vm_info['conf']['interfaces']['Port-Channel1']['ipv4']).decode('utf-8')
E AttributeError: 'str' object has no attribute 'decode'

#### How did you do it?
Use six.ensure_text. In Python2, ensure_text returns unicode and returns str in Python3.
In Python3, there is no need to use decode()

#### How did you verify/test it?
Manually run the test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
