### PR TITLE
change bgp session up wait time to wait until

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -9,6 +9,7 @@ import time
 from scapy.all import sniff, IP
 from scapy.contrib import bgp
 from tests.common.helpers.bgp import BGPNeighbor
+from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.mux_simulator_control import mux_server_url
@@ -32,6 +33,7 @@ NEIGHBOR_ASN0 = 61000
 NEIGHBOR_ASN1 = 61001
 NEIGHBOR_PORT0 = 11000
 NEIGHBOR_PORT1 = 11001
+WAIT_TIMEOUT = 120
 
 
 @contextlib.contextmanager
@@ -144,6 +146,21 @@ def constants(is_quagga, setup_interfaces):
         )
     return _constants
 
+def is_neighbor_sessions_established(duthost, neighbors):
+    is_established = True
+
+    # handle both multi-sic and single-asic
+    bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())[
+        "ansible_facts"
+    ]
+    for neighbor in neighbors:
+        is_established &= (
+            neighbor.ip in bgp_facts["bgp_neighbors"]
+            and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
+        )
+
+    return is_established
+
 
 def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                           toggle_all_simulator_ports_to_rand_selected_tor_m):
@@ -206,16 +223,20 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
         n0.start_session()
         n1.start_session()
 
-        # sleep till new sessions are steady
-        time.sleep(60)
+        # ensure new sessions are ready
+        if not wait_until(
+            WAIT_TIMEOUT,
+            5,
+            20,
+            lambda: is_neighbor_sessions_established(duthost, (n0, n1)),
+        ):
+            pytest.fail("Could not establish bgp sessions")
 
         # ensure new sessions are ready
         # handle both multi-sic and single-asic
         bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]
         assert n0.ip in bgp_facts["bgp_neighbors"]
         assert n1.ip in bgp_facts["bgp_neighbors"]
-        assert bgp_facts["bgp_neighbors"][n0.ip]["state"] == "established"
-        assert bgp_facts["bgp_neighbors"][n1.ip]["state"] == "established"
 
         announce_intervals = []
         withdraw_intervals = []


### PR DESCRIPTION
Summary:
test_bgp_update_timer test case failure because bgp session not up in 60 seconds.
It only happens in 202012 occasionally, on internal and 202205 wait time extended to 90 seconds.

![image](https://user-images.githubusercontent.com/111116206/233905979-7ecf1d0f-1aaf-48d1-a7ea-4344255d9512.png)


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Improve test_bgp_update_timer.py stability, improve for corner case. 

#### How did you do it?
extend bgp session wait time from 60s to 90s, use wait until instead of time.sleep().
Keep same value with master and 202205


#### How did you verify/test it?
run test_bgp_update_timer.py 
![Uploading image.png…]()

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
