### PR TITLE
[qos] trigger arp learning before sai_qos_tests.DscpMappingPB test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1309,6 +1309,10 @@ class QosSaiBase(QosBase):
         if saiQosTest:
             testParams = dutTestParams["basicParams"]
             testParams.update(dutConfig["testPorts"])
+            testParams.update({
+                "testPortIds": dutConfig["testPortIds"],
+                "testPortIps": dutConfig["testPortIps"]
+            })
             self.runPtfTest(
                 ptfhost, testCase=saiQosTest, testParams=testParams
             )

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -335,6 +335,11 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         print("dst_port_id: %d, src_port_id: %d" %
               (dst_port_id, src_port_id), file=sys.stderr)
 
+        self.exec_cmd_on_dut(self.server, self.test_params['dut_username'],
+                             self.test_params['dut_password'],
+                             'ping {} -c 3'.format(dst_port_ip))
+        time.sleep(8)
+
         # in case dst_port_id is part of LAG, find out the actual dst port
         # for given IP parameters
         dst_port_id = get_rx_port(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

In testQosSaiSeparatedDscpQueueMapping, encounter below case failure:
```
sai_qos_tests.DscpMappingPB ... dst_port_id: 20, src_port_id: 44
actual dst_port_id: 20
dst_port_mac: 8a:52:64:f3:b0:14, src_port_mac: 76:2a:8e:f0:53:2c, src_port_ip: 10.0.0.45, dst_port_ip: 10.0.0.13
port list {0: 4294967330, 1: 4294967331, 62: 4294967374, 61: 4294967373, 60: 4294967372, 50: 4294967412, 52: 4294967404, 21: 4294967399, 34: 4294967338, 58: 4294967370, 44: 4294967311, 16: 4294967376, 5: 4294967335, 17: 4294967377, 45: 4294967312, 54: 4294967406, 46: 4294967344, 47: 4294967345, 53: 4294967405, 37: 4294967341, 55: 4294967407, 36: 4294967340, 4: 4294967334, 42: 4294967307, 20: 4294967398, 38: 4294967303, 39: 4294967304, 63: 4294967375}
dscp: 0, calling send_packet()
END OF TEST
FAIL

======================================================================
FAIL: sai_qos_tests.DscpMappingPB
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 388, in runTest
    dst_port_id, cnt, result.format()))
    AssertionError: Expected packet was not received on port 20. Total received: 0.
========== RECEIVED ==========
0 total packets.
==============================
```

RCA:
before execute get_rx_port() to get actuall dst port in portchannel, arp table is not existing relevant dst ip address.
so there is a timing issue: during broadcast arp, possible get wrong dst port result in get_rx_port()

#### How did you do it?

before execute get_rx_port(), send a icmp to trigger arp learning. and then get_rx_port() can return solid and correct dst port.

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
