### PR TITLE
[Python3 migration]Fix test failure caused by set_do_not_care_packet/set_do_not_care_scapy

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -860,16 +860,16 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         exp_pkt = pkt.copy()
 
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, "dst")
-        exp_pkt.set_do_not_care_packet(packet.Ether, "src")
+        exp_pkt.set_do_not_care_scapy(packet.Ether, "dst")
+        exp_pkt.set_do_not_care_scapy(packet.Ether, "src")
 
         if ip_version == "ipv4":
-            exp_pkt.set_do_not_care_packet(packet.IP, "chksum")
+            exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")
             # In multi-asic we cannot determine this so ignore.
-            exp_pkt.set_do_not_care_packet(packet.IP, 'ttl')
+            exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
         else:
             # In multi-asic we cannot determine this so ignore.
-            exp_pkt.set_do_not_care_packet(packet.IPv6, 'hlim')
+            exp_pkt.set_do_not_care_scapy(packet.IPv6, 'hlim')
 
         return exp_pkt
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_a
 from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args
 from ptf import testutils
+from ptf.mask import Mask
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -2148,3 +2149,7 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
 # HACK: testutils.verify_packets_any to workaround code bug
 # TODO: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
 testutils.verify_packets_any = verify_packets_any_fixed
+
+# HACK: We are using set_do_not_care_scapy but it will be deprecated.
+if not hasattr(Mask, "set_do_not_care_scapy"):
+    Mask.set_do_not_care_scapy = Mask.set_do_not_care_packet

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -210,8 +210,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = 120
         exp_pkt.payload.chksum = 0x0100
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route 10.156.94.34")["stdout_lines"], pc_ports_map)
@@ -280,8 +280,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = 120
         exp_pkt.payload.chksum = 0x0100
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route 10.156.94.34")["stdout_lines"], pc_ports_map)
@@ -349,8 +349,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = 120
         exp_pkt.payload.chksum = 0x0100
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route 10.156.94.34")["stdout_lines"], pc_ports_map)
@@ -420,8 +420,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = 121
         exp_pkt.payload.chksum = 0x0001
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route 10.156.190.188")["stdout_lines"], pc_ports_map)
@@ -488,8 +488,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = 121
         exp_pkt.payload.chksum = 0x0000
         exp_pkt = mask.Mask(exp_pkt)
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route 10.156.94.34")["stdout_lines"], pc_ports_map)
@@ -548,8 +548,8 @@ class TestIPPacket(object):
         exp_pkt.payload.ttl = pkt.payload.ttl - 1
         exp_pkt = mask.Mask(exp_pkt)
 
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
 
         out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
             duthost.command("show ip route %s" % peer_ip_ifaces_pair[1][0])["stdout_lines"],

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -289,10 +289,10 @@ def test_po_update_io_no_loss(
         exp_pkt = pkt.copy()
         exp_pkt = mask.Mask(exp_pkt)
 
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'dst')
-        exp_pkt.set_do_not_care_packet(packet.Ether, 'src')
-        exp_pkt.set_do_not_care_packet(packet.IP, 'chksum')
-        exp_pkt.set_do_not_care_packet(packet.IP, 'ttl')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
+        exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
 
         ptfadapter.dataplane.flush()
         member_update_finished_flag = Queue(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #8003 Getting AttributeError: Mask instance has no attribute 'set_do_not_care_packet' error while running acl test suite

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In python2, ptf version is 0.9.1.
In python3, ptf version is 0.9.3.
Bound method set_do_not_care_packet for a Mask object is only available in ptf 0.9.3.

#### How did you do it?
Change set_do_not_care_packet back to set_do_not_care_scapy
New 0.9.3 code, set_do_not_care_scapy is a warpper of set_do_not_care_packet for compatibility.

#### How did you verify/test it?
Manually run test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
