### PR TITLE
delay after mux toggle json to avoid trigger before config push in test_decap_active_tor

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -125,6 +125,7 @@ def test_decap_active_tor(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    time.sleep(10)
     with stop_garp(ptfhost):
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: config from muxactive.json is applied in serial order and it seems to take longer time to apply all the configs. If we send test traffic before that, we won't see expected behavior. Hence wait is needed.
Fixes # (issue)
test_decap_active_tor tc failure

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Test case(new/improvement)

### Back port request
- [x] 202205

### Approach
**Why I did it**
**#3 is happening before #2 in NOK run**
**1)when ansible command was executed(syslog)**
Apr 5 **07:35:33**.150580 mth-t0-64 INFO python[151529]: ansible-command Invoked with _uses_shell=True _raw_params=docker exec swss sh -c "swssconfig /muxactive.json" warn=True stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
**First config push from orchagent**
Apr 5 **07:35:33**.379735 mth-t0-64 NOTICE swss#orchagent: :- setState: [Ethernet100] Set MUX state from standby to active
**Last config push from orchagent**
Apr 5 **07:35:43**.036387 mth-t0-64 NOTICE swss#orchagent: :- addOperation: Mux State set to active for port Ethernet96

**2)when it took effect from sairedis(sairedis.rec)**
2023-04-05.07:35:42.420027|c|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"192.168.0.2","rif":"oid:0x6000000000994","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=40:A6:B7:43:75:06
2023-04-05.07:35:42.425521|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000b13|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=192.168.0.2|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x6000000000994
2023-04-05.07:35:42.446386|r|SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"[192.168.0.2/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000042](https://192.168.0.2/32%22,%22switch_id%22:%22oid:0x21000000000000%22,%22vr%22:%22oid:0x3000000000042)"}

**3)when did trigger happen(test log)**
05/04/2023 07:35:34 base._run L0063 DEBUG | /data/tests/common/devices/multi_asic.py::_run_on_asics#108: [mth-t0-64] AnsibleModule::shell, args=["docker exec swss sh -c "swssconfig /muxactive.json""], kwargs={}
05/04/2023 07:35:37 base._run L0086 DEBUG |
05/04/2023 07:35:37 test_ipinip.test_decap_active_tor L0127 INFO | send encapsulated packet from ptf t1 interface eth1
05/04/2023 **07:35:39** testutils.verify_packet L2400 DEBUG | Checking for pkt on device 0, port 6

**How I did it**
Introduced a delay of 10s between mux toggle on DUT and send packet from T1(PTF)

**How to verify it**
Verified that packets are sent to DUT after #2 is finished and test case passes.

Which release branch to backport (provide reason below if selected)
202205

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->