### PR TITLE
Fix fixture not fount issue for test_drop_counters

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.drop_counters.drop_counters import verify_drop_counters,\
     ensure_no_l3_drops, ensure_no_l2_drops
 from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_UPDATE_INTERVAL,\
-    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params
+    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params, setup, fanouthost, pkt_fields, ports_info, tx_dut_ports, rif_port_down  # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -91,8 +91,8 @@ def parse_combined_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
                     break
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports=None,
-                      skip_counter_check=False, drop_information=None):
+def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,
+                      tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -263,7 +263,7 @@ def do_test(duthosts):
 
 
 def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                            setup, fanouthost, pkt_fields, ports_info):
+                            setup, fanouthost, pkt_fields, ports_info):  # noqa F811
     """
     @summary: Verify that packet with reserved DMAC is dropped and L2 drop counter incremented
     @used_mac_address:
@@ -300,7 +300,7 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
 
 
-def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):
+def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):  # noqa F811
     """
     @summary: Verify that packets on ingress port are not dropped
               when egress RIF link is down and check that drop counters not incremented

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -91,7 +91,7 @@ def parse_combined_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
                     break
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,
+def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,   # noqa F811
                       tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
@@ -238,7 +238,7 @@ def check_if_skip():
 
 @pytest.fixture(scope='module')
 def do_test(duthosts):
-    def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,
+    def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa F811
                          comparable_pkt=None, skip_counter_check=False, drop_information=None):
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
@@ -322,7 +322,7 @@ def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, p
 
 
 def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):
+                           setup, tx_dut_ports, pkt_fields, ports_info):  # noqa F811
     """
     @summary: Verify that packet with link-local address "169.254.0.0/16" is dropped and L3 drop counter incremented
     """
@@ -348,7 +348,7 @@ def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
-def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, mtu_config, ports_info):
+def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, mtu_config, ports_info):  # noqa F811
     """
     @summary: Verify that IP packet with exceeded MTU is dropped and L3 drop counter incremented
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_drop_counters threw the error below:
```
failed on setup with "file /azp/_work/8/s/tests/drop_packets/test_drop_counters.py, line 324
  def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
E       fixture 'setup' not found
>       available fixtures: __pytest_repeat_step_number, active_active_ports, active_active_ports_config, active_standby_ports, ansible_adhoc, ansible_facts, ansible_module, backup_and_restore_config_db_session, cable_type, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, celery_app, celery_class_tasks, celery_config, celery_enable_logging, celery_includes, celery_parameters, celery_session_app, celery_session_worker, celery_worker, celery_worker_parameters, celery_worker_pool, check_bgp, check_dbmemory, check_dut_asic_type, check_interfaces, check_monit, check_mux_simulator, check_neighbor_macsec_empty, check_processes, check_secureboot, check_simulator_read_side, cleanup_cache_for_session, clear_neigh_entries, collect_db_dump, collect_techsupport, collect_techsupport_all_du
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix fixture not found issue for test_drop_counters.


#### How did you do it?
import missed fixtures in test_drop_counters.
Use `# noqa F401` and `# noqa F811` to ignore the pre-commit error.

#### How did you verify/test it?
Run test_drop_counters.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
