### PR TITLE
[dualtor-aa] Skip `test_mux_toggle` on `dualtor-aa` testbed

### DIFF
--- a/tests/dualtor_mgmt/test_toggle_mux.py
+++ b/tests/dualtor_mgmt/test_toggle_mux.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse=True)
-def check_topo(active_standby_ports, tbinfo):
+def check_topo(active_standby_ports, tbinfo):                                                           # noqa: F811
     if 'dualtor' not in tbinfo['topo']['name']:
         pytest.skip('Skip on non-dualtor testbed')
 

--- a/tests/dualtor_mgmt/test_toggle_mux.py
+++ b/tests/dualtor_mgmt/test_toggle_mux.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
-from tests.common.dualtor.dual_tor_common import active_standby_ports
+from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa: F401
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
 from tests.common.dualtor.dual_tor_utils import recover_linkmgrd_probe_interval, update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until

--- a/tests/dualtor_mgmt/test_toggle_mux.py
+++ b/tests/dualtor_mgmt/test_toggle_mux.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
+from tests.common.dualtor.dual_tor_common import active_standby_ports
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
 from tests.common.dualtor.dual_tor_utils import recover_linkmgrd_probe_interval, update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until
@@ -16,9 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse=True)
-def check_topo(tbinfo):
+def check_topo(active_standby_ports, tbinfo):
     if 'dualtor' not in tbinfo['topo']['name']:
         pytest.skip('Skip on non-dualtor testbed')
+
+    if not active_standby_ports:
+        pytest.skip("Skip as no 'active-standby' mux ports available")
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip `test_mux_toggle` testcases on `dualtor-aa` topo

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Check if `active_standby_ports` is empty, simply skip it.

#### How did you verify/test it?
Run over both `dualtor-aa` and `dualtor` testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
