### PR TITLE
Add a delay between assertion and de-assertion of low-power mode.

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -755,9 +755,14 @@ class TestSfpApi(PlatformApiTestBase):
                 if ret is None:
                     logger.warning("test_lpmode: Skipping transceiver {} (not supported on this platform)".format(i))
                     break
+                if state is True:
+                    delay = self.lp_mode_assert_delay(info_dict)
+                else:
+                    delay = self.lp_mode_deassert_delay(info_dict)
                 self.expect(ret is True, "Failed to {} low-power mode for transceiver {}"
                             .format("enable" if state is True else "disable", i))
-                self.expect(wait_until(5, 1, self.lp_mode_assert_delay(info_dict) if state is True else self.lp_mode_deassert_delay(info_dict), self._check_lpmode_status, sfp, platform_api_conn, i, state),
+                self.expect(wait_until(5, 1, delay,
+                                       self._check_lpmode_status, sfp, platform_api_conn, i, state),
                             "Transceiver {} expected low-power state {} is not aligned with the real state"
                             .format(i, "enable" if state is True else "disable"))
         self.assert_expectations()


### PR DESCRIPTION
Summary:
Fixes link-down issue after test_lpmode. 

### Type of change

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
A port with a PowerClass4 QSFP100 AOC module could stay down permanently after running test_lpmode. The link cannot come up because the AOC module is stuck in a bad state after de-asserting the low-power pin. The only way to recover the link is to toggle the hardware reset pin. 

#### How did you do it?
The test code does not consider that QSFP100 has a control/status timing requirement. Based on SFF-8679  (Table 8-1), "LpMode Assert Time", ton_LPMode, is 100ms. If the lpMode pin is de-asserted when the module is about to reach the low-power state, the module may enter a bad state. To avoid this issue, the test might have a small delay before de-asserting lpMode. To be safe, I think 300ms is sufficient.

#### How did you verify/test it?
Manually run api/test_sfp.py against platform with Power Class 4 AOC modules.

#### Any platform specific information?
This Issue is not seen with Power Class 2 or Power Class 3 AOC modules.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
[SFF-8679_018.pdf](https://github.com/sonic-net/sonic-mgmt/files/11317643/SFF-8679_018.pdf)

