### PR TITLE
[BugFix] Fix test_vlan_ping test failure on mx topology

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -63,8 +63,12 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
             break
 
     py_assert(vm_name is not None, "Can't get neighbor vm")
-    vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Port-Channel1']['ipv4'])
-    output = vm_info['host'].command("ip addr show dev po1")
+    if topo_name == "mx":
+        vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Ethernet1']['ipv4'])
+        output = vm_info['host'].command("ip addr show dev eth1")
+    else:
+        vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Port-Channel1']['ipv4'])
+        output = vm_info['host'].command("ip addr show dev po1")
     vm_host_info["mac"] = output['stdout_lines'][1].split()[1]
     vm_ip_intf = ipaddress.IPv4Interface(vm_ip_with_prefix).ip
     vm_host_info["ipv4"] = vm_ip_intf
@@ -77,15 +81,21 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
     for a_bgp_nbr in mg_facts['minigraph_bgp']:
         # Get the bgp neighbor connected to the selected VM
         if a_bgp_nbr['name'] == vm_name and a_bgp_nbr['addr'] == str(vm_host_info['ipv4']):
-            # Find the port channel that connects to the selected VM
-            for intf in mg_facts['minigraph_portchannel_interfaces']:
-                if intf['peer_addr'] == str(vm_host_info['ipv4']):
-                    portchannel = intf['attachto']
-                    ifaces_list = []
-                    for iface in mg_facts['minigraph_portchannels'][portchannel]['members']:
-                        ifaces_list.append(mg_facts['minigraph_ptf_indices'][iface])
-                    vm_host_info['port_index_list'] = ifaces_list
-                    break
+            # Find the interface that connects to the selected VM
+            if topo_name == "mx":
+                for intf in mg_facts['minigraph_interfaces']:
+                    if intf['peer_addr'] == str(vm_host_info['ipv4']):
+                        vm_host_info['port_index_list'] = [mg_facts['minigraph_ptf_indices'][intf['attachto']]]
+                        break
+            else:
+                for intf in mg_facts['minigraph_portchannel_interfaces']:
+                    if intf['peer_addr'] == str(vm_host_info['ipv4']):
+                        portchannel = intf['attachto']
+                        ifaces_list = []
+                        for iface in mg_facts['minigraph_portchannels'][portchannel]['members']:
+                            ifaces_list.append(mg_facts['minigraph_ptf_indices'][iface])
+                        vm_host_info['port_index_list'] = ifaces_list
+                        break
             break
 
     # getting the ipv4, ipv6 and vlan id of a vlan in DUT with 2 or more vlan members


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix `test_vlan_ping` test failure on mx topology.

Since mx doesn't use port-channel as uplink, the testcase failed as setup stage with below error log:
```
vlan/test_vlan_ping.py::test_vlan_ping 
-------------------------------- live log setup --------------------------------
12:07:38 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError('Port-Channel1',)
Traceback (most recent call last):
  File "/azp/_work/1/s/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/azp/_work/1/s/tests/vlan/test_vlan_ping.py", line 65, in vlan_ping_setup
    vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Port-Channel1']['ipv4'])
KeyError: 'Port-Channel1'
ERROR
```
I updated the code to use `Eth1` instead of `Po1` as it's upstream link.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix `test_vlan_ping` test failure on mx topology.

#### How did you do it?
Use `Eth1` instead of `Po1` as the uplink of `mx` topology.

#### How did you verify/test it?
Verified on both 7215-Mx and 7215-M0.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
