### PR TITLE
[202205] Fix regex for PORT_READY

### DIFF
--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -28,7 +28,7 @@ SERVICE_PATTERNS = {
 OTHER_PATTERNS = {
     "COMMON": {
         "PORT_INIT|Start": re.compile(r'.*NOTICE swss#orchagent.*initPort: Initialized port.*'),
-        "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set.* to up.*'),
+        "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set from down to up.*'),
         "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
         "FINALIZER|End": re.compile(r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),
         "FPMSYNCD_RECONCILIATION|Start": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer started.*'),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We are seeing below errors in `test_advanced_reboot`
```
E       Failed: Advanced-reboot failure. Failed test: test_fast_reboot[str2-msn4600c-acs-04], failure summary:
E       [('test_fast_reboot[str2-msn4600c-acs-04]None', ['FAIL: Event PORT_READY was found 88 times, when expected exactly 44 times'])]
```
By checking the syslog, we found below logs are caught by the regex, which is not expected
```
Apr 27 23:26:11.248332 str2-msn4600c-acs-04 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet88 oper state set from up to up
Apr 27 23:26:11.251663 str2-msn4600c-acs-04 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet92 oper state set from up to up
Apr 27 23:26:11.254169 str2-msn4600c-acs-04 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet96 oper state set from up to up
```
This PR addressed the issue by fixing the regex.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix the regex for `PORT_READY`.

#### How did you do it?
Update the regex to 
```
.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set from down to up.*
```
#### How did you verify/test it?
The regex is verified by running grep on DUT. 

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
