### PR TITLE
Fix VLAN failure test case tc4 and tc5

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2130,7 +2130,7 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0, timeout=None)
         if port in ports:
             logging.debug("Checking for pkt on device %d, port %d", device_number, port)
             result = testutils.dp_poll(test, device_number=device, port_number=port,
-                timeout=timeout, exp_pkt=pkt)
+                                       timeout=timeout, exp_pkt=pkt)
             if isinstance(result, test.dataplane.PollSuccess):
                 received = True
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2111,7 +2111,7 @@ def on_exit():
     on_exit.cleanup()
 
 
-def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
+def verify_packets_any_fixed(test, pkt, ports=[], device_number=0, timeout=None):
     """
     Check that a packet is received on _any_ of the specified ports belonging to
     the given device (default device_number is 0).
@@ -2129,7 +2129,8 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
             continue
         if port in ports:
             logging.debug("Checking for pkt on device %d, port %d", device_number, port)
-            result = testutils.dp_poll(test, device_number=device, port_number=port, exp_pkt=pkt)
+            result = testutils.dp_poll(test, device_number=device, port_number=port,
+                timeout=timeout, exp_pkt=pkt)
             if isinstance(result, test.dataplane.PollSuccess):
                 received = True
             else:

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -319,11 +319,11 @@ def verify_icmp_packets(ptfadapter, send_pkt, work_vlan_ports_list, vlan_port, v
                                     portchannel_ports=tagged_dst_pc_ports)
 
 
-def verify_unicast_packets(ptfadapter, send_pkt, exp_pkt, src_port, dst_ports):
+def verify_unicast_packets(ptfadapter, send_pkt, exp_pkt, src_port, dst_ports, timeout=None):
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, src_port, send_pkt)
     try:
-        testutils.verify_packets_any(ptfadapter, exp_pkt, ports=dst_ports)
+        testutils.verify_packets_any(ptfadapter, exp_pkt, ports=dst_ports, timeout=timeout)
     except AssertionError as detail:
         if "Did not receive expected packet on any of ports" in str(detail):
             logger.error("Expected packet was not received")
@@ -460,7 +460,8 @@ def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_di
             tagged_test_vlan, src_port, dst_port))
 
         verify_unicast_packets(
-            ptfadapter, transmit_tagged_pkt, transmit_tagged_pkt, src_port[0], dst_port)
+            ptfadapter, transmit_tagged_pkt, transmit_tagged_pkt, src_port[0],
+            dst_port, timeout=5)
 
         logger.info("One Way Tagged Packet Transmission Works")
         logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
@@ -470,7 +471,7 @@ def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_di
             tagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_tagged_pkt,
-                               return_transmit_tagged_pkt, dst_port[0], src_port)
+            return_transmit_tagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Tagged Packet Transmission Works")
         logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
@@ -511,7 +512,8 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_
             untagged_test_vlan, src_port, dst_port))
 
         verify_unicast_packets(
-            ptfadapter, transmit_untagged_pkt, transmit_untagged_pkt, src_port[0], dst_port)
+            ptfadapter, transmit_untagged_pkt, transmit_untagged_pkt, src_port[0],
+            dst_port, timeout=5)
 
         logger.info("One Way Untagged Packet Transmission Works")
         logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(
@@ -521,7 +523,7 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_
             untagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_untagged_pkt,
-                               return_transmit_untagged_pkt, dst_port[0], src_port)
+            return_transmit_untagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Untagged Packet Transmission Works")
         logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -471,7 +471,7 @@ def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_di
             tagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_tagged_pkt,
-            return_transmit_tagged_pkt, dst_port[0], src_port, timeout=5)
+                               return_transmit_tagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Tagged Packet Transmission Works")
         logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
@@ -523,7 +523,7 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_
             untagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_untagged_pkt,
-            return_transmit_untagged_pkt, dst_port[0], src_port, timeout=5)
+                               return_transmit_untagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Untagged Packet Transmission Works")
         logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(


### PR DESCRIPTION
### Description of PR
The below two VLAN test case failed.
It is observed that the expected packet were not recieved as first packet.
        Analysis the packet capture, the expected packet were recieved at
        packet number 7, instead of packet number 0.

        **vlan/test_vlan.py::test_vlan_tc4_tagged_unicast
        vlan/test_vlan.py::test_vlan_tc5_untagged_unicast**

Summary: Add timeout value of 5 sec wait for expected packet to come.
Fixes # (issue) 

### Type of change

- [ x] Bug fix
- [ ]  Testbed and Framework(new/improvement)
- [ ]  Test case(new/improvement)

### Back port request
 
- [ ] 201911
- [ ]  202012
- [x ]  202205

### Approach
**What is the motivation for this PR?**
The timeout of few sec (5 seconds here) for the expected packet is right way, before declaring failure.

#### What is the motivation for this PR?
Add timeout for VLAN test case.
Timeout was not correctly done in the call to dp_poll via the verify_packet_any_fixed()
>>>>>
#### How did you do it?

Capture the packets on PTF to verify expected packets are recieved within the timeout value.


#### How did you verify/test it?

Run test with the fix to verify expected packets is received.

#### Any platform specific information?
This should be applicable to all platform, and not just for Cisco platform.

#### Supported testbed topology if it's a new test case?
Not a new test case.


### Documentation
None

        