### PR TITLE
Enhance qos tests to support single-asic, multi-asic, and multi-dut testing

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1954,22 +1954,6 @@ Totals               6450                 6449
 
         return "RUNNING" in service_status
 
-    def remove_ssh_tunnel_sai_rpc(self):
-        """
-        Removes any ssh tunnels if present created for syncd RPC communication
-
-        Returns:
-            None
-        """
-        try:
-            pid_list = self.shell(
-                r'pgrep -f "ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -fN -L \*:9092"'
-            )["stdout_lines"]
-        except RunAnsibleModuleFail:
-            return
-        for pid in pid_list:
-            self.shell("kill {}".format(pid), module_ignore_errors=True)
-
     def get_up_ip_ports(self):
         """
         Get a list for all up ip interfaces

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -19,6 +19,7 @@ class SonicAsic(object):
 
     _MULTI_ASIC_SERVICE_NAME = "{}@{}"   # service name, asic_id
     _MULTI_ASIC_DOCKER_NAME = "{}{}"     # docker name,  asic_id
+    _RPC_PORT_FOR_SSH_TUNNEL = 9092
 
     def __init__(self, sonichost, asic_index):
         """ Initializing a ASIC on a SONiC host.
@@ -325,6 +326,9 @@ class SonicAsic(object):
 
         logger.debug(output)
 
+    def get_rpc_port_ssh_tunnel(self):
+        return self._RPC_PORT_FOR_SSH_TUNNEL + self.asic_index
+
     def remove_ssh_tunnel_sai_rpc(self):
         """
         Removes any ssh tunnels if present created for syncd RPC communication
@@ -334,7 +338,15 @@ class SonicAsic(object):
         """
         if not self.sonichost.is_multi_asic:
             return
-        return self.sonichost.remove_ssh_tunnel_sai_rpc()
+
+        try:
+            pid_list = self.sonichost.shell(
+                r'pgrep -f "ssh -o StrictHostKeyChecking=no -fN -L \*:{}"'.format(self.get_rpc_port_ssh_tunnel())
+            )["stdout_lines"]
+        except RunAnsibleModuleFail:
+            return
+        for pid in pid_list:
+            self.shell("kill {}".format(pid), module_ignore_errors=True)
 
     def create_ssh_tunnel_sai_rpc(self):
         """
@@ -362,8 +374,9 @@ class SonicAsic(object):
             raise Exception("Invalid V4 address {}".format(ns_docker_if_ipv4))
 
         self.sonichost.shell(
-            ("ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -fN"
-             " -L *:9092:{}:9092 localhost").format(ns_docker_if_ipv4))
+            ("ssh -o StrictHostKeyChecking=no -fN"
+             " -L *:{}:{}:{} localhost").format(self.get_rpc_port_ssh_tunnel(), ns_docker_if_ipv4,
+                                                self._RPC_PORT_FOR_SSH_TUNNEL))
 
     def command(self, cmdstr):
         """

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -448,8 +448,8 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     duthost.shell_cmds(cmds=cmds)
 
 
-@pytest.fixture(scope='module')
-def dut_qos_maps(rand_selected_front_end_dut):
+@pytest.fixture(scope='class')
+def dut_qos_maps(get_src_dst_asic_and_duts):
     """
     A module level fixture to get QoS map from DUT host.
     Return a dict
@@ -466,32 +466,32 @@ def dut_qos_maps(rand_selected_front_end_dut):
     or an empty dict if failed to parse the output
     """
     maps = {}
+    dut = get_src_dst_asic_and_duts['src_dut']
     try:
-        if rand_selected_front_end_dut.is_multi_asic:
+        if dut.is_multi_asic:
             sonic_cfggen_cmd = "sonic-cfggen -n asic0 -d --var-json"
         else:
             sonic_cfggen_cmd = "sonic-cfggen -d --var-json"
 
         # port_qos_map
-        port_qos_map_data = rand_selected_front_end_dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['port_qos_map'] = json.loads(port_qos_map_data) if port_qos_map_data else None
+        port_qos_map = dut.shell("{} 'PORT_QOS_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['port_qos_map'] = json.loads(port_qos_map) if port_qos_map else None
+
         # dscp_to_tc_map
-        dscp_to_tc_map_data = rand_selected_front_end_dut.shell(
-            "{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map_data) if dscp_to_tc_map_data else None
+        dscp_to_tc_map = dut.shell("{} 'DSCP_TO_TC_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['dscp_to_tc_map'] = json.loads(dscp_to_tc_map) if dscp_to_tc_map else None
+
         # tc_to_queue_map
-        tc_to_queue_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map_data) if tc_to_queue_map_data else None
+        tc_to_queue_map = dut.shell("{} 'TC_TO_QUEUE_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_queue_map'] = json.loads(tc_to_queue_map) if tc_to_queue_map else None
+
         # tc_to_priority_group_map
-        tc_to_priority_group_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_priority_group_map'] = json.loads(
-            tc_to_priority_group_map_data) if tc_to_priority_group_map_data else None
+        tc_to_priority_group_map = dut.shell("{} 'TC_TO_PRIORITY_GROUP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_priority_group_map'] = json.loads(tc_to_priority_group_map) if tc_to_priority_group_map else None
+
         # tc_to_dscp_map
-        tc_to_dscp_map_data = rand_selected_front_end_dut.shell(
-            "{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
-        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map_data) if tc_to_dscp_map_data else None
+        tc_to_dscp_map = dut.shell("{} 'TC_TO_DSCP_MAP'".format(sonic_cfggen_cmd))['stdout']
+        maps['tc_to_dscp_map'] = json.loads(tc_to_dscp_map) if tc_to_dscp_map else None
     except Exception as e:
         logger.error("Got exception: " + repr(e))
     return maps

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -521,7 +521,7 @@ def separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module):
     downlink/unlink ports.
     """
     dscp_to_tc_map_names = set()
-    for port_name, qos_map in dut_qos_maps_module['port_qos_map'].iteritems():
+    for port_name, qos_map in dut_qos_maps_module['port_qos_map'].items():
         if port_name == "global":
             continue
         dscp_to_tc_map_names.add(qos_map.get("dscp_to_tc_map", ""))

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -543,7 +543,7 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
         asic_idx = 0
         dut_port = None
 
-        if len(dut_intf_map.keys()) == 4:
+        if len(dut_intf_map.keys()) == 2:
             # PTF port is mapped to two DUTs -> dualtor topology and the PTF port is a vlan port
             # Packet sent from this ptf port will only be accepted by the active side DUT
             # DualToR DUTs use same special Vlan interface MAC addres
@@ -559,7 +559,7 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
             }
         else:
             # PTF port is mapped to single DUT
-            dut_index_for_pft_port = int(dut_intf_map.keys()[0])
+            dut_index_for_pft_port = int(list(dut_intf_map.keys())[0])
             if router_macs[dut_index_for_pft_port] is None:
                 continue
             target_dut_index = int(list(dut_intf_map.keys())[0])

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -518,7 +518,7 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
                 ]
 
     disabled_ptf_ports = set()
-    for ptf_map in list(tbinfo['topo']['ptf_map_disabled'].values()):
+    for ptf_map in tbinfo['topo']['ptf_map_disabled'].values():
         # Loop ptf_map of each DUT. Each ptf_map maps from ptf port index to dut port index
         disabled_ptf_ports = disabled_ptf_ports.union(set(ptf_map.keys()))
 
@@ -543,7 +543,7 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
         asic_idx = 0
         dut_port = None
 
-        if len(list(dut_intf_map.keys())) == 2:
+        if len(dut_intf_map.keys()) == 4:
             # PTF port is mapped to two DUTs -> dualtor topology and the PTF port is a vlan port
             # Packet sent from this ptf port will only be accepted by the active side DUT
             # DualToR DUTs use same special Vlan interface MAC addres

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from tests.common.devices.cisco import CiscoHost
 from tests.common.helpers.parallel import parallel_run
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session    # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                        # noqa F401
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active         # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session              # noqa F401
 
 from tests.common.helpers.constants import (
@@ -1707,6 +1708,59 @@ def duts_running_config_facts(duthosts):
 
 
 @pytest.fixture(scope='class')
+def dut_test_params_qos(duthosts, tbinfo, ptfhost, get_src_dst_asic_and_duts, lower_tor_host, creds,
+                        mux_server_url, mux_status_from_nic_simulator, duts_running_config_facts, duts_minigraph_facts):
+    if 'dualtor' in tbinfo['topo']['name']:
+        all_duts = [lower_tor_host]
+    else:
+        all_duts = get_src_dst_asic_and_duts['all_duts']
+
+    src_asic = get_src_dst_asic_and_duts['src_asic']
+    dst_asic = get_src_dst_asic_and_duts['dst_asic']
+
+    src_dut = get_src_dst_asic_and_duts['src_dut']
+    src_dut_ip = src_dut.host.options['inventory_manager'].get_host(src_dut.hostname).vars['ansible_host']
+    src_server = "{}:{}".format(src_dut_ip, src_asic.get_rpc_port_ssh_tunnel())
+
+    duthost = all_duts[0]
+    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
+    topo = tbinfo["topo"]["name"]
+
+    rtn_dict = {
+        "topo": topo,
+        "hwsku": mgFacts["minigraph_hwsku"],
+        "basicParams": {
+            "router_mac": duthost.facts["router_mac"],
+            "src_server": src_server,
+            "port_map_file": ptf_test_port_map_active_active(
+                ptfhost, tbinfo, duthosts, mux_server_url,
+                duts_running_config_facts, duts_minigraph_facts,
+                mux_status_from_nic_simulator()),
+            "sonic_asic_type": duthost.facts['asic_type'],
+            "sonic_version": duthost.os_version,
+            "src_dut_index": get_src_dst_asic_and_duts['src_dut_index'],
+            "src_asic_index": get_src_dst_asic_and_duts['src_asic_index'],
+            "dst_dut_index": get_src_dst_asic_and_duts['dst_dut_index'],
+            "dst_asic_index": get_src_dst_asic_and_duts['dst_asic_index'],
+            "dut_username": creds['sonicadmin_user'],
+            "dut_password": creds['sonicadmin_password']
+        },
+
+    }
+
+    # Add dst server info if src and dst asic are different
+    if src_asic != dst_asic:
+        dst_dut = get_src_dst_asic_and_duts['dst_dut']
+        dst_dut_ip = dst_dut.host.options['inventory_manager'].get_host(dst_dut.hostname).vars['ansible_host']
+        rtn_dict["basicParams"]["dst_server"] = "{}:{}".format(dst_dut_ip, dst_asic.get_rpc_port_ssh_tunnel())
+
+    if 'platform_asic' in duthost.facts:
+        rtn_dict['basicParams']["platform_asic"] = duthost.facts['platform_asic']
+
+    yield rtn_dict
+
+
+@ pytest.fixture(scope='class')
 def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
                     ptf_portmap_file, lower_tor_host, creds):   # noqa F811
     """

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -2,8 +2,9 @@ import math
 
 
 class QosParamMellanox(object):
-    def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile, ingressLossyProfile,
-                 egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize, dualTor):
+    def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile,
+                 ingressLossyProfile, egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
+                 dualTor, src_dut_index, src_asic_index, dst_asic_index, dst_dut_index):
         self.asic_param_dic = {
             'spc1': {
                 'cell_size': 96,
@@ -51,7 +52,10 @@ class QosParamMellanox(object):
             self.sharedHeadroomPoolSize = None
         self.dutConfig = dutConfig
         self.dualTor = dualTor
-
+        self.src_dut_index = src_dut_index
+        self.src_asic_index = src_asic_index
+        self.dst_dut_index = dst_dut_index
+        self.dst_asic_index = dst_asic_index
         return
 
     def run(self):
@@ -97,18 +101,19 @@ class QosParamMellanox(object):
         pkts_num_trig_egr_drp = egress_lossy_size + 1
 
         if self.sharedHeadroomPoolSize:
-            testPortIds = self.dutConfig['testPortIds']
+            src_testPortIds = self.dutConfig['testPortIds'][self.src_dut_index][self.src_asic_index]
+            dst_testPortIds = self.dutConfig['testPortIds'][self.dst_dut_index][self.dst_asic_index]
             ingress_ports_num_shp = 8
             pkts_num_trig_pfc_shp = []
             ingress_ports_list_shp = []
             occupancy_per_port = ingress_lossless_size
-            self.qos_parameters['dst_port_id'] = testPortIds[0]
+            self.qos_parameters['dst_port_id'] = dst_testPortIds[0]
             pgs_per_port = 2 if not self.dualTor else 4
             for i in range(1, ingress_ports_num_shp):
                 for j in range(pgs_per_port):
                     pkts_num_trig_pfc_shp.append(occupancy_per_port + xon + hysteresis)
-                    occupancy_per_port //= 2
-                ingress_ports_list_shp.append(testPortIds[i])
+                    occupancy_per_port /= 2
+                ingress_ports_list_shp.append(src_testPortIds[i])
             self.qos_parameters['pkts_num_trig_pfc_shp'] = pkts_num_trig_pfc_shp
             self.qos_parameters['src_port_ids'] = ingress_ports_list_shp
             self.qos_parameters['pkts_num_hdrm_full'] = xoff - 2

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -39,6 +39,8 @@ def eos_to_linux_intf(eos_intf_name, hwsku=None):
     if hwsku == "MLNX-OS":
         linux_intf_name = eos_intf_name.replace(
             "ernet 1/", "sl1p").replace("/", "sp")
+    elif hwsku and "Nokia" in hwsku:
+        linux_intf_name = eos_intf_name
     else:
         linux_intf_name = eos_intf_name.replace(
             'Ethernet', 'et').replace('/', '_')

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -83,7 +83,7 @@ class QosBase:
             if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
                 default_vlan_name = vlan_cfgs['default_vlan_config']
                 if default_vlan_name:
-                    for vlan in list(vlan_cfgs[default_vlan_name].values()):
+                    for vlan in vlan_cfgs[default_vlan_name].values():
                         if 'mac' in vlan and vlan['mac']:
                             dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
                             break
@@ -613,7 +613,7 @@ class QosSaiBase(QosBase):
         if dstPorts is None:
             if dst_port_ids:
                 pytest_assert(
-                    len(set(testPortIds).intersection(
+                    len(set(dst_test_port_ids).intersection(
                         set(dst_port_ids))) == len(set(dst_port_ids)),
                     "Dest port id passed in qos.yml not valid"
                 )
@@ -628,7 +628,7 @@ class QosSaiBase(QosBase):
         if srcPorts is None:
             if src_port_ids:
                 pytest_assert(
-                    len(set(testPortIds).intersection(
+                    len(set(src_test_port_ids).intersection(
                         set(src_port_ids))) == len(set(src_port_ids)),
                     "Source port id passed in qos.yml not valid"
                 )
@@ -722,12 +722,12 @@ class QosSaiBase(QosBase):
             )
             dutLagInterfaces = []
             testPortIds[src_dut_index] = {}
-            for _, lag in list(src_mgFacts["minigraph_portchannels"].items()):
+            for _, lag in src_mgFacts["minigraph_portchannels"].items():
                 for intf in lag["members"]:
                     dutLagInterfaces.append(src_mgFacts["minigraph_ptf_indices"][intf])
 
             testPortIds[src_dut_index][src_asic_index] = set(src_mgFacts["minigraph_ptf_indices"][port]
-                                for port in list(src_mgFacts["minigraph_ports"].keys()))
+                                for port in src_mgFacts["minigraph_ports"].keys())
             testPortIds[src_dut_index][src_asic_index] -= set(dutLagInterfaces)
             if isMellanoxDevice(src_dut):
                 # The last port is used for up link from DUT switch
@@ -786,7 +786,7 @@ class QosSaiBase(QosBase):
             testPortIds[src_dut_index] = {}
             for dut_asic in get_src_dst_asic_and_duts['all_asics']:
                 dutPortIps[src_dut_index][dut_asic.asic_index] = {}
-                for iface, addr in list(dut_asic.get_active_ip_interfaces(tbinfo).items()):
+                for iface, addr in dut_asic.get_active_ip_interfaces(tbinfo).items():
                     vlan_id = None
                     if iface.startswith("Ethernet"):
                         portName = iface
@@ -836,7 +836,8 @@ class QosSaiBase(QosBase):
             dutPortIps[src_dut_index] = {}
             testPortIds[src_dut_index] = {}
             dutPortIps[src_dut_index][src_asic_index] = {}
-            for iface,addr in list(src_asic.get_active_ip_interfaces(tbinfo).items()):
+            active_ips = src_asic.get_active_ip_interfaces(tbinfo)
+            for iface,addr in active_ips.items():
                 if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
                     portIndex = src_mgFacts["minigraph_ptf_indices"][iface]
                     portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
@@ -890,7 +891,7 @@ class QosSaiBase(QosBase):
         dutAsic = None
         for asic in self.SUPPORTED_ASIC_LIST:
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-            if vendorAsic in list(hostvars.keys()) and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
+            if vendorAsic in hostvars.keys() and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
                 dutAsic = asic
                 break
 
@@ -943,7 +944,7 @@ class QosSaiBase(QosBase):
                         dutinterfaces[ptf_port] = ptf_val['port']
         else:
             dutinterfaces = {
-                index: port for port, index in list(src_mgFacts["minigraph_ptf_indices"].items())
+                index: port for port, index in src_mgFacts["minigraph_ptf_indices"].items()
             }
 
         yield {

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -324,12 +324,12 @@ class QosSaiBase(QosBase):
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
             out = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
-                        "wred_profile"
-                    ]
-                )[0]
+                argv=[
+                    "redis-cli", "-n", "4", "HGET",
+                    "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
+                    "wred_profile"
+                ]
+            )[0]
             if six.PY2:
                 wredProfileName = out.encode("utf-8").translate(None, "[]")
             else:
@@ -384,11 +384,11 @@ class QosSaiBase(QosBase):
         """
         if check_qos_db_fv_reference_with_table(dut_asic):
             out = dut_asic.run_redis_cmd(
-                    argv=[
-                        "redis-cli", "-n", "4", "HGET",
-                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
-                    ]
-                )[0]
+                argv=[
+                    "redis-cli", "-n", "4", "HGET",
+                    "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                ]
+            )[0]
             if six.PY2:
                 schedProfile = out.encode("utf-8").translate(None, "[]")
             else:
@@ -527,7 +527,7 @@ class QosSaiBase(QosBase):
                     src_asic_index = 0
                     dst_asic_index = 1
                     found_multi_asic_dut = True
-                    logger.info ("Using dut {} for single_dut_multi_asic testing".format(a_dut.hostname))
+                    logger.info("Using dut {} for single_dut_multi_asic testing".format(a_dut.hostname))
                     break
             if not found_multi_asic_dut:
                 pytest.skip("Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
@@ -609,7 +609,6 @@ class QosSaiBase(QosBase):
         dst_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
         dst_test_port_ips = dst_dut_port_ips[get_src_dst_asic_and_duts['dst_asic_index']]
 
-
         if dstPorts is None:
             if dst_port_ids:
                 pytest_assert(
@@ -677,7 +676,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class', autouse=True)
     def dutConfig(
         self, request, duthosts, get_src_dst_asic_and_duts,
-        lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps): # noqa F811
+        lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps):  # noqa F811
         """
             Build DUT host config pertaining to QoS SAI tests
 
@@ -691,7 +690,7 @@ class QosSaiBase(QosBase):
         """
 
         """
-        Below are dictionaries with key being dut_index and value a dictionary with key asic_index 
+        Below are dictionaries with key being dut_index and value a dictionary with key asic_index
         Example for 2 DUTs with 2 asics each
             { 0: { 0: <asic0_value>, 1: <asic1_value>}, 1: { 0: <asic0_value>, 1: <asic1_value> }}
         """
@@ -712,7 +711,6 @@ class QosSaiBase(QosBase):
         src_mgFacts = src_dut.get_extended_minigraph_facts(tbinfo)
         topo = tbinfo["topo"]["name"]
 
-
         # LAG ports in T1 TOPO need to be removed in Mellanox devices
         if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(src_dut):
             # Only single asic is supported for this scenario, so use src_dut and src_asic - which will be the same
@@ -727,13 +725,14 @@ class QosSaiBase(QosBase):
                     dutLagInterfaces.append(src_mgFacts["minigraph_ptf_indices"][intf])
 
             testPortIds[src_dut_index][src_asic_index] = set(src_mgFacts["minigraph_ptf_indices"][port]
-                                for port in src_mgFacts["minigraph_ports"].keys())
+                                                             for port in src_mgFacts["minigraph_ports"].keys())
             testPortIds[src_dut_index][src_asic_index] -= set(dutLagInterfaces)
             if isMellanoxDevice(src_dut):
                 # The last port is used for up link from DUT switch
                 testPortIds[src_dut_index][src_asic_index] -= {len(src_mgFacts["minigraph_ptf_indices"]) - 1}
             testPortIds[src_dut_index][src_asic_index] = sorted(testPortIds[src_dut_index][src_asic_index])
-            pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0, "Skip test since no ports are available for testing")
+            pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0,
+                           "Skip test since no ports are available for testing")
 
             # get current DUT port IPs
             dutPortIps[src_dut_index] = {}
@@ -817,7 +816,8 @@ class QosSaiBase(QosBase):
                             uplinkPortIps.append(addr["peer_ipv4"])
                             uplinkPortNames.append(portName)
 
-                testPortIds[src_dut_index][dut_asic.asic_index] = sorted(dutPortIps[src_dut_index][dut_asic.asic_index].keys())
+                testPortIds[src_dut_index][dut_asic.asic_index] = sorted(
+                    dutPortIps[src_dut_index][dut_asic.asic_index].keys())
 
             # Need to fix this
             testPortIps[src_dut_index] = {}
@@ -837,7 +837,7 @@ class QosSaiBase(QosBase):
             testPortIds[src_dut_index] = {}
             dutPortIps[src_dut_index][src_asic_index] = {}
             active_ips = src_asic.get_active_ip_interfaces(tbinfo)
-            for iface,addr in active_ips.items():
+            for iface, addr in active_ips.items():
                 if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
                     portIndex = src_mgFacts["minigraph_ptf_indices"][iface]
                     portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
@@ -923,7 +923,8 @@ class QosSaiBase(QosBase):
         if dualTor:
             testPortIds = dualTorPortIndexes
 
-        testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts)
+        testPorts = self.__buildTestPorts(request, testPortIds, testPortIps,
+                                          src_port_ids, dst_port_ids, get_src_dst_asic_and_duts)
         # Update the uplink/downlink ports to testPorts
         testPorts.update({
             "uplink_port_ids": uplinkPortIds,
@@ -938,8 +939,8 @@ class QosSaiBase(QosBase):
         if tbinfo["topo"]["type"] == "t2":
             #dutportIps={0: {0: {0: {'peer_addr': u'10.0.0.1', 'port': u'Ethernet8'}, 2: {'peer_addr': u'10.0.0.5', 'port': u'Ethernet17'}}}}
             # { 0: 'Ethernet8', 2: 'Ethernet17' }
-            for dut_index,dut_val in dutPortIps.items():
-                for asic_index,asic_val in dut_val.items():
+            for dut_index, dut_val in dutPortIps.items():
+                for asic_index, asic_val in dut_val.items():
                     for ptf_port, ptf_val in asic_val.items():
                         dutinterfaces[ptf_port] = ptf_val['port']
         else:
@@ -955,7 +956,7 @@ class QosSaiBase(QosBase):
             "qosConfigs": qosConfigs,
             "dutAsic": dutAsic,
             "dutTopo": dutTopo,
-            "srcDutInstance" : src_dut,
+            "srcDutInstance": src_dut,
             "dstDutInstance": get_src_dst_asic_and_duts['dst_dut'],
             "dualTor": request.config.getoption("--qos_dual_tor"),
             "dualTorScenario": len(dualtor_ports_for_duts) != 0
@@ -1006,7 +1007,7 @@ class QosSaiBase(QosBase):
     def stopServices(
         self, duthosts, get_src_dst_asic_and_duts,
         swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status,
-        tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
+        tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports):  # noqa F811
         """
             Stop services (lldp-syncs, lldpd, bgpd) on DUT host prior to test start
 
@@ -1059,7 +1060,7 @@ class QosSaiBase(QosBase):
 
             try:
                 lower_tor_host.shell("ls %s" % file)
-                lower_tor_host.shell("sudo cp {} {}".format(file,backup_file))
+                lower_tor_host.shell("sudo cp {} {}".format(file, backup_file))
                 lower_tor_host.shell("sudo rm {}".format(file))
                 lower_tor_host.shell("sudo touch {}".format(file))
             except:
@@ -1083,8 +1084,8 @@ class QosSaiBase(QosBase):
                 {"docker": dst_asic.get_docker_name("lldp"), "service": "lldpd"},
                 {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpd"},
                 {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpmon"},
-            	{"docker": dst_asic.get_docker_name("radv"), "service": "radvd"},
-            	{"docker": dst_asic.get_docker_name("swss"), "service": "arp_update"}
+                {"docker": dst_asic.get_docker_name("radv"), "service": "radvd"},
+                {"docker": dst_asic.get_docker_name("swss"), "service": "arp_update"}
             ]
 
         feature_list = ['lldp', 'bgp', 'syncd', 'swss']
@@ -1109,17 +1110,17 @@ class QosSaiBase(QosBase):
 
         """ Start mux conatiner for dual ToR """
         if 'dualtor' in tbinfo['topo']['name']:
-           try:
-               lower_tor_host.shell("ls %s" % backup_file)
-               lower_tor_host.shell("sudo cp {} {}".format(backup_file,file))
-               lower_tor_host.shell("sudo chmod +x {}".format(file))
-               lower_tor_host.shell("sudo rm {}".format(backup_file))
-           except:
-               pytest.skip('file {} not found'.format(backup_file))
+            try:
+                lower_tor_host.shell("ls %s" % backup_file)
+                lower_tor_host.shell("sudo cp {} {}".format(backup_file, file))
+                lower_tor_host.shell("sudo chmod +x {}".format(file))
+                lower_tor_host.shell("sudo rm {}".format(backup_file))
+            except:
+                pytest.skip('file {} not found'.format(backup_file))
 
-           lower_tor_host.shell('sudo config feature state mux enabled')
-           lower_tor_host.shell('sudo config feature state mux enabled')
-           logger.info("Start mux container for dual ToR testbed")
+            lower_tor_host.shell('sudo config feature state mux enabled')
+            lower_tor_host.shell('sudo config feature state mux enabled')
+            logger.info("Start mux container for dual ToR testbed")
 
         enable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
         if src_asic != dst_asic:
@@ -1127,7 +1128,6 @@ class QosSaiBase(QosBase):
         if 'dualtor' in tbinfo['topo']['name']:
             enable_container_autorestart(
                 duthost_upper, testcase="test_qos_sai", feature_list=feature_list)
-
 
     @pytest.fixture(autouse=True)
     def updateLoganalyzerExceptions(self, get_src_dst_asic_and_duts, loganalyzer):
@@ -1299,7 +1299,7 @@ class QosSaiBase(QosBase):
 
         elif 'broadcom' in duthost.facts['asic_type'].lower():
             if 'platform_asic' in duthost.facts and duthost.facts['platform_asic'] == 'broadcom-dnx':
-                logger.info ("THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
+                logger.info("THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
                 qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
             else:
                 bufferConfig = self.dutBufferConfig(duthost, dut_asic)
@@ -1687,7 +1687,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def lossySchedProfile(
         self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
-   ):
+    ):
         """
             Retreives lossy scheduler profile
 
@@ -1735,7 +1735,7 @@ class QosSaiBase(QosBase):
             """
             for a_asic in get_src_dst_asic_and_duts['all_asics']:
                 a_asic.run_redis_cmd(
-                    argv = [
+                    argv=[
                         "redis-cli",
                         "-n",
                         "4",

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -745,7 +745,7 @@ class QosSaiBase(QosBase):
             else:
                 intf_map = src_mgFacts["minigraph_interfaces"]
 
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(dut_qos_maps)
             for portConfig in intf_map:
                 intf = portConfig["attachto"].split(".")[0]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == 4:
@@ -781,7 +781,7 @@ class QosSaiBase(QosBase):
         elif topo in self.SUPPORTED_T1_TOPOS:
             # T1 is supported only for 'single_asic' or 'single_dut_multi_asic'.
             # So use src_dut as the dut
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(dut_qos_maps)
             dutPortIps[src_dut_index] = {}
             testPortIds[src_dut_index] = {}
             for dut_asic in get_src_dst_asic_and_duts['all_asics']:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -8,6 +8,7 @@ import random
 import os
 import sys
 import six
+import copy
 
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -63,44 +64,43 @@ class QosBase:
         return self.buffer_model
 
     @pytest.fixture(scope='class', autouse=True)
-    def dutTestParams(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                      dut_test_params, tbinfo):
+    def dutTestParams(self, duthosts, dut_test_params_qos, tbinfo, get_src_dst_asic_and_duts):
         """
             Prepares DUT host test params
             Returns:
                 dutTestParams (dict): DUT host test params
         """
         # update router mac
-        dut_test_params["basicParams"]["asic_id"] = enum_frontend_asic_index
-        if dut_test_params["topo"] in self.SUPPORTED_T0_TOPOS:
-            dut_test_params["basicParams"]["router_mac"] = ''
+        if dut_test_params_qos["topo"] in self.SUPPORTED_T0_TOPOS:
+            dut_test_params_qos["basicParams"]["router_mac"] = ''
 
         elif "dualtor" in tbinfo["topo"]["name"]:
             # For dualtor qos test scenario, DMAC of test traffic is default vlan interface's MAC address.
             # To reduce duplicated code, put "is_dualtor" and "def_vlan_mac" into dutTestParams['basicParams'].
-            dut_test_params["basicParams"]["is_dualtor"] = True
+            dut_test_params_qos["basicParams"]["is_dualtor"] = True
+
             vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
             if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
                 default_vlan_name = vlan_cfgs['default_vlan_config']
                 if default_vlan_name:
                     for vlan in list(vlan_cfgs[default_vlan_name].values()):
                         if 'mac' in vlan and vlan['mac']:
-                            dut_test_params["basicParams"]["def_vlan_mac"] = vlan['mac']
+                            dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
                             break
 
             pytest_assert(dut_test_params["basicParams"]["def_vlan_mac"] is not None,
                           "Dual-TOR miss default VLAN MAC address")
         else:
             try:
-                duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+                duthost = get_src_dst_asic_and_duts['src_dut']
                 asic = duthost.asic_instance().asic_index
-                dut_test_params['basicParams']["router_mac"] = duthost.shell(
+                dut_test_params_qos['basicParams']["router_mac"] = duthost.shell(
                     'sonic-db-cli -n asic{} CONFIG_DB hget "DEVICE_METADATA|localhost" mac'.format(asic))['stdout']
             except RunAnsibleModuleFail:
-                dut_test_params['basicParams']["router_mac"] = duthost.shell(
+                dut_test_params_qos['basicParams']["router_mac"] = duthost.shell(
                     'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" mac')['stdout']
 
-        yield dut_test_params
+        yield dut_test_params_qos
 
     def runPtfTest(self, ptfhost, testCase='', testParams={}):
         """
@@ -455,7 +455,136 @@ class QosSaiBase(QosBase):
 
         return dutPortIps
 
-    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids):
+    @pytest.fixture(scope='class')
+    def swapSyncd_on_selected_duts(self, request, duthosts, get_src_dst_asic_and_duts, creds, tbinfo, lower_tor_host):
+        """
+            Swap syncd on DUT host
+
+            Args:
+                request (Fixture): pytest request object
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Returns:
+                None
+        """
+        swapSyncd = request.config.getoption("--qos_swap_syncd")
+        public_docker_reg = request.config.getoption("--public_docker_registry")
+        try:
+            if swapSyncd:
+                if public_docker_reg:
+                    new_creds = copy.deepcopy(creds)
+                    new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
+                    new_creds['docker_registry_username'] = ''
+                    new_creds['docker_registry_password'] = ''
+                else:
+                    new_creds = creds
+                for duthost in get_src_dst_asic_and_duts["all_duts"]:
+                    docker.swap_syncd(duthost, new_creds)
+            yield
+        finally:
+            if swapSyncd:
+                for duthost in get_src_dst_asic_and_duts["all_duts"]:
+                    docker.restore_default_syncd(duthost, new_creds)
+
+    @pytest.fixture(scope='class', name="select_src_dst_dut_and_asic",
+                    params=("single_asic", "single_dut_multi_asic", "multi_dut"))
+    def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo, lower_tor_host):
+        test_port_selection_criteria = request.param
+        logger.info("test_port_selection_criteria is {}".format(test_port_selection_criteria))
+        src_dut_index = 0
+        dst_dut_index = 0
+        src_asic_index = 0
+        dst_asic_index = 0
+        topo = tbinfo["topo"]["name"]
+        if 'dualtor' in tbinfo['topo']['name']:
+            # index of lower_tor_host
+            for a_dut_index in range(len(duthosts)):
+                if duthosts[a_dut_index] == lower_tor_host:
+                    lower_tor_dut_index = a_dut_index
+                    break
+
+        duthost = duthosts.frontend_nodes[0]
+        if test_port_selection_criteria == 'single_asic':
+            # We should randomly pick a dut from duthosts.frontend_nodes and a random asic in that selected DUT
+            # for now hard code the first DUT and the first asic
+            if 'dualtor' in tbinfo['topo']['name']:
+                src_dut_index = lower_tor_dut_index
+            else:
+                src_dut_index = 0
+            dst_dut_index = src_dut_index
+            src_asic_index = 0
+            dst_asic_index = 0
+
+        elif test_port_selection_criteria == "single_dut_multi_asic":
+            if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+                pytest.skip("single_dut_multi_asic is not supported on T0 topologies")
+            found_multi_asic_dut = False
+            for a_dut_index in range(len(duthosts.frontend_nodes)):
+                a_dut = duthosts.frontend_nodes[a_dut_index]
+                if a_dut.sonichost.is_multi_asic:
+                    src_dut_index = a_dut_index
+                    dst_dut_index = a_dut_index
+                    src_asic_index = 0
+                    dst_asic_index = 1
+                    found_multi_asic_dut = True
+                    logger.info ("Using dut {} for single_dut_multi_asic testing".format(a_dut.hostname))
+                    break
+            if not found_multi_asic_dut:
+                pytest.skip("Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
+        else:
+            # Dealing with multi-dut
+            if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+                pytest.skip("multi-dut is not supported on T0 topologies")
+            elif topo in self.SUPPORTED_T1_TOPOS:
+                pytest.skip("multi-dut is not supported on T1 topologies")
+
+            if (len(duthosts.frontend_nodes)) < 2:
+                pytest.skip("Don't have 2 frontend nodes - so can't run multi_dut tests")
+
+            src_dut_index = 0
+            dst_dut_index = 1
+            src_asic_index = 0
+            dst_asic_index = 0
+
+        yield {
+            "src_dut_index": src_dut_index,
+            "dst_dut_index": dst_dut_index,
+            "src_asic_index": src_asic_index,
+            "dst_asic_index": dst_asic_index
+        }
+
+    @pytest.fixture(scope='class')
+    def get_src_dst_asic_and_duts(self, duthosts, tbinfo, select_src_dst_dut_and_asic, lower_tor_host):
+        if 'dualtor' in tbinfo['topo']['name']:
+            src_dut = lower_tor_host
+            dst_dut = lower_tor_host
+        else:
+            src_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["src_dut_index"]]
+            dst_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["dst_dut_index"]]
+
+        src_asic = src_dut.asics[select_src_dst_dut_and_asic["src_asic_index"]]
+        dst_asic = dst_dut.asics[select_src_dst_dut_and_asic["dst_asic_index"]]
+
+        all_asics = [src_asic]
+        if src_asic != dst_asic:
+            all_asics.append(dst_asic)
+
+        all_duts = [src_dut]
+        if src_dut != dst_dut:
+            all_duts.append(dst_dut)
+
+        rtn_dict = {
+            "src_asic": src_asic,
+            "dst_asic": dst_asic,
+            "src_dut": src_dut,
+            "dst_dut": dst_dut,
+            "all_asics": all_asics,
+            "all_duts": all_duts
+        }
+        rtn_dict.update(select_src_dst_dut_and_asic)
+        yield rtn_dict
+
+    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts):
         """
             Build map of test ports index and IPs
 
@@ -470,6 +599,17 @@ class QosSaiBase(QosBase):
         dstPorts = request.config.getoption("--qos_dst_ports")
         srcPorts = request.config.getoption("--qos_src_ports")
 
+        src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
+        src_test_port_ids = src_dut_port_ids[get_src_dst_asic_and_duts['src_asic_index']]
+        dst_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['dst_dut_index']]
+        dst_test_port_ids = dst_dut_port_ids[get_src_dst_asic_and_duts['dst_asic_index']]
+
+        src_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['src_dut_index']]
+        src_test_port_ips = src_dut_port_ips[get_src_dst_asic_and_duts['src_asic_index']]
+        dst_dut_port_ips = testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
+        dst_test_port_ips = dst_dut_port_ips[get_src_dst_asic_and_duts['dst_asic_index']]
+
+
         if dstPorts is None:
             if dst_port_ids:
                 pytest_assert(
@@ -478,9 +618,9 @@ class QosSaiBase(QosBase):
                     "Dest port id passed in qos.yml not valid"
                 )
                 dstPorts = dst_port_ids
-            elif len(testPortIds) >= 4:
+            elif len(dst_test_port_ids) >= 4:
                 dstPorts = [0, 2, 3]
-            elif len(testPortIds) == 3:
+            elif len(dst_test_port_ids) == 3:
                 dstPorts = [0, 2, 2]
             else:
                 dstPorts = [0, 0, 0]
@@ -497,7 +637,7 @@ class QosSaiBase(QosBase):
             else:
                 srcPorts = [1]
 
-        pytest_assert(len(testPortIds) >= 2, "Provide at least 2 test ports")
+        pytest_assert(len(dst_test_port_ids) >= 1 and len(src_test_port_ids) >= 1, "Provide at least 2 test ports")
         logging.debug(
             "Test Port IDs:{} IPs:{}".format(testPortIds, testPortIps)
         )
@@ -511,33 +651,33 @@ class QosSaiBase(QosBase):
         )
 
         # TODO: Randomize port selection
-        dstPort = dstPorts[0] if dst_port_ids else testPortIds[dstPorts[0]]
-        dstVlan = testPortIps[dstPort]['vlan_id'] if 'vlan_id' in testPortIps[dstPort] else None
-        dstPort2 = dstPorts[1] if dst_port_ids else testPortIds[dstPorts[1]]
-        dstVlan2 = testPortIps[dstPort2]['vlan_id'] if 'vlan_id' in testPortIps[dstPort2] else None
-        dstPort3 = dstPorts[2] if dst_port_ids else testPortIds[dstPorts[2]]
-        dstVlan3 = testPortIps[dstPort3]['vlan_id'] if 'vlan_id' in testPortIps[dstPort3] else None
-        srcPort = srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]
-        srcVlan = testPortIps[srcPort]['vlan_id'] if 'vlan_id' in testPortIps[srcPort] else None
+        dstPort = dstPorts[0] if dst_port_ids else dst_test_port_ids[dstPorts[0]]
+        dstVlan = dst_test_port_ips[dstPort]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort] else None
+        dstPort2 = dstPorts[1] if dst_port_ids else dst_test_port_ids[dstPorts[1]]
+        dstVlan2 = dst_test_port_ips[dstPort2]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort2] else None
+        dstPort3 = dstPorts[2] if dst_port_ids else dst_test_port_ids[dstPorts[2]]
+        dstVlan3 = dst_test_port_ips[dstPort3]['vlan_id'] if 'vlan_id' in dst_test_port_ips[dstPort3] else None
+        srcPort = srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]
+        srcVlan = src_test_port_ips[srcPort]['vlan_id'] if 'vlan_id' in src_test_port_ips[srcPort] else None
         return {
             "dst_port_id": dstPort,
-            "dst_port_ip": testPortIps[dstPort]['peer_addr'],
+            "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
             "dst_port_vlan": dstVlan,
             "dst_port_2_id": dstPort2,
-            "dst_port_2_ip": testPortIps[dstPort2]['peer_addr'],
+            "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
             "dst_port_2_vlan": dstVlan2,
             'dst_port_3_id': dstPort3,
-            "dst_port_3_ip": testPortIps[dstPort3]['peer_addr'],
+            "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
             "dst_port_3_vlan": dstVlan3,
-            "src_port_id": srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]],
-            "src_port_ip": testPortIps[srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]]["peer_addr"],
+            "src_port_id": srcPort,
+            "src_port_ip": src_test_port_ips[srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]]["peer_addr"],
             "src_port_vlan": srcVlan
         }
 
     @pytest.fixture(scope='class', autouse=True)
     def dutConfig(
-            self, request, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-            enum_frontend_asic_index, lower_tor_host, tbinfo, dualtor_ports, dut_qos_maps):  # noqa F811
+        self, request, duthosts, get_src_dst_asic_and_duts,
+        lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps): # noqa F811
         """
             Build DUT host config pertaining to QoS SAI tests
 
@@ -549,16 +689,16 @@ class QosSaiBase(QosBase):
                 dutConfig (dict): Map of DUT config containing dut interfaces,
                 test port IDs, test port IPs, and test ports
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-            dut_asic = duthost.asic_instance(enum_frontend_asic_index)
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dutLagInterfaces = []
+        """
+        Below are dictionaries with key being dut_index and value a dictionary with key asic_index 
+        Example for 2 DUTs with 2 asics each
+            { 0: { 0: <asic0_value>, 1: <asic1_value>}, 1: { 0: <asic0_value>, 1: <asic1_value> }}
+        """
         dutPortIps = {}
         testPortIps = {}
+        testPortIds = {}
+        dualTorPortIndexes = {}
         uplinkPortIds = []
         uplinkPortIps = []
         uplinkPortNames = []
@@ -566,58 +706,62 @@ class QosSaiBase(QosBase):
         downlinkPortIps = []
         downlinkPortNames = []
 
-        mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        src_mgFacts = src_dut.get_extended_minigraph_facts(tbinfo)
         topo = tbinfo["topo"]["name"]
 
-        dualTorPortIndexes = []
 
-        testPortIds = []
         # LAG ports in T1 TOPO need to be removed in Mellanox devices
-        if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
+        if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(src_dut):
+            # Only single asic is supported for this scenario, so use src_dut and src_asic - which will be the same
+            # as dst_dut and dst_asic
             pytest_assert(
-                not duthost.sonichost.is_multi_asic, "Fixture not supported on T0 multi ASIC"
+                not src_dut.sonichost.is_multi_asic, "Fixture not supported on T0 multi ASIC"
             )
-            for _, lag in list(mgFacts["minigraph_portchannels"].items()):
+            dutLagInterfaces = []
+            testPortIds[src_dut_index] = {}
+            for _, lag in list(src_mgFacts["minigraph_portchannels"].items()):
                 for intf in lag["members"]:
-                    dutLagInterfaces.append(
-                        mgFacts["minigraph_ptf_indices"][intf])
+                    dutLagInterfaces.append(src_mgFacts["minigraph_ptf_indices"][intf])
 
-            testPortIds = set(mgFacts["minigraph_ptf_indices"][port]
-                              for port in list(mgFacts["minigraph_ports"].keys()))
-            testPortIds -= set(dutLagInterfaces)
-            if isMellanoxDevice(duthost):
+            testPortIds[src_dut_index][src_asic_index] = set(src_mgFacts["minigraph_ptf_indices"][port]
+                                for port in list(src_mgFacts["minigraph_ports"].keys()))
+            testPortIds[src_dut_index][src_asic_index] -= set(dutLagInterfaces)
+            if isMellanoxDevice(src_dut):
                 # The last port is used for up link from DUT switch
-                testPortIds -= {len(mgFacts["minigraph_ptf_indices"]) - 1}
-            testPortIds = sorted(testPortIds)
-            pytest_require(len(testPortIds) != 0,
-                           "Skip test since no ports are available for testing")
+                testPortIds[src_dut_index][src_asic_index] -= {len(src_mgFacts["minigraph_ptf_indices"]) - 1}
+            testPortIds[src_dut_index][src_asic_index] = sorted(testPortIds[src_dut_index][src_asic_index])
+            pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0, "Skip test since no ports are available for testing")
 
             # get current DUT port IPs
-            dutPortIps = {}
+            dutPortIps[src_dut_index] = {}
+            dutPortIps[src_dut_index][src_asic_index] = {}
+            dualTorPortIndexes[src_dut_index] = {}
+            dualTorPortIndexes[src_dut_index][src_asic_index] = {}
             if 'backend' in topo:
-                intf_map = mgFacts["minigraph_vlan_sub_interfaces"]
+                intf_map = src_mgFacts["minigraph_vlan_sub_interfaces"]
             else:
-                intf_map = mgFacts["minigraph_interfaces"]
+                intf_map = src_mgFacts["minigraph_interfaces"]
 
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(
-                duthost, dut_qos_maps)
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
             for portConfig in intf_map:
                 intf = portConfig["attachto"].split(".")[0]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == 4:
-                    portIndex = mgFacts["minigraph_ptf_indices"][intf]
-                    if portIndex in testPortIds:
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
+                    if portIndex in testPortIds[src_dut_index][src_asic_index]:
                         portIpMap = {'peer_addr': portConfig["peer_addr"]}
                         if 'vlan' in portConfig:
                             portIpMap['vlan_id'] = portConfig['vlan']
-                        dutPortIps.update({portIndex: portIpMap})
-                        if intf in dualtor_ports:
-                            dualTorPortIndexes.append(portIndex)
+                        dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
+                        if intf in dualtor_ports_for_duts:
+                            dualTorPortIndexes[src_dut_index][src_asic_index].append(portIndex)
                     # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
                     # we also need to test them separately
                     # for mellanox device, we run it on t1 topo mocked by ptf32 topo
-                    if use_separated_upkink_dscp_tc_map and isMellanoxDevice(duthost):
-                        neighName = mgFacts["minigraph_neighbors"].get(
-                            intf, {}).get("name", "").lower()
+                    if use_separated_upkink_dscp_tc_map and isMellanoxDevice(src_dut):
+                        neighName = src_mgFacts["minigraph_neighbors"].get(intf, {}).get("name", "").lower()
                         if 't0' in neighName:
                             downlinkPortIds.append(portIndex)
                             downlinkPortIps.append(portConfig["peer_addr"])
@@ -627,81 +771,126 @@ class QosSaiBase(QosBase):
                             uplinkPortIps.append(portConfig["peer_addr"])
                             uplinkPortNames.append(intf)
 
-            testPortIps = self.__assignTestPortIps(mgFacts, topo)
+            testPortIps[src_dut_index] = {}
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo)
+
+            # restore currently assigned IPs
+            if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
+                testPortIps.update(dutPortIps)
 
         elif topo in self.SUPPORTED_T1_TOPOS:
-            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(
-                duthost, dut_qos_maps)
-            for iface, addr in list(dut_asic.get_active_ip_interfaces(tbinfo).items()):
-                vlan_id = None
-                if iface.startswith("Ethernet"):
-                    portName = iface
-                    if "." in iface:
-                        portName, vlan_id = iface.split(".")
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
-                    if vlan_id is not None:
-                        portIpMap['vlan_id'] = vlan_id
-                    dutPortIps.update({portIndex: portIpMap})
-                elif iface.startswith("PortChannel"):
-                    portName = next(
-                        iter(mgFacts["minigraph_portchannels"]
-                             [iface]["members"])
-                    )
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
-                    dutPortIps.update({portIndex: portIpMap})
-                # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
-                # we also need to test them separately
-                if use_separated_upkink_dscp_tc_map:
-                    neighName = mgFacts["minigraph_neighbors"].get(
-                        portName, {}).get("name", "").lower()
-                    if 't0' in neighName:
-                        downlinkPortIds.append(portIndex)
-                        downlinkPortIps.append(addr["peer_ipv4"])
-                        downlinkPortNames.append(portName)
-                    elif 't2' in neighName:
-                        uplinkPortIds.append(portIndex)
-                        uplinkPortIps.append(addr["peer_ipv4"])
-                        uplinkPortNames.append(portName)
+            # T1 is supported only for 'single_asic' or 'single_dut_multi_asic'.
+            # So use src_dut as the dut
+            use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(src_dut, dut_qos_maps)
+            dutPortIps[src_dut_index] = {}
+            testPortIds[src_dut_index] = {}
+            for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+                dutPortIps[src_dut_index][dut_asic.asic_index] = {}
+                for iface, addr in list(dut_asic.get_active_ip_interfaces(tbinfo).items()):
+                    vlan_id = None
+                    if iface.startswith("Ethernet"):
+                        portName = iface
+                        if "." in iface:
+                            portName, vlan_id = iface.split(".")
+                        portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                        if vlan_id is not None:
+                            portIpMap['vlan_id'] = vlan_id
+                        dutPortIps[src_dut_index][dut_asic.asic_index].update({portIndex: portIpMap})
+                    elif iface.startswith("PortChannel"):
+                        portName = next(
+                            iter(src_mgFacts["minigraph_portchannels"][iface]["members"])
+                        )
+                        portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                        dutPortIps[src_dut_index][dut_asic.asic_index].update({portIndex: portIpMap})
+                    # If the leaf router is using separated DSCP_TO_TC_MAP on uplink/downlink ports.
+                    # we also need to test them separately
+                    if use_separated_upkink_dscp_tc_map:
+                        neighName = src_mgFacts["minigraph_neighbors"].get(portName, {}).get("name", "").lower()
+                        if 't0' in neighName:
+                            downlinkPortIds.append(portIndex)
+                            downlinkPortIps.append(addr["peer_ipv4"])
+                            downlinkPortNames.append(portName)
+                        elif 't2' in neighName:
+                            uplinkPortIds.append(portIndex)
+                            uplinkPortIps.append(addr["peer_ipv4"])
+                            uplinkPortNames.append(portName)
 
-            testPortIds = sorted(dutPortIps.keys())
+                testPortIds[src_dut_index][dut_asic.asic_index] = sorted(dutPortIps[src_dut_index][dut_asic.asic_index].keys())
+
+            # Need to fix this
+            testPortIps[src_dut_index] = {}
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo)
+
+            # restore currently assigned IPs
+            if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
+                testPortIps.update(dutPortIps)
 
         elif tbinfo["topo"]["type"] == "t2":
-            for iface, addr in list(dut_asic.get_active_ip_interfaces(tbinfo).items()):
-                vlan_id = None
+            src_asic = get_src_dst_asic_and_duts['src_asic']
+            dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+            dst_asic = get_src_dst_asic_and_duts['dst_asic']
+
+            # Lets get data for the src dut and src asic
+            dutPortIps[src_dut_index] = {}
+            testPortIds[src_dut_index] = {}
+            dutPortIps[src_dut_index][src_asic_index] = {}
+            for iface,addr in list(src_asic.get_active_ip_interfaces(tbinfo).items()):
                 if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
-                    if "." in iface:
-                        iface, vlan_id = iface.split(".")
-                    portIndex = mgFacts["minigraph_ptf_indices"][iface]
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][iface]
                     portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
-                    if vlan_id is not None:
-                        portIpMap['vlan_id'] = vlan_id
-                    dutPortIps.update({portIndex: portIpMap})
+                    dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
                 elif iface.startswith("PortChannel"):
                     portName = next(
-                        iter(mgFacts["minigraph_portchannels"]
-                             [iface]["members"])
+                        iter(src_mgFacts["minigraph_portchannels"][iface]["members"])
                     )
-                    portIndex = mgFacts["minigraph_ptf_indices"][portName]
+                    portIndex = src_mgFacts["minigraph_ptf_indices"][portName]
                     portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': portName}
-                    dutPortIps.update({portIndex: portIpMap})
+                    dutPortIps[src_dut_index][src_asic_index].update({portIndex: portIpMap})
 
-            testPortIds = sorted(dutPortIps.keys())
+            testPortIds[src_dut_index][src_asic_index] = sorted(dutPortIps[src_dut_index][src_asic_index].keys())
 
-        # restore currently assigned IPs
-        testPortIps.update(dutPortIps)
+            if dst_asic != src_asic:
+                # Dealing with different asic
+                dst_dut = get_src_dst_asic_and_duts['dst_dut']
+                dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+                if dst_dut_index != src_dut_index:
+                    dst_mgFacts = dst_dut.get_extended_minigraph_facts(tbinfo)
+                    dutPortIps[dst_dut_index] = {}
+                    testPortIds[dst_dut_index] = {}
+                else:
+                    dst_mgFacts = src_mgFacts
+                dutPortIps[dst_dut_index][dst_asic_index] = {}
+                active_ips = dst_asic.get_active_ip_interfaces(tbinfo)
+                for iface, addr in active_ips.items():
+                    if iface.startswith("Ethernet") and ("Ethernet-Rec" not in iface):
+                        portIndex = dst_mgFacts["minigraph_ptf_indices"][iface]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': iface}
+                        dutPortIps[dst_dut_index][dst_asic_index].update({portIndex: portIpMap})
+                    elif iface.startswith("PortChannel"):
+                        portName = next(
+                            iter(dst_mgFacts["minigraph_portchannels"][iface]["members"])
+                        )
+                        portIndex = dst_mgFacts["minigraph_ptf_indices"][portName]
+                        portIpMap = {'peer_addr': addr["peer_ipv4"], 'port': portName}
+                        dutPortIps[dst_dut_index][dst_asic_index].update({portIndex: portIpMap})
+
+                testPortIds[dst_dut_index][dst_asic_index] = sorted(dutPortIps[dst_dut_index][dst_asic_index].keys())
+
+            # restore currently assigned IPs
+            testPortIps.update(dutPortIps)
 
         qosConfigs = {}
         with open(r"qos/files/qos.yml") as file:
             qosConfigs = yaml.load(file, Loader=yaml.FullLoader)
-
-        vendor = duthost.facts["asic_type"]
-        hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        # Assuming the same chipset for all DUTs so can use src_dut to get asic type
+        vendor = src_dut.facts["asic_type"]
+        hostvars = src_dut.host.options['variable_manager']._hostvars[src_dut.hostname]
         dutAsic = None
         for asic in self.SUPPORTED_ASIC_LIST:
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-            if vendorAsic in list(hostvars.keys()) and mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
+            if vendorAsic in list(hostvars.keys()) and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
                 dutAsic = asic
                 break
 
@@ -733,8 +922,7 @@ class QosSaiBase(QosBase):
         if dualTor:
             testPortIds = dualTorPortIndexes
 
-        testPorts = self.__buildTestPorts(
-            request, testPortIds, testPortIps, src_port_ids, dst_port_ids)
+        testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts)
         # Update the uplink/downlink ports to testPorts
         testPorts.update({
             "uplink_port_ids": uplinkPortIds,
@@ -747,12 +935,16 @@ class QosSaiBase(QosBase):
         dutinterfaces = {}
 
         if tbinfo["topo"]["type"] == "t2":
-            for ptf_port, ptf_val in list(dutPortIps.items()):
-                dutinterfaces[ptf_port] = ptf_val['port']
+            #dutportIps={0: {0: {0: {'peer_addr': u'10.0.0.1', 'port': u'Ethernet8'}, 2: {'peer_addr': u'10.0.0.5', 'port': u'Ethernet17'}}}}
+            # { 0: 'Ethernet8', 2: 'Ethernet17' }
+            for dut_index,dut_val in dutPortIps.items():
+                for asic_index,asic_val in dut_val.items():
+                    for ptf_port, ptf_val in asic_val.items():
+                        dutinterfaces[ptf_port] = ptf_val['port']
         else:
-            for port, index in list(mgFacts["minigraph_ptf_indices"].items()):
-                if 'Ethernet-Rec' not in port and 'Ethernet-IB' not in port:
-                    dutinterfaces[index] = port
+            dutinterfaces = {
+                index: port for port, index in list(src_mgFacts["minigraph_ptf_indices"].items())
+            }
 
         yield {
             "dutInterfaces": dutinterfaces,
@@ -762,32 +954,26 @@ class QosSaiBase(QosBase):
             "qosConfigs": qosConfigs,
             "dutAsic": dutAsic,
             "dutTopo": dutTopo,
-            "dutInstance": duthost,
+            "srcDutInstance" : src_dut,
+            "dstDutInstance": get_src_dst_asic_and_duts['dst_dut'],
             "dualTor": request.config.getoption("--qos_dual_tor"),
-            "dualTorScenario": len(dualtor_ports) != 0
+            "dualTorScenario": len(dualtor_ports_for_duts) != 0
         }
 
     @pytest.fixture(scope='class')
-    def ssh_tunnel_to_syncd_rpc(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-            swapSyncd, tbinfo, lower_tor_host  # noqa: F811
-    ):
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dut_asic.create_ssh_tunnel_sai_rpc()
+    def ssh_tunnel_to_syncd_rpc(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
+        all_asics = get_src_dst_asic_and_duts['all_asics']
+
+        for a_asic in all_asics:
+            a_asic.create_ssh_tunnel_sai_rpc()
 
         yield
 
-        dut_asic.remove_ssh_tunnel_sai_rpc()
+        for a_asic in all_asics:
+            a_asic.remove_ssh_tunnel_sai_rpc()
 
     @pytest.fixture(scope='class')
-    def updateIptables(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, swapSyncd, tbinfo,
-            lower_tor_host  # noqa: F811
-    ):
+    def updateIptables(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
         """
             Update iptables on DUT host with drop rule for BGP SYNC packets
 
@@ -798,31 +984,28 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        all_asics = get_src_dst_asic_and_duts['all_asics']
 
         ipVersions = [{"ip_version": "ipv4"}, {"ip_version": "ipv6"}]
 
         logger.info(
             "Add ip[6]tables rule to drop BGP SYN Packet from peer so that we do not ACK back")
         for ipVersion in ipVersions:
-            dut_asic.bgp_drop_rule(state="present", **ipVersion)
+            for a_asic in all_asics:
+                a_asic.bgp_drop_rule(state="present", **ipVersion)
 
         yield
 
         logger.info("Remove ip[6]tables rule to drop BGP SYN Packet from Peer")
         for ipVersion in ipVersions:
-            dut_asic.bgp_drop_rule(state="absent", **ipVersion)
+            for a_asic in all_asics:
+                a_asic.bgp_drop_rule(state="absent", **ipVersion)
 
     @pytest.fixture(scope='class')
     def stopServices(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-            enum_frontend_asic_index, swapSyncd, enable_container_autorestart,
-            disable_container_autorestart, get_mux_status, tbinfo, upper_tor_host,      # noqa F811
-            lower_tor_host, toggle_all_simulator_ports):                                # noqa F811
+        self, duthosts, get_src_dst_asic_and_duts,
+        swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status,
+        tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports): # noqa F811
         """
             Stop services (lldp-syncs, lldpd, bgpd) on DUT host prior to test start
 
@@ -833,13 +1016,13 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-            duthost_upper = upper_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        dst_asic = get_src_dst_asic_and_duts['dst_asic']
+        dst_dut = get_src_dst_asic_and_duts['dst_dut']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        if 'dualtor' in tbinfo['topo']['name']:
+            duthost_upper = upper_tor_host
 
         def updateDockerService(host, docker="", action="", service=""):  # noqa: F811
             """
@@ -874,64 +1057,79 @@ class QosSaiBase(QosBase):
             validate_check_result(check_result, duthosts, get_mux_status)
 
             try:
-                duthost.shell("ls %s" % file)
-                duthost.shell("sudo cp {} {}".format(file, backup_file))
-                duthost.shell("sudo rm {}".format(file))
-                duthost.shell("sudo touch {}".format(file))
-            except Exception:
+                lower_tor_host.shell("ls %s" % file)
+                lower_tor_host.shell("sudo cp {} {}".format(file,backup_file))
+                lower_tor_host.shell("sudo rm {}".format(file))
+                lower_tor_host.shell("sudo touch {}".format(file))
+            except:
                 pytest.skip('file {} not found'.format(file))
 
             duthost_upper.shell('sudo config feature state mux disabled')
-            duthost.shell('sudo config feature state mux disabled')
+            lower_tor_host.shell('sudo config feature state mux disabled')
 
-        services = [
-            {"docker": dut_asic.get_docker_name(
-                "lldp"), "service": "lldp-syncd"},
-            {"docker": dut_asic.get_docker_name("lldp"), "service": "lldpd"},
-            {"docker": dut_asic.get_docker_name("bgp"), "service": "bgpd"},
-            {"docker": dut_asic.get_docker_name("bgp"), "service": "bgpmon"},
-            {"docker": dut_asic.get_docker_name("radv"), "service": "radvd"},
-            {"docker": dut_asic.get_docker_name(
-                "swss"), "service": "arp_update"}
+        src_services = [
+            {"docker": src_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
+            {"docker": src_asic.get_docker_name("lldp"), "service": "lldpd"},
+            {"docker": src_asic.get_docker_name("bgp"),  "service": "bgpd"},
+            {"docker": src_asic.get_docker_name("bgp"),  "service": "bgpmon"},
+            {"docker": src_asic.get_docker_name("radv"), "service": "radvd"},
+            {"docker": src_asic.get_docker_name("swss"), "service": "arp_update"}
         ]
+        dst_services = []
+        if src_asic != dst_asic:
+            dst_services = [
+                {"docker": dst_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
+                {"docker": dst_asic.get_docker_name("lldp"), "service": "lldpd"},
+                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpd"},
+                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpmon"},
+            	{"docker": dst_asic.get_docker_name("radv"), "service": "radvd"},
+            	{"docker": dst_asic.get_docker_name("swss"), "service": "arp_update"}
+            ]
 
         feature_list = ['lldp', 'bgp', 'syncd', 'swss']
         if 'dualtor' in tbinfo['topo']['name']:
             disable_container_autorestart(
                 duthost_upper, testcase="test_qos_sai", feature_list=feature_list)
 
-        disable_container_autorestart(
-            duthost, testcase="test_qos_sai", feature_list=feature_list)
-        for service in services:
-            updateDockerService(duthost, action="stop", **service)
-
+        disable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
+        for service in src_services:
+            updateDockerService(src_dut, action="stop", **service)
+        if src_asic != dst_asic:
+            disable_container_autorestart(dst_dut, testcase="test_qos_sai", feature_list=feature_list)
+            for service in dst_services:
+                updateDockerService(dst_dut, action="stop", **service)
         yield
 
-        for service in services:
-            updateDockerService(duthost, action="start", **service)
+        for service in src_services:
+            updateDockerService(src_dut, action="start", **service)
+        if src_asic != dst_asic:
+            for service in dst_services:
+                updateDockerService(dst_dut, action="start", **service)
 
         """ Start mux conatiner for dual ToR """
         if 'dualtor' in tbinfo['topo']['name']:
-            try:
-                duthost.shell("ls %s" % backup_file)
-                duthost.shell("sudo cp {} {}".format(backup_file, file))
-                duthost.shell("sudo chmod +x {}".format(file))
-                duthost.shell("sudo rm {}".format(backup_file))
-            except Exception:
-                pytest.skip('file {} not found'.format(backup_file))
+           try:
+               lower_tor_host.shell("ls %s" % backup_file)
+               lower_tor_host.shell("sudo cp {} {}".format(backup_file,file))
+               lower_tor_host.shell("sudo chmod +x {}".format(file))
+               lower_tor_host.shell("sudo rm {}".format(backup_file))
+           except:
+               pytest.skip('file {} not found'.format(backup_file))
 
-            duthost.shell('sudo config feature state mux enabled')
-            duthost_upper.shell('sudo config feature state mux enabled')
-            logger.info("Start mux container for dual ToR testbed")
+           lower_tor_host.shell('sudo config feature state mux enabled')
+           lower_tor_host.shell('sudo config feature state mux enabled')
+           logger.info("Start mux container for dual ToR testbed")
 
-        enable_container_autorestart(
-            duthost, testcase="test_qos_sai", feature_list=feature_list)
+        enable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
+        if src_asic != dst_asic:
+            enable_container_autorestart(dst_dut, testcase="test_qos_sai", feature_list=feature_list)
         if 'dualtor' in tbinfo['topo']['name']:
             enable_container_autorestart(
                 duthost_upper, testcase="test_qos_sai", feature_list=feature_list)
 
+
     @pytest.fixture(autouse=True)
-    def updateLoganalyzerExceptions(self, enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+    def updateLoganalyzerExceptions(self, get_src_dst_asic_and_duts, loganalyzer):
         """
             Update loganalyzer ignore regex list
 
@@ -965,14 +1163,14 @@ class QosSaiBase(QosBase):
                 ".*WARNING syncd#SDK:.*sai_set_attribute: Failed attribs check, key:Switch ID.*",
                 ".*WARNING syncd#SDK:.*check_rate: Set max rate to 0.*"
             ]
-            loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(
-                ignoreRegex)
+            for a_dut in get_src_dst_asic_and_duts['all_duts']:
+                loganalyzer[a_dut.hostname].ignore_regex.extend(ignoreRegex)
 
         yield
 
     @pytest.fixture(scope='class', autouse=True)
     def disablePacketAging(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, stopServices
+        self, duthosts, get_src_dst_asic_and_duts, stopServices
     ):
         """
             disable packet aging on DUT host
@@ -984,37 +1182,34 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            if isMellanoxDevice(duthost):
+                logger.info("Disable Mellanox packet aging")
+                duthost.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
+                duthost.command("docker cp /tmp/packets_aging.py syncd:/")
+                duthost.command("docker exec syncd python /packets_aging.py disable")
 
-        if isMellanoxDevice(duthost):
-            logger.info("Disable Mellanox packet aging")
-            duthost.copy(
-                src="qos/files/mellanox/packets_aging.py", dest="/tmp")
-            duthost.command("docker cp /tmp/packets_aging.py syncd:/")
-            duthost.command(
-                "docker exec syncd python /packets_aging.py disable")
+            yield
 
-        yield
-
-        if isMellanoxDevice(duthost):
-            logger.info("Enable Mellanox packet aging")
-            duthost.command(
-                "docker exec syncd python /packets_aging.py enable")
-            duthost.command("docker exec syncd rm -rf /packets_aging.py")
+            if isMellanoxDevice(duthost):
+                logger.info("Enable Mellanox packet aging")
+                duthost.command("docker exec syncd python /packets_aging.py enable")
+                duthost.command("docker exec syncd rm -rf /packets_aging.py")
 
     def dutArpProxyConfig(self, duthost):
         # so far, only record ARP proxy config to logging for debug purpose
-        vlanInterface = {}
-        try:
-            vlanInterface = json.loads(duthost.shell('sonic-cfggen -d --var-json "VLAN_INTERFACE"')['stdout'])
-        except:  # noqa: E722
-            logger.info('Failed to read vlan interface config')
-        if not vlanInterface:
-            return
-        for key, value in list(vlanInterface.items()):
-            if 'proxy_arp' in value:
-                logger.info('ARP proxy is {} on {}'.format(
-                    value['proxy_arp'], key))
+        for a_asic in duthost.asics:
+            vlanInterface = {}
+            try:
+                sonic_cfgen_cmd = 'sonic-cfggen {} -d --var-json "VLAN_INTERFACE"'.format(a_asic.cli_ns_option)
+                vlanInterface = json.loads(duthost.shell(sonic_cfgen_cmd)['stdout'])
+            except:
+                logger.info('Failed to read vlan interface config')
+            if not vlanInterface:
+                return
+            for key, value in vlanInterface.items():
+                if 'proxy_arp' in value:
+                    logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
 
     def dutBufferConfig(self, duthost, dut_asic):
         bufferConfig = {}
@@ -1038,10 +1233,10 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
-            self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-            dutConfig, ingressLosslessProfile, ingressLossyProfile,
-            egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
-            tbinfo, lower_tor_host  # noqa: F811
+        self, duthosts, get_src_dst_asic_and_duts,
+        dutConfig, ingressLosslessProfile, ingressLossyProfile,
+        egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
+        tbinfo, lower_tor_host
     ):
         """
             Prepares DUT host QoS configuration
@@ -1054,12 +1249,9 @@ class QosSaiBase(QosBase):
             Returns:
                 QoSConfig (dict): Map containing DUT host QoS configuration
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
         pytest_assert("minigraph_hwsku" in mgFacts, "Could not find DUT SKU")
 
@@ -1096,14 +1288,17 @@ class QosSaiBase(QosBase):
                                                        egressLosslessProfile,
                                                        egressLossyProfile,
                                                        sharedHeadroomPoolSize,
-                                                       dutConfig["dualTor"]
+                                                       dutConfig["dualTor"],
+                                                       get_src_dst_asic_and_duts['src_dut_index'],
+                                                       get_src_dst_asic_and_duts['src_asic_index'],
+                                                       get_src_dst_asic_and_duts['dst_dut_index'],
+                                                       get_src_dst_asic_and_duts['dst_asic_index']
                                                        )
             qosParams = qpm.run()
 
         elif 'broadcom' in duthost.facts['asic_type'].lower():
             if 'platform_asic' in duthost.facts and duthost.facts['platform_asic'] == 'broadcom-dnx':
-                logger.info(
-                    "THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
+                logger.info ("THDI_BUFFER_CELL_LIMIT_SP is not valid for broadcom DNX - ignore dynamic buffer config")
                 qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
             else:
                 bufferConfig = self.dutBufferConfig(duthost, dut_asic)
@@ -1166,8 +1361,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def releaseAllPorts(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, dutTestParams,
-            updateIptables, ssh_tunnel_to_syncd_rpc
+        self, duthosts, ptfhost, dutTestParams, updateIptables, ssh_tunnel_to_syncd_rpc
     ):
         """
             Release all paused ports prior to running QoS SAI test cases
@@ -1219,7 +1413,7 @@ class QosSaiBase(QosBase):
             duthost.file(path=file["path"], state="absent")
 
     @pytest.fixture(scope='class', autouse=True)
-    def handleFdbAging(self, tbinfo, duthosts, lower_tor_host, enum_rand_one_per_hwsku_frontend_hostname):  # noqa: F811
+    def handleFdbAging(self, duthosts, get_src_dst_asic_and_duts):
         """
             Disable FDB aging and reenable at the end of tests
 
@@ -1232,39 +1426,32 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         fdbAgingTime = 0
-
-        self.__deleteTmpSwitchConfig(duthost)
-        duthost.docker_copy_from_asic(
-            "swss", "/etc/swss/config.d/switch.json", "/tmp")
-        duthost.replace(
-            dest='/tmp/switch.json',
-            regexp='"fdb_aging_time": ".*"',
-            replace='"fdb_aging_time": "{0}"'.format(fdbAgingTime),
-            backup=True
-        )
-        duthost.docker_copy_to_all_asics(
-            "swss", "/tmp/switch.json", "/etc/swss/config.d/switch.json")
-        self.__loadSwssConfig(duthost)
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            self.__deleteTmpSwitchConfig(duthost)
+            duthost.docker_copy_from_asic("swss", "/etc/swss/config.d/switch.json", "/tmp")
+            duthost.replace(
+                dest='/tmp/switch.json',
+                regexp='"fdb_aging_time": ".*"',
+                replace='"fdb_aging_time": "{0}"'.format(fdbAgingTime),
+                backup=True
+            )
+            duthost.docker_copy_to_all_asics("swss", "/tmp/switch.json", "/etc/swss/config.d/switch.json")
+            self.__loadSwssConfig(duthost)
 
         yield
-
-        result = duthost.find(path=["/tmp"], patterns=["switch.json.*"])
-        if result["matched"] > 0:
-            src = result["files"][0]["path"]
-            duthost.docker_copy_to_all_asics(
-                "swss", src, "/etc/swss/config.d/switch.json")
-            self.__loadSwssConfig(duthost)
-        self.__deleteTmpSwitchConfig(duthost)
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            result = duthost.find(path=["/tmp"], patterns=["switch.json.*"])
+            if result["matched"] > 0:
+                src = result["files"][0]["path"]
+                duthost.docker_copy_to_all_asics("swss", src, "/etc/swss/config.d/switch.json")
+                self.__loadSwssConfig(duthost)
+            self.__deleteTmpSwitchConfig(duthost)
 
     @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
-            self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-            ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host  # noqa: F811
+        self, duthosts, get_src_dst_asic_and_duts,
+        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host
     ):
         """
             Update ARP entries of QoS SAI test ports
@@ -1283,15 +1470,6 @@ class QosSaiBase(QosBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-
-        dut_asic.command('sonic-clear fdb all')
-        dut_asic.command('sonic-clear arp')
 
         saiQosTest = None
         if dutTestParams["topo"] in self.SUPPORTED_T0_TOPOS:
@@ -1299,11 +1477,11 @@ class QosSaiBase(QosBase):
         elif dutTestParams["topo"] in self.SUPPORTED_PTF_TOPOS:
             saiQosTest = "sai_qos_tests.ARPpopulatePTF"
         else:
-            result = dut_asic.command("arp -n")
-            pytest_assert(
-                result["rc"] == 0, "failed to run arp command on {0}".format(duthost.hostname))
-            if result["stdout"].find("incomplete") == -1:
-                saiQosTest = "sai_qos_tests.ARPpopulate"
+            for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+                result = dut_asic.command("arp -n")
+                pytest_assert(result["rc"] == 0, "failed to run arp command on {0}".format(dut_asic.sonichost.hostname))
+                if result["stdout"].find("incomplete") == -1:
+                    saiQosTest = "sai_qos_tests.ARPpopulate"
 
         if saiQosTest:
             testParams = dutTestParams["basicParams"]
@@ -1317,22 +1495,18 @@ class QosSaiBase(QosBase):
             )
 
     @pytest.fixture(scope='class', autouse=True)
-    def dut_disable_ipv6(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host):  # noqa: F811
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-        duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
+    def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host):
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
         yield
-        duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
+
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(
-            self, request, duthosts, enum_frontend_asic_index,
-            enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host  # noqa: F811
+        self, request, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
     ):
         """
             Retreives shared headroom pool size
@@ -1345,20 +1519,14 @@ class QosSaiBase(QosBase):
                 size: shared headroom pool size
                       none if it is not defined
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
         yield self.__getSharedHeadroomPoolSize(
             request,
-            duthost.asic_instance(enum_frontend_asic_index)
+            get_src_dst_asic_and_duts['src_asic']
         )
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLosslessProfile(
-            self, request, duthosts, enum_frontend_asic_index,
-            enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports  # noqa: F811
+        self, request, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives ingress lossless profile
@@ -1372,16 +1540,12 @@ class QosSaiBase(QosBase):
             Returns:
                 ingressLosslessProfile (dict): Map of ingress lossless buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]
-                                             ["src_port_id"]]
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             pgs = "2-4"
         else:
             pgs = "3-4"
@@ -1398,8 +1562,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLossyProfile(
-            self, request, duthosts, enum_frontend_asic_index,
-            enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host  # noqa: F811
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
     ):
         """
             Retreives ingress lossy profile
@@ -1413,12 +1576,8 @@ class QosSaiBase(QosBase):
             Returns:
                 ingressLossyProfile (dict): Map of ingress lossy buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
         yield self.__getBufferProfile(
             request,
             dut_asic,
@@ -1431,8 +1590,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLosslessProfile(
-            self, request, duthosts, enum_frontend_asic_index,
-            enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports  # noqa: F811
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives egress lossless profile
@@ -1446,16 +1604,12 @@ class QosSaiBase(QosBase):
             Returns:
                 egressLosslessProfile (dict): Map of egress lossless buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]
-                                             ["src_port_id"]]
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             queues = "2-4"
         else:
             queues = "3-4"
@@ -1472,8 +1626,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLossyProfile(
-            self, request, duthosts, enum_frontend_asic_index,
-            enum_rand_one_per_hwsku_frontend_hostname, dutConfig, tbinfo, lower_tor_host, dualtor_ports  # noqa: F811
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
     ):
         """
             Retreives egress lossy profile
@@ -1487,16 +1640,12 @@ class QosSaiBase(QosBase):
             Returns:
                 egressLossyProfile (dict): Map of egress lossy buffer profile attributes
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]
-                                             ["src_port_id"]]
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
 
-        if srcport in dualtor_ports:
+        if srcport in dualtor_ports_for_duts:
             queues = "0-1"
         else:
             queues = "0-2"
@@ -1513,8 +1662,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def losslessSchedProfile(
-            self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-            dutConfig, tbinfo, lower_tor_host  # noqa: F811
+            self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
     ):
         """
             Retreives lossless scheduler profile
@@ -1527,22 +1675,18 @@ class QosSaiBase(QosBase):
             Returns:
                 losslessSchedProfile (dict): Map of scheduler parameters
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
 
         yield self.__getSchedulerParam(
-            duthost.asic_instance(enum_frontend_asic_index),
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSLESS_QUEUE_SCHED
         )
 
     @pytest.fixture(scope='class')
     def lossySchedProfile(
-            self, duthosts, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname,
-            dutConfig, tbinfo, lower_tor_host  # noqa: F811
-    ):
+        self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+   ):
         """
             Retreives lossy scheduler profile
 
@@ -1554,21 +1698,17 @@ class QosSaiBase(QosBase):
             Returns:
                 lossySchedProfile (dict): Map of scheduler parameters
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
+        dut_asic = get_src_dst_asic_and_duts['src_asic']
         yield self.__getSchedulerParam(
-            duthost.asic_instance(enum_frontend_asic_index),
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSY_QUEUE_SCHED
         )
 
     @pytest.fixture
     def updateSchedProfile(
-            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-            dutQosConfig, losslessSchedProfile, lossySchedProfile, tbinfo, lower_tor_host  # noqa: F811
+        self, duthosts, get_src_dst_asic_and_duts,
+        dutQosConfig, losslessSchedProfile, lossySchedProfile, tbinfo, lower_tor_host
     ):
         """
             Updates lossless/lossy scheduler profiles
@@ -1582,11 +1722,6 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
         def updateRedisSchedParam(schedParam):
             """
                 Helper function to updates lossless/lossy scheduler profiles
@@ -1597,17 +1732,18 @@ class QosSaiBase(QosBase):
                 Returns:
                     None
             """
-            duthost.asic_instance(enum_frontend_asic_index).run_redis_cmd(
-                argv=[
-                    "redis-cli",
-                    "-n",
-                    "4",
-                    "HSET",
-                    schedParam["profile"],
-                    "weight",
-                    schedParam["qosConfig"]
-                ]
-            )
+            for a_asic in get_src_dst_asic_and_duts['all_asics']:
+                a_asic.run_redis_cmd(
+                    argv = [
+                        "redis-cli",
+                        "-n",
+                        "4",
+                        "HSET",
+                        schedParam["profile"],
+                        "weight",
+                        schedParam["qosConfig"]
+                    ]
+                )
 
         wrrSchedParams = [
             {
@@ -1640,8 +1776,9 @@ class QosSaiBase(QosBase):
             updateRedisSchedParam(schedParam)
 
     @pytest.fixture
-    def resetWatermark(self, duthosts, enum_frontend_asic_index,
-                       enum_rand_one_per_hwsku_frontend_hostname, tbinfo, lower_tor_host):  # noqa: F811
+    def resetWatermark(
+        self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
+    ):
         """
             Reset queue watermark
 
@@ -1651,14 +1788,65 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            duthost = lower_tor_host
-        else:
-            duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        dut_asic = duthost.asic_instance(enum_frontend_asic_index)
-        dut_asic.command("counterpoll watermark enable")
-        dut_asic.command("counterpoll queue enable")
-        dut_asic.command("sleep 70")
-        dut_asic.command("counterpoll watermark disable")
-        dut_asic.command("counterpoll queue disable")
+        for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+            dut_asic.command("counterpoll watermark enable")
+            dut_asic.command("counterpoll queue enable")
+            dut_asic.command("sleep 70")
+            dut_asic.command("counterpoll watermark disable")
+            dut_asic.command("counterpoll queue disable")
+
+    @pytest.fixture(scope='class')
+    def dualtor_ports_for_duts(request, get_src_dst_asic_and_duts):
+        # Fetch dual ToR ports
+        logger.info("Starting fetching dual ToR info")
+
+        fetch_dual_tor_ports_script = "\
+            local remap_enabled = redis.call('HGET', 'SYSTEM_DEFAULTS|tunnel_qos_remap', 'status')\
+            if remap_enabled ~= 'enabled' then\
+                return {}\
+            end\
+            local type = redis.call('HGET', 'DEVICE_METADATA|localhost', 'type')\
+            local expected_neighbor_type\
+            local expected_neighbor_suffix\
+            if type == 'LeafRouter' then\
+                expected_neighbor_type = 'ToRRouter'\
+                expected_neighbor_suffix = 'T0'\
+            else\
+                if type == 'ToRRouter' then\
+                    local subtype = redis.call('HGET', 'DEVICE_METADATA|localhost', 'subtype')\
+                    if subtype == 'DualToR' then\
+                        expected_neighbor_type = 'LeafRouter'\
+                        expected_neighbor_suffix = 'T1'\
+                    end\
+                end\
+            end\
+            if expected_neighbor_type == nil then\
+                return {}\
+            end\
+            local result = {}\
+            local all_ports_with_neighbor = redis.call('KEYS', 'DEVICE_NEIGHBOR|*')\
+            for i = 1, #all_ports_with_neighbor, 1 do\
+                local neighbor = redis.call('HGET', all_ports_with_neighbor[i], 'name')\
+                if neighbor ~= nil and string.sub(neighbor, -2, -1) == expected_neighbor_suffix then\
+                    local peer_type = redis.call('HGET', 'DEVICE_NEIGHBOR_METADATA|' .. neighbor, 'type')\
+                    if peer_type == expected_neighbor_type then\
+                        table.insert(result, string.sub(all_ports_with_neighbor[i], 17, -1))\
+                    end\
+                end\
+            end\
+            return result\
+        "
+
+        duthost = get_src_dst_asic_and_duts['src_dut']
+
+        dualtor_ports_str = get_src_dst_asic_and_duts['src_asic'].run_redis_cmd(
+            argv=["sonic-db-cli", "CONFIG_DB", "eval", fetch_dual_tor_ports_script, "0"])
+        if dualtor_ports_str:
+            dualtor_ports_set = set(dualtor_ports_str)
+        else:
+            dualtor_ports_set = set({})
+
+        logger.info("Finish fetching dual ToR info {}".format(dualtor_ports_set))
+
+        return dualtor_ports_set

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -88,7 +88,7 @@ class QosBase:
                             dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
                             break
 
-            pytest_assert(dut_test_params["basicParams"]["def_vlan_mac"] is not None,
+            pytest_assert(dut_test_params_qos["basicParams"]["def_vlan_mac"] is not None,
                           "Dual-TOR miss default VLAN MAC address")
         else:
             try:
@@ -456,7 +456,7 @@ class QosSaiBase(QosBase):
         return dutPortIps
 
     @pytest.fixture(scope='class')
-    def swapSyncd_on_selected_duts(self, request, duthosts, get_src_dst_asic_and_duts, creds, tbinfo, lower_tor_host):
+    def swapSyncd_on_selected_duts(self, request, duthosts, get_src_dst_asic_and_duts, creds, tbinfo, lower_tor_host): # noqa F811
         """
             Swap syncd on DUT host
 
@@ -488,7 +488,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', name="select_src_dst_dut_and_asic",
                     params=("single_asic", "single_dut_multi_asic", "multi_dut"))
-    def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo, lower_tor_host):
+    def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo, lower_tor_host): # noqa F811
         test_port_selection_criteria = request.param
         logger.info("test_port_selection_criteria is {}".format(test_port_selection_criteria))
         src_dut_index = 0
@@ -530,7 +530,8 @@ class QosSaiBase(QosBase):
                     logger.info("Using dut {} for single_dut_multi_asic testing".format(a_dut.hostname))
                     break
             if not found_multi_asic_dut:
-                pytest.skip("Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
+                pytest.skip(
+                    "Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests")
         else:
             # Dealing with multi-dut
             if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(duthost):
@@ -554,7 +555,7 @@ class QosSaiBase(QosBase):
         }
 
     @pytest.fixture(scope='class')
-    def get_src_dst_asic_and_duts(self, duthosts, tbinfo, select_src_dst_dut_and_asic, lower_tor_host):
+    def get_src_dst_asic_and_duts(self, duthosts, tbinfo, select_src_dst_dut_and_asic, lower_tor_host): # noqa F811
         if 'dualtor' in tbinfo['topo']['name']:
             src_dut = lower_tor_host
             dst_dut = lower_tor_host
@@ -584,7 +585,8 @@ class QosSaiBase(QosBase):
         rtn_dict.update(select_src_dst_dut_and_asic)
         yield rtn_dict
 
-    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts):
+    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids,
+                         dst_port_ids, get_src_dst_asic_and_duts):
         """
             Build map of test ports index and IPs
 
@@ -659,18 +661,18 @@ class QosSaiBase(QosBase):
         srcPort = srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]
         srcVlan = src_test_port_ips[srcPort]['vlan_id'] if 'vlan_id' in src_test_port_ips[srcPort] else None
         return {
-            "dst_port_id": dstPort,
-            "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
-            "dst_port_vlan": dstVlan,
-            "dst_port_2_id": dstPort2,
-            "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
-            "dst_port_2_vlan": dstVlan2,
-            'dst_port_3_id': dstPort3,
-            "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
-            "dst_port_3_vlan": dstVlan3,
-            "src_port_id": srcPort,
-            "src_port_ip": src_test_port_ips[srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]]["peer_addr"],
-            "src_port_vlan": srcVlan
+         "dst_port_id": dstPort,
+         "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
+         "dst_port_vlan": dstVlan,
+         "dst_port_2_id": dstPort2,
+         "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
+         "dst_port_2_vlan": dstVlan2,
+         'dst_port_3_id': dstPort3,
+         "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
+         "dst_port_3_vlan": dstVlan3,
+         "src_port_id": srcPort,
+         "src_port_ip": src_test_port_ips[srcPorts[0] if src_port_ids else src_test_port_ids[srcPorts[0]]]["peer_addr"],
+         "src_port_vlan": srcVlan
         }
 
     @pytest.fixture(scope='class', autouse=True)
@@ -937,7 +939,8 @@ class QosSaiBase(QosBase):
         dutinterfaces = {}
 
         if tbinfo["topo"]["type"] == "t2":
-            #dutportIps={0: {0: {0: {'peer_addr': u'10.0.0.1', 'port': u'Ethernet8'}, 2: {'peer_addr': u'10.0.0.5', 'port': u'Ethernet17'}}}}
+            # dutportIps={0: {0: {0: {'peer_addr': u'10.0.0.1', 'port': u'Ethernet8'},
+            # 2: {'peer_addr': u'10.0.0.5', 'port': u'Ethernet17'}}}}
             # { 0: 'Ethernet8', 2: 'Ethernet17' }
             for dut_index, dut_val in dutPortIps.items():
                 for asic_index, asic_val in dut_val.items():
@@ -963,7 +966,7 @@ class QosSaiBase(QosBase):
         }
 
     @pytest.fixture(scope='class')
-    def ssh_tunnel_to_syncd_rpc(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
+    def ssh_tunnel_to_syncd_rpc(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host): # noqa F811
         all_asics = get_src_dst_asic_and_duts['all_asics']
 
         for a_asic in all_asics:
@@ -975,7 +978,7 @@ class QosSaiBase(QosBase):
             a_asic.remove_ssh_tunnel_sai_rpc()
 
     @pytest.fixture(scope='class')
-    def updateIptables(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host):
+    def updateIptables(self, duthosts, get_src_dst_asic_and_duts, swapSyncd_on_selected_duts, tbinfo, lower_tor_host): # noqa F811
         """
             Update iptables on DUT host with drop rule for BGP SYNC packets
 
@@ -1006,7 +1009,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class')
     def stopServices(
         self, duthosts, get_src_dst_asic_and_duts,
-        swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status,
+        swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status, # noqa F811
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports):  # noqa F811
         """
             Stop services (lldp-syncs, lldpd, bgpd) on DUT host prior to test start
@@ -1063,8 +1066,8 @@ class QosSaiBase(QosBase):
                 lower_tor_host.shell("sudo cp {} {}".format(file, backup_file))
                 lower_tor_host.shell("sudo rm {}".format(file))
                 lower_tor_host.shell("sudo touch {}".format(file))
-            except:
-                pytest.skip('file {} not found'.format(file))
+            except Exception as e:
+                pytest.skip('file {} not found. Exception {}'.format(file, str(e)))
 
             duthost_upper.shell('sudo config feature state mux disabled')
             lower_tor_host.shell('sudo config feature state mux disabled')
@@ -1115,8 +1118,8 @@ class QosSaiBase(QosBase):
                 lower_tor_host.shell("sudo cp {} {}".format(backup_file, file))
                 lower_tor_host.shell("sudo chmod +x {}".format(file))
                 lower_tor_host.shell("sudo rm {}".format(backup_file))
-            except:
-                pytest.skip('file {} not found'.format(backup_file))
+            except Exception as e:
+                pytest.skip('file {} not found. Exception {}'.format(backup_file, str(e)))
 
             lower_tor_host.shell('sudo config feature state mux enabled')
             lower_tor_host.shell('sudo config feature state mux enabled')
@@ -1204,8 +1207,8 @@ class QosSaiBase(QosBase):
             try:
                 sonic_cfgen_cmd = 'sonic-cfggen {} -d --var-json "VLAN_INTERFACE"'.format(a_asic.cli_ns_option)
                 vlanInterface = json.loads(duthost.shell(sonic_cfgen_cmd)['stdout'])
-            except:
-                logger.info('Failed to read vlan interface config')
+            except Exception as e:
+                logger.info('Failed to read vlan interface config. Excpetion {}'.format(str(e)))
             if not vlanInterface:
                 return
             for key, value in vlanInterface.items():
@@ -1237,7 +1240,7 @@ class QosSaiBase(QosBase):
         self, duthosts, get_src_dst_asic_and_duts,
         dutConfig, ingressLosslessProfile, ingressLossyProfile,
         egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
-        tbinfo, lower_tor_host
+        tbinfo, lower_tor_host # noqa F811
     ):
         """
             Prepares DUT host QoS configuration
@@ -1452,7 +1455,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
         self, duthosts, get_src_dst_asic_and_duts,
-        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host
+        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host # noqa F811
     ):
         """
             Update ARP entries of QoS SAI test ports
@@ -1496,7 +1499,7 @@ class QosSaiBase(QosBase):
             )
 
     @pytest.fixture(scope='class', autouse=True)
-    def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host):
+    def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host): # noqa F811
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
@@ -1507,8 +1510,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(
-        self, request, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
-    ):
+        self, request, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host): # noqa F811
         """
             Retreives shared headroom pool size
 
@@ -1527,7 +1529,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLosslessProfile(
-        self, request, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
+        self, request, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts # noqa F811
     ):
         """
             Retreives ingress lossless profile
@@ -1563,7 +1565,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def ingressLossyProfile(
-        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host # noqa F811
     ):
         """
             Retreives ingress lossy profile
@@ -1591,7 +1593,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLosslessProfile(
-        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts # noqa F811
     ):
         """
             Retreives egress lossless profile
@@ -1627,7 +1629,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def egressLossyProfile(
-        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts
+        self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host, dualtor_ports_for_duts # noqa F811
     ):
         """
             Retreives egress lossy profile
@@ -1663,7 +1665,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def losslessSchedProfile(
-            self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+            self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host  # noqa F811
     ):
         """
             Retreives lossless scheduler profile
@@ -1686,7 +1688,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def lossySchedProfile(
-        self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host
+        self, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host  # noqa F811
     ):
         """
             Retreives lossy scheduler profile
@@ -1709,7 +1711,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture
     def updateSchedProfile(
         self, duthosts, get_src_dst_asic_and_duts,
-        dutQosConfig, losslessSchedProfile, lossySchedProfile, tbinfo, lower_tor_host
+        dutQosConfig, losslessSchedProfile, lossySchedProfile, tbinfo, lower_tor_host  # noqa F811
     ):
         """
             Updates lossless/lossy scheduler profiles
@@ -1778,7 +1780,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture
     def resetWatermark(
-        self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host
+        self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host   # noqa F811
     ):
         """
             Reset queue watermark
@@ -1839,7 +1841,7 @@ class QosSaiBase(QosBase):
             return result\
         "
 
-        duthost = get_src_dst_asic_and_duts['src_dut']
+        duthost = get_src_dst_asic_and_duts['src_dut']  # noqa F841
 
         dualtor_ports_str = get_src_dst_asic_and_duts['src_asic'].run_redis_cmd(
             argv=["sonic-db-cli", "CONFIG_DB", "eval", fetch_dual_tor_ports_script, "0"])

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -51,13 +51,15 @@ PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer):
-    """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_attribute:1920 updating switch mac addr failed with error -2"""
+    """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_
+       attribute:1920 updating switch mac addr failed with error -2"""
     ignore_regex = [
         ".*ERR syncd[0-9]*#syncd.*brcm_sai_set_switch_attribute.*updating switch mac addr failed with error.*"
     ]
     if loganalyzer:
         for a_dut in get_src_dst_asic_and_duts['all_duts']:
             loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex)
+
 
 class TestQosSai(QosSaiBase):
     """TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.
@@ -148,7 +150,7 @@ class TestQosSai(QosSaiBase):
             portNumbers = []
             portIds = []
             for idName in qosParams.keys():
-                if re.match('(?:src|dst)_port\S+ids?', idName):
+                if re.match(r'(?:src|dst)_port\S+ids?', idName):
                     portIdNames.append(idName)
                     ids = qosParams[idName]
                     if isinstance(ids, list):
@@ -640,7 +642,8 @@ class TestQosSai(QosSaiBase):
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
 
-        if ('platform_asic' in dutTestParams["basicParams"] and dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+        if ('platform_asic' in dutTestParams["basicParams"] and
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
             # Need to adjust hdrm_pool_size src_port_ids, dst_port_id and pgs_num based on how many source and dst ports
             # present
             src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
@@ -667,7 +670,8 @@ class TestQosSai(QosSaiBase):
             "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr']
                              for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip":
+                testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
@@ -842,9 +846,11 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
             "pgs": qosConfig["hdrm_pool_size"]["pgs"],
             "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
-            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr']
+                             for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip":
+                testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
@@ -1095,7 +1101,7 @@ class TestQosSai(QosSaiBase):
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
-        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps # noqa F811
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1114,7 +1120,7 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         # Skip the regular dscp to pg mapping test. Will run another test case instead.
-        duthost = get_src_dst_asic_and_duts['src_dut']
+        duthost = get_src_dst_asic_and_duts['src_dut']    # noqa F841
         if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is applied")
@@ -1627,7 +1633,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDscpToPgMapping(
-        self, get_src_dst_asic_and_duts, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
+        self, get_src_dst_asic_and_duts, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps  # noqa F811
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1115,7 +1115,7 @@ class TestQosSai(QosSaiBase):
         """
         # Skip the regular dscp to pg mapping test. Will run another test case instead.
         duthost = get_src_dst_asic_and_duts['src_dut']
-        if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+        if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is applied")
 
@@ -1166,7 +1166,7 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         # Only run this test on T1 testbed when separated DSCP_TO_TC_MAP is defined
-        if not separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+        if not separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is not applied")
         if "dualtor" in dutTestParams['topo']:
@@ -1653,7 +1653,7 @@ class TestQosSai(QosSaiBase):
         if disableTest:
             pytest.skip("DSCP to PG mapping test disabled")
         # Skip the regular dscp to pg mapping test. Will run another test case instead.
-        if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+        if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is applied")
 
@@ -1702,7 +1702,7 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if not separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+        if not separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is not applied")
         if "dualtor" in dutTestParams['topo']:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -50,18 +50,14 @@ PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
-    """
-    ignore the syslog ERR syncd0#syncd:
-    [03:00.0] brcm_sai_set_switch_attribute:1920 updating switch mac addr failed with error -2
-    """
+def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer):
+    """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_attribute:1920 updating switch mac addr failed with error -2"""
     ignore_regex = [
         ".*ERR syncd[0-9]*#syncd.*brcm_sai_set_switch_attribute.*updating switch mac addr failed with error.*"
     ]
     if loganalyzer:
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(
-            ignore_regex)
-
+        for a_dut in get_src_dst_asic_and_duts['all_duts']:
+            loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex)
 
 class TestQosSai(QosSaiBase):
     """TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.
@@ -118,10 +114,18 @@ class TestQosSai(QosSaiBase):
 
         return True
 
-    def updateTestPortIdIp(self, dutConfig, qosParams=None):
+    def updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts, qosParams=None):
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        src_testPortIds = dutConfig["testPortIds"][src_dut_index][src_asic_index]
+        dst_testPortIds = dutConfig["testPortIds"][dst_dut_index][dst_asic_index]
+        testPortIds = src_testPortIds + list(set(dst_testPortIds) - set(src_testPortIds))
 
         portIdNames = []
         portIds = []
+
         for idName in dutConfig["testPorts"]:
             if re.match(r'(?:src|dst)_port\S+id', idName):
                 portIdNames.append(idName)
@@ -129,19 +133,22 @@ class TestQosSai(QosSaiBase):
                 pytest_assert(
                     ipName in dutConfig["testPorts"], 'Not find {} for {} in dutConfig'.format(ipName, idName))
                 portIds.append(dutConfig["testPorts"][idName])
-        pytest_assert(self.replaceNonExistentPortId(
-            dutConfig["testPortIds"], portIds), "No enough test ports")
+        pytest_assert(self.replaceNonExistentPortId(testPortIds, set(portIds)), "No enough test ports")
         for idx, idName in enumerate(portIdNames):
             dutConfig["testPorts"][idName] = portIds[idx]
             ipName = idName.replace('id', 'ip')
-            dutConfig["testPorts"][ipName] = dutConfig["testPortIps"][portIds[idx]]['peer_addr']
+            if 'src' in ipName:
+                testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+            else:
+                testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
+            dutConfig["testPorts"][ipName] = testPortIps[portIds[idx]]['peer_addr']
 
         if qosParams is not None:
             portIdNames = []
             portNumbers = []
             portIds = []
-            for idName in list(qosParams.keys()):
-                if re.match(r'(?:src|dst)_port\S+ids?', idName):
+            for idName in qosParams.keys():
+                if re.match('(?:src|dst)_port\S+ids?', idName):
                     portIdNames.append(idName)
                     ids = qosParams[idName]
                     if isinstance(ids, list):
@@ -152,8 +159,7 @@ class TestQosSai(QosSaiBase):
                         portIds.append(ids)
                         # record None to indicate it's just one port
                         portNumbers.append(None)
-            pytest_assert(self.replaceNonExistentPortId(
-                dutConfig["testPortIds"], portIds), "No enough test ports")
+            pytest_assert(self.replaceNonExistentPortId(testPortIds, portIds), "No enough test ports")
             startPos = 0
             for idx, idName in enumerate(portIdNames):
                 if portNumbers[idx] is not None:    # port list
@@ -165,17 +171,18 @@ class TestQosSai(QosSaiBase):
                     startPos += 1
 
     def testParameter(
-        self, duthost, dutConfig, dutQosConfig, ingressLosslessProfile,
-        ingressLossyProfile, egressLosslessProfile, dualtor_ports           # noqa F811
+        self, duthosts, get_src_dst_asic_and_duts, dutConfig, dutQosConfig, ingressLosslessProfile,
+        ingressLossyProfile, egressLosslessProfile, dualtor_ports_for_duts
     ):
-        logger.info("asictype {}".format(duthost.facts["asic_type"]))
+        logger.info("asictype {}".format(get_src_dst_asic_and_duts['src_dut'].facts["asic_type"]))
         logger.info("config {}".format(dutConfig))
         logger.info("qosConfig {}".format(dutQosConfig))
-        logger.info("dualtor_ports {}".format(dualtor_ports))
+        logger.info("dualtor_ports {}".format(dualtor_ports_for_duts))
 
     @pytest.mark.parametrize("xoffProfile", ["xoff_1", "xoff_2", "xoff_3", "xoff_4"])
     def testQosSaiPfcXoffLimit(
-        self, xoffProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, xoffProfile, duthosts, get_src_dst_asic_and_duts,
+        ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLosslessProfile
     ):
         """
@@ -208,7 +215,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -324,7 +331,7 @@ class TestQosSai(QosSaiBase):
             testParams["cell_size"] = qosConfig[xonProfile]["cell_size"]
 
         # Params required for generating a PFC Storm
-        duthost = dutConfig["dutInstance"]
+        duthost = dutConfig["srcDutInstance"]
         pfcwd_timers = set_pfc_timers()
         pfcwd_test_port_id = dutConfig["testPorts"]["src_port_id"]
         pfcwd_test_port = dutConfig["dutInterfaces"][pfcwd_test_port_id]
@@ -434,7 +441,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
-        self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
     ):
         """
@@ -469,7 +476,7 @@ class TestQosSai(QosSaiBase):
             else:
                 qosConfig = dutQosConfig["param"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         dst_port_count = set([
             dutConfig["testPorts"]["dst_port_id"],
@@ -530,8 +537,8 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LosslessVoqProfile", ["lossless_voq_1", "lossless_voq_2",
                              "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
-            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig,
-            dutQosConfig, singleMemberPortStaticRoute, nearbySourcePorts
+            self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+            singleMemberPortStaticRoute, nearbySourcePorts, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -554,12 +561,15 @@ class TestQosSai(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
-        self.updateTestPortIdIp(dutConfig, qosConfig[LosslessVoqProfile])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LosslessVoqProfile])
 
         dst_port_id, dst_port_ip = singleMemberPortStaticRoute
         src_port_1_id, src_port_2_id = nearbySourcePorts
 
-        testPortIps = dutConfig["testPortIps"]
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({
@@ -593,7 +603,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiHeadroomPoolSize(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
     ):
         """
@@ -625,7 +635,26 @@ class TestQosSai(QosSaiBase):
             qosConfig['hdrm_pool_size']['pgs'] = qosConfig['hdrm_pool_size']['pgs'][:2]
             qosConfig['hdrm_pool_size']['dscps'] = qosConfig['hdrm_pool_size']['dscps'][:2]
 
-        self.updateTestPortIdIp(dutConfig, qosConfig["hdrm_pool_size"])
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+
+        if ('platform_asic' in dutTestParams["basicParams"] and dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+            # Need to adjust hdrm_pool_size src_port_ids, dst_port_id and pgs_num based on how many source and dst ports
+            # present
+            src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
+            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+                # Src and dst are the same asics, leave one for dst port and the rest for src ports
+                qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
+                qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
+                qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+            else:
+                qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
+                qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
+                qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -635,9 +664,10 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
             "pgs": qosConfig["hdrm_pool_size"]["pgs"],
             "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
-            "src_port_ips": [testPortIps[port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr']
+                             for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
@@ -675,7 +705,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("sharedResSizeKey", ["shared_res_size_1", "shared_res_size_2"])
     def testQosSaiSharedReservationSize(
-        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig
+        self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI shared reservation size
@@ -693,7 +723,12 @@ class TestQosSai(QosSaiBase):
         """
 
         qosConfig = dutQosConfig["param"]
-        testPortIps = dutConfig["testPortIps"]
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        src_testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+        dst_testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
 
         if sharedResSizeKey not in list(qosConfig.keys()):
             pytest.skip(
@@ -703,14 +738,13 @@ class TestQosSai(QosSaiBase):
             # Skip if buffer pools and profiles are not be present, marked by qos param generator
             pytest.skip(qosConfig[sharedResSizeKey]["skip"])
 
-        self.updateTestPortIdIp(dutConfig, qosConfig[sharedResSizeKey])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[sharedResSizeKey])
 
-        port_idx_to_id = list(testPortIps.keys())
+        src_port_idx_to_id = list(src_testPortIps.keys())
+        dst_port_idx_to_id = list(dst_testPortIps.keys())
         # Translate requested port indices to available port IDs
-        src_port_ids = [port_idx_to_id[idx]
-                        for idx in qosConfig[sharedResSizeKey]["src_port_i"]]
-        dst_port_ids = [port_idx_to_id[idx]
-                        for idx in qosConfig[sharedResSizeKey]["dst_port_i"]]
+        src_port_ids = [src_port_idx_to_id[idx] for idx in qosConfig[sharedResSizeKey]["src_port_i"]]
+        dst_port_ids = [dst_port_idx_to_id[idx] for idx in qosConfig[sharedResSizeKey]["dst_port_i"]]
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -721,9 +755,9 @@ class TestQosSai(QosSaiBase):
             "pgs": qosConfig[sharedResSizeKey]["pgs"],
             "queues": qosConfig[sharedResSizeKey]["queues"],
             "src_port_ids": src_port_ids,
-            "src_port_ips": [testPortIps[port]['peer_addr'] for port in src_port_ids],
+            "src_port_ips": [src_testPortIps[port]['peer_addr'] for port in src_port_ids],
             "dst_port_ids": dst_port_ids,
-            "dst_port_ips": [testPortIps[port]['peer_addr'] for port in dst_port_ids],
+            "dst_port_ips": [dst_testPortIps[port]['peer_addr'] for port in dst_port_ids],
             "pkt_counts":  qosConfig[sharedResSizeKey]["pkt_counts"],
             "shared_limit_bytes": qosConfig[sharedResSizeKey]["shared_limit_bytes"],
             "hwsku": dutTestParams['hwsku']
@@ -749,7 +783,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiHeadroomPoolWatermark(
-        self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,  ptfhost, dutTestParams,
+        self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
         resetWatermark
     ):
@@ -774,9 +808,8 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        cmd_output = duthost.shell(
-            "show headroom-pool watermark", module_ignore_errors=True)
+        duthost = get_src_dst_asic_and_duts['src_dut']
+        cmd_output = duthost.shell("show headroom-pool watermark", module_ignore_errors=True)
         if cmd_output['rc'] != 0:
             pytest.skip("Headroom pool watermark is not supported")
 
@@ -786,6 +819,21 @@ class TestQosSai(QosSaiBase):
         if 'hdrm_pool_size' not in list(qosConfig.keys()):
             pytest.skip("Headroom pool size is not enabled on this DUT")
 
+        src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
+        dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
+        src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+        src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
+        if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+            # Src and dst are the same asics, leave one for dst port and the rest for src ports
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+        else:
+            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
+            qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
+            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({
@@ -794,9 +842,9 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
             "pgs": qosConfig["hdrm_pool_size"]["pgs"],
             "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
-            "src_port_ips": [testPortIps[port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "src_port_ips": [testPortIps[src_dut_index][src_asic_index][port]['peer_addr'] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
             "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
-            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
+            "dst_port_ip": testPortIps[dst_dut_index][dst_asic_index][qosConfig["hdrm_pool_size"]["dst_port_id"]]['peer_addr'],
             "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
@@ -828,7 +876,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
-        self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, request, get_src_dst_asic_and_duts, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLossyProfile, resetWatermark,
     ):
         """
@@ -904,7 +952,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiLossyQueue(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
         ingressLossyProfile
     ):
         """
@@ -930,7 +978,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -975,7 +1023,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute
+            ingressLossyProfile, duthost, localhost, singleMemberPortStaticRoute, get_src_dst_asic_and_duts
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -1006,7 +1054,7 @@ class TestQosSai(QosSaiBase):
             setup_markings_dut(duthost, localhost,
                                voq_allocation_mode="default")
 
-        self.updateTestPortIdIp(dutConfig, qosConfig[LossyVoq])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LossyVoq])
 
         try:
             dst_port_id, dst_port_ip = singleMemberPortStaticRoute
@@ -1047,7 +1095,7 @@ class TestQosSai(QosSaiBase):
                 setup_markings_dut(duthost, localhost, **original_voq_markings)
 
     def testQosSaiDscpQueueMapping(
-        self, duthost, ptfhost, dutTestParams, dutConfig, dut_qos_maps      # noqa F811
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1066,11 +1114,12 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         # Skip the regular dscp to pg mapping test. Will run another test case instead.
+        duthost = get_src_dst_asic_and_duts['src_dut']
         if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
             pytest.skip(
                 "Skip this test since separated DSCP_TO_TC_MAP is applied")
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1233,7 +1282,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDwrr(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
+        self, ptfhost, duthosts, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
     ):
         """
             Test QoS SAI DWRR
@@ -1258,9 +1307,10 @@ class TestQosSai(QosSaiBase):
             qosConfigWrr = qosConfig[portSpeedCableLength]["wrr"]
         else:
             qosConfigWrr = qosConfig["wrr"]
+        duthost = get_src_dst_asic_and_duts['src_dut']
         qos_remap_enable = is_tunnel_qos_remap_enabled(duthost)
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1301,7 +1351,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
-        self, pgProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
         resetWatermark
     ):
         """
@@ -1339,7 +1389,7 @@ class TestQosSai(QosSaiBase):
             pktsNumFillShared = int(
                 qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1383,7 +1433,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPgHeadroomWatermark(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig, resetWatermark,
     ):
         """
             Test QoS SAI PG headroom watermark test
@@ -1408,7 +1458,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1501,7 +1551,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
-        self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         resetWatermark
     ):
         """
@@ -1537,7 +1587,7 @@ class TestQosSai(QosSaiBase):
                 qosConfig = dutQosConfig["param"]
             triggerDrop = qosConfig[queueProfile]["pkts_num_trig_egr_drp"]
 
-        self.updateTestPortIdIp(dutConfig)
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1577,7 +1627,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDscpToPgMapping(
-        self, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps     # noqa F401
+        self, get_src_dst_asic_and_duts, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -1613,7 +1663,7 @@ class TestQosSai(QosSaiBase):
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
-            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"]
         })
 
         if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000':
@@ -1691,7 +1741,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiDwrrWeightChange(
-        self, ptfhost, duthost, dutTestParams, dutConfig, dutQosConfig,
+        self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         updateSchedProfile
     ):
         """
@@ -1719,6 +1769,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfigWrrChg = qosConfig["wrr_chg"]
 
+        duthost = get_src_dst_asic_and_duts['src_dut']
         qos_remap_enable = is_tunnel_qos_remap_enabled(duthost)
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -9,7 +9,7 @@ from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_garp_service          # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode  # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import separated_dscp_to_tc_map_on_uplink
@@ -43,7 +43,7 @@ DUMMY_MAC = "aa:aa:aa:aa:aa:aa"
 VLAN_MAC = "00:aa:bb:cc:dd:ee"
 DEFAULT_RPC_PORT = "9092"
 
-PFC_PKT_COUNT = 10000000 # Cost 32 seconds
+PFC_PKT_COUNT = 10000000  # Cost 32 seconds
 PFC_PAUSE_TEST_RETRY_MAX = 5
 
 
@@ -234,8 +234,8 @@ def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_du
     3. Build regular packet with dst_ip = dummy IP (routed by default route)
     4. Ingress the packet from downlink port, verify the packets egressed from expected queue
     """
-    pytest_require(separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module), 
-                    "Skip test because separated QoS map is not applied")
+    pytest_require(separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module),
+                   "Skip test because separated QoS map is not applied")
     dualtor_meta = dualtor_info(ptfhost, rand_unselected_dut, rand_selected_dut, tbinfo)
     t1_ports = get_t1_active_ptf_ports(rand_selected_dut, tbinfo)
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
@@ -389,10 +389,10 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
         peer_info = leaf_fanout_peer_info(
             rand_selected_dut, conn_graph_facts, mg_facts, actual_port)
         storm_handler = PFCStorm(rand_selected_dut, fanout_graph_facts, fanouthosts,
-                                    pfc_queue_idx=prio,
-                                    pfc_frames_number=PFC_PKT_COUNT,
-                                    peer_info=peer_info)
-        
+                                 pfc_queue_idx=prio,
+                                 pfc_frames_number=PFC_PKT_COUNT,
+                                 peer_info=peer_info)
+
         retry = 0
         while retry < PFC_PAUSE_TEST_RETRY_MAX:
             try:
@@ -410,6 +410,7 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
                     pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
                         queue, actual_port_name))
             time.sleep(5)
+
 
 def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
     """
@@ -456,9 +457,9 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
         peer_info = leaf_fanout_peer_info(
             rand_selected_dut, conn_graph_facts, mg_facts, dualtor_meta['target_server_port'])
         storm_handler = PFCStorm(rand_selected_dut, fanout_graph_facts, fanouthosts,
-                                    pfc_queue_idx=prio,
-                                    pfc_frames_number=PFC_PKT_COUNT,
-                                    peer_info=peer_info)
+                                 pfc_queue_idx=prio,
+                                 pfc_frames_number=PFC_PKT_COUNT,
+                                 peer_info=peer_info)
         dst_ports = dualtor_meta['target_server_port']
         if not isinstance(dualtor_meta['target_server_port'], list):
             dst_ports = [dualtor_meta['target_server_port']]
@@ -511,21 +512,21 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
     tunnel_qos_map = load_tunnel_qos_map(asic_name=asic)
     test_params = dict()
     test_params.update({
-            "src_port_id": dut_config["lag_port_ptf_id"],
-            "dst_port_id": dut_config["server_port_ptf_id"],
-            "dst_port_ip": dut_config["server_ip"],
-            "active_tor_mac": dut_config["selected_tor_mac"],
-            "active_tor_ip": dut_config["selected_tor_loopback"],
-            "standby_tor_mac": dut_config["unselected_tor_mac"],
-            "standby_tor_ip": dut_config["unselected_tor_loopback"],
-            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
-            "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
-            "port_map_file_ini": dut_config["port_map_file_ini"],
-            "sonic_asic_type": dut_config["asic_type"],
-            "platform_asic": dut_config["platform_asic"],
-            "cell_size": cell_size
-        })
-    
+        "src_port_id": dut_config["lag_port_ptf_id"],
+        "dst_port_id": dut_config["server_port_ptf_id"],
+        "dst_port_ip": dut_config["server_ip"],
+        "active_tor_mac": dut_config["selected_tor_mac"],
+        "active_tor_ip": dut_config["selected_tor_loopback"],
+        "standby_tor_mac": dut_config["unselected_tor_mac"],
+        "standby_tor_ip": dut_config["unselected_tor_loopback"],
+        "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
+        "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
+        "port_map_file_ini": dut_config["port_map_file_ini"],
+        "sonic_asic_type": dut_config["asic_type"],
+        "platform_asic": dut_config["platform_asic"],
+        "cell_size": cell_size
+    })
+
     run_ptf_test(
         ptfhost,
         test_case="sai_qos_tests.TunnelDscpToPgMapping",
@@ -550,18 +551,18 @@ def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_
     time.sleep(5)
     test_params = dict()
     test_params.update({
-            "src_port_id": dut_config["lag_port_ptf_id"],
-            "dst_port_id": dut_config["server_port_ptf_id"],
-            "dst_port_ip": dut_config["server_ip"],
-            "active_tor_mac": dut_config["selected_tor_mac"],
-            "active_tor_ip": dut_config["selected_tor_loopback"],
-            "standby_tor_mac": dut_config["unselected_tor_mac"],
-            "standby_tor_ip": dut_config["unselected_tor_loopback"],
-            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
-            "port_map_file_ini": dut_config["port_map_file_ini"],
-            "platform_asic": dut_config["platform_asic"],
-            "sonic_asic_type": dut_config["asic_type"],
-        })
+        "src_port_id": dut_config["lag_port_ptf_id"],
+        "dst_port_id": dut_config["server_port_ptf_id"],
+        "dst_port_ip": dut_config["server_ip"],
+        "active_tor_mac": dut_config["selected_tor_mac"],
+        "active_tor_ip": dut_config["selected_tor_loopback"],
+        "standby_tor_mac": dut_config["unselected_tor_mac"],
+        "standby_tor_ip": dut_config["unselected_tor_loopback"],
+        "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
+        "port_map_file_ini": dut_config["port_map_file_ini"],
+        "platform_asic": dut_config["platform_asic"],
+        "sonic_asic_type": dut_config["asic_type"],
+    })
     if dut_config["asic_type"] == 'mellanox':
         test_params.update({'cell_size': 144, 'packet_size': 300})
     # Update qos config into test_params

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -4,15 +4,14 @@ import sys
 import time
 from ptf.mask import Mask
 import ptf.packet as scapy
-
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_saitests_directory     # noqa F401
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder          # noqa F401
-from tests.common.fixtures.ptfhost_utils import run_garp_service            # noqa F401
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
-from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module     # noqa F401
-from tests.common.fixtures.duthost_utils import dut_qos_maps                # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_garp_service          # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # lgtm[py/unused-import]
+from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import separated_dscp_to_tc_map_on_uplink
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 
@@ -42,8 +41,9 @@ SERVER_IP = "192.168.0.2"
 DUMMY_IP = "1.1.1.1"
 DUMMY_MAC = "aa:aa:aa:aa:aa:aa"
 VLAN_MAC = "00:aa:bb:cc:dd:ee"
+DEFAULT_RPC_PORT = "9092"
 
-PFC_PKT_COUNT = 10000000  # Cost 32 seconds
+PFC_PKT_COUNT = 10000000 # Cost 32 seconds
 PFC_PAUSE_TEST_RETRY_MAX = 5
 
 
@@ -225,9 +225,7 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
         counter_poll_config(rand_selected_dut, 'queue', 10000)
 
 
-def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut,
-                                  toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                  tbinfo, ptfadapter, dut_qos_maps):                    # noqa F811
+def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, dut_qos_maps_module):
     """
     The test case is to verify separated DSCP_TO_TC_MAP/TC_TO_QUEUE_MAP on uplink and downlink ports of dualtor
     Test steps
@@ -236,10 +234,9 @@ def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_du
     3. Build regular packet with dst_ip = dummy IP (routed by default route)
     4. Ingress the packet from downlink port, verify the packets egressed from expected queue
     """
-    pytest_require(separated_dscp_to_tc_map_on_uplink(rand_selected_dut, dut_qos_maps),
-                   "Skip test because separated QoS map is not applied")
-    dualtor_meta = dualtor_info(
-        ptfhost, rand_unselected_dut, rand_selected_dut, tbinfo)
+    pytest_require(separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module), 
+                    "Skip test because separated QoS map is not applied")
+    dualtor_meta = dualtor_info(ptfhost, rand_unselected_dut, rand_selected_dut, tbinfo)
     t1_ports = get_t1_active_ptf_ports(rand_selected_dut, tbinfo)
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     portchannel_info = mg_facts['minigraph_portchannels']
@@ -341,9 +338,7 @@ def pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, dut, port, queue,
         stop_pfc_storm(storm_handler)
 
 
-def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
-                                          toggle_all_simulator_ports_to_rand_unselected_tor,            # noqa F811
-                                          tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):    # noqa F811
+def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_unselected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
     Test steps:
@@ -394,10 +389,10 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
         peer_info = leaf_fanout_peer_info(
             rand_selected_dut, conn_graph_facts, mg_facts, actual_port)
         storm_handler = PFCStorm(rand_selected_dut, fanout_graph_facts, fanouthosts,
-                                 pfc_queue_idx=prio,
-                                 pfc_frames_number=PFC_PKT_COUNT,
-                                 peer_info=peer_info)
-
+                                    pfc_queue_idx=prio,
+                                    pfc_frames_number=PFC_PKT_COUNT,
+                                    peer_info=peer_info)
+        
         retry = 0
         while retry < PFC_PAUSE_TEST_RETRY_MAX:
             try:
@@ -416,10 +411,7 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
                         queue, actual_port_name))
             time.sleep(5)
 
-
-def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
-                                         toggle_all_simulator_ports_to_rand_selected_tor,               # noqa F811
-                                         tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):     # noqa F811
+def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
     Test steps:
@@ -464,9 +456,9 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
         peer_info = leaf_fanout_peer_info(
             rand_selected_dut, conn_graph_facts, mg_facts, dualtor_meta['target_server_port'])
         storm_handler = PFCStorm(rand_selected_dut, fanout_graph_facts, fanouthosts,
-                                 pfc_queue_idx=prio,
-                                 pfc_frames_number=PFC_PKT_COUNT,
-                                 peer_info=peer_info)
+                                    pfc_queue_idx=prio,
+                                    pfc_frames_number=PFC_PKT_COUNT,
+                                    peer_info=peer_info)
 
         dst_ports = dualtor_meta['target_server_port']
         if not isinstance(dualtor_meta['target_server_port'], list):
@@ -516,21 +508,21 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
     tunnel_qos_map = load_tunnel_qos_map(asic_name=asic)
     test_params = dict()
     test_params.update({
-        "src_port_id": dut_config["lag_port_ptf_id"],
-        "dst_port_id": dut_config["server_port_ptf_id"],
-        "dst_port_ip": dut_config["server_ip"],
-        "active_tor_mac": dut_config["selected_tor_mac"],
-        "active_tor_ip": dut_config["selected_tor_loopback"],
-        "standby_tor_mac": dut_config["unselected_tor_mac"],
-        "standby_tor_ip": dut_config["unselected_tor_loopback"],
-        "server": dut_config["selected_tor_mgmt"],
-        "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
-        "port_map_file": dut_config["port_map_file"],
-        "sonic_asic_type": dut_config["asic_type"],
-        "platform_asic": dut_config["platform_asic"],
-        "cell_size": cell_size
-    })
-
+            "src_port_id": dut_config["lag_port_ptf_id"],
+            "dst_port_id": dut_config["server_port_ptf_id"],
+            "dst_port_ip": dut_config["server_ip"],
+            "active_tor_mac": dut_config["selected_tor_mac"],
+            "active_tor_ip": dut_config["selected_tor_loopback"],
+            "standby_tor_mac": dut_config["unselected_tor_mac"],
+            "standby_tor_ip": dut_config["unselected_tor_loopback"],
+            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
+            "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
+            "port_map_file_ini": dut_config["port_map_file_ini"],
+            "sonic_asic_type": dut_config["asic_type"],
+            "platform_asic": dut_config["platform_asic"],
+            "cell_size": cell_size
+        })
+    
     run_ptf_test(
         ptfhost,
         test_case="sai_qos_tests.TunnelDscpToPgMapping",
@@ -555,18 +547,18 @@ def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_
     time.sleep(5)
     test_params = dict()
     test_params.update({
-        "src_port_id": dut_config["lag_port_ptf_id"],
-        "dst_port_id": dut_config["server_port_ptf_id"],
-        "dst_port_ip": dut_config["server_ip"],
-        "active_tor_mac": dut_config["selected_tor_mac"],
-        "active_tor_ip": dut_config["selected_tor_loopback"],
-        "standby_tor_mac": dut_config["unselected_tor_mac"],
-        "standby_tor_ip": dut_config["unselected_tor_loopback"],
-        "server": dut_config["selected_tor_mgmt"],
-        "port_map_file": dut_config["port_map_file"],
-        "platform_asic": dut_config["platform_asic"],
-        "sonic_asic_type": dut_config["asic_type"],
-    })
+            "src_port_id": dut_config["lag_port_ptf_id"],
+            "dst_port_id": dut_config["server_port_ptf_id"],
+            "dst_port_ip": dut_config["server_ip"],
+            "active_tor_mac": dut_config["selected_tor_mac"],
+            "active_tor_ip": dut_config["selected_tor_loopback"],
+            "standby_tor_mac": dut_config["unselected_tor_mac"],
+            "standby_tor_ip": dut_config["unselected_tor_loopback"],
+            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
+            "port_map_file_ini": dut_config["port_map_file_ini"],
+            "platform_asic": dut_config["platform_asic"],
+            "sonic_asic_type": dut_config["asic_type"],
+        })
     if dut_config["asic_type"] == 'mellanox':
         test_params.update({'cell_size': 144, 'packet_size': 300})
     # Update qos config into test_params

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -4,14 +4,14 @@ import sys
 import time
 from ptf.mask import Mask
 import ptf.packet as scapy
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_garp_service          # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode  # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # lgtm[py/unused-import]
-from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_garp_service          # noqa F401
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode  # noqa F401
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # noqa F401
+from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # noqa F401
 from tests.common.fixtures.duthost_utils import separated_dscp_to_tc_map_on_uplink
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 
@@ -225,7 +225,8 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
         counter_poll_config(rand_selected_dut, 'queue', 10000)
 
 
-def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, dut_qos_maps_module):
+def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut,
+        toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, dut_qos_maps_module):  # noqa F811
     """
     The test case is to verify separated DSCP_TO_TC_MAP/TC_TO_QUEUE_MAP on uplink and downlink ports of dualtor
     Test steps
@@ -338,7 +339,8 @@ def pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, dut, port, queue,
         stop_pfc_storm(storm_handler)
 
 
-def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_unselected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
+def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
+        toggle_all_simulator_ports_to_rand_unselected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts): # noqa F811
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
     Test steps:
@@ -412,7 +414,8 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
             time.sleep(5)
 
 
-def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
+def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
+        toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts): # noqa F811
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
     Test steps:

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -459,6 +459,9 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
                                     pfc_queue_idx=prio,
                                     pfc_frames_number=PFC_PKT_COUNT,
                                     peer_info=peer_info)
+        dst_ports = dualtor_meta['target_server_port']
+        if not isinstance(dualtor_meta['target_server_port'], list):
+            dst_ports = [dualtor_meta['target_server_port']]
 
         dst_ports = dualtor_meta['target_server_port']
         if not isinstance(dualtor_meta['target_server_port'], list):

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -162,7 +162,10 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     asic_type = duthost.facts["asic_type"]
-    platform_asic = duthost.facts['platform_asic']
+    if 'platform_asic' in duthost.facts:
+        platform_asic = duthost.facts['platform_asic']
+    else:
+        platform_asic = None
     # Always use the first portchannel member
     lag_port_name = list(mg_facts['minigraph_portchannels'].values())[
         0]['members'][0]
@@ -200,7 +203,7 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
         "unselected_tor_mgmt": unselected_tor_mgmt,
         "unselected_tor_mac": unselected_tor_mac,
         "unselected_tor_loopback": unselected_tor_loopback,
-        "port_map_file": ptf_portmap_file_module
+        "port_map_file_ini": ptf_portmap_file_module
     }
 
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -60,6 +60,7 @@ class ThriftInterface(BaseTest):
         else:
             self.dst_server_ip = self.src_server_ip
             dst_server_port = src_server_port
+        self.server = self.dst_server_ip
 
         if "port_map_file" in self.test_params:
             user_input = self.test_params['port_map_file']

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -174,8 +174,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1],"enable wd failed '{}' on asic '{}' on '{}'".format(cmd,
-                            self.src_asic_index, self.src_server_ip)
+            assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(
+                    cmd, self.src_asic_index, self.src_server_ip)
 
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
 
@@ -187,8 +187,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1],"disable wd failed '{}' on asic '{}' on '{}'".format(cmd,
-                            self.src_asic_index, self.src_server_ip)
+            assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(
+                    cmd, self.src_asic_index, self.src_server_ip)
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -174,8 +174,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                                      self.src_server_ip)
+            assert 'Success rv = 0' in stdOut[1],"enable wd failed '{}' on asic '{}' on '{}'".format(cmd,
+                            self.src_asic_index, self.src_server_ip)
 
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
 
@@ -187,8 +187,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                                       self.src_server_ip)
+            assert 'Success rv = 0' in stdOut[1],"disable wd failed '{}' on asic '{}' on '{}'".format(cmd,
+                            self.src_asic_index, self.src_server_ip)
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -41,9 +41,6 @@ class ThriftInterface(BaseTest):
         BaseTest.setUp(self)
 
         self.test_params = testutils.test_params_get()
-        self.platform_asic = self.test_params.get('platform_asic', None)
-        self.src_asic_index = self.test_params.get('src_asic_index', None)
-        self.dst_asic_index = self.test_params.get('dst_asic_index', None)
 
         # server is a list [ <server_ip_for_dut1>, <server_ip_for_dut2>, ... }
         if "src_server" in self.test_params:
@@ -70,8 +67,9 @@ class ThriftInterface(BaseTest):
             with open(user_input) as f:
                 ptf_test_port_map = json.load(f)
                 src_dut_index = self.test_params['src_dut_index']
+                self.src_asic_index = self.test_params.get('src_asic_index', None)
                 dst_dut_index = self.test_params['dst_dut_index']
-
+                self.dst_asic_index = self.test_params.get('dst_asic_index', None)
                 for a_ptf_port, a_ptf_port_info in ptf_test_port_map.items():
                     if src_dut_index in a_ptf_port_info['target_dut'] and \
                             a_ptf_port_info['asic_idx'] == self.src_asic_index:
@@ -106,6 +104,8 @@ class ThriftInterface(BaseTest):
             self.dst_client = switch_sai_rpc.Client(self.dst_protocol)
             self.dst_transport.open()
             self.clients['dst'] = self.dst_client
+
+        self.platform_asic = self.test_params.get('platform_asic', None)
 
     def tearDown(self):
         if config["log_dir"] is not None:

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -51,7 +51,6 @@ class ThriftInterface(BaseTest):
         else:
             self.src_server_ip = 'localhost'
             src_server_port = 9092
-
         if "dst_server" in self.test_params:
             # server has format <server_ip>:<server_port>
             dst_server = self.test_params['dst_server'].strip().split(":")
@@ -81,6 +80,18 @@ class ThriftInterface(BaseTest):
                         if dst_dut_index in a_ptf_port_info['target_dut'] and \
                                 a_ptf_port_info['asic_idx'] == self.dst_asic_index:
                             interface_to_front_mapping['dst'][a_ptf_port] = a_ptf_port_info['dut_port']
+                else:
+                    interface_to_front_mapping['dst'] = interface_to_front_mapping['src']
+        elif "port_map_file_ini" in self.test_params:
+            user_input = self.test_params['port_map_file_ini']
+            interface_to_front_mapping['src'] = {}
+            f = open(user_input, 'r')
+            for line in f:
+                if (len(line) > 0 and (line[0] == '#' or line[0] == ';' or line[0]=='/')):
+                    continue
+                interface_front_pair = line.split("@")
+                interface_to_front_mapping['src'][interface_front_pair[0]] = interface_front_pair[1].strip()
+            f.close()
         else:
             exit("No ptf interface<-> switch front port mapping, please specify as parameter or in external file")
         # dictionary with key 'src' or 'dst'
@@ -163,8 +174,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                            self.src_server_ip))
+            assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+                                                                                            self.src_server_ip)
 
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
 
@@ -176,7 +187,7 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1]), "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+            assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
                                                                                         self.src_server_ip)
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -87,7 +87,7 @@ class ThriftInterface(BaseTest):
             interface_to_front_mapping['src'] = {}
             f = open(user_input, 'r')
             for line in f:
-                if (len(line) > 0 and (line[0] == '#' or line[0] == ';' or line[0]=='/')):
+                if (len(line) > 0 and (line[0] == '#' or line[0] == ';' or line[0] == '/')):
                     continue
                 interface_front_pair = line.split("@")
                 interface_to_front_mapping['src'][interface_front_pair[0]] = interface_front_pair[1].strip()
@@ -175,7 +175,7 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_password'],
                                                             cmd)
             assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                            self.src_server_ip)
+                                                                                                      self.src_server_ip)
 
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
 
@@ -188,8 +188,9 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_password'],
                                                             cmd)
             assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                        self.src_server_ip)
+                                                                                                       self.src_server_ip)
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
+
 
 class ThriftInterfaceDataPlane(ThriftInterface):
     """

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -835,7 +835,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # The inner DSCP is set to testing value,
                 # and the outer DSCP is set to 0 as it has no impact on remapping
                 # On Nvidia platforms, the dscp mode is pipe and the PG is determined by the outer dscp before decap
-                outer_dscp = inner_dscp if asic_type == 'mellanox' else 0
+                outer_dscp = inner_dscp if asic_type == 'mellanox' else 0  # noqa F841
                 pkt = self._build_testing_pkt(
                     active_tor_mac=active_tor_mac,
                     standby_tor_mac=standby_tor_mac,
@@ -1093,7 +1093,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, (pkts_num_egr_mem +
-                                                     pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                                                     pkts_num_leak_out +
+                                                     pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
             elif 'cisco-8000' in asic_type:
                 assert (fill_leakout_plus_one(self, src_port_id, dst_port_id,
                                               pkt, int(self.test_params['pg']), asic_type))
@@ -1121,7 +1122,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(                     # noqa F523
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg]), \
@@ -1176,7 +1177,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(                        # noqa F841
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \
@@ -1203,7 +1204,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
             sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(                           # noqa F841
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \
@@ -1646,9 +1647,9 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
         switch_init(self.clients)
-        last_pfc_counter = 0
-        recv_port_counters = []
-        transmit_port_counters = []
+        last_pfc_counter = 0  # noqa F841
+        recv_port_counters = [] # noqa F841
+        transmit_port_counters = []  # noqa F841
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -2043,8 +2044,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             port_cnt_tbl.add_row(['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
-           # recv port no pfc
-            assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(
+            # recv port no pfc
+            assert(
+                recv_counters[pg] == recv_counters_base[pg]
+                ), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(
                 pg, port_counter_fields[pg], step_id, step_desc)
             # recv port no ingress drop
             for cntr in ingress_counters:
@@ -3365,18 +3368,18 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                         + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
                                         + ['Ing Pg{} Pkt'.format(pg)]
                                         + ['Ing Pg{} Share Wm'.format(pg)])
-        if sport_cntr == None:
+        if sport_cntr is None:
             sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
-        if sport_pg_cntr == None:
+        if sport_pg_cntr is None:
             sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
-        if sport_pg_share_wm == None:
+        if sport_pg_share_wm is None:
             sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
                 self.src_client, asic_type, port_list['src'][src_port_id])
-        if dport_cntr == None:
+        if dport_cntr is None:
             dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
-        if dport_pg_cntr == None:
+        if dport_pg_cntr is None:
             dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
-        if dport_pg_share_wm == None:
+        if dport_pg_share_wm is None:
             dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
         stats_tbl.add_row(['base src port']
@@ -3514,7 +3517,8 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
             if pg_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
                 dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters,
-                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_history, self, src_port_id, pkt, 40)
 
             pg_cntrs = sai_thrift_read_pg_counters(
                 self.src_client, port_list['src'][src_port_id])
@@ -3572,9 +3576,14 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, int(pkts_num))
                 time.sleep(8)
 
-                if pg_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
+                if (
+                    (pg_min_pkts_num == 0)
+                    and (pkts_num <= 1 + margin)
+                    and check_leackout_compensation_support(asic_type, hwsku)
+                ):
                     dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters,
-                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
@@ -3631,7 +3640,8 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
             if platform_asic and platform_asic == "broadcom-dnx":
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
-                    pkts_num, ((expected_wm + cell_occupancy) * (packet_length + internal_hdr_size)), pg_shared_wm_res[pg]), file=sys.stderr)
+                    pkts_num, ((expected_wm + cell_occupancy) * (packet_length + internal_hdr_size)),
+                    pg_shared_wm_res[pg]), file=sys.stderr)
                 assert (expected_wm * (packet_length + internal_hdr_size) <= (
                         expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
             else:
@@ -3740,7 +3750,8 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
             if check_leackout_compensation_support(asic_type, hwsku):
                 dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
-                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_base, self, src_port_id, pkt, 30)
 
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
                 self.src_client, port_list['src'][src_port_id])
@@ -3774,9 +3785,14 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
                     self.src_client, port_list['src'][src_port_id])
 
-                print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size *
-                                                                              cell_occupancy, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size * cell_occupancy)),
-                      file=sys.stderr)
+                print(
+                    "lower bound: %d, actual value: %d, upper bound: %d"
+                    % (
+                        (expected_wm - margin) * cell_size * cell_occupancy,
+                        pg_headroom_wm_res[pg],
+                        ((expected_wm + margin) * cell_size * cell_occupancy)
+                    ),
+                    file=sys.stderr)
 
                 if platform_asic and platform_asic == "broadcom-dnx":
                     logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " +
@@ -3936,17 +3952,17 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                         + ['Ing Pg{} headroom Wm'.format(que)]
                                         + ['Que{} Share Wm'.format(que)])
 
-        if sport_cntr == None:
+        if sport_cntr is None:
             sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
-        if sport_pg_cntr == None:
+        if sport_pg_cntr is None:
             sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         if None in [sport_pg_share_wm, sport_pg_headroom_wm, sport_que_share_wm]:
             sport_que_share_wm, sport_pg_share_wm, sport_pg_headroom_wm = \
                 sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
 
-        if dport_cntr == None:
+        if dport_cntr is None:
             dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
-        if dport_pg_cntr == None:
+        if dport_pg_cntr is None:
             dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
         if None in [dport_pg_share_wm, dport_pg_headroom_wm, dport_que_share_wm]:
             dport_que_share_wm, dport_pg_share_wm, dport_pg_headroom_wm = \
@@ -4165,7 +4181,11 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 time.sleep(8)
 
-                if que_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
+                if(
+                    que_min_pkts_num == 0
+                    and pkts_num <= 1 + margin
+                    and check_leackout_compensation_support(asic_type, hwsku)
+                ):
                     dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
                                                    port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                    xmit_counters_history, self, src_port_id, pkt, 40)
@@ -4178,8 +4198,15 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
-                print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin)
-                                                                              * cell_size, q_wm_res[queue], (expected_wm + margin) * cell_size), file=sys.stderr)
+                print(
+                      "lower bound: %d, actual value: %d, upper bound: %d"
+                      % (
+                            (expected_wm - margin) * cell_size,
+                            q_wm_res[queue],
+                            (expected_wm + margin) * cell_size,
+                      ),
+                      file=sys.stderr,
+                )
 
                 self.show_stats('Fill queue shared', asic_type,
                                 queue, src_port_id, dst_port_id, ingress_counters, egress_counters,
@@ -4389,8 +4416,17 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 time.sleep(8)
                 buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
                     self.src_client, buf_pool_roid) - buffer_pool_wm_base
-                print("lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (lower_bound_margin, (expected_wm - lower_bound_margin)
-                                                                                          * cell_size, buffer_pool_wm, upper_bound_margin, (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
+                print(
+                      "lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d"
+                      % (
+                          lower_bound_margin,
+                          (expected_wm - lower_bound_margin) * cell_size,
+                          buffer_pool_wm,
+                          upper_bound_margin,
+                          (expected_wm + upper_bound_margin) * cell_size,
+                      ),
+                      file=sys.stderr,
+                )
                 assert(buffer_pool_wm <= (expected_wm +
                                           upper_bound_margin) * cell_size)
                 assert((expected_wm - lower_bound_margin)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4552,7 +4552,7 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             # Enable tx on dest port
             self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+                self.dst_client, asic_type, [dst_port_id])
 
 
 class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -229,6 +229,16 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
                 return True
     return False
 
+def get_peer_addresses(data):
+    def get_peer_addr(data, addr):
+        if isinstance(data, dict) and 'peer_addr' in data:
+            addr.add(data['peer_addr'])
+        elif isinstance(data, dict):
+            for val in data.values():
+                get_peer_addr(val, addr)
+    addresses = set()
+    get_peer_addr(data, addresses)
+    return list(addresses)
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
@@ -277,10 +287,10 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         send_packet(self, self.dst_port_3_id, arpreq_pkt)
 
         # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
-        if self.test_port_ids and self.test_port_ips:
-            for portid in self.test_port_ids:
+        if self.test_port_ips:
+            for ip in get_peer_addresses(self.test_port_ips):
                 self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
-                                     'ping -q -c 3 {}'.format(self.test_port_ips[portid]['peer_addr']))
+                    'ping -q -c 3 {}'.format(ip))
 
         time.sleep(8)
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -217,12 +217,12 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
     # Returns whether 1 packet was successfully enqueued.
     if asic_type in ['cisco-8000']:
         queue_counters_base = sai_thrift_read_queue_occupancy(
-            test_case.client, dst_port_id)
+            test_case.dst_client, "dst", dst_port_id)
         max_packets = 500
         for packet_i in range(max_packets):
             send_packet(test_case, src_port_id, pkt, 1)
             queue_counters = sai_thrift_read_queue_occupancy(
-                test_case.client, dst_port_id)
+                test_case.clients['dst'], "dst", dst_port_id)
             if queue_counters[queue] > queue_counters_base[queue]:
                 print("fill_leakout_plus_one: Success, sent %d packets, queue occupancy bytes rose from %d to %d" % (
                     packet_i + 1, queue_counters_base[queue], queue_counters[queue]), file=sys.stderr)
@@ -234,7 +234,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         self.router_mac = self.test_params['router_mac']
@@ -304,20 +304,20 @@ class ARPpopulatePTF(sai_base_test.ThriftInterfaceDataPlane):
 
 class ReleaseAllPorts(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         asic_type = self.test_params['sonic_asic_type']
 
-        self.sai_thrift_port_tx_enable(
-            self.client, asic_type, list(port_list.keys()))
+        for target, a_client in self.clients.items():
+            self.sai_thrift_port_tx_enable(a_client, asic_type, list(port_list[target].keys()), target=target)
 
 # DSCP to queue mapping
 
 
 class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
-    def get_port_id(self, port_name):
-        sai_port_id = self.client.sai_thrift_get_port_id_by_front_port(
+    def get_port_id(self, client, port_name):
+        sai_port_id = client.sai_thrift_get_port_id_by_front_port(
             port_name
         )
         print("Port name {}, SAI port id {}".format(
@@ -326,7 +326,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         return sai_port_id
 
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         router_mac = self.test_params['router_mac']
         dst_port_id = int(self.test_params['dst_port_id'])
@@ -360,14 +360,13 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         test_dst_port_name = self.test_params.get("test_dst_port_name")
         sai_dst_port_id = None
         if test_dst_port_name is not None:
-            sai_dst_port_id = self.get_port_id(test_dst_port_name)
+            sai_dst_port_id = self.get_port_id(self.dst_client, test_dst_port_name)
         else:
-            sai_dst_port_id = port_list[dst_port_id]
+            sai_dst_port_id = port_list['dst'][dst_port_id]
 
         time.sleep(10)
         # port_results is not of our interest here
-        port_results, queue_results_base = sai_thrift_read_port_counters(
-            self.client, asic_type, sai_dst_port_id)
+        port_results, queue_results_base = sai_thrift_read_port_counters(self.dst_client, asic_type, sai_dst_port_id)
 
         # DSCP Mapping test
         try:
@@ -420,8 +419,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             time.sleep(10)
-            port_results, queue_results = sai_thrift_read_port_counters(
-                self.client, asic_type, sai_dst_port_id)
+            port_results, queue_results = sai_thrift_read_port_counters(self.dst_client, asic_type, sai_dst_port_id)
 
             print(list(map(operator.sub, queue_results,
                   queue_results_base)), file=sys.stderr)
@@ -482,7 +480,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
 class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -527,7 +525,7 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for queue, dot1ps in list(queue_dot1p_map.items()):
                 port_results, queue_results_base = sai_thrift_read_port_counters(
-                    self.client, asic_type, port_list[dst_port_id])
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
                 # send pkts with dot1ps that map to the same queue
                 for dot1p in dot1ps:
@@ -561,7 +559,7 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # validate queue counters increment by the correct pkt num
                 time.sleep(8)
                 port_results, queue_results = sai_thrift_read_port_counters(
-                    self.client, asic_type, port_list[dst_port_id])
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
                 print(queue_results_base, file=sys.stderr)
                 print(queue_results, file=sys.stderr)
                 print(list(map(operator.sub, queue_results,
@@ -607,7 +605,7 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
 
 class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -659,7 +657,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for pg, dscps in list(pg_dscp_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 # send pkts with dscps that map to the same pg
                 for dscp in dscps:
@@ -680,7 +678,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print(pg_cntrs_base, file=sys.stderr)
                 print(pg_cntrs, file=sys.stderr)
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
@@ -718,8 +716,8 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     tos |= 1
                     try:
                         if (recv_pkt.payload.tos == tos) and (recv_pkt.payload.src == src_port_ip) and \
-                                (recv_pkt.payload.dst == dst_port_ip) and \
-                                (recv_pkt.payload.ttl == exp_ttl) and (recv_pkt.payload.id == exp_ip_id):
+                            (recv_pkt.payload.dst == dst_port_ip) and \
+                           (recv_pkt.payload.ttl == exp_ttl) and (recv_pkt.payload.id == exp_ip_id):
 
                             dscp_recv_cnt += 1
                             print("dscp: %d, total received: %d" %
@@ -737,16 +735,16 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 # Tunnel DSCP to PG mapping test
 class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
-    def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip,
-                           standby_tor_ip, inner_dscp, outer_dscp, dst_ip, ecn=1):
+    def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp,
+                           outer_dscp, dst_ip, ecn=1):
         pkt = simple_tcp_packet(
-            eth_dst=standby_tor_mac,
-            ip_src='1.1.1.1',
-            ip_dst=dst_ip,
-            ip_dscp=inner_dscp,
-            ip_ecn=ecn,
-            ip_ttl=64
-        )
+                eth_dst=standby_tor_mac,
+                ip_src='1.1.1.1',
+                ip_dst=dst_ip,
+                ip_dscp=inner_dscp,
+                ip_ecn=ecn,
+                ip_ttl=64
+                )
 
         ipinip_packet = simple_ipv4ip_packet(
             eth_dst=active_tor_mac,
@@ -764,7 +762,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         This test case is to tx some ip_in_ip packet from Mux tunnel, and check if the traffic is
         mapped to expected PGs.
         """
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         active_tor_mac = self.test_params['active_tor_mac']
@@ -801,8 +799,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             # Disable tx on EGRESS port so that headroom buffer cannot be free
-            self.sai_thrift_port_tx_disable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
             # There are packet leak even port tx is disabled (18 packets leak on TD3 found)
             # Hence we send some packet to fill the leak before testing
@@ -828,37 +825,34 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # On Nvidia platforms, the dscp mode is pipe and the PG is determined by the outer dscp before decap
                 outer_dscp = inner_dscp if asic_type == 'mellanox' else 0
                 pkt = self._build_testing_pkt(
-                    active_tor_mac=active_tor_mac,
-                    standby_tor_mac=standby_tor_mac,
-                    active_tor_ip=active_tor_ip,
-                    standby_tor_ip=standby_tor_ip,
-                    inner_dscp=inner_dscp,
-                    outer_dscp=outer_dscp,
-                    dst_ip=dst_port_ip
-                )
-                pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
-                    self.client, asic_type, port_list[src_port_id])
-                logging.info(pg_shared_wm_res_base)
+                                            active_tor_mac=active_tor_mac,
+                                            standby_tor_mac=standby_tor_mac,
+                                            active_tor_ip=active_tor_ip,
+                                            standby_tor_ip=standby_tor_ip,
+                                            inner_dscp=dscp,
+                                            outer_dscp=0,
+                                            dst_ip=dst_port_ip
+                                        )
+                pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
+                                                                            port_list['src'][src_port_id])
                 send_packet(self, src_port_id, pkt, PKT_NUM)
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
-                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                    self.client, asic_type, port_list[src_port_id])
-                logging.info(pg_shared_wm_res)
+                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, 
+                                                                       port_list['src'][src_port_id])
+
                 assert (pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
                         <= (PKT_NUM + ERROR_TOLERANCE[pg]) * cell_size)
                 assert (pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
                         >= (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size)
         finally:
             # Enable tx on dest port
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
-
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # DOT1P to pg mapping
 class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         router_mac = self.test_params['router_mac']
@@ -899,7 +893,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         try:
             for pg, dot1ps in list(pg_dot1p_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 # send pkts with dot1ps that map to the same pg
                 for dot1p in dot1ps:
@@ -933,7 +927,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print(pg_cntrs_base, file=sys.stderr)
                 print(pg_cntrs, file=sys.stderr)
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
@@ -980,7 +974,7 @@ class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -1014,7 +1008,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # dscp  3 -> pg 3
             # dscp  4 -> pg 4
             pg_dropped_cntrs_old = sai_thrift_read_pg_drop_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
 
         # Prepare IP packet data
         ttl = 64
@@ -1056,9 +1050,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_id])
+            self.src_client, asic_type, port_list['src'][src_port_id])
         xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1071,7 +1065,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
@@ -1101,31 +1095,31 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_id], TRANSMITTED_PKTS,
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                xmit_counters_base, self, src_port_id, pkt, 10)
 
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
-            sys.stderr.write(
-                '{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'
-                .format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
-            assert (recv_counters[pg] == recv_counters_base[pg]
-                    ), 'unexpectedly PFC counter increase, {}'.format(test_stage)
+            assert(recv_counters[pg] == recv_counters_base[pg]), \
+                'unexpectedly PFC counter increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert (recv_counters[cntr] == recv_counters_base[cntr]
-                        ), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert (xmit_counters[cntr] == xmit_counters_base[cntr]
-                        ), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send 1 packet to trigger pfc
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -1135,24 +1129,24 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
             recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger PFC'
             sys.stderr.write(
                 '{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'
                 .format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert (recv_counters[pg] > recv_counters_base[pg]
-                    ), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert (recv_counters[cntr] == recv_counters_base[cntr]
-                        ), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert (xmit_counters[cntr] == xmit_counters_base[cntr]
-                        ), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, (pkts_num_trig_ingr_drp -
@@ -1163,24 +1157,24 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
             recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write(
-                '{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'
-                .format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert (recv_counters[pg] > recv_counters_base[pg]
-                    ), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert (recv_counters[cntr] == recv_counters_base[cntr]
-                        ), 'unexpectedly RX drop counter increase, {}'.format(test_stage)
+                assert(recv_counters[cntr] == recv_counters_base[cntr]), \
+                    'unexpectedly RX drop counter increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:
-                assert (xmit_counters[cntr] == xmit_counters_base[cntr]
-                        ), 'unexpectedly TX drop counter increase, {}'.format(test_stage)
+                assert(xmit_counters[cntr] == xmit_counters_base[cntr]), \
+                    'unexpectedly TX drop counter increase, {}'.format(test_stage)
 
             # send 1 packet to trigger ingress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -1190,17 +1184,17 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
             recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write(
-                '{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\txmit_counters {}\n\txmit_counters_base {}\n'
-                .format(test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
-            assert (recv_counters[pg] > recv_counters_base[pg]
-                    ), 'unexpectedly PFC counter not increase, {}'.format(test_stage)
-
+            assert(recv_counters[pg] > recv_counters_base[pg]), \
+                'unexpectedly PFC counter not increase, {}'.format(test_stage)
+            # recv port ingress drop
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info(
                     "On J2C+ don't support port level drop counters - so ignoring this step for now")
@@ -1216,14 +1210,14 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
             if '201811' not in sonic_version and 'mellanox' in asic_type:
                 pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 logging.info("Dropped packet counters on port #{} :{} {} packets, current dscp: {}".format(
                     src_port_id, pg_dropped_cntrs[dscp], pg_dropped_cntrs_old[dscp], dscp))
                 # Check that counters per lossless PG increased
                 assert pg_dropped_cntrs[dscp] > pg_dropped_cntrs_old[dscp]
             if '201811' not in sonic_version and 'cisco-8000' in asic_type:
                 pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 logging.info("Dropped packet counters on port #{} :{} {} packets, current dscp: {}".format(
                     src_port_id, pg_dropped_cntrs[dscp], pg_dropped_cntrs_old[dscp], dscp))
                 # check that counters per lossless PG increased
@@ -1235,14 +1229,12 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                         assert pg_dropped_cntrs[i] == pg_dropped_cntrs_old[i]
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
-
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -1332,11 +1324,11 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         recv_counters_base1, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_1_id])
+            self.src_client, asic_type, port_list['src'][src_port_1_id])
         recv_counters_base2, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_2_id])
+            self.src_client, asic_type, port_list['src'][src_port_2_id])
         xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1345,7 +1337,7 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
         else:
             margin = 2
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             assert (fill_leakout_plus_one(self, src_port_1_id,
@@ -1373,11 +1365,11 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters1, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_1_id])
+                self.src_client, asic_type, port_list['src'][src_port_1_id])
             recv_counters2, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_2_id])
+                self.src_client, asic_type, port_list['src'][src_port_2_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             pfc_txd = recv_counters1[pg] - recv_counters_base1[pg]
             assert pfc_txd == 0, "Unexpected PFC TX {} on port {}".format(
@@ -1419,11 +1411,11 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters_base1 = recv_counters1
             recv_counters_base2 = recv_counters2
             recv_counters1, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_1_id])
+                self.src_client, asic_type, port_list['src'][src_port_1_id])
             recv_counters2, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_2_id])
+                self.src_client, asic_type, port_list['src'][src_port_2_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port pfc
             assert recv_counters1[pg] > recv_counters_base1[pg], "PFC TX counters did not increase for port {}".format(
                 src_port_1_id)
@@ -1444,8 +1436,7 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
                     diff, dst_port_id)
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # Base class used for individual PTF runs used in the following: testPfcStormWithSharedHeadroomOccupancy
 
@@ -1498,7 +1489,7 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
     def runTest(self):
 
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         self.parse_test_params()
         pkts_num_trig_pfc = int(self.test_params['pkts_num_trig_pfc'])
@@ -1520,18 +1511,17 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id]
+        )
 
         logging.info("Disabling xmit ports: {}".format(self.dst_port_id))
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
-        num_pkts = (pkts_num_trig_pfc +
-                    pkts_num_private_headrooom) // self.cell_occupancy
-        logging.info("Send {} pkts to egress out of {}".format(
-            num_pkts, self.dst_port_id))
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id]
+        )
+        num_pkts = (pkts_num_trig_pfc + pkts_num_private_headrooom) // self.cell_occupancy
+        logging.info("Send {} pkts to egress out of {}".format(num_pkts, self.dst_port_id))
         # send packets to dst port 1, to cross into shared headrooom
         send_packet(self, self.src_port_id, pkt, num_pkts)
 
@@ -1540,9 +1530,9 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         # get a snapshot of counter values at recv and transmit ports
         # queue counters value is not of our interest here
         recv_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         xmit_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(
             recv_counters, recv_counters_base))
@@ -1563,28 +1553,29 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
 
     def runTest(self):
         time.sleep(1)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         self.parse_test_params()
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id]
+        )
 
         xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id]
+        )
 
         logging.info("Enable xmit ports: {}".format(self.dst_port_id))
-        self.sai_thrift_port_tx_enable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         # allow enough time for the dut to sync up the counter values in counters_db
         time.sleep(8)
 
         # get new base counter values at recv ports
         recv_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         # no ingress drop
         for cntr in self.ingress_counters:
             assert (recv_counters[cntr] == recv_counters_base[cntr])
@@ -1595,9 +1586,9 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
 
         # get the current snapshot of counter values at recv and transmit ports
         recv_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.src_port_id])
+            self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         xmit_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+            self.dst_client, self.asic-type, port_list['dst'][self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(
             recv_counters, recv_counters_base))
@@ -1618,10 +1609,9 @@ class PtfEnableDstPorts(PfcStormTestWithSharedHeadroom):
 
     def runTest(self):
         time.sleep(1)
-        switch_init(self.client)
+        switch_init(self.clients)
         self.parse_test_params()
-        self.sai_thrift_port_tx_enable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 # This test looks to measure xon threshold (pg_reset_floor)
@@ -1640,7 +1630,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
+        last_pfc_counter = 0
+        recv_port_counters = []
+        transmit_port_counters = []
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -1681,7 +1674,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_id])
+            self.src_client, asic_type, port_list['src'][src_port_id]
+        )
 
         # The number of packets that will trek into the headroom space;
         # We observe in test that if the packets are sent to multiple destination ports,
@@ -1770,8 +1764,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         step_id = 1
         step_desc = 'disable TX for dst_port_id, dst_port_2_id, dst_port_3_id'
         sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [
-            dst_port_id, dst_port_2_id, dst_port_3_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
         try:
             '''
@@ -1792,13 +1785,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                                                                                                        in dst port 3            # noqa E501
             '''
             # send packets to dst port 1, occupying the "xon"
-
             step_id += 1
             step_desc = 'send packets to dst port 1, occupying the xon'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
 
-            xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            xmit_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id]
+            )
 
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
@@ -1831,8 +1824,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out, pkts_num_trig_pfc, pkts_num_dismiss_pfc, hysteresis, cell_occupancy))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_id], TRANSMITTED_PKTS,
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                xmit_counters_base, self, src_port_id, pkt, 40)
 
             # send packets to dst port 2, occupying the shared buffer
@@ -1840,8 +1833,9 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_desc = 'send packets to dst port 2, occupying the shared buffer'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
 
-            xmit_2_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_2_id])
+            xmit_2_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id]
+            )
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 send_packet(
                     self, src_port_id, pkt2,
@@ -1866,16 +1860,15 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_leak_out, pkts_num_dismiss_pfc, hysteresis, cell_occupancy, margin))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_2_id], TRANSMITTED_PKTS,
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_2_id], TRANSMITTED_PKTS,
                                                xmit_2_counters_base, self, src_port_id, pkt2, 40)
 
             # send 1 packet to dst port 3, triggering PFC
             step_id += 1
             step_desc = 'send 1 packet to dst port 3, triggering PFC'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            xmit_3_counters_base, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_3_id])
+            xmit_3_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 send_packet(self, src_port_id, pkt3,
                             pkts_num_egr_mem + pkts_num_leak_out + 1)
@@ -1889,41 +1882,30 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     'send_packet(src_port_id, pkt3, ({} + 1)\n'.format(pkts_num_leak_out))
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_3_id], TRANSMITTED_PKTS,
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_3_id], TRANSMITTED_PKTS,
                                                xmit_3_counters_base, self, src_port_id, pkt3, 40)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             xmit_2_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_2_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
             xmit_3_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_3_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
 
-            port_cnt_tbl = texttable.TextTable(
-                [''] + [port_counter_fields[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
             # recv port pfc
@@ -1950,41 +1932,26 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_id += 1
             step_desc = 'enable TX for dst_port_2_id, to drain off buffer in dst_port_2'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_2_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_2_id], last_port=False)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
             recv_counters_base = recv_counters
-            recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
-            xmit_2_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_2_id])
-            xmit_3_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_3_id])
-
-            port_cnt_tbl = texttable.TextTable(
-                [''] + [port_counter_fields[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
+            port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
             # recv port pfc
@@ -2011,15 +1978,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_id += 1
             step_desc = 'enable TX for dst_port_3_id, to drain off buffer in dst_port_3'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_3_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_3_id], last_port=False)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get new base counter values at recv ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
 
             port_cnt_tbl = texttable.TextTable(
                 [''] + [port_counter_fields[idx] for idx in port_counter_indexes])
@@ -2042,39 +2007,26 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(30)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             xmit_2_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_2_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
             xmit_3_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_3_id])
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
 
-            port_cnt_tbl = texttable.TextTable(
-                [''] + [port_counter_fields[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
-            port_cnt_tbl.add_row(
-                ['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters_base'] + [xmit_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_counters'] + [xmit_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters_base'] + [xmit_2_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_2_counters'] + [xmit_2_counters[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters_base'] + [xmit_3_counters_base[idx] for idx in port_counter_indexes])
+            port_cnt_tbl.add_row(['xmit_3_counters'] + [xmit_3_counters[idx] for idx in port_counter_indexes])
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
-            # recv port no pfc
-            assert (recv_counters[pg] == recv_counters_base[pg]),\
-                'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(
-                pg, port_counter_fields[pg], step_id, step_desc)
+           # recv port no pfc
+            assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(pg, port_counter_fields[pg], step_id, step_desc)
             # recv port no ingress drop
             for cntr in ingress_counters:
                 assert (recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN),\
@@ -2093,15 +2045,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     port_counter_fields[cntr], step_id, step_desc)
 
         finally:
-            self.sai_thrift_port_tx_enable(self.client, asic_type, [
-                dst_port_id, dst_port_2_id, dst_port_3_id])
-
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
 class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         self.testbed_type = self.test_params['testbed_type']
@@ -2141,25 +2091,25 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             self.pkt_size_factor = 1
 
         if self.pkts_num_trig_pfc:
-            print(("pkts num: leak_out: %d, trig_pfc: %d, hdrm_full: %d, hdrm_partial: %d, pkt_size %d" %
-                   (self.pkts_num_leak_out, self.pkts_num_trig_pfc, self.pkts_num_hdrm_full,
-                    self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
+            print(("pkts num: leak_out: %d, trig_pfc: %d, hdrm_full: %d, hdrm_partial: %d, pkt_size %d" % (
+                self.pkts_num_leak_out, self.pkts_num_trig_pfc, self.pkts_num_hdrm_full,
+                self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
         elif self.pkts_num_trig_pfc_shp:
-            print(("pkts num: leak_out: {}, trig_pfc: {}, hdrm_full: {}, hdrm_partial: {}, pkt_size {}"
-                   .format(self.pkts_num_leak_out, self.pkts_num_trig_pfc_shp, self.pkts_num_hdrm_full,
-                           self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
+            print(("pkts num: leak_out: {}, trig_pfc: {}, hdrm_full: {}, hdrm_partial: {}, pkt_size {}".format(
+                self.pkts_num_leak_out, self.pkts_num_trig_pfc_shp, self.pkts_num_hdrm_full,
+                self.pkts_num_hdrm_partial, self.pkt_size)), file=sys.stderr)
 
         # used only for headroom pool watermark
-        if all(key in self.test_params for key in ['hdrm_pool_wm_multiplier', 'buf_pool_roid',
-                                                   'cell_size', 'max_headroom']):
-            self.cell_size = int(self.test_params['cell_size'])
-            self.wm_multiplier = self.test_params['hdrm_pool_wm_multiplier']
-            print("Wm multiplier: %d buf_pool_roid: %s" % (
-                self.wm_multiplier, self.test_params['buf_pool_roid']), file=sys.stderr)
-            self.buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
-            print("buf_pool_roid: 0x%lx" %
-                  (self.buf_pool_roid), file=sys.stderr)
-            self.max_headroom = int(self.test_params['max_headroom'])
+        if all(key in self.test_params for key in [
+            'hdrm_pool_wm_multiplier', 'buf_pool_roid', 'cell_size', 'max_headroom']):
+           self.cell_size = int(self.test_params['cell_size'])
+           self.wm_multiplier = self.test_params['hdrm_pool_wm_multiplier']
+           print("Wm multiplier: %d buf_pool_roid: %s" % (
+               self.wm_multiplier, self.test_params['buf_pool_roid']), file=sys.stderr)
+           self.buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
+           print("buf_pool_roid: 0x%lx" %
+                 (self.buf_pool_roid), file=sys.stderr)
+           self.max_headroom = int(self.test_params['max_headroom'])
         else:
             self.wm_multiplier = None
 
@@ -2216,18 +2166,12 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         port_cnt_tbl = texttable.TextTable(
             [''] + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes])
         for srcPortIdx, srcPortId in enumerate(self.src_port_ids):
-            port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [
-                                 rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
-            rx_curr, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[srcPortId])
-            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(
-                srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
-        port_cnt_tbl.add_row(['base dst_port_id{}'.format(
-            self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
-        tx_curr, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[self.dst_port_id])
-        port_cnt_tbl.add_row(['     dst_port_id{}'.format(
-            self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
+            rx_curr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][srcPortId])
+            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+        port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
+        tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
+        port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
     def runTest(self):
@@ -2244,18 +2188,15 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_bases = [sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
-        xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[self.dst_port_id])
+        recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[0] for sid in self.src_port_ids]
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
         # Pause egress of dut xmit port
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
             # send packets to leak out
@@ -2326,7 +2267,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkt_cnt = 0
 
                 recv_counters, _ = sai_thrift_read_port_counters(
-                    self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
+                    self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 while (recv_counters[sidx_dscp_pg_tuples[i][2]] ==
                        recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]]) and (pkt_cnt < 10):
                     send_packet(
@@ -2338,8 +2279,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     # get a snapshot of counter values at recv and transmit ports
                     # queue_counters value is not of our interest here
                     recv_counters, _ = sai_thrift_read_port_counters(
-                        self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-
+                        self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 time.sleep(8)   # wait pfc counter refresh
                 self.show_port_counter(
                     self.asic_type, recv_counters_bases, xmit_counters_base,
@@ -2352,8 +2292,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (recv_counters[sidx_dscp_pg_tuples[i][2]] >
                         recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (
-                    pkt_cnt, self.src_port_ids[sidx_dscp_pg_tuples[i][0]],
-                    sidx_dscp_pg_tuples[i][2] - 2), file=sys.stderr)
+                    pkt_cnt, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], sidx_dscp_pg_tuples[i][2] - 2),
+                      file=sys.stderr)
                 sys.stderr.flush()
 
             print("PFC triggered", file=sys.stderr)
@@ -2362,7 +2302,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             upper_bound = 2 * margin + 1
             if self.wm_multiplier:
                 hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                    self.client, self.buf_pool_roid)
+                    self.src_client, self.buf_pool_roid)
                 print("Actual headroom pool watermark value to start: %d" %
                       hdrm_pool_wm, file=sys.stderr)
                 assert (hdrm_pool_wm <= (upper_bound *
@@ -2399,7 +2339,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
                 recv_counters, _ = sai_thrift_read_port_counters(
-                    self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
+                    self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 # assert no ingress drop
                 for cntr in self.ingress_counters:
                     # corner case: in previous step in which trigger PFC, a few packets were dropped,
@@ -2416,7 +2356,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     wm_pkt_num += (self.pkts_num_hdrm_full if i !=
                                    self.pgs_num - 1 else self.pkts_num_hdrm_partial)
                     hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                        self.client, self.buf_pool_roid)
+                        self.src_client, self.buf_pool_roid)
                     expected_wm = wm_pkt_num * self.cell_size * self.wm_multiplier
                     upper_bound_wm = expected_wm + \
                         (upper_bound * self.cell_size * self.wm_multiplier)
@@ -2447,20 +2387,18 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
             recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-
+                self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info(
                     "On J2C+ don't support port level drop counters - so ignoring this step for now")
             else:
                 # assert ingress drop
                 for cntr in self.ingress_counters:
-                    assert (
-                        recv_counters[cntr] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr])
+                    assert(recv_counters[cntr] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr])
 
             # assert no egress drop at the dut xmit port
             xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[self.dst_port_id])
+                self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info(
@@ -2471,33 +2409,30 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             print("pg hdrm filled", file=sys.stderr)
             if self.wm_multiplier:
-                # assert hdrm pool wm still remains the same
-                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                    self.client, self.buf_pool_roid)
-                sys.stderr.write('After PG headroom filled, actual headroom pool watermark {}, upper_bound {}\n'.format(
-                    hdrm_pool_wm, upper_bound_wm))
-                if 'innovium' not in self.asic_type:
-                    assert (expected_wm <= hdrm_pool_wm)
-                assert (hdrm_pool_wm <= upper_bound_wm)
-                # at this point headroom pool should be full. send few more packets to continue causing drops
-                print("overflow headroom pool", file=sys.stderr)
-                send_packet(
-                    self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 10)
-                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                    self.client, self.buf_pool_roid)
-                assert (hdrm_pool_wm <= self.max_headroom)
+               # assert hdrm pool wm still remains the same
+               hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
+                   self.src_client, self.buf_pool_roid)
+               sys.stderr.write('After PG headroom filled, actual headroom pool watermark {}, upper_bound {}\n'.format(hdrm_pool_wm, upper_bound_wm))
+               if 'innovium' not in self.asic_type:
+                   assert(expected_wm <= hdrm_pool_wm)
+               assert(hdrm_pool_wm <= upper_bound_wm)
+               # at this point headroom pool should be full. send few more packets to continue causing drops
+               print("overflow headroom pool", file=sys.stderr)
+               send_packet(self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 10)
+               hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
+                   self.src_client, self.buf_pool_roid)
+               assert(hdrm_pool_wm <= self.max_headroom)
             sys.stderr.flush()
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         self.testbed_type = self.test_params['testbed_type']
@@ -2592,14 +2527,13 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         recv_counters_bases = [sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
+            self.src_client, self.asic_type, port_list['src'][sid])[0] for sid in self.src_port_ids]
         xmit_counters_bases = [sai_thrift_read_port_counters(
-            self.client, self.asic_type, port_list[sid])[0] for sid in self.dst_port_ids]
+            self.dst_client, self.asic_type, port_list['dst'][sid])[0] for sid in self.dst_port_ids]
 
         # Disable all dst ports
         uniq_dst_ports = list(set(self.dst_port_ids))
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, uniq_dst_ports)
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, uniq_dst_ports)
 
         try:
             for i in range(len(self.src_port_ids)):
@@ -2631,7 +2565,7 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     sys.stderr.flush()
                     time.sleep(8)
                     recv_counters = sai_thrift_read_port_counters(
-                        self.client, self.asic_type, port_list[src_port_id])[0]
+                        self.src_client, self.asic_type, port_list['src'][src_port_id])[0]
                     xoff_txd = recv_counters[self.pg_cntr_indices[i]] - \
                         recv_counters_bases[i][self.pg_cntr_indices[i]]
                     assert xoff_txd == 0, "XOFF triggered too early on final iteration, XOFF count is %d" % xoff_txd
@@ -2654,16 +2588,16 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     sys.stderr.flush()
                     time.sleep(8)
                     recv_counters = sai_thrift_read_port_counters(
-                        self.client, self.asic_type, port_list[src_port_id])[0]
+                        self.src_client, self.asic_type, port_list['src'][src_port_id])[0]
                     xoff_txd = recv_counters[self.pg_cntr_indices[i]] - \
                         recv_counters_bases[i][self.pg_cntr_indices[i]]
                     assert xoff_txd > 0, "Failed to trigger XOFF on final iteration"
 
             # Verify no ingress/egress drops for all ports
-            recv_counters_list = [sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[sid])[0] for sid in self.src_port_ids]
-            xmit_counters_list = [sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[sid])[0] for sid in self.dst_port_ids]
+            recv_counters_list = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
+                                                                0] for sid in self.src_port_ids]
+            xmit_counters_list = [sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][sid])[
+                                                                0] for sid in self.dst_port_ids]
             for i in range(len(self.src_port_ids)):
                 for cntr in self.ingress_counters:
                     drops = recv_counters_list[i][cntr] - \
@@ -2675,15 +2609,14 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     assert drops == 0, "Detected %d egress drops" % drops
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, uniq_dst_ports)
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, uniq_dst_ports)
 
 # TODO: remove sai_thrift_clear_all_counters and change to use incremental counter values
 
 
 class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -2701,19 +2634,21 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         limit = self.test_params['limit']
         min_limit = self.test_params['min_limit']
         cell_size = self.test_params['cell_size']
+        asic_type = self.test_params['sonic_asic_type']
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
 
         # STOP PORT FUNCTION
         sched_prof_id = sai_thrift_create_scheduler_profile(
-            self.client, STOP_PORT_MAX_RATE)
+            self.src_client, STOP_PORT_MAX_RATE)
         attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
         attr = sai_thrift_attribute_t(
             id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-        self.client.sai_thrift_set_port_attribute(port_list[dst_port_id], attr)
+        self.dst_client.sai_thrift_set_port_attribute(port_list['dst'][dst_port_id], attr)
 
         # Clear Counters
-        sai_thrift_clear_all_counters(self.client)
+        sai_thrift_clear_all_counters(self.src_client, 'src')
+        sai_thrift_clear_all_counters(self.dst_client, 'dst')
 
         # send packets
         try:
@@ -2737,13 +2672,13 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
 
             # Clear Counters
-            sai_thrift_clear_all_counters(self.client)
+            sai_thrift_clear_all_counters(self.src_client, 'src')
+            sai_thrift_clear_all_counters(self.dst_client, 'dst')
 
             # Set receiving socket buffers to some big value
             for p in list(self.dataplane.ports.values()):
@@ -2752,12 +2687,12 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             # RELEASE PORT
             sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.client, RELEASE_PORT_MAX_RATE)
+                self.src_client, RELEASE_PORT_MAX_RATE)
             attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
             attr = sai_thrift_attribute_t(
                 id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(
-                port_list[dst_port_id], attr)
+            self.dst_client.sai_thrift_set_port_attribute(
+                port_list['dst'][dst_port_id], attr)
 
             # if (ecn == 1) - capture and parse all incoming packets
             marked_cnt = 0
@@ -2796,8 +2731,7 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(5)
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
             if (ecn == 0):
@@ -2820,18 +2754,18 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             # RELEASE PORT
             sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.client, RELEASE_PORT_MAX_RATE)
+                self.src_client, RELEASE_PORT_MAX_RATE)
             attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
             attr = sai_thrift_attribute_t(
                 id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(
-                port_list[dst_port_id], attr)
+            self.dst_client.sai_thrift_set_port_attribute(
+                port_list['dst'][dst_port_id], attr)
             print("END OF TEST")
 
 
 class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         ecn = int(self.test_params['ecn'])
@@ -2846,9 +2780,9 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         qos_remap_enable = bool(
             self.test_params.get('qos_remap_enable', False))
         print("dst_port_id: %d, src_port_id: %d qos_remap_enable: %d" %
-              (dst_port_id, src_port_id, qos_remap_enable), file=sys.stderr)
+              (dst_port_id, src_port_id, qos_remap_enable))
         print("dst_port_mac: %s, src_port_mac: %s, src_port_ip: %s, dst_port_ip: %s" % (
-            dst_port_mac, src_port_mac, src_port_ip, dst_port_ip), file=sys.stderr)
+            dst_port_mac, src_port_mac, src_port_ip, dst_port_ip))
         asic_type = self.test_params['sonic_asic_type']
         default_packet_length = 1500
         exp_ip_id = 110
@@ -2924,13 +2858,12 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         )
         print("actual dst_port_id: {}".format(dst_port_id), file=sys.stderr)
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         send_packet(self, src_port_id, pkt, pkts_num_leak_out)
 
         # Get a snapshot of counter values
-        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # Send packets to each queue based on priority/dscp field
         for prio, pkt_cnt in zip(prio_list, q_pkt_cnt):
@@ -2951,7 +2884,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
 
         # Release port
-        self.sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
         cnt = 0
         pkts = []
@@ -3013,8 +2946,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # Read counters
         print("DST port counters: ")
-        port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+        port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         print(list(map(operator.sub, queue_counters,
               queue_counters_base)), file=sys.stderr)
 
@@ -3024,7 +2956,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
 class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3086,10 +3018,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -3102,7 +3032,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
         try:
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
@@ -3129,19 +3059,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or \
                     hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                    self.client, asic_type, port_list[dst_port_id])
-                actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - \
-                    xmit_counters_base[TRANSMITTED_PKTS]
+                    self.dst_client, asic_type, port_list['dst'][dst_port_id])
+                actual_pkts_num_leak_out = xmit_counters[TRANSMITTED_PKTS] - xmit_counters_base[TRANSMITTED_PKTS]
                 send_packet(self, src_port_id, pkt, actual_pkts_num_leak_out)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert (recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -3157,10 +3084,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert (recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -3179,15 +3104,14 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                     assert (xmit_counters[cntr] > xmit_counters_base[cntr])
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
         # Parse input parameters
         self.dscp = int(self.test_params['dscp'])
         self.ecn = int(self.test_params['ecn'])
@@ -3243,8 +3167,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         flow_1_udp = 2048
         pkt = self._build_testing_pkt(flow_1_udp)
 
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                              port_list[self.dst_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                              port_list['dst'][self.dst_port_id])
         # add slight tolerance in threshold characterization to consider
         # the case that npu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -3253,8 +3177,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             margin = 2
 
-        self.sai_thrift_port_tx_disable(
-            self.client, self.asic_type, [self.dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
             # send packets to begin egress drop on flow1, requires sending the "single"
@@ -3267,8 +3190,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                         self.pkts_num_trig_egr_drp)
             time.sleep(2)
             # Verify egress drop
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.dst_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                             port_list['dst'][self.dst_port_id])
             for cntr in egress_counters:
                 diff = xmit_counters[cntr] - xmit_counters_base[cntr]
                 assert diff > 0, "Failed to cause TX drop on port {}".format(
@@ -3283,10 +3206,9 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                 xmit_counters_base = xmit_counters
                 send_packet(self, self.src_port_id, pkt2, 1)
                 time.sleep(2)
-                xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                 port_list[self.dst_port_id])
-                drop_counts = [xmit_counters[cntr] - xmit_counters_base[cntr]
-                               for cntr in egress_counters]
+                xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                 port_list['dst'][self.dst_port_id])
+                drop_counts = [xmit_counters[cntr] - xmit_counters_base[cntr] for cntr in egress_counters]
                 assert len(set(drop_counts)) == 1, \
                     "Egress drop counters were different at port {}, counts: {}".format(
                         self.dst_port_id, drop_counts)
@@ -3311,16 +3233,14 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
                     "Failed to find a flow that uses a second queue despite being in mode '{}'"\
                     .format(self.flow_config)
             # Cleanup for multi-flow test
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
             time.sleep(2)
             # Test multi-flow with detected multi-flow udp ports
-            self.sai_thrift_port_tx_disable(
-                self.client, self.asic_type, [self.dst_port_id])
-            recv_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                  port_list[self.src_port_id])
-            xmit_counters_base, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                                  port_list[self.dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
+            recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type,
+                                                                  port_list['src'][self.src_port_id])
+            xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                  port_list['dst'][self.dst_port_id])
             assert fill_leakout_plus_one(self, self.src_port_id, self.dst_port_id, pkt,
                                          int(self.test_params['pg']), self.asic_type), \
                 "Failed to fill leakout on dest port {}".format(
@@ -3339,10 +3259,10 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt2, short_of_drop_npkts)
             # allow enough time for counters to update
             time.sleep(2)
-            recv_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.client, self.asic_type,
-                                                             port_list[self.dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type,
+                                                             port_list['src'][self.src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                             port_list['dst'][self.dst_port_id])
             # recv port no pfc
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
@@ -3365,10 +3285,8 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt2, npkts)
             # allow enough time for counters to update
             time.sleep(2)
-            recv_counters, _ = sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[self.src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(
-                self.client, self.asic_type, port_list[self.dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][self.src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
             # recv port no pfc
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
@@ -3385,8 +3303,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             print("Successfully dropped {} packets".format(
                 drops), file=sys.stderr)
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, self.asic_type, [self.dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 
 # pg shared pool applied to both lossy and lossless traffic
@@ -3406,28 +3323,21 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         port_counter_indexes += [TRANSMITTED_PKTS, RECEIVED_PKTS,
                                  RECEIVED_NON_UC_PKTS, TRANSMITTED_NON_UC_PKTS, EGRESS_PORT_QLEN]
         stats_tbl = texttable.TextTable(['']
-                                        + [port_counter_fields[fieldIdx]
-                                            for fieldIdx in port_counter_indexes]
-                                        + ['Ing Pg{} Pkt'.format(pg)]
-                                        + ['Ing Pg{} Share Wm'.format(pg)])
-        if sport_cntr is None:
-            sport_cntr, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-        if sport_pg_cntr is None:
-            sport_pg_cntr = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
-        if sport_pg_share_wm is None:
-            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[src_port_id])
-        if dport_cntr is None:
-            dport_cntr, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
-        if dport_pg_cntr is None:
-            dport_pg_cntr = sai_thrift_read_pg_counters(
-                self.client, port_list[dst_port_id])
-        if dport_pg_share_wm is None:
-            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[dst_port_id])
+                                      + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
+                                      + ['Ing Pg{} Pkt'.format(pg)]
+                                      + ['Ing Pg{} Share Wm'.format(pg)])
+        if sport_cntr == None:
+            sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        if sport_pg_cntr == None:
+            sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+        if sport_pg_share_wm == None:
+            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
+        if dport_cntr == None:
+            dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        if dport_pg_cntr == None:
+            dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
+        if dport_pg_share_wm == None:
+            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         stats_tbl.add_row(['base src port']
                           + [sport_cntr_base[fieldIdx]
                               for fieldIdx in port_counter_indexes]
@@ -3452,7 +3362,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3518,24 +3428,17 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 "pkts_num_margin") else 2
 
         # Get a snapshot of counter values
-        recv_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
-
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
-        pg_cntrs_base = sai_thrift_read_pg_counters(
-            self.client, port_list[src_port_id])
-        dst_pg_cntrs_base = sai_thrift_read_pg_counters(
-            self.client, port_list[dst_port_id])
-        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
-            self.client, asic_type, port_list[src_port_id])
-        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
-            self.client, asic_type, port_list[dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
+        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
+        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3545,8 +3448,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             pg_min_pkts_num = 0
 
             # send packets to fill pg min but not trek into shared pool
@@ -3567,14 +3469,12 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if pg_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_id], TRANSMITTED_PKTS,
-                                               xmit_counters_history, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
             pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
@@ -3624,22 +3524,19 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("pkts num to send: %d, total pkts: %d, pg shared: %d" %
                       (pkts_num, expected_wm, total_shared), file=sys.stderr)
 
-                send_packet(self, src_port_id, pkt, pkts_num)
+                send_packet(self, src_port_id, pkt,int(pkts_num))
                 time.sleep(8)
 
-                if pg_min_pkts_num == 0 and pkts_num <= 1 + margin and \
-                        check_leackout_compensation_support(asic_type, hwsku):
-                    dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                                   port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history,
-                                                   self, src_port_id, pkt, 40)
+                if pg_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
+                    dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
 
                 pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                    self.client, asic_type, port_list[src_port_id])
+                    self.src_client, asic_type, port_list['src'][src_port_id])
                 pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
 
@@ -3671,9 +3568,9 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(
-                self.client, asic_type, port_list[src_port_id])
+                self.src_client, asic_type, port_list['src'][src_port_id])
             pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[pg] - pg_cntrs_base[pg]), file=sys.stderr)
 
@@ -3688,20 +3585,16 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
             if platform_asic and platform_asic == "broadcom-dnx":
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
-                    pkts_num, ((expected_wm + cell_occupancy) * (packet_length + internal_hdr_size)),
-                    pg_shared_wm_res[pg]), file=sys.stderr)
-                assert (expected_wm * (packet_length + internal_hdr_size) <= (expected_wm +
-                        margin + cell_occupancy) * (packet_length + internal_hdr_size))
-
+                    pkts_num, ((expected_wm + cell_occupancy) * (packet_length + internal_hdr_size)), pg_shared_wm_res[pg]), file=sys.stderr)
+                assert (expected_wm * (packet_length + internal_hdr_size) <= (
+                        expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
             else:
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
-                    pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]), file=sys.stderr)
+                          pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]),file=sys.stderr)
                 assert (expected_wm * cell_size <= pg_shared_wm_res[pg] <= (
-                    expected_wm + margin + cell_occupancy) * cell_size)
-
+                        expected_wm + margin + cell_occupancy) * cell_size)
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # pg headroom is a notion for lossless traffic only
 
@@ -3709,7 +3602,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3778,10 +3671,9 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
-        xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3801,12 +3693,9 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_id], TRANSMITTED_PKTS,
-                                               xmit_counters_base, self, src_port_id, pkt, 30)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
 
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[src_port_id])
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " +
                              "stat - so ignoring this step for now")
@@ -3835,7 +3724,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
                 q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                    self.client, port_list[src_port_id])
+                    self.src_client, port_list['src'][src_port_id])
 
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size *
                       cell_occupancy, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size * cell_occupancy)),
@@ -3856,7 +3745,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
             time.sleep(8)
             q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[src_port_id])
+                self.src_client, port_list['src'][src_port_id])
             print("exceeded pkts num sent: %d" % (pkts_num), file=sys.stderr)
             print("lower bound: %d, actual value: %d, upper bound: %d" %
                   ((expected_wm - margin) * cell_size * cell_occupancy, pg_headroom_wm_res[pg],
@@ -3873,14 +3762,12 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                         cell_occupancy <= pg_headroom_wm_res[pg])
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
-
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -3929,11 +3816,10 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
             pass_iterations = 0
             assert iterations > 0, "Need at least 1 iteration"
             for test_i in range(iterations):
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
-                pg_dropped_cntrs_base = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
+                pg_dropped_cntrs_base=sai_thrift_read_pg_drop_counters(
+                    self.src_client, port_list['src'][src_port_id])
 
                 # Send packets to trigger PFC
                 print("Iteration {}/{}, sending {} packets to trigger PFC".format(
@@ -3942,12 +3828,12 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 # Account for leakout
                 if 'cisco-8000' in asic_type:
-                    queue_counters = sai_thrift_read_queue_occupancy(
-                        self.client, dst_port_id)
-                    occ_pkts = queue_counters[queue] // (packet_length + 24)
-                    leaked_pkts = pkts_num_trig_pfc - occ_pkts
+                    queue_counters=sai_thrift_read_queue_occupancy(
+                        self.dst_client, "dst", dst_port_id)
+                    occ_pkts=queue_counters[queue] // (packet_length + 24)
+                    leaked_pkts=pkts_num_trig_pfc - occ_pkts
                     print("resending leaked packets {}".format(
-                        leaked_pkts), file=sys.stderr)
+                        leaked_pkts))
                     send_packet(self, src_port_id, pkt, leaked_pkts)
 
                 # Trigger drop
@@ -3956,9 +3842,9 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkt_inc), file=sys.stderr)
                 send_packet(self, src_port_id, pkt, pkt_inc)
 
-                pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
-                    self.client, port_list[src_port_id])
-                pg_drops = pg_dropped_cntrs[pg] - pg_dropped_cntrs_base[pg]
+                pg_dropped_cntrs=sai_thrift_read_pg_drop_counters(
+                    self.src_client, port_list['src'][src_port_id])
+                pg_drops=pg_dropped_cntrs[pg] - pg_dropped_cntrs_base[pg]
 
                 actual_num_trig_ingr_drp = pkts_num_trig_ingr_drp + \
                     margin - (pg_drops - 1)
@@ -3968,19 +3854,16 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("expected trig drop: {}, actual trig drop: {}, diff: {}".format(
                     pkts_num_trig_ingr_drp, actual_num_trig_ingr_drp, ingr_drop_diff), file=sys.stderr)
 
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
             print("pass iterations: {}, total iterations: {}, margin: {}".format(
                 pass_iterations, iterations, margin), file=sys.stderr)
-            assert pass_iterations >= int(0.75 * iterations),\
-                "Passed iterations {} insufficient to meet minimum required iterations {}"\
-                .format(pass_iterations, int(0.75 * iterations))
+            assert pass_iterations >= int(
+                0.75 * iterations), "Passed iterations {} insufficient to meet minimum required iterations {}".format(
+                pass_iterations, int(0.75 * iterations))
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
-
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
@@ -3997,32 +3880,27 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         port_counter_indexes += [TRANSMITTED_PKTS, RECEIVED_PKTS,
                                  RECEIVED_NON_UC_PKTS, TRANSMITTED_NON_UC_PKTS, EGRESS_PORT_QLEN]
         stats_tbl = texttable.TextTable(['']
-                                        + [port_counter_fields[fieldIdx]
-                                            for fieldIdx in port_counter_indexes]
-                                        + ['Ing Pg{} Pkt'.format(que)]
-                                        + ['Ing Pg{} Share Wm'.format(que)]
-                                        + ['Ing Pg{} headroom Wm'.format(que)]
-                                        + ['Que{} Share Wm'.format(que)])
+                                      + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
+                                      + ['Ing Pg{} Pkt'.format(que)]
+                                      + ['Ing Pg{} Share Wm'.format(que)]
+                                      + ['Ing Pg{} headroom Wm'.format(que)]
+                                      + ['Que{} Share Wm'.format(que)])
 
-        if sport_cntr is None:
-            sport_cntr, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
-        if sport_pg_cntr is None:
-            sport_pg_cntr = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+        if sport_cntr == None:
+            sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        if sport_pg_cntr == None:
+            sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         if None in [sport_pg_share_wm, sport_pg_headroom_wm, sport_que_share_wm]:
-            sport_que_share_wm, sport_pg_share_wm, sport_pg_headroom_wm = sai_thrift_read_port_watermarks(
-                self.client, port_list[src_port_id])
+            sport_que_share_wm, sport_pg_share_wm, sport_pg_headroom_wm = \
+                sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
 
-        if dport_cntr is None:
-            dport_cntr, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
-        if dport_pg_cntr is None:
-            dport_pg_cntr = sai_thrift_read_pg_counters(
-                self.client, port_list[dst_port_id])
+        if dport_cntr == None:
+            dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        if dport_pg_cntr == None:
+            dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
         if None in [dport_pg_share_wm, dport_pg_headroom_wm, dport_que_share_wm]:
-            dport_que_share_wm, dport_pg_share_wm, dport_pg_headroom_wm = sai_thrift_read_port_watermarks(
-                self.client, port_list[dst_port_id])
+            dport_que_share_wm, dport_pg_share_wm, dport_pg_headroom_wm = \
+                sai_thrift_read_port_watermarks(self.src_client, port_list['dst'][dst_port_id])
 
         stats_tbl.add_row(['base src port']
                           + [sport_cntr_base[fieldIdx]
@@ -4056,7 +3934,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         ingress_counters, egress_counters = get_counter_names(
@@ -4131,19 +4009,13 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
-        recv_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[src_port_id])
-        xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.client, asic_type, port_list[dst_port_id])
-        self.sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
-        pg_cntrs_base = sai_thrift_read_pg_counters(
-            self.client, port_list[src_port_id])
-        dst_pg_cntrs_base = sai_thrift_read_pg_counters(
-            self.client, port_list[dst_port_id])
-        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(
-            self.client, port_list[src_port_id])
-        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(
-            self.client, port_list[dst_port_id])
+        recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+        dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
+        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
+        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.dst_client, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -4153,8 +4025,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             que_min_pkts_num = 0
 
             # send packets to fill queue min but not trek into shared pool
@@ -4172,14 +4043,14 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if que_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                               port_list[dst_port_id], TRANSMITTED_PKTS,
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                xmit_counters_history, self, src_port_id, pkt, 40)
 
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[dst_port_id])
-            pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+                self.dst_client, port_list['dst'][dst_port_id])
+            pg_cntrs=sai_thrift_read_pg_counters(
+                self.src_client, port_list['src'][src_port_id])
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 que_min_pkts_num, pkts_num_fill_min, q_wm_res[queue]), file=sys.stderr)
             print("Received packets: %d" %
@@ -4198,7 +4069,11 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             elif 'cisco-8000' in asic_type:
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             else:
-                assert (q_wm_res[queue] <= 1 * cell_size)
+                if platform_asic and platform_asic == "broadcom-dnx":
+                    logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " + \
+                                 "stat - so ignoring this step for now")
+                else:
+                    assert(q_wm_res[queue] <= 1 * cell_size)
 
             # send packet batch of fixed packet numbers to fill queue shared
             # first round sends only 1 packet
@@ -4221,10 +4096,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     fragment = total_shared - expected_wm
 
                 if 'cisco-8000' in asic_type:
-                    self.sai_thrift_port_tx_disable(
-                        self.client, asic_type, [dst_port_id])
-                    assert (fill_leakout_plus_one(self, src_port_id,
-                                                  dst_port_id, pkt, queue, asic_type))
+                    self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+                    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
                     pkts_total += pkts_num
                     pkts_num = pkts_total - 1
 
@@ -4235,22 +4108,21 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 if 'cisco-8000' in asic_type:
                     self.sai_thrift_port_tx_enable(
-                        self.client, asic_type, [dst_port_id])
+                        self.dst_client, asic_type, [dst_port_id])
 
                 time.sleep(8)
 
-                if que_min_pkts_num == 0 and pkts_num <= 1 + margin and \
-                        check_leackout_compensation_support(asic_type, hwsku):
-                    dynamically_compensate_leakout(self.client, asic_type, sai_thrift_read_port_counters,
-                                                   port_list[dst_port_id], TRANSMITTED_PKTS, xmit_counters_history,
-                                                   self, src_port_id, pkt, 40)
+                if que_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
+                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
-                q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                    self.client, port_list[dst_port_id])
-                pg_cntrs = sai_thrift_read_pg_counters(
-                    self.client, port_list[src_port_id])
+                q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+                    self.dst_client, port_list['dst'][dst_port_id])
+                pg_cntrs=sai_thrift_read_pg_counters(
+                    self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin)
@@ -4276,10 +4148,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkts_num = pkts_inc
 
             if 'cisco-8000' in asic_type:
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
-                assert (fill_leakout_plus_one(self, src_port_id,
-                                              dst_port_id, pkt, queue, asic_type))
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+                assert(fill_leakout_plus_one(self, src_port_id,
+                       dst_port_id, pkt, queue, asic_type))
                 pkts_total += pkts_num
                 pkts_num = pkts_total - 1
 
@@ -4287,14 +4158,13 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num)
 
             if 'cisco-8000' in asic_type:
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
             time.sleep(8)
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
-                self.client, port_list[dst_port_id])
-            pg_cntrs = sai_thrift_read_pg_counters(
-                self.client, port_list[src_port_id])
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+                self.dst_client, port_list['dst'][dst_port_id])
+            pg_cntrs=sai_thrift_read_pg_counters(
+                self.src_client, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
             print("exceeded pkts num sent: %d, actual value: %d, lower bound: %d, upper bound: %d" % (
@@ -4319,8 +4189,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (q_wm_res[queue] <= (expected_wm + margin) * cell_size)
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # TODO: buffer pool roid should be obtained via rpc calls
 # based on the pg or queue index
@@ -4330,7 +4199,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         time.sleep(5)
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
@@ -4362,8 +4231,8 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         buffer_pool_wm_base = 0
         if 'cisco-8000' in asic_type:
             # Some small amount of memory is always occupied
-            buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid)
+            buffer_pool_wm_base=sai_thrift_read_buffer_pool_watermark(
+                self.src_client, buf_pool_roid)
 
         # Prepare TCP packet data
         tos = dscp << 2
@@ -4415,15 +4284,13 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             # the impact caused by lossy traffic
             #
             # TH2 uses scheduler-based TX enable, this does not require sending packets to leak out
-            self.sai_thrift_port_tx_disable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             pkts_num_to_send += (pkts_num_leak_out + pkts_num_fill_min)
             send_packet(self, src_port_id, pkt, pkts_num_to_send)
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
-            buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid) - buffer_pool_wm_base
+            buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+                self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 (pkts_num_leak_out + pkts_num_fill_min), pkts_num_fill_min, buffer_pool_wm), file=sys.stderr)
             if pkts_num_fill_min:
@@ -4457,8 +4324,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("pkts num to send: %d, total pkts: %d, shared: %d" %
                       (pkts_num, expected_wm, total_shared), file=sys.stderr)
 
-                self.sai_thrift_port_tx_disable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
                 pkts_num_to_send += pkts_num
                 if 'cisco-8000' in asic_type:
                     assert (fill_leakout_plus_one(self, src_port_id,
@@ -4466,25 +4332,21 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     send_packet(self, src_port_id, pkt, pkts_num_to_send - 1)
                 else:
                     send_packet(self, src_port_id, pkt, pkts_num_to_send)
-                self.sai_thrift_port_tx_enable(
-                    self.client, asic_type, [dst_port_id])
+                self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
                 time.sleep(8)
-                buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
-                    self.client, buf_pool_roid) - buffer_pool_wm_base
-                print("lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" %
-                      (lower_bound_margin, (expected_wm - lower_bound_margin)
-                       * cell_size, buffer_pool_wm, upper_bound_margin,
-                       (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
-                assert (buffer_pool_wm <= (expected_wm +
-                                           upper_bound_margin) * cell_size)
-                assert ((expected_wm - lower_bound_margin)
-                        * cell_size <= buffer_pool_wm)
+                buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+                    self.src_client, buf_pool_roid) - buffer_pool_wm_base
+                print("lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (lower_bound_margin, (expected_wm - lower_bound_margin)
+                      * cell_size, buffer_pool_wm, upper_bound_margin, (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
+                assert(buffer_pool_wm <= (expected_wm + \
+                       upper_bound_margin) * cell_size)
+                assert((expected_wm - lower_bound_margin)
+                       * cell_size <= buffer_pool_wm)
 
                 pkts_num = pkts_inc
 
             # overflow the shared pool
-            self.sai_thrift_port_tx_disable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             pkts_num_to_send += pkts_num
             if 'cisco-8000' in asic_type:
                 assert (fill_leakout_plus_one(self, src_port_id,
@@ -4493,11 +4355,10 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 send_packet(self, src_port_id, pkt, pkts_num_to_send)
 
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
-            buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
-                self.client, buf_pool_roid) - buffer_pool_wm_base
+            buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+                self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                 pkts_num, (expected_wm * cell_size), buffer_pool_wm), file=sys.stderr)
             assert (expected_wm == total_shared)
@@ -4507,8 +4368,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 expected_wm + extra_cap_margin) * cell_size)
 
         finally:
-            self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 
 class PacketTransmit(sai_base_test.ThriftInterfaceDataPlane):
@@ -4598,7 +4458,7 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
         and then egress to server.
         Tx is disabled on the egress port to trigger PFC pause.
         """
-        switch_init(self.client)
+        switch_init(self.clients)
 
         # Parse input parameters
         active_tor_mac = self.test_params['active_tor_mac']
@@ -4635,14 +4495,11 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             cell_occupancy = 1
         try:
             # Disable tx on EGRESS port so that headroom buffer cannot be free
-            self.sai_thrift_port_tx_disable(
-                self.client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             # Make a snapshot of transmitted packets
-            tx_counters_base, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
+            tx_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # Make a snapshot of received packets
-            rx_counters_base, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+            rx_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             if tunnel_traffic_test:
                 # Build IPinIP packet for testing
                 pkt = self._build_testing_ipinip_pkt(active_tor_mac=active_tor_mac,
@@ -4658,33 +4515,28 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 # Build regular packet
                 pkt = self._build_testing_pkt(active_tor_mac=active_tor_mac,
-                                              dscp=inner_dscp,
-                                              dst_ip=dst_port_ip,
-                                              ecn=ecn,
-                                              packet_size=packet_size)
-
+                                            dscp=inner_dscp,
+                                            dst_ip=dst_port_ip,
+                                            ecn=ecn,
+                                            packet_size=packet_size)
             # Send packets short of triggering pfc
             send_packet(self, src_port_id, pkt, pkts_num_trig_pfc // cell_occupancy - 1 - pkts_num_margin)
             time.sleep(8)
             # Read TX_OK again to calculate leaked packet number
-            tx_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[dst_port_id])
-            leaked_packet_number = tx_counters[TRANSMITTED_PKTS] - \
-                tx_counters_base[TRANSMITTED_PKTS]
+            tx_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            leaked_packet_number = tx_counters[TRANSMITTED_PKTS] - tx_counters_base[TRANSMITTED_PKTS]
             # Send packets to compensate the leaked packets
             send_packet(self, src_port_id, pkt, leaked_packet_number)
             time.sleep(8)
             # Read rx counter again. No PFC pause frame should be triggered
-            rx_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+            rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             # Verify no pfc
             assert (rx_counters[pg] == rx_counters_base[pg])
             rx_counters_base = rx_counters
             # Send some packets to trigger PFC
             send_packet(self, src_port_id, pkt, 1 + 2 * pkts_num_margin)
             time.sleep(8)
-            rx_counters, _ = sai_thrift_read_port_counters(
-                self.client, asic_type, port_list[src_port_id])
+            rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             # Verify PFC pause frame is generated on expected PG
             assert (rx_counters[pg] > rx_counters_base[pg])
         finally:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -229,6 +229,7 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
                 return True
     return False
 
+
 def get_peer_addresses(data):
     def get_peer_addr(data, addr):
         if isinstance(data, dict) and 'peer_addr' in data:
@@ -239,6 +240,7 @@ def get_peer_addresses(data):
     addresses = set()
     get_peer_addr(data, addresses)
     return list(addresses)
+
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
@@ -290,7 +292,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         if self.test_port_ips:
             for ip in get_peer_addresses(self.test_port_ips):
                 self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
-                    'ping -q -c 3 {}'.format(ip))
+                                     'ping -q -c 3 {}'.format(ip))
 
         time.sleep(8)
 
@@ -432,7 +434,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             port_results, queue_results = sai_thrift_read_port_counters(self.dst_client, asic_type, sai_dst_port_id)
 
             print(list(map(operator.sub, queue_results,
-                  queue_results_base)), file=sys.stderr)
+                           queue_results_base)), file=sys.stderr)
             # dual_tor_scenario: represents whether the device is deployed into a dual ToR scenario
             # dual_tor: represents whether the source and
             #           destination ports are configured with additional lossless queues
@@ -573,7 +575,7 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
                 print(queue_results_base, file=sys.stderr)
                 print(queue_results, file=sys.stderr)
                 print(list(map(operator.sub, queue_results,
-                      queue_results_base)), file=sys.stderr)
+                               queue_results_base)), file=sys.stderr)
                 for i in range(0, QUEUE_NUM):
                     if i == queue:
                         assert (
@@ -748,13 +750,13 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp,
                            outer_dscp, dst_ip, ecn=1):
         pkt = simple_tcp_packet(
-                eth_dst=standby_tor_mac,
-                ip_src='1.1.1.1',
-                ip_dst=dst_ip,
-                ip_dscp=inner_dscp,
-                ip_ecn=ecn,
-                ip_ttl=64
-                )
+            eth_dst=standby_tor_mac,
+            ip_src='1.1.1.1',
+            ip_dst=dst_ip,
+            ip_dscp=inner_dscp,
+            ip_ecn=ecn,
+            ip_ttl=64
+        )
 
         ipinip_packet = simple_ipv4ip_packet(
             eth_dst=active_tor_mac,
@@ -835,20 +837,20 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 # On Nvidia platforms, the dscp mode is pipe and the PG is determined by the outer dscp before decap
                 outer_dscp = inner_dscp if asic_type == 'mellanox' else 0
                 pkt = self._build_testing_pkt(
-                                            active_tor_mac=active_tor_mac,
-                                            standby_tor_mac=standby_tor_mac,
-                                            active_tor_ip=active_tor_ip,
-                                            standby_tor_ip=standby_tor_ip,
-                                            inner_dscp=dscp,
-                                            outer_dscp=0,
-                                            dst_ip=dst_port_ip
-                                        )
+                    active_tor_mac=active_tor_mac,
+                    standby_tor_mac=standby_tor_mac,
+                    active_tor_ip=active_tor_ip,
+                    standby_tor_ip=standby_tor_ip,
+                    inner_dscp=dscp,
+                    outer_dscp=0,
+                    dst_ip=dst_port_ip
+                )
                 pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
                                                                             port_list['src'][src_port_id])
                 send_packet(self, src_port_id, pkt, PKT_NUM)
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
-                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, 
+                pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
                                                                        port_list['src'][src_port_id])
 
                 assert (pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
@@ -860,6 +862,8 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
 # DOT1P to pg mapping
+
+
 class Dot1pToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         switch_init(self.clients)
@@ -1089,17 +1093,17 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, (pkts_num_egr_mem +
-                            pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                                                     pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
             elif 'cisco-8000' in asic_type:
                 assert (fill_leakout_plus_one(self, src_port_id, dst_port_id,
                                               pkt, int(self.test_params['pg']), asic_type))
                 # Send 1 less packet due to leakout filling
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
-                            pkts_num_trig_pfc) // cell_occupancy - 2 - margin)
+                                                     pkts_num_trig_pfc) // cell_occupancy - 2 - margin)
             else:
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
-                            pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                                                     pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
 
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
@@ -1116,9 +1120,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
                              'xmit_counters {}\n\txmit_counters_base {}\n'.format(
-                test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg]), \
                 'unexpectedly PFC counter increase, {}'.format(test_stage)
@@ -1160,7 +1164,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, (pkts_num_trig_ingr_drp -
-                        pkts_num_trig_pfc) // cell_occupancy - 1 - 2 * margin)
+                                                 pkts_num_trig_pfc) // cell_occupancy - 1 - 2 * margin)
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
@@ -1171,7 +1175,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
                              'xmit_counters {}\n\txmit_counters_base {}\n'.format(
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
@@ -1198,7 +1202,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' +
                              'xmit_counters {}\n\txmit_counters_base {}\n'.format(
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
@@ -1240,6 +1244,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
 
 class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
@@ -1351,9 +1356,9 @@ class LosslessVoq(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             assert (fill_leakout_plus_one(self, src_port_1_id,
-                    dst_port_id, pkt, int(self.test_params['pg']), asic_type))
+                                          dst_port_id, pkt, int(self.test_params['pg']), asic_type))
             assert (fill_leakout_plus_one(self, src_port_2_id,
-                    dst_port_id, pkt3, int(self.test_params['pg']), asic_type))
+                                          dst_port_id, pkt3, int(self.test_params['pg']), asic_type))
             # send packets short of triggering pfc
             # Send 1 less packet due to leakout filling
             if num_of_flows == 'multiple':
@@ -1878,7 +1883,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             step_id += 1
             step_desc = 'send 1 packet to dst port 3, triggering PFC'
             sys.stderr.write('step {}: {}\n'.format(step_id, step_desc))
-            xmit_3_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
+            xmit_3_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 send_packet(self, src_port_id, pkt3,
                             pkts_num_egr_mem + pkts_num_leak_out + 1)
@@ -1951,8 +1957,10 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters_base = recv_counters
             recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
-            xmit_2_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
-            xmit_3_counters, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
+            xmit_2_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_2_id])
+            xmit_3_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
             port_cnt_tbl = texttable.TextTable([''] + [port_counter_fields[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters_base'] + [recv_counters_base[idx] for idx in port_counter_indexes])
             port_cnt_tbl.add_row(['recv_counters'] + [recv_counters[idx] for idx in port_counter_indexes])
@@ -2036,7 +2044,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             sys.stderr.write('{}\n'.format(port_cnt_tbl))
 
            # recv port no pfc
-            assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(pg, port_counter_fields[pg], step_id, step_desc)
+            assert(recv_counters[pg] == recv_counters_base[pg]), 'unexpectedly trigger PFC for PG {} (counter: {}), at step {} {}'.format(
+                pg, port_counter_fields[pg], step_id, step_desc)
             # recv port no ingress drop
             for cntr in ingress_counters:
                 assert (recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN),\
@@ -2056,6 +2065,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
+
 
 class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
@@ -2111,15 +2121,15 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # used only for headroom pool watermark
         if all(key in self.test_params for key in [
-            'hdrm_pool_wm_multiplier', 'buf_pool_roid', 'cell_size', 'max_headroom']):
-           self.cell_size = int(self.test_params['cell_size'])
-           self.wm_multiplier = self.test_params['hdrm_pool_wm_multiplier']
-           print("Wm multiplier: %d buf_pool_roid: %s" % (
-               self.wm_multiplier, self.test_params['buf_pool_roid']), file=sys.stderr)
-           self.buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
-           print("buf_pool_roid: 0x%lx" %
-                 (self.buf_pool_roid), file=sys.stderr)
-           self.max_headroom = int(self.test_params['max_headroom'])
+                'hdrm_pool_wm_multiplier', 'buf_pool_roid', 'cell_size', 'max_headroom']):
+            self.cell_size = int(self.test_params['cell_size'])
+            self.wm_multiplier = self.test_params['hdrm_pool_wm_multiplier']
+            print("Wm multiplier: %d buf_pool_roid: %s" % (
+                self.wm_multiplier, self.test_params['buf_pool_roid']), file=sys.stderr)
+            self.buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
+            print("buf_pool_roid: 0x%lx" %
+                  (self.buf_pool_roid), file=sys.stderr)
+            self.max_headroom = int(self.test_params['max_headroom'])
         else:
             self.wm_multiplier = None
 
@@ -2176,12 +2186,16 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         port_cnt_tbl = texttable.TextTable(
             [''] + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes])
         for srcPortIdx, srcPortId in enumerate(self.src_port_ids):
-            port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
+                                 [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
             rx_curr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][srcPortId])
-            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
-        port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
+                                 [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+        port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx]
+                                                                                for fieldIdx in port_counter_indexes])
         tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
-        port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+        port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx]
+                                                                                for fieldIdx in port_counter_indexes])
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
     def runTest(self):
@@ -2198,8 +2212,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[0] for sid in self.src_port_ids]
-        xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
+        recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
+            0] for sid in self.src_port_ids]
+        xmit_counters_base, _ = sai_thrift_read_port_counters(
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
@@ -2303,7 +2319,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                         recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (
                     pkt_cnt, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], sidx_dscp_pg_tuples[i][2] - 2),
-                      file=sys.stderr)
+                    file=sys.stderr)
                 sys.stderr.flush()
 
             print("PFC triggered", file=sys.stderr)
@@ -2316,7 +2332,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("Actual headroom pool watermark value to start: %d" %
                       hdrm_pool_wm, file=sys.stderr)
                 assert (hdrm_pool_wm <= (upper_bound *
-                        self.cell_size * self.wm_multiplier))
+                                         self.cell_size * self.wm_multiplier))
 
             expected_wm = 0
             wm_pkt_num = 0
@@ -2419,19 +2435,20 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             print("pg hdrm filled", file=sys.stderr)
             if self.wm_multiplier:
-               # assert hdrm pool wm still remains the same
-               hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                   self.src_client, self.buf_pool_roid)
-               sys.stderr.write('After PG headroom filled, actual headroom pool watermark {}, upper_bound {}\n'.format(hdrm_pool_wm, upper_bound_wm))
-               if 'innovium' not in self.asic_type:
-                   assert(expected_wm <= hdrm_pool_wm)
-               assert(hdrm_pool_wm <= upper_bound_wm)
-               # at this point headroom pool should be full. send few more packets to continue causing drops
-               print("overflow headroom pool", file=sys.stderr)
-               send_packet(self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 10)
-               hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
-                   self.src_client, self.buf_pool_roid)
-               assert(hdrm_pool_wm <= self.max_headroom)
+                # assert hdrm pool wm still remains the same
+                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
+                    self.src_client, self.buf_pool_roid)
+                sys.stderr.write('After PG headroom filled, actual headroom pool watermark {}, upper_bound {}\n'.format(
+                    hdrm_pool_wm, upper_bound_wm))
+                if 'innovium' not in self.asic_type:
+                    assert(expected_wm <= hdrm_pool_wm)
+                assert(hdrm_pool_wm <= upper_bound_wm)
+                # at this point headroom pool should be full. send few more packets to continue causing drops
+                print("overflow headroom pool", file=sys.stderr)
+                send_packet(self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, 10)
+                hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
+                    self.src_client, self.buf_pool_roid)
+                assert(hdrm_pool_wm <= self.max_headroom)
             sys.stderr.flush()
 
         finally:
@@ -2605,9 +2622,9 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             # Verify no ingress/egress drops for all ports
             recv_counters_list = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
-                                                                0] for sid in self.src_port_ids]
+                0] for sid in self.src_port_ids]
             xmit_counters_list = [sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][sid])[
-                                                                0] for sid in self.dst_port_ids]
+                0] for sid in self.dst_port_ids]
             for i in range(len(self.src_port_ids)):
                 for cntr in self.ingress_counters:
                     drops = recv_counters_list[i][cntr] - \
@@ -2682,7 +2699,8 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
 
@@ -2741,7 +2759,8 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(5)
             # Read Counters
             print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            port_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             print(port_counters)
             print(queue_counters)
             if (ecn == 0):
@@ -2873,7 +2892,8 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         send_packet(self, src_port_id, pkt, pkts_num_leak_out)
 
         # Get a snapshot of counter values
-        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # Send packets to each queue based on priority/dscp field
         for prio, pkt_cnt in zip(prio_list, q_pkt_cnt):
@@ -2956,9 +2976,10 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # Read counters
         print("DST port counters: ")
-        port_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        port_counters, queue_counters = sai_thrift_read_port_counters(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
         print(list(map(operator.sub, queue_counters,
-              queue_counters_base)), file=sys.stderr)
+                       queue_counters_base)), file=sys.stderr)
 
         # All packets sent should be received intact
         assert (q_cnt_sum == total_pkts)
@@ -3028,8 +3049,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
-        recv_counters_base, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
-        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        recv_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.src_client, asic_type, port_list['src'][src_port_id])
+        xmit_counters_base, queue_counters = sai_thrift_read_port_counters(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
         # add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -3077,8 +3100,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert (recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -3094,8 +3119,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
             # get a snapshot of counter values at recv and transmit ports
             # queue counters value is not of our interest here
-            recv_counters, queue_counters = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
-            xmit_counters, queue_counters = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            recv_counters, queue_counters = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
             assert (recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
@@ -3295,8 +3322,10 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, self.src_port_id, pkt2, npkts)
             # allow enough time for counters to update
             time.sleep(2)
-            recv_counters, _ = sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][self.src_port_id])
-            xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, self.asic_type, port_list['src'][self.src_port_id])
+            xmit_counters, _ = sai_thrift_read_port_counters(
+                self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
             # recv port no pfc
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
@@ -3333,21 +3362,23 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         port_counter_indexes += [TRANSMITTED_PKTS, RECEIVED_PKTS,
                                  RECEIVED_NON_UC_PKTS, TRANSMITTED_NON_UC_PKTS, EGRESS_PORT_QLEN]
         stats_tbl = texttable.TextTable(['']
-                                      + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
-                                      + ['Ing Pg{} Pkt'.format(pg)]
-                                      + ['Ing Pg{} Share Wm'.format(pg)])
+                                        + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
+                                        + ['Ing Pg{} Pkt'.format(pg)]
+                                        + ['Ing Pg{} Share Wm'.format(pg)])
         if sport_cntr == None:
             sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
         if sport_pg_cntr == None:
             sport_pg_cntr = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         if sport_pg_share_wm == None:
-            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
+            sport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
+                self.src_client, asic_type, port_list['src'][src_port_id])
         if dport_cntr == None:
             dport_cntr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
         if dport_pg_cntr == None:
             dport_pg_cntr = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
         if dport_pg_share_wm == None:
-            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            dport_pg_share_wm = sai_thrift_read_pg_shared_watermark(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
         stats_tbl.add_row(['base src port']
                           + [sport_cntr_base[fieldIdx]
                               for fieldIdx in port_counter_indexes]
@@ -3447,8 +3478,10 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
         pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
-        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type, port_list['src'][src_port_id])
-        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
+            self.src_client, asic_type, port_list['src'][src_port_id])
+        dst_pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -3458,7 +3491,8 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             pg_min_pkts_num = 0
 
             # send packets to fill pg min but not trek into shared pool
@@ -3479,7 +3513,8 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             time.sleep(8)
 
             if pg_min_pkts_num > 0 and check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
             pg_cntrs = sai_thrift_read_pg_counters(
                 self.src_client, port_list['src'][src_port_id])
@@ -3534,11 +3569,12 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 print("pkts num to send: %d, total pkts: %d, pg shared: %d" %
                       (pkts_num, expected_wm, total_shared), file=sys.stderr)
 
-                send_packet(self, src_port_id, pkt,int(pkts_num))
+                send_packet(self, src_port_id, pkt, int(pkts_num))
                 time.sleep(8)
 
                 if pg_min_pkts_num == 0 and pkts_num <= 1 + margin and check_leackout_compensation_support(asic_type, hwsku):
-                    dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
+                    dynamically_compensate_leakout(self.src_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_history, self, src_port_id, pkt, 40)
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
@@ -3600,7 +3636,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                         expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
             else:
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
-                          pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]),file=sys.stderr)
+                    pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]), file=sys.stderr)
                 assert (expected_wm * cell_size <= pg_shared_wm_res[pg] <= (
                         expected_wm + margin + cell_occupancy) * cell_size)
         finally:
@@ -3695,17 +3731,19 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             # send packets to trigger pfc but not trek into headroom
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 send_packet(self, src_port_id, pkt, (pkts_num_egr_mem +
-                            pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - margin)
+                                                     pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - margin)
             else:
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
-                            pkts_num_trig_pfc) // cell_occupancy - margin)
+                                                     pkts_num_trig_pfc) // cell_occupancy - margin)
 
             time.sleep(8)
 
             if check_leackout_compensation_support(asic_type, hwsku):
-                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters, port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS, xmit_counters_base, self, src_port_id, pkt, 30)
 
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
+                self.src_client, port_list['src'][src_port_id])
             if platform_asic and platform_asic == "broadcom-dnx":
                 logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " +
                              "stat - so ignoring this step for now")
@@ -3737,7 +3775,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     self.src_client, port_list['src'][src_port_id])
 
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin) * cell_size *
-                      cell_occupancy, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size * cell_occupancy)),
+                                                                              cell_occupancy, pg_headroom_wm_res[pg], ((expected_wm + margin) * cell_size * cell_occupancy)),
                       file=sys.stderr)
 
                 if platform_asic and platform_asic == "broadcom-dnx":
@@ -3773,6 +3811,7 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
 
 class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
@@ -3828,7 +3867,7 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
             for test_i in range(iterations):
                 self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
-                pg_dropped_cntrs_base=sai_thrift_read_pg_drop_counters(
+                pg_dropped_cntrs_base = sai_thrift_read_pg_drop_counters(
                     self.src_client, port_list['src'][src_port_id])
 
                 # Send packets to trigger PFC
@@ -3838,10 +3877,10 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 # Account for leakout
                 if 'cisco-8000' in asic_type:
-                    queue_counters=sai_thrift_read_queue_occupancy(
+                    queue_counters = sai_thrift_read_queue_occupancy(
                         self.dst_client, "dst", dst_port_id)
-                    occ_pkts=queue_counters[queue] // (packet_length + 24)
-                    leaked_pkts=pkts_num_trig_pfc - occ_pkts
+                    occ_pkts = queue_counters[queue] // (packet_length + 24)
+                    leaked_pkts = pkts_num_trig_pfc - occ_pkts
                     print("resending leaked packets {}".format(
                         leaked_pkts))
                     send_packet(self, src_port_id, pkt, leaked_pkts)
@@ -3852,9 +3891,9 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkt_inc), file=sys.stderr)
                 send_packet(self, src_port_id, pkt, pkt_inc)
 
-                pg_dropped_cntrs=sai_thrift_read_pg_drop_counters(
+                pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(
                     self.src_client, port_list['src'][src_port_id])
-                pg_drops=pg_dropped_cntrs[pg] - pg_dropped_cntrs_base[pg]
+                pg_drops = pg_dropped_cntrs[pg] - pg_dropped_cntrs_base[pg]
 
                 actual_num_trig_ingr_drp = pkts_num_trig_ingr_drp + \
                     margin - (pg_drops - 1)
@@ -3875,6 +3914,7 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
+
 class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
     def show_stats(self, banner, asic_type,
@@ -3890,11 +3930,11 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         port_counter_indexes += [TRANSMITTED_PKTS, RECEIVED_PKTS,
                                  RECEIVED_NON_UC_PKTS, TRANSMITTED_NON_UC_PKTS, EGRESS_PORT_QLEN]
         stats_tbl = texttable.TextTable(['']
-                                      + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
-                                      + ['Ing Pg{} Pkt'.format(que)]
-                                      + ['Ing Pg{} Share Wm'.format(que)]
-                                      + ['Ing Pg{} headroom Wm'.format(que)]
-                                      + ['Que{} Share Wm'.format(que)])
+                                        + [port_counter_fields[fieldIdx] for fieldIdx in port_counter_indexes]
+                                        + ['Ing Pg{} Pkt'.format(que)]
+                                        + ['Ing Pg{} Share Wm'.format(que)]
+                                        + ['Ing Pg{} headroom Wm'.format(que)]
+                                        + ['Que{} Share Wm'.format(que)])
 
         if sport_cntr == None:
             sport_cntr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
@@ -4024,8 +4064,10 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
         pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
-        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.src_client, port_list['src'][src_port_id])
-        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(self.dst_client, port_list['dst'][dst_port_id])
+        q_wm_res_base, pg_shared_wm_res_base, pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(
+            self.src_client, port_list['src'][src_port_id])
+        dst_q_wm_res_base, dst_pg_shared_wm_res_base, dst_pg_headroom_wm_res_base = sai_thrift_read_port_watermarks(
+            self.dst_client, port_list['dst'][dst_port_id])
 
         # send packets
         try:
@@ -4035,7 +4077,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            xmit_counters_history, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            xmit_counters_history, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             que_min_pkts_num = 0
 
             # send packets to fill queue min but not trek into shared pool
@@ -4057,9 +4100,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                                port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                xmit_counters_history, self, src_port_id, pkt, 40)
 
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
                 self.dst_client, port_list['dst'][dst_port_id])
-            pg_cntrs=sai_thrift_read_pg_counters(
+            pg_cntrs = sai_thrift_read_pg_counters(
                 self.src_client, port_list['src'][src_port_id])
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 que_min_pkts_num, pkts_num_fill_min, q_wm_res[queue]), file=sys.stderr)
@@ -4080,7 +4123,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             else:
                 if platform_asic and platform_asic == "broadcom-dnx":
-                    logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " + \
+                    logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " +
                                  "stat - so ignoring this step for now")
                 else:
                     assert(q_wm_res[queue] <= 1 * cell_size)
@@ -4129,14 +4172,14 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 # these counters are clear on read, ensure counter polling
                 # is disabled before the test
-                q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+                q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
                     self.dst_client, port_list['dst'][dst_port_id])
-                pg_cntrs=sai_thrift_read_pg_counters(
+                pg_cntrs = sai_thrift_read_pg_counters(
                     self.src_client, port_list['src'][src_port_id])
                 print("Received packets: %d" %
                       (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
                 print("lower bound: %d, actual value: %d, upper bound: %d" % ((expected_wm - margin)
-                      * cell_size, q_wm_res[queue], (expected_wm + margin) * cell_size), file=sys.stderr)
+                                                                              * cell_size, q_wm_res[queue], (expected_wm + margin) * cell_size), file=sys.stderr)
 
                 self.show_stats('Fill queue shared', asic_type,
                                 queue, src_port_id, dst_port_id, ingress_counters, egress_counters,
@@ -4160,7 +4203,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             if 'cisco-8000' in asic_type:
                 self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
                 assert(fill_leakout_plus_one(self, src_port_id,
-                       dst_port_id, pkt, queue, asic_type))
+                                             dst_port_id, pkt, queue, asic_type))
                 pkts_total += pkts_num
                 pkts_num = pkts_total - 1
 
@@ -4171,9 +4214,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
             time.sleep(8)
-            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res=sai_thrift_read_port_watermarks(
+            q_wm_res, pg_shared_wm_res, pg_headroom_wm_res = sai_thrift_read_port_watermarks(
                 self.dst_client, port_list['dst'][dst_port_id])
-            pg_cntrs=sai_thrift_read_pg_counters(
+            pg_cntrs = sai_thrift_read_pg_counters(
                 self.src_client, port_list['src'][src_port_id])
             print("Received packets: %d" %
                   (pg_cntrs[queue] - pg_cntrs_base[queue]), file=sys.stderr)
@@ -4241,7 +4284,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         buffer_pool_wm_base = 0
         if 'cisco-8000' in asic_type:
             # Some small amount of memory is always occupied
-            buffer_pool_wm_base=sai_thrift_read_buffer_pool_watermark(
+            buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
                 self.src_client, buf_pool_roid)
 
         # Prepare TCP packet data
@@ -4299,7 +4342,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             send_packet(self, src_port_id, pkt, pkts_num_to_send)
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
-            buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+            buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
                 self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("Init pkts num sent: %d, min: %d, actual watermark value to start: %d" % (
                 (pkts_num_leak_out + pkts_num_fill_min), pkts_num_fill_min, buffer_pool_wm), file=sys.stderr)
@@ -4344,12 +4387,12 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     send_packet(self, src_port_id, pkt, pkts_num_to_send)
                 self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
                 time.sleep(8)
-                buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+                buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
                     self.src_client, buf_pool_roid) - buffer_pool_wm_base
                 print("lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (lower_bound_margin, (expected_wm - lower_bound_margin)
-                      * cell_size, buffer_pool_wm, upper_bound_margin, (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
-                assert(buffer_pool_wm <= (expected_wm + \
-                       upper_bound_margin) * cell_size)
+                                                                                          * cell_size, buffer_pool_wm, upper_bound_margin, (expected_wm + upper_bound_margin) * cell_size), file=sys.stderr)
+                assert(buffer_pool_wm <= (expected_wm +
+                                          upper_bound_margin) * cell_size)
                 assert((expected_wm - lower_bound_margin)
                        * cell_size <= buffer_pool_wm)
 
@@ -4367,7 +4410,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(8)
-            buffer_pool_wm=sai_thrift_read_buffer_pool_watermark(
+            buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
                 self.src_client, buf_pool_roid) - buffer_pool_wm_base
             print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                 pkts_num, (expected_wm * cell_size), buffer_pool_wm), file=sys.stderr)
@@ -4507,9 +4550,11 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             # Disable tx on EGRESS port so that headroom buffer cannot be free
             self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             # Make a snapshot of transmitted packets
-            tx_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            tx_counters_base, _ = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # Make a snapshot of received packets
-            rx_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
+            rx_counters_base, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
             if tunnel_traffic_test:
                 # Build IPinIP packet for testing
                 pkt = self._build_testing_ipinip_pkt(active_tor_mac=active_tor_mac,
@@ -4525,10 +4570,10 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 # Build regular packet
                 pkt = self._build_testing_pkt(active_tor_mac=active_tor_mac,
-                                            dscp=inner_dscp,
-                                            dst_ip=dst_port_ip,
-                                            ecn=ecn,
-                                            packet_size=packet_size)
+                                              dscp=inner_dscp,
+                                              dst_ip=dst_port_ip,
+                                              ecn=ecn,
+                                              packet_size=packet_size)
             # Send packets short of triggering pfc
             send_packet(self, src_port_id, pkt, pkts_num_trig_pfc // cell_occupancy - 1 - pkts_num_margin)
             time.sleep(8)
@@ -4633,8 +4678,8 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
                     # leakout
                     if 'cisco-8000' in asic_type:
                         assert fill_leakout_plus_one(self, src_port_id,
-                               dst_port_id, pkt, queue, asic_type), \
-                               "Failed to fill leakout on dest port {}".format(dst_port_id)
+                                                     dst_port_id, pkt, queue, asic_type), \
+                            "Failed to fill leakout on dest port {}".format(dst_port_id)
 
                     # send packet
                     send_packet(self, src_port_id, pkt, pkt_count)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1598,7 +1598,7 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
         recv_counters, queue_counters = sai_thrift_read_port_counters(
             self.src_client, self.asic_type, port_list['src'][self.src_port_id])
         xmit_counters, queue_counters = sai_thrift_read_port_counters(
-            self.dst_client, self.asic-type, port_list['dst'][self.dst_port_id])
+            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         logging.debug("Recv Counters: {}, Base: {}".format(
             recv_counters, recv_counters_base))

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -129,7 +129,7 @@ def switch_init(clients):
         return _port_list, _sai_port_list, _front_port_list
 
     port_list['src'], sai_port_list['src'], front_port_list['src'] = _get_data_for_client(clients['src'], 'src')
-    if 'dst' not in clients:
+    if 'dst' not in clients or clients['src'] == clients['dst']:
         port_list['dst'] = port_list['src']
         sai_port_list['dst'] = sai_port_list['src']
         front_port_list['dst'] = front_port_list['src']

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -69,7 +69,7 @@ from switch_sai_thrift.sai_headers import SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRES
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
-switch_inited=0
+switch_inited = 0
 # All below are dictionary with key 'src' or 'dst' and val is value for that client
 port_list = {}
 sai_port_list = {}

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -67,6 +67,8 @@ from switch_sai_thrift.sai_headers import SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRES
     SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS, SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS, SAI_PORT_STAT_IF_OUT_QLEN
 
 
+from switch_sai_thrift.sai_headers import SAI_SWITCH_ATTR_SRC_MAC_ADDRESS
+
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
 switch_inited = 0

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -173,7 +173,8 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
 
 
 def collect_dut_lossless_prio(dut):
-    config_facts = dut.config_facts(host=dut.hostname, source="running")['ansible_facts']
+    dut_asic = dut.asic_instance()
+    config_facts = dut_asic.config_facts(host=dut.hostname, source="running")['ansible_facts']
 
     if "PORT_QOS_MAP" not in list(config_facts.keys()):
         return []
@@ -192,7 +193,8 @@ def collect_dut_lossless_prio(dut):
 
 
 def collect_dut_all_prio(dut):
-    config_facts = dut.config_facts(host=dut.hostname, source="running")['ansible_facts']
+    dut_asic = dut.asic_instance()
+    config_facts = dut_asic.config_facts(host=dut.hostname, source="running")['ansible_facts']
 
     if "DSCP_TO_TC_MAP" not in list(config_facts.keys()):
         return []


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The existing QoS (test_qos_sai.py) is written to accomodata a single asic on a single Dut. But, we require the same tests to be executed against a T2 chassis (with single/multi-asic linecards) and multi-asic pizza boxes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
All the test cases create a list of src and dst ports. For the different modes, here is the distribution of the src and dst ports:
- single_asic: The src and dst ports are on the same asic on the same linecard.
- single_dut_multi_asic: On a multi-asic DUT/linecard, the src port is on an asic, while the dst ports are on another asic on the same DUT/linecard
- multi_dut: The src port is on an asic on one of the DUT/linecards, and the dst port is on another asic on another DUT/linecard. This is currently only required for T2 topology

#### How did you do it?
Approach to accomplish this is the following:
- All the tests have to parameterized for the 3 modes defined above.
  - This is done using the 'select_src_and_dst_dut_and_asic' fixture that is parameterized for 'single_asic', 'single_dut_multi_asic', 'multi_dut' - Based on the mode, it sets the src_dut_index, dst_dut_index, src_asic_index and dst_asic_index
  - Added fixture 'get_src_dst_asic_and_duts' that returns dictionary of the src_dut_index, dst_dut_index, src_asic_index, and dst_asic_index, and the src_dut and dst_dut (instances of MultiAsicSonicHost), src_asic and dst_asic (instances of Asic), and also a list of all DUTs and all Asics
- dutConfig is modified such that testPortIds and testPortIps are collecting from all the duts and asics involved and stored in a dictionary with key being the dutIndex and value being a dictionary per asic index.
   - __buildTestPorts then sets the src and dst ports based on the src_dut_index, dst_dut_index, src_asic_index and dst_asic_index
- All the other fixtures and tests, we use 'get_src_dst_asci_and_duts' fixture instead of enum_rand_one_frontend_hostname and enum_frontend_index.
  - The code instead the fixtures and tests is modified to the actions on the correct src/dst dut or asic. For example: - swap_syncd fixture would swap syncd docker on all DUT's (both src and dst) instead of just one DUT as before. - stopServices - do it all_duts (src and dst duts)

- Similarly, changes to saitests involved dealing with multiple DUTs (and thus multiple sai clients) and modifying other data structure like 'interface_to_front_mapping' in sai_base_test.py and port_list, sai_port_list, front_port_list in switch.py to deal with multiple duts (modified to be dictionary with keys being 'src' and 'dst')
  - default_interface_to_front_map.ini file in ptf modified to have syntax: ptf_port@dut_port:dut_index - Done by using new fixture 'ptf_portmap_file_all_frontend_nodes' in ptfhost_utils.py
  - tests in sai_qos_tests.py pass src_dut_index and dst_dut_index in the testParams.
     - The saitests classes then use this to do the actions on the right client and ports.

- Assumptions:
  - For multi-dut, we are assuming that hwsku for all the cards are same.

#### How did you verify/test it?
Ran the tests against T2 J2C+ chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->