### PR TITLE
Stop all processes managed by supervisor before the PTF container is stopped

### DIFF
--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -194,4 +194,20 @@
       that: exabgp_running.stdout|int == 0
       fail_msg: "exabgp processes are still running on PTF, please check manually"
 
+  - name: Stop all processes managed by supervisor on PTF
+    block:
+    - name: Stop all processes managed by supervisor on PTF
+      shell: "supervisorctl stop all"
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Get count of running processes managed by supervisor
+      shell: "supervisorctl status | grep RUNNING | wc -l"
+      register: supervisor_proc_running
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Verify all the processes managed by supervisor are not running
+      assert:
+        that: supervisor_proc_running.stdout|int == 0
+        fail_msg: "There are still processes managed by supervisor running on PTF, please check manually"
+
   when: exabgp_action == 'stop' and ptf_accessible is defined and not ptf_accessible.failed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In order to prevent CPU stuck and server crash while removing topo, added some steps to stop all processes managed by supervisor in PTF before the PTF container is stopped\.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In order to prevent CPU stuck and server crash while removing topo. 

#### How did you do it?
Add some steps to stop all processes managed by supervisor in PTF before the PTF container is stopped.

#### How did you verify/test it?
Verified by redeploy topology on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
