### PR TITLE
Skip watchdog reboot for T1 topo Cisco Platform x86_64-8102_64h_o-r0

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -857,9 +857,11 @@ platform_tests/test_reboot.py::test_warm_reboot:
 
 platform_tests/test_reboot.py::test_watchdog_reboot:
   skip:
-    reason: "Skip watchdog reboot test for Wistron / Nokia 7215"
+    reason: "Skip watchdog reboot test for Wistron / Nokia 7215 / cisco platform x86_64-8102_64h_o-r0"
+    conditions_logical_operator: or
     conditions:
       - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "'t1' in topo_type and platform in ['x86_64-8102_64h_o-r0']"
 
 #######################################
 #####   test_reload_config.py     #####


### PR DESCRIPTION

Description of PR

Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga
msft cannot upgrade from the Ref. point to newer FPD 
Upgrading to newer fpd will brick the box
they have old Proto boxes in their lab, Hence skipping this test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205

### Approach
#### What is the motivation for this PR?
Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga

#### How did you do it?
Added skip in conditional_mark file

#### How did you verify/test it?
============================================================================================= short test summary info =============================================================================================
SKIPPED [1] platform_tests/test_reboot.py: Skip watchdog reboot test for Wistron / Nokia 7215 / cisco platform x86_64-8102_64h_o-r0
============================================================================================ 1 skipped in 9.26 seconds ============================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
