### PR TITLE
Fix arp_responder.py failed to start in many tests

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -104,11 +104,23 @@ class ARPResponder(object):
 
     def action(self, interface):
         data = interface.recv()
+        eth_type = struct.unpack('!H', data[12:14])[0]
 
-        if len(data) <= self.ARP_PKT_LEN:
-            return self.reply_to_arp(data, interface)
-        elif len(data) <= self.NDP_PKT_LEN:
-            return self.reply_to_ndp(data, interface)
+        if eth_type == 0x0806:  # ARP
+            if len(data) <= self.ARP_PKT_LEN:
+                return self.reply_to_arp(data, interface)
+            else:
+                # Handle the case where data length is greater than ARP packet length
+                pass
+        elif eth_type == 0x86DD:  # IPv6
+            if len(data) <= self.NDP_PKT_LEN:
+                return self.reply_to_ndp(data, interface)
+            else:
+                # Handle the case where data length is greater than NDP packet length
+                pass
+        else:
+            # Handle other Ethernet types
+            pass
 
     def reply_to_arp(self, data, interface):
         remote_mac, remote_ip, request_ip, op_type, vlan_id = self.extract_arp_info(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes arp_responder.py failed to start due to receiving unknown ethernet type packets

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
When ARP responder received malformed packet, it cannot handle it and just crashed. This caused a lot of testcase failures.

#### How did you do it?
Add more logic to check the received packet.

#### How did you verify/test it?
Run test_acl.py::TestBasicACL and got 100% pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
