### PR TITLE
[voq][chassis] Fix check_interface in sanity

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -35,8 +35,12 @@ __all__ = CHECK_ITEMS
 
 def _find_down_phy_ports(dut, phy_interfaces):
     down_phy_ports = []
+    include_inband_intfs = True if dut.sonichost.get_facts().get(
+        'switch_type', None) == 'voq' else False
     intf_facts = dut.show_interface(command='status',
-                                    include_internal_intfs=('201811' not in dut.os_version))[
+                                    include_internal_intfs=(
+                                        '201811' not in dut.os_version),
+                                    include_inband_intfs=include_inband_intfs)[
                                         'ansible_facts']['int_status']
     for intf in phy_interfaces:
         try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6352 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In the sanity check `check_interfaces`  the down ports are determined by checking the ports status from the command output `show interface status` for every port in config_db.

For voq chassis the `show interface status` does not display the `Inb` and `Rec`. These ports are present in the config_db so these ports are determined as down.

To fix this a new flag `include_inband_intfs` is added to `show_interface.py` ansible library module to get the status of 'inb` and 'rec` ports.



#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
