### PR TITLE
[Python3 migration]Fix test failure in dual_tor_io.py

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -594,7 +594,7 @@ class DualTorIO:
                 payload_bytes = bytes(packet[scapyall.TCP].payload).decode()
             payload_int = int(payload_bytes.replace('X', ''))
             return (payload_int, packet.time)
-        
+
         # For each server's packet list, sort by payload then timestamp
         # (in case of duplicates)
         for server in list(server_to_packet_map.keys()):

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -588,11 +588,11 @@ class DualTorIO:
 
         # E731 Use a def instead of a lambda
         def get_packet_sort_key(packet):
+            payload_bytes = convert_scapy_packet_to_bytes(packet[scapyall.TCP].payload)
             if six.PY2:
-                payload_bytes = str(packet[scapyall.TCP].payload)
+                payload_int = int(payload_bytes.replace('X', ''))
             else:
-                payload_bytes = bytes(packet[scapyall.TCP].payload).decode()
-            payload_int = int(payload_bytes.replace('X', ''))
+                payload_int = int(payload_bytes.decode().replace('X', ''))
             return (payload_int, packet.time)
 
         # For each server's packet list, sort by payload then timestamp
@@ -633,10 +633,11 @@ class DualTorIO:
                 # scapy 2.4.5 will use Decimal to calulcate time, but json.dumps
                 # can't recognize Decimal, transform to float here
                 curr_time = float(packet.time)
+                curr_payload_bytes = convert_scapy_packet_to_bytes(packet[scapyall.TCP].payload)
                 if six.PY2:
-                    curr_payload = int(str(packet[scapyall.TCP].payload).replace('X', ''))
+                    curr_payload = int(curr_payload_bytes.replace('X', ''))
                 else:
-                    curr_payload = int(bytes(packet[scapyall.TCP].payload).decode().replace('X', ''))
+                    curr_payload = int(curr_payload_bytes.decode().replace('X', ''))
 
                 # Look back at the previous received packet to check for gaps/duplicates
                 # Only if we've already received some packets
@@ -713,11 +714,12 @@ class DualTorIO:
             sequential TCP Payload
         """
         try:
+            payload_bytes = convert_scapy_packet_to_bytes(packet[scapyall.TCP].payload)
             if six.PY2:
-                int(str(packet[scapyall.TCP].payload).replace('X', '')) in range(
+                int(payload_bytes.replace('X', '')) in range(
                     self.packets_to_send)
             else:
-                int(bytes(packet[scapyall.TCP].payload).decode().replace('X', '')) in range(
+                int(payload_bytes.decode().replace('X', '')) in range(
                     self.packets_to_send)
             return True
         except Exception:

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -817,3 +817,16 @@ def get_downstream_neigh_type(topo_type, is_upper=True):
         return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
 
     return None
+
+
+def convert_scapy_packet_to_bytes(packet):
+    """Convert scapy packet to bytes for python2 and python3 compatibility
+    Args:
+        packet: scapy packet
+    Returns:
+        str or bytes: packet in bytes
+    """
+    if six.PY2:
+        return str(packet)
+    else:
+        return bytes(packet)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #8021 dualtor_io tests fail for converting to python3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
dualtor_io test failed after converting to python3 migration with error:
E           IndexError: Layer [Ether] not found

#### How did you do it?
In Python2, str() is used to process packet.
In Python3, bytes() should be used.

#### How did you verify/test it?
Manually run test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
