### PR TITLE
Fix incorrect pdu_index when there are multiple ports for one PDU

### DIFF
--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -50,8 +50,8 @@ class PduManager():
         self.controllers = []
 
     def _update_outlets(self, outlets, pdu_index, controller_index=None):
-        for outlet_idx, outlet in enumerate(outlets):
-            outlet['pdu_index'] = pdu_index + outlet_idx
+        for outlet in outlets:
+            outlet['pdu_index'] = pdu_index
             if controller_index is None:
                 controller_index = pdu_index
             outlet['pdu_name'] = self.controllers[controller_index]['psu_peer']['peerdevice']

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -281,6 +281,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             "DUT is MgmtTsToR, the last 2 outlets are reserved for Console Switch and are not visible from DUT.")
     for outlet in all_outlet_status:
         psu_under_test = None
+        if outlet['outlet_on'] is False:
+            continue
 
         logging.info("Turn off outlet {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

If PDU has multiple ports, like one PDU has 4 ports, normally it only has one port.
Currently, it has incorrect outlets with wrong pdu index.

```
[
  {
    'outlet_on': False,
    'pdu_index': 0,
    'outlet_id': '.2.10',
    'pdu_name': 'pdu-89'
  },
  {
    'outlet_on': True,
    'pdu_index': 1,
    'outlet_id': '.4.10',
    'pdu_name': 'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 2,
    'outlet_id': '.3.10',
    'pdu_name': 'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 3,
    'outlet_id': '.1.10',
    'pdu_name': 'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 1,
    'outlet_id': '.2.12',
    'pdu_name': 'pdu-90'
  },
  {
    'outlet_on': True,
    'pdu_index': 2,
    'outlet_id': '.4.12',
    'pdu_name': 'pdu-90'
  },
  {
    'outlet_on': False,
    'pdu_index': 3,
    'outlet_id': '.3.12',
    'pdu_name': 'pdu-90'
  },
  {
    'outlet_on': False,
    'pdu_index': 4,
    'outlet_id': '.1.12',
    'pdu_name': 'pdu-90'
  }
]
```

It only has 2 PDUs, not 4.
```
pdu-89,10,str3-7060-acs-2,PSU1
pdu-90,12,str3-7060-acs-2,PSU2
```

pdu_index should be 0,1, not 0,1,2,3,4.
That's why `platform_tests/test_platform_info.p::test_turn_on_off_psu_and_check_psustatus` failed with following error:

```
self = <tests.common.plugins.pdu_controller.pdu_manager.PduManager instance at 0x7f86edb67140>
pdu_index = 2

    def _get_pdu_controller(self, pdu_index):
>       pdu = self.controllers[pdu_index]
E       IndexError: list index out of range

pdu_index  = 2
self       = <tests.common.plugins.pdu_controller.pdu_manager.PduManager instance at 0x7f86edb67140>
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix incorrect pdu_index for outlets array.

the correct outlets should be like this:
```
[
  {
    'outlet_on': False,
    'pdu_index': 0,
    'outlet_id': '.2.10',
    'pdu_name': u'pdu-89'
  },
  {
    'outlet_on': True,
    'pdu_index': 0,
    'outlet_id': '.4.10',
    'pdu_name': u'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 0,
    'outlet_id': '.3.10',
    'pdu_name': u'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 0,
    'outlet_id': '.1.10',
    'pdu_name': u'pdu-89'
  },
  {
    'outlet_on': False,
    'pdu_index': 1,
    'outlet_id': '.2.12',
    'pdu_name': u'pdu-90'
  },
  {
    'outlet_on': True,
    'pdu_index': 1,
    'outlet_id': '.4.12',
    'pdu_name': u'pdu-90'
  },
  {
    'outlet_on': False,
    'pdu_index': 1,
    'outlet_id': '.3.12',
    'pdu_name': u'pdu-90'
  },
  {
    'outlet_on': False,
    'pdu_index': 1,
    'outlet_id': '.1.12',
    'pdu_name': u'pdu-90'
  }
]
```

#### How did you do it?
Don't plus outlet_idx for pdu_index.
Don't power off PDU whose outlet_on is already false in case test_turn_on_off_psu_and_check_psustatus.

#### How did you verify/test it?
Run `platform_tests/test_platform_info.p::test_turn_on_off_psu_and_check_psustatus`
By using "devutil -a pdu_status" to verify it with both from connection graphand inventory
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
