### PR TITLE
[Python3 migration]Fix test failure in passw_hardening

### DIFF
--- a/tests/passw_hardening/passw_hardening_utils.py
+++ b/tests/passw_hardening/passw_hardening_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import difflib
 import operator
+import six
 from tests.common.helpers.assertions import pytest_assert
 
 CURR_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -77,7 +78,7 @@ def compare_passw_policies_in_linux(duthost, pam_file_expected=PAM_PASSWORD_CONF
     logging.debug('DUT command = {}'.format(read_command_password))
     read_command_password_cmd = duthost.command(read_command_password)
     command_password_stdout = read_command_password_cmd["stdout_lines"]
-    command_password_stdout = [line.encode('utf-8') for line in command_password_stdout]
+    command_password_stdout = [six.ensure_str(line) for line in command_password_stdout]
 
     common_password_expected = []
     with open(pam_file_expected, 'r') as expected_common_password_file:

--- a/tests/passw_hardening/test_passw_hardening.py
+++ b/tests/passw_hardening/test_passw_hardening.py
@@ -9,6 +9,7 @@ import logging
 import re
 import pytest
 import datetime
+import six
 from tests.common.helpers.assertions import pytest_assert
 from . import passw_hardening_utils
 
@@ -52,7 +53,7 @@ def get_user_expire_time_global(duthost, age_type):
     regex_days = AGE_DICT[age_type]['REGEX_DAYS']
     command = '{} /etc/login.defs'.format(regex_days)
 
-    grep_max_days_out = duthost.command(command)["stdout_lines"][FIRST_LINE].encode()
+    grep_max_days_out = six.ensure_str(duthost.command(command)["stdout_lines"][FIRST_LINE])
 
     days_num = grep_max_days_out.split()[DAY_INDEX]
     logging.debug('command output lines = {}'.format(grep_max_days_out))
@@ -79,9 +80,9 @@ def get_passw_expire_time_existing_user(duthost, normal_account):
     chage_stdout = duthost.command(command)["stdout_lines"]
 
     for line in chage_stdout:
-        m1 = re.match(REGEX_MAX_PASSW_CHANGE, line.decode('utf-8'))
+        m1 = re.match(REGEX_MAX_PASSW_CHANGE, six.ensure_text(line))
         if m1:
-            last_passw_change = m1.group("max_passw_change").decode('utf-8')
+            last_passw_change = six.ensure_text(m1.group("max_passw_change"))
             break
 
     return last_passw_change


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in passw_hardening after Python3 migration

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
common_password_diff = [li for li in difflib.ndiff(command_password_stdout, common_password_expected) if
  File "/usr/lib/python3.8/difflib.py", line 902, in compare
    yield from g
  File "/usr/lib/python3.8/difflib.py", line 1009, in _fancy_replace
    yield from self._qformat(aelt, belt, atags, btags)
  File "/usr/lib/python3.8/difflib.py", line 1048, in _qformat
    yield "- " + aline
TypeError: can only concatenate str (not "bytes") to str

command_password_stdout = [**b**'#THIS IS AN AUTO-GENERATED FILE', b'#', b'# /etc/pam.d/common-password - password-related modules common to all ser...her service-specific PAM config files,', b'# and should contain a list of modules that define the services to be', ...]
common_password_expected = ['#THIS IS AN AUTO-GENERATED FILE', '#', '# /etc/pam.d/common-password - password-related modules common to all servic...ther service-specific PAM config files,', '# and should contain a list of modules that define the services to be', ...]       

#### How did you do it?
One variable is bytes string while another variable is string. They cannot work together.
Use six.ensure_text() to replace encode().
In PY2, ensure_text() makes sure unicode->str and str->str.
In PY3, ensure_text() makes sure str->str and bytes->str.

#### How did you verify/test it?
Manually run test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
