### PR TITLE
platform_tests/api: Fix iptables rule removal after reboot test

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -80,8 +80,10 @@ def stop_platform_api_service(duthosts):
                 duthost.command('docker exec -i pmon supervisorctl reread')
                 duthost.command('docker exec -i pmon supervisorctl update')
 
-                # Delete the iptables rule we added
-                duthost.command(IPTABLES_DELETE_RULE_CMD)
+                # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
+                # no longer have the rule we added in the start_platform_api_service fixture, even if the
+                # platform_api_server is running.
+                duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After a reboot test, the iptables rule inserted via the `start_platform_api_server` fixture will no longer exist and removing it will cause an error. The code does currently check if the server is running but that is not sufficient because the platform API server will come back up after restart. Thus, just ignore the error so that cleanup can continue and the test will pass, given that the iptables rule is expected to sometimes no longer be present.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

Fix an issue after platform API reboot tests where the iptables rule that is added in the pre-test fixture no longer exists, causing a failure during the teardown fixture.

#### How did you do it?

I ignored the error since it is expected that the iptables rule may not always exist.

#### How did you verify/test it?

I ran the platform API tests and verified that the issue no longer occurred.