### PR TITLE
Fix test failure in test_cont_link_flap.py

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -54,7 +54,7 @@ class TestContLinkFlap(object):
 
         # Record Redis Memory at start
         start_time_redis_memory = duthost.shell(
-            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\\1/'")["stdout"]
+            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
         logging.info("Redis Memory: %s M", start_time_redis_memory)
 
         # Record ipv4 route counts at start

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -137,7 +137,7 @@ class TestContLinkFlap(object):
 
         # Record Redis Memory at end
         end_time_redis_memory = duthost.shell(
-            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\\1/'")["stdout"]
+            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
         logging.info("Redis Memory at start: %s M", start_time_redis_memory)
         logging.info("Redis Memory at end: %s M", end_time_redis_memory)
 

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -37,7 +37,7 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
 
     # Record Redis Memory at start
     start_time_redis_memory = duthost.shell(
-        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\\1/'")["stdout"]
+        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
     logger.info("Redis Memory: %s M", start_time_redis_memory)
 
     # Make Sure Orch CPU < orch_cpu_threshold before starting test.
@@ -76,7 +76,7 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
 
     # Record Redis Memory at end
     end_time_redis_memory = duthost.shell(
-        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\\1/'")["stdout"]
+        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
     logger.info("Redis Memory at start: %s M", start_time_redis_memory)
     logger.info("Redis Memory at end: %s M", end_time_redis_memory)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in test_cont_link_flap.py caused by #7968 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed with error:
File "/azp/_work/6/s/tests/platform_tests/link_flap/test_cont_link_flap.py", line 145, in test_cont_link_flap
incr_redis_memory = float(end_time_redis_memory) - float(start_time_redis_memory)
ValueError: could not convert string to float: '\\1'

#### How did you do it?
Correct reg express.

#### How did you verify/test it?
Manually run test case: test_cont_link_flap.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
