### PR TITLE
[dualtor-aa] Fix test_server_failure errors over dualtor-aa topo 

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -640,7 +640,9 @@ def simulator_server_down(set_drop, set_output):
         set_drop(interface_name, [UPPER_TOR, LOWER_TOR])
 
     yield _drop_helper
-    set_output(tmp_list[0], [UPPER_TOR, LOWER_TOR])
+
+    for port in tmp_list:
+        set_output(port, [UPPER_TOR, LOWER_TOR])
 
 
 @pytest.fixture

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -35,18 +35,22 @@ def test_server_down(duthosts, tbinfo, active_standby_ports, simulator_flap_coun
 
     if loganalyzer:
         for analyzer in list(loganalyzer.values()):
-            analyzer.ignore_regex.append(r".*ERR swss#orchagent: :- setState: State transition from active to active is not-handled")
+            analyzer.ignore_regex.append(
+                r".*ERR swss#orchagent: :- setState: State transition from active to active is not-handled"
+            )
 
     upper_tor = duthosts[tbinfo['duts'][0]]
     lower_tor = duthosts[tbinfo['duts'][1]]
 
     def upper_tor_mux_state_verification(state, health):
         mux_state_upper_tor = show_muxcable_status(upper_tor)
-        return mux_state_upper_tor[test_iface]['status'] == state and mux_state_upper_tor[test_iface]['health'] == health
+        return (mux_state_upper_tor[test_iface]['status'] == state and
+                mux_state_upper_tor[test_iface]['health'] == health)
 
     def lower_tor_mux_state_verfication(state, health):
         mux_state_lower_tor = show_muxcable_status(lower_tor)
-        return mux_state_lower_tor[test_iface]['status'] == state and mux_state_lower_tor[test_iface]['health'] == health
+        return (mux_state_lower_tor[test_iface]['status'] == state and
+                mux_state_lower_tor[test_iface]['health'] == health)
 
     # Set upper_tor as active
     toggle_simulator_port_to_upper_tor(test_iface)

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -1,11 +1,16 @@
+import logging
 import pytest
+import random
+
 from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, \
                                                        simulator_flap_counter, simulator_server_down    # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.dualtor.dual_tor_utils import show_muxcable_status, rand_selected_interface           # noqa: F401
+from tests.common.dualtor.dual_tor_utils import show_muxcable_status                                    # noqa: F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                                      # noqa: F401
 from tests.common.utilities import wait_until
+
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -18,35 +23,38 @@ def skip_if_non_dualtor_topo(tbinfo):
     pytest_require('dualtor' in tbinfo['topo']['name'], "Only run on dualtor testbed")
 
 
-def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_counter,             # noqa F811
+def test_server_down(duthosts, tbinfo, active_standby_ports, simulator_flap_counter,                # noqa F811
                      simulator_server_down, toggle_simulator_port_to_upper_tor, loganalyzer):       # noqa F811
     """
     Verify that mux cable is not toggled excessively.
     """
 
-    for analyzer in list(loganalyzer.values()):
-        analyzer.ignore_regex.append(r".*ERR swss#orchagent: :- setState: \
-                                     State transition from active to active is not-handled")
+    pytest_require(active_standby_ports, "No active-standby ports are found in the dualtor topology")
+    test_iface = random.choice(active_standby_ports)
+    logging.info("Selected active-standby interface %s to test", test_iface)
+
+    if loganalyzer:
+        for analyzer in list(loganalyzer.values()):
+            analyzer.ignore_regex.append(r".*ERR swss#orchagent: :- setState: State transition from active to active is not-handled")
 
     upper_tor = duthosts[tbinfo['duts'][0]]
     lower_tor = duthosts[tbinfo['duts'][1]]
 
     def upper_tor_mux_state_verification(state, health):
         mux_state_upper_tor = show_muxcable_status(upper_tor)
-        return mux_state_upper_tor[itfs]['status'] == state and mux_state_upper_tor[itfs]['health'] == health
+        return mux_state_upper_tor[test_iface]['status'] == state and mux_state_upper_tor[test_iface]['health'] == health
 
     def lower_tor_mux_state_verfication(state, health):
         mux_state_lower_tor = show_muxcable_status(lower_tor)
-        return mux_state_lower_tor[itfs]['status'] == state and mux_state_lower_tor[itfs]['health'] == health
+        return mux_state_lower_tor[test_iface]['status'] == state and mux_state_lower_tor[test_iface]['health'] == health
 
-    itfs, _ = rand_selected_interface
     # Set upper_tor as active
-    toggle_simulator_port_to_upper_tor(itfs)
+    toggle_simulator_port_to_upper_tor(test_iface)
     pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy'),
                   "mux_cable status is unexpected. Should be (active, healthy). Test can't proceed. ")
-    mux_flap_counter_0 = simulator_flap_counter(itfs)
+    mux_flap_counter_0 = simulator_flap_counter(test_iface)
     # Server down
-    simulator_server_down(itfs)
+    simulator_server_down(test_iface)
     # Verify mux_cable state on upper_tor is active
     pytest_assert(wait_until(20, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'),
                   "mux_cable status is unexpected. Should be (active, unhealthy)")
@@ -57,7 +65,7 @@ def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_c
     # lower_tor(standby) -> active -> standby
     # upper_tor(active) -> active
     # The toggle from both tor may be overlapped and invisible
-    mux_flap_counter_1 = simulator_flap_counter(itfs)
+    mux_flap_counter_1 = simulator_flap_counter(test_iface)
     pytest_assert(mux_flap_counter_1 - mux_flap_counter_0 <= 3,
                   "The mux_cable flap count should be no larger than 3 ({})"
                   .format(mux_flap_counter_1 - mux_flap_counter_0))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
As it requires `active-standby` mux ports to test, skip it if no
`active-standby` mux ports available.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
Run over both `dualtor-aa` and `dualtor` testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
