### PR TITLE
[dualtor-aa] Fix `test_fdb[ethernet]`

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -9,6 +9,7 @@ import requests
 from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                             # noqa F401
 from tests.common.dualtor.dual_tor_common import mux_config                             # noqa F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
@@ -507,8 +508,8 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
     Before toggling, this fixture firstly sets all muxcables to 'manual' mode on all ToRs.
     After test is done, restore all mux cables to 'auto' mode on all ToRs in teardown phase.
     """
-    # Skip on non dualtor testbed
-    if 'dualtor' not in tbinfo['topo']['name']:
+    # Skip on non dualtor testbed or dualtor testbed without active-standby ports
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
         yield
         return
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -15,8 +15,11 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.duthost_utils import disable_fdb_aging           # noqa F401
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby     # noqa F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup            # noqa F401
 from tests.common.dualtor.mux_simulator_control import mux_server_url, \
                                                        toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dualtor.dual_tor_common import active_active_ports        # noqa F401
 from .utils import fdb_cleanup, send_eth, send_arp_request, send_arp_reply, send_recv_eth
 
 pytestmark = [
@@ -271,10 +274,31 @@ def record_mux_status(request, rand_selected_dut, tbinfo):
         logger.warning("fdb test failed. Mux status are \n {}".format(mux_status))
 
 
+@pytest.fixture(params=PKT_TYPES)
+def pkt_type(request):
+    """Packet type to test."""
+    return request.param
+
+
+@pytest.fixture
+def setup_active_active_ports(active_active_ports, rand_selected_dut, rand_unselected_dut,                  # noqa F811
+                              pkt_type, config_active_active_dualtor_active_standby,                        # noqa F811
+                              validate_active_active_dualtor_setup):                                        # noqa F811
+    if active_active_ports and pkt_type == "ethernet":
+        # for active-active dualtor, the upstream traffic is ECMPed to both ToRs, so let's
+        # config the unselected ToR as standby to ensure all ethernet type packets are
+        # forwarded to the selected ToR.
+        logger.info("Configuring {} as active".format(rand_selected_dut.hostname))
+        logger.info("Configuring {} as standby".format(rand_unselected_dut.hostname))
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+
+    return
+
+
 @pytest.mark.bsl
-@pytest.mark.parametrize("pkt_type", PKT_TYPES)
 def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type,
-             toggle_all_simulator_ports_to_rand_selected_tor_m, record_mux_status, get_dummay_mac_count):   # noqa F811
+             toggle_all_simulator_ports_to_rand_selected_tor_m, record_mux_status,              # noqa F811
+             setup_active_active_ports, get_dummay_mac_count):                                  # noqa F811
 
     # Perform FDB clean up before each test and at the end of the final test
     fdb_cleanup(duthosts, rand_one_dut_hostname)
@@ -368,7 +392,6 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
     assert dummy_mac_count == configured_dummay_mac_count * vlan_member_count
 
 
-@pytest.mark.parametrize("pkt_type", PKT_TYPES)
 def test_self_mac_not_learnt(ptfadapter, rand_selected_dut, pkt_type,
                              toggle_all_simulator_ports_to_rand_selected_tor_m, tbinfo):    # noqa F811
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix `test_fdb[ethernet]` failure on `dualtor-aa` testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
For pkt_type etherent, the packets to populate the fdb are ECMPed to
either ToRs, neither of the ToRs could have the full set of fdb entries.
And as the I/O also gets ECMPed in the validation step, the I/O could
not be guaranteed to be forwarded to the ToR that has the corresponding
fdb entry.

Let's fall back to active-standby mode to test this scenario for
active-active ports.

#### How did you verify/test it?
Run on `dualtor-aa` testbed.
```
fdb/test_fdb.py::test_fdb[ethernet] PASSED                                                                                                                                                                                           [100%]

================================================================================================= 1 passed, 3 deselected in 361.35 seconds =================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
