### PR TITLE
[202205][qos] address qos helper exception when hwsku is None

### DIFF
--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -35,7 +35,7 @@ def eos_to_linux_intf(eos_intf_name, hwsku=None):
     """
     if hwsku == "MLNX-OS":
         linux_intf_name = eos_intf_name.replace("ernet 1/", "sl1p").replace("/", "sp")
-    elif "Nokia" in hwsku:
+    elif hwsku and "Nokia" in hwsku:
         linux_intf_name = eos_intf_name
     else:
         linux_intf_name = eos_intf_name.replace('Ethernet', 'et').replace('/', '_')


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This change is to address an issue introduced by PR #8059, where hwsku might be None since caller didn't pass it in. And the check "Nokia" in hwsku causes exception.

#### How did you do it?
Protect against hwsku is None scenario.

#### How did you verify/test it?
Manually tested the new code structure when hwsku is none.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
