### PR TITLE
Ignore kernel error in tech_support test

### DIFF
--- a/tests/show_techsupport/conftest.py
+++ b/tests/show_techsupport/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+    """
+        In Mellanox, when techsupport is taken, it invokes fw dump.
+        While taking the fw dump, the fw is busy and doesn't respond to other calls.
+        The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields
+        every 60 seconds which fails during the fw dump.
+        This is a temporary issue and this log can be ignored.
+        Issue link: https://github.com/sonic-net/sonic-buildimage/issues/12621
+        The fixture is auto used to all test scripts in this directory.
+    """
+    ignoreRegex = [
+        ".*ERR kernel:.*Reg cmd access status failed.*",
+        ".*ERR kernel:.*Reg cmd access failed.*",
+        ".*ERR kernel:.*Eeprom query failed.*",
+        ".*ERR kernel:.*Fails to access.*register MCIA.*",
+        ".*ERR kernel:.*Fails to read module eeprom.*",
+        ".*ERR kernel:.*Fails to access.*module eeprom.*",
+        ".*ERR kernel:.*Fails to get module type.*",
+        ".*ERR pmon#xcvrd:.*Failed to read sfp.*"
+    ]
+
+    if loganalyzer:
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)

--- a/tests/show_techsupport/conftest.py
+++ b/tests/show_techsupport/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
     """
         In Mellanox, when techsupport is taken, it invokes fw dump.
         While taking the fw dump, the fw is busy and doesn't respond to other calls.
@@ -22,6 +22,6 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
         ".*ERR kernel:.*Fails to get module type.*",
         ".*ERR pmon#xcvrd:.*Failed to read sfp.*"
     ]
-
-    if loganalyzer:
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
+    for dut in duthosts:
+        if loganalyzer and loganalyzer[dut.hostname]:
+            loganalyzer[dut.hostname].ignore_regex.extend(ignoreRegex)

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -280,31 +280,6 @@ def execute_command(duthost, since):
     return True
 
 
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
-    """
-        In Mellanox, when techsupport is taken, it invokes fw dump.
-        While taking the fw dump, the fw is busy and doesn't respond to other calls.
-        The access of sfp eeprom happens through firmware and xcvrd gets the DOM fields
-        every 60 seconds which fails during the fw dump.
-        This is a temporary issue and this log can be ignored.
-        Issue link: https://github.com/sonic-net/sonic-buildimage/issues/12621
-    """
-    ignoreRegex = [
-        ".*ERR kernel:.*Reg cmd access status failed.*",
-        ".*ERR kernel:.*Reg cmd access failed.*",
-        ".*ERR kernel:.*Eeprom query failed.*",
-        ".*ERR kernel:.*Fails to access.*register MCIA.*",
-        ".*ERR kernel:.*Fails to read module eeprom.*",
-        ".*ERR kernel:.*Fails to access.*module eeprom.*",
-        ".*ERR kernel:.*Fails to get module type.*",
-        ".*ERR pmon#xcvrd:.*Failed to read sfp.*"
-    ]
-
-    if loganalyzer:
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
-
-
 def test_techsupport(request, config, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     test the "show techsupport" command in a loop


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to ignore some kernel error in tech_support test cases. These errors are expected during collecting tech support according to https://github.com/sonic-net/sonic-buildimage/issues/12621.
Before this change, we only ignore the errors for test script `test_techsupport.py`. But I also see same error pattern in other test case under `show_techsupport`. To ignore the log patterns for all test script under `show_techsupport`, I moved the autoused fixture `ignore_expected_loganalyzer_exceptions` from `test_techsupport.py` to `conftest.py`.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to ignore some kernel error in tech_support test cases. 

#### How did you do it?
I moved the autoused fixture `ignore_expected_loganalyzer_exceptions` from `test_techsupport.py` to `conftest.py`.

#### How did you verify/test it?
The change is verified by running `TestAutoTechSupport`.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
