### PR TITLE
Fix fixture not found issue for test_platform_info

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -15,7 +15,8 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from .thermal_control_test_helper import ThermalPolicyFileContext,\
-    check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status
+    check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status,\
+    mocker_factory, disable_thermal_policy  # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -316,7 +317,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
 @pytest.mark.disable_loganalyzer
 def test_show_platform_fanstatus_mocked(duthosts, enum_rand_one_per_hwsku_hostname,
-                                        mocker_factory, disable_thermal_policy):
+                                        mocker_factory, disable_thermal_policy):  # noqa F811
     """
     @summary: Check output of 'show platform fan'.
     """
@@ -337,7 +338,7 @@ def test_show_platform_fanstatus_mocked(duthosts, enum_rand_one_per_hwsku_hostna
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP], indirect=True)
 def test_show_platform_temperature_mocked(duthosts, enum_rand_one_per_hwsku_hostname,
-                                          mocker_factory, ignore_particular_error_log):
+                                          mocker_factory, ignore_particular_error_log):  # noqa F811
     """
     @summary: Check output of 'show platform temperature'
     """
@@ -395,7 +396,7 @@ def check_thermal_control_load_invalid_file(duthost, file_name):
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_fan_status(duthosts, enum_rand_one_per_hwsku_hostname, mocker_factory):
+def test_thermal_control_fan_status(duthosts, enum_rand_one_per_hwsku_hostname, mocker_factory):  # noqa F811
     """
     @summary: Make FAN absence, over speed and under speed, check logs and LED color.
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
`test_show_platform_fanstatus_mocked` failed due to the following error:
```
  def test_show_platform_fanstatus_mocked(duthosts, enum_rand_one_per_hwsku_hostname,
E       fixture 'mocker_factory' not found
>       available fixtures: __pytest_repeat_step_number, active_active_ports, active_active_ports_config, active_standby_ports, advanceboot_loganalyzer, advanceboot_neighbor_restore, ansible_adhoc, ansible_facts, ansible_module, backup_and_restore_config_db_session, bring_up_dut_interfaces, cable_type, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capture_interface_counters, celery_app, celery_class_tasks, celery_config, celery_enable_logging, celery_includes, celery_parameters, celery_session_app, celery_session_worker, celery_worker, celery_worker_parameters, celery_worker_pool, check_bgp, check_dbmemory, check_dut_asic_type, check_interfaces, check_monit, check_mux_simulator, check_neighbor_macsec_empty, check_processes, check_secureboot, check_simulator_read_side, cleanup_cache_for_session, clear_neigh_entries, collect_db_dump, collect_techsupport, collect_techsupport_all_duts, conn_graph_facts, core_dump_and_config_check, creds, creds_all_duts, depends_on_current_app, disable_container_autorestart, doctest_namespace, dut_test_params, duthost, duthost_console, duthosts, duts_minigraph_facts, duts_running_config_facts, enable_container_autorestart, enable_l2_mode, enhance_inventory, enum_asic_index, enum_backend_asic_index, enum_dut_feature, enum_dut_hostname, enum_frontend_asic_index, enum_frontend_dut_hostname, enum_rand_one_asic_index, enum_rand_one_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_per_hwsku_hostname, enum_supervisor_dut_hostname, eos, extra, fanouthosts, force_active_tor, force_standby_tor, get_mux_status, get_pdu_controller, get_reboot_cause, ignore_particular_error_log, include_metadata_in_junit_xml, k8scluster, k8smasters, localhost, loganalyzer, lower_tor_host, metadata, mg_facts, monkeypatch, mux_config, mux_server_info, mux_server_url, mux_status_from_nic_simulator, nbr_device_numbers, nbr_ptfadapter, nbrhosts, nic_simulator_channel, nic_simulator_client, nic_simulator_info, nic_simulator_url, on_exit, patch_lldpctl, pdu, pdu_controller, psu_test_setup_teardown, ptf_portmap_file, ptf_server_intf, ptfadapter, ptfhost, pytestconfig, rand_one_dut_front_end_hostname, rand_one_dut_hostname, rand_one_dut_lossless_prio, rand_one_dut_portname_oper_up, rand_selected_dut, rand_selected_front_end_dut, rand_unselected_dut, record_property, record_testsuite_property, record_xml_attribute, recover_all_directions, recwarn, reset_critical_services_list, reset_simulator_port, restart_mux_simulator, restart_nic_simulator, restart_nic_simulator_session, run_icmp_responder_session, sanity_check, selected_rand_one_per_hwsku_hostname, set_drop, set_drop_active_active, set_output, skip_on_simx, sonic, stop_nic_grpc_server, swapSyncd, t1_lower_tor_intfs, t1_upper_tor_intfs, tag_test_report, tbinfo, thermal_manager_enabled, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, toggle_active_active_simulator_ports, toggle_active_all_ports_both_tors, toggle_all_simulator_ports, toggle_all_simulator_ports_to_another_side, toggle_all_simulator_ports_to_lower_tor, toggle_all_simulator_ports_to_random_side, toggle_all_simulator_ports_to_upper_tor, toggle_auto_all_ports_both_tors, toggle_simulator_port_to_lower_tor, toggle_simulator_port_to_upper_tor, tor_mux_intf, tor_mux_intfs, unpatch_lldpctl, upper_tor_host, url, use_celery_app_trap, vmhost, worker_id, xcvr_skip_list
>       use 'pytest --fixtures [testpath]' for help on them
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
#7968 remove import * for test_platform_info.py.
`mocker_factory, disable_thermal_policy` fixtures can't be found.

#### How did you do it?
import them and add `# noqa F401` and   `# noqa F811` to ignore pre-commit error.

#### How did you verify/test it?
run test_platform_info.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
