### PR TITLE
[active-active] Fix keyError in `test_ipinip_hash_negative`

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -442,6 +442,7 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_co
     logger.info('active_dut_map={}'.format(active_dut_map))
     logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
     logger.info('router_macs={}'.format(router_macs))
+    logger.info('tbinfo={}'.format(tbinfo))
 
     asic_idx = 0
     ports_map = {}
@@ -502,7 +503,8 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
             for port_index, port_status in list(active_active_ports_mux_status.items()):
                 active_dut_map[str(port_index)] = [active_dut_index for active_dut_index in (0, 1)
                                                    if port_status[active_dut_index]]
-
+                                                   
+    logger.info("active_active_ports_mux_status={}".format(active_active_ports_mux_status))
     disabled_ptf_ports = set()
     for ptf_map in list(tbinfo['topo']['ptf_map_disabled'].values()):
         # Loop ptf_map of each DUT. Each ptf_map maps from ptf port index to dut port index

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -442,7 +442,6 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_co
     logger.info('active_dut_map={}'.format(active_dut_map))
     logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
     logger.info('router_macs={}'.format(router_macs))
-    logger.info('tbinfo={}'.format(tbinfo))
 
     asic_idx = 0
     ports_map = {}

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -503,8 +503,7 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
             for port_index, port_status in list(active_active_ports_mux_status.items()):
                 active_dut_map[str(port_index)] = [active_dut_index for active_dut_index in (0, 1)
                                                    if port_status[active_dut_index]]
-                                                   
-    logger.info("active_active_ports_mux_status={}".format(active_active_ports_mux_status))
+
     disabled_ptf_ports = set()
     for ptf_map in list(tbinfo['topo']['ptf_map_disabled'].values()):
         # Loop ptf_map of each DUT. Each ptf_map maps from ptf port index to dut port index

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -376,7 +376,7 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files
 
 def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files_per_function,          # noqa F811
                               ptfhost, ipver, tbinfo, mux_server_url, ignore_ttl, single_fib_for_duts,  # noqa F811
-                              duts_running_config_facts, duts_minigraph_facts):
+                              duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator):
     hash_keys = ['inner_length']
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(
@@ -393,8 +393,9 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
                "hash_test.IPinIPHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                              duts_running_config_facts, duts_minigraph_facts,
+                                                              mux_status_from_nic_simulator()),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -393,9 +393,11 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
                "hash_test.IPinIPHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts,
-                                                              mux_status_from_nic_simulator()),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(
+                           ptfhost, tbinfo, duthosts, mux_server_url,
+                           duts_running_config_facts, duts_minigraph_facts,
+                           mux_status_from_nic_simulator()
+                        ),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fixing keyError in `ptf_test_port_map`. When testing active-active dualtor DUTs, `active_dut_map` did't include all port to active dut mappings, we should use `ptf_test_port_map_active_active` instead. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on active-standby, active-active DUTs, all passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
