### PR TITLE
GCU E2E Test Case Fix: change ethernet interface port index

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -218,6 +218,7 @@ def test_replace_fec(duthost, ensure_dut_readiness, fec):
     finally:
         delete_tmpfile(duthost, tmpfile)
 
+
 def test_update_invalid_index(duthost, ensure_dut_readiness):
     json_patch = [
         {
@@ -239,7 +240,7 @@ def test_update_invalid_index(duthost, ensure_dut_readiness):
 
 def test_update_valid_index(duthost, ensure_dut_readiness):
     output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\*')["stdout"]
-    interfaces = {} # to be filled with two interfaces mapped to their indeces
+    interfaces = {}  # to be filled with two interfaces mapped to their indeces
 
     for line in output.split('\n'):
         if line.startswith('PORT|Ethernet'):

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -239,7 +239,7 @@ def test_update_invalid_index(duthost, ensure_dut_readiness):
 
 
 def test_update_valid_index(duthost, ensure_dut_readiness):
-    output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\*')["stdout"]
+    output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\\*')["stdout"]
     interfaces = {}  # to be filled with two interfaces mapped to their indeces
 
     for line in output.split('\n'):

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -220,7 +220,7 @@ def test_replace_fec(duthost, ensure_dut_readiness, fec):
 
 
 @pytest.mark.parametrize("index, is_valid", [
-    ("33", True),
+    ("29", True),
     ("abc1", False)
 ])
 def test_update_valid_invalid_index(duthost, ensure_dut_readiness, index, is_valid):

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -218,17 +218,12 @@ def test_replace_fec(duthost, ensure_dut_readiness, fec):
     finally:
         delete_tmpfile(duthost, tmpfile)
 
-
-@pytest.mark.parametrize("index, is_valid", [
-    ("29", True),
-    ("abc1", False)
-])
-def test_update_valid_invalid_index(duthost, ensure_dut_readiness, index, is_valid):
+def test_update_invalid_index(duthost, ensure_dut_readiness):
     json_patch = [
         {
             "op": "replace",
             "path": "/PORT/Ethernet0/index",
-            "value": "{}".format(index)
+            "value": "abc1"
         }
     ]
 
@@ -237,10 +232,43 @@ def test_update_valid_invalid_index(duthost, ensure_dut_readiness, index, is_val
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        if is_valid:
-            expect_op_success(duthost, output)
-        else:
-            expect_op_failure(output)
+        expect_op_failure(output)
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+
+def test_update_valid_index(duthost, ensure_dut_readiness):
+    output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\*')["stdout"]
+    interfaces = {} # to be filled with two interfaces mapped to their indeces
+
+    for line in output.split('\n'):
+        if line.startswith('PORT|Ethernet'):
+            interface = line[line.index('Ethernet'):].strip()
+            index = duthost.shell('sonic-db-cli CONFIG_DB hget "PORT|{}" index'.format(interface))["stdout"]
+            interfaces[interface] = index
+            if len(interfaces) == 2:
+                break
+    pytest_assert(len(interfaces) == 2, "Failed to retrieve two interfaces to swap indeces in test")
+
+    json_patch = [
+        {
+            "op": "replace",
+            "path": "/PORT/{}/index".format(list(interfaces.keys())[0]),
+            "value": "{}".format(list(interfaces.values())[1])
+        },
+        {
+            "op": "replace",
+            "path": "/PORT/{}/index".format(list(interfaces.keys())[1]),
+            "value": "{}".format(list(interfaces.values())[0])
+        }
+    ]
+
+    tmpfile = generate_tmpfile(duthost)
+    logger.info("tmpfile {}".format(tmpfile))
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
     finally:
         delete_tmpfile(duthost, tmpfile)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes xcvrd exception being thrown due to invalid port index

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some platforms have 32 ports, so setting port index to 33 was throwing an xcvrd exception
#### How did you do it?
Change the port index to 29

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
