### PR TITLE
Improve stability for test test_reload_config.py::test_reload_configuration_checks

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -139,5 +139,5 @@ def check_interfaces_config_service_status(duthost):
     # check interfaces-config.service status
     regx_interface_config_service_exit = r'.*Main PID: \d+ \(code=exited, status=0\/SUCCESS\).*'
     interface_config_server_status = duthost.command(
-        'systemctl status interfaces-config.service')['stdout']
+        'systemctl status interfaces-config.service', module_ignore_errors=True)['stdout']
     return re.search(regx_interface_config_service_exit, interface_config_server_status)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test occasionally fails with error:
```
DEBUG    tests.common.devices.base:base.py:102 /root/mars/workspace/sonic-mgmt/tests/common/devices/multi_asic.py::_run_on_asics#115: [r-panther-13] AnsibleModule::command Result => {"stderr_lines": [], "changed": true, "end": "2023-04-21 22:10:22.352795", "_ansible_no_log": false, "stdout": "\u25cf interfaces-config.service - Update interfaces configuration\n     Loaded: loaded (/lib/systemd/system/interfaces-config.service; enabled-runtime; vendor preset: enabled)\n     Active: activating (start) since Fri 2023-04-21 22:10:17 IDT; 5s ago\n   Main PID: 4778 (interfaces-conf)\n      Tasks: 2 (limit: 9440)\n     Memory: 15.9M\n     CGroup: /system.slice/interfaces-config.service\n             \u251c\u25004778 /bin/bash /usr/bin/interfaces-config.sh\n             \u2514\u25005068 /usr/bin/python3 /usr/local/bin/sonic-cfggen -d -j /tmp/ztp_input.json -t /usr/share/sonic/templates/interfaces.j2,/etc/network/interfaces -t /usr/share/sonic/templates/90-dhcp6-systcl.conf.j2,/etc/sysctl.d/90-dhcp6-systcl.conf -t /usr/share/sonic/templates/dhclient.conf.j2,/etc/dhcp/dhclient.conf\n\nApr 21 22:10:17 r-panther-13 systemd[1]: Starting Update interfaces configuration...", "cmd": ["systemctl", "status", "interfaces-config.service"], "failed": true, "delta": "0:00:00.031136", "stderr": "", "rc": 3, "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "systemctl status interfaces-config.service", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["\u25cf interfaces-config.service - Update interfaces configuration", "     Loaded: loaded (/lib/systemd/system/interfaces-config.service; enabled-runtime; vendor preset: enabled)", "     Active: activating (start) since Fri 2023-04-21 22:10:17 IDT; 5s ago", "   Main PID: 4778 (interfaces-conf)", "      Tasks: 2 (limit: 9440)", "     Memory: 15.9M", "     CGroup: /system.slice/interfaces-config.service", "             \u251c\u25004778 /bin/bash /usr/bin/interfaces-config.sh", "             \u2514\u25005068 /usr/bin/python3 /usr/local/bin/sonic-cfggen -d -j /tmp/ztp_input.json -t /usr/share/sonic/templates/interfaces.j2,/etc/network/interfaces -t /usr/share/sonic/templates/90-dhcp6-systcl.conf.j2,/etc/sysctl.d/90-dhcp6-systcl.conf -t /usr/share/sonic/templates/dhclient.conf.j2,/etc/dhcp/dhclient.conf", "", "Apr 21 22:10:17 r-panther-13 systemd[1]: Starting Update interfaces configuration..."], "start": "2023-04-21 22:10:22.321659", "msg": "non-zero return code"}
ERROR    root:__init__.py:40 Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/root/mars/workspace/sonic-mgmt/tests/platform_tests/test_reload_config.py", line 92, in test_reload_configuration_checks
    wait_until(60, 1, 0, check_interfaces_config_service_status, duthost)
  File "/root/mars/workspace/sonic-mgmt/tests/common/utilities.py", line 121, in wait_until
    condition.__name__, "".join(details), e
  File "/root/mars/workspace/sonic-mgmt/tests/common/errors.py", line 33, in __str__
    return self._to_string()
  File "/root/mars/workspace/sonic-mgmt/tests/common/errors.py", line 30, in _to_string
    dump_ansible_results(self.results)).encode().decode("utf-8")
UnicodeEncodeError: 'ascii' codec can't encode character u'\u25cf' in position 283: ordinal not in range(128)
```
This error occurs in the check check_interfaces_config_service_status when running command  "systemctl status interfaces-config.service" on the dut right after a reboot.
The root cause is after a reboot, when the system is not fully loaded, sometimes the command "systemctl status interfaces-config.service" will return with a rc 3. And in this case, the ansible command module fails, and then dump_ansible_results(self.results)).encode().decode("utf-8") is called in the errors.py. But in the output there is some Unicode characters that cannot be encoded as ascii.

We can just ignore the ansible module error because the output is checked against a regexp in check_interfaces_config_service_status, and there is a wait_until for this check.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Improve the stability of test test_reload_config.py::test_reload_configuration_checks
#### How did you do it?
Ignore the ansible module errors in the check check_interfaces_config_service_status.
#### How did you verify/test it?
By automatin, test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
