### PR TITLE
TestAclReboot test fix for Nokia-400G-T2 chassis

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,7 +22,7 @@ from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,7 +22,7 @@ from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,7 +22,7 @@ from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
 
@@ -583,7 +583,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         """
         pass
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):   # noqa F811
         """Perform actions after rules have been applied.
 
         Args:
@@ -613,7 +613,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 
     @pytest.fixture(scope="class", autouse=True)
     def acl_rules(self, duthosts, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo,
-                  ip_version, conn_graph_facts):
+                  ip_version, conn_graph_facts):   # noqa F811
         """Setup/teardown ACL rules for the current set of tests.
 
         Args:
@@ -1176,7 +1176,7 @@ class TestAclWithReboot(TestBasicAcl):
     upon startup.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts): # noqa F811
         """Save configuration and reboot after rules are applied.
 
         Args:
@@ -1213,7 +1213,7 @@ class TestAclWithPortToggle(TestBasicAcl):
     Verify that ACLs still function as expected after links flap.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):  # noqa F811
         """Toggle ports after rules are applied.
 
         Args:

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,6 +22,9 @@ from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.platform.interface_utils import check_all_interface_information
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +33,8 @@ pytestmark = [
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
     pytest.mark.topology("t0", "t1", "t2", "m0", "mx"),
 ]
+
+MAX_WAIT_TIME_FOR_INTERFACES = 360
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = "acl_test_dir"  # Keep it under home dir so it persists through reboot
@@ -151,7 +156,6 @@ def remove_dataacl_table(duthosts):
     for duthost in duthosts:
         config_reload(duthost, config_source="minigraph")
 
-
 def get_t2_info(duthosts, tbinfo):
     # Get the list of upstream/downstream ports
     downstream_ports, upstream_ports, acl_table_ports_per_dut = defaultdict(list), defaultdict(list), defaultdict(list)
@@ -230,7 +234,6 @@ def get_t2_info(duthosts, tbinfo):
     }
 
     return t2_information
-
 
 @pytest.fixture(scope="module")
 def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario):
@@ -449,7 +452,6 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
     duthost.command("sonic-clear fdb all")
     duthost.command("sonic-clear arp")
 
-
 @pytest.fixture(scope="module", params=["ingress", "egress"])
 def stage(request, duthosts, rand_one_dut_hostname, tbinfo):
     """Parametrize tests for Ingress/Egress stage testing.
@@ -578,7 +580,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         """
         pass
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
         """Perform actions after rules have been applied.
 
         Args:
@@ -607,7 +609,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         dut.command("config acl update full {}".format(remove_rules_dut_path))
 
     @pytest.fixture(scope="class", autouse=True)
-    def acl_rules(self, duthosts, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo, ip_version):
+    def acl_rules(self, duthosts, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo,
+                  ip_version, conn_graph_facts):
         """Setup/teardown ACL rules for the current set of tests.
 
         Args:
@@ -634,7 +637,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                 with loganalyzer:
                     self.setup_rules(duthost, acl_table, ip_version)
 
-                self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
+                self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts)
 
                 assert self.check_rule_counters(duthost), "Rule counters should be ready!"
 
@@ -1170,7 +1173,7 @@ class TestAclWithReboot(TestBasicAcl):
     upon startup.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
         """Save configuration and reboot after rules are applied.
 
         Args:
@@ -1184,6 +1187,19 @@ class TestAclWithReboot(TestBasicAcl):
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
             time.sleep(240)
+
+        # We need additional delay and make sure ports are up for Nokia-IXR7250E-36x400G
+        if dut.facts["hwsku"] == "Nokia-IXR7250E-36x400G":
+            interfaces = conn_graph_facts["device_conn"][dut.hostname]
+            logging.info("Wait until all critical services are fully started")
+            wait_critical_processes(dut)
+
+            xcvr_skip_list = {dut.hostname: []}
+            result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, 0, check_all_interface_information, dut, interfaces,
+                                xcvr_skip_list)
+            assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
+                MAX_WAIT_TIME_FOR_INTERFACES)
+
         populate_vlan_arp_entries()
 
 
@@ -1194,7 +1210,7 @@ class TestAclWithPortToggle(TestBasicAcl):
     Verify that ACLs still function as expected after links flap.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):
         """Toggle ports after rules are applied.
 
         Args:

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -156,6 +156,7 @@ def remove_dataacl_table(duthosts):
     for duthost in duthosts:
         config_reload(duthost, config_source="minigraph")
 
+
 def get_t2_info(duthosts, tbinfo):
     # Get the list of upstream/downstream ports
     downstream_ports, upstream_ports, acl_table_ports_per_dut = defaultdict(list), defaultdict(list), defaultdict(list)
@@ -234,6 +235,7 @@ def get_t2_info(duthosts, tbinfo):
     }
 
     return t2_information
+
 
 @pytest.fixture(scope="module")
 def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario):
@@ -451,6 +453,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
 
     duthost.command("sonic-clear fdb all")
     duthost.command("sonic-clear arp")
+
 
 @pytest.fixture(scope="module", params=["ingress", "egress"])
 def stage(request, duthosts, rand_one_dut_hostname, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- TestAclWithReboot ACL test case is not waiting long enough for the interfaces to come up with respect to Nokia IXR7250E-36x400G DUT.
- Due to this, ACL tests' call (_under TestAclWithReboot_) start thinking all interfaces are up and fails.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- This PR helps to fix the _TestAclWithReboot_ ACL test cases w.r.t _Nokia IXR7250E-36x400G_ platform.
- Test cases are not waiting long enough for the interfaces to come up with respect to _Nokia IXR7250E-36x400G_ DUT.

#### How did you do it?
- If the platform is '_Nokia IXR7250E-36x400G_', wait long enough and make sure all the interfaces and transceivers are UP & running.
- Once the ports are up, then proceed with running the ACL test calls.

#### How did you verify/test it?
- Ran all the ACL test cases against a multi-asic line card in a T2 chassis including _Nokia IXR7250E-36x400G_.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![ACL-Apr27](https://user-images.githubusercontent.com/114024719/234971798-e6ec7a55-727e-4511-a593-aa35edc58fa8.JPG)
