### PR TITLE
Fix six package is not imported in test_vlan_ping.py

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 import logging
 import ptf.testutils as testutils
+import six
 from tests.common.helpers.assertions import pytest_assert as py_assert
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes six package is not imported in test_vlan_ping.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed in test_vlan_ping.py
vlan/test_vlan_ping.py::test_vlan_ping 
-------------------------------- live log setup --------------------------------
11:14:41 __init__._fixture_generator_decorator    L0088 ERROR  | 
AttributeError("'module' object has no attribute 'ensure_text'",)
Traceback (most recent call last):
  File "/azp/_work/10/s/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/azp/_work/10/s/tests/vlan/test_vlan_ping.py", line 69, in vlan_ping_setup
    vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Port-Channel1']['ipv4'])
AttributeError: 'module' object has no attribute 'ensure_text'

#### How did you do it?
Import six package.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
