### PR TITLE
Adding watchdog timeout for cisco closed pid

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -119,6 +119,30 @@ x86_64-8800_lc_48h_o-r0:
     greater_timeout: 6553
     too_big_timeout: 6554
 
+x86_64-88_lc0_36fh_m-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-88_lc0_36fh-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-8800_lc_48h-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-8800_rp-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
 # Cisco-Churchill-Mono watchdog
 x86_64-8101_32fh_o-r0:
   default:


### PR DESCRIPTION

### Description of PR
Adding watchdog timeout values for cisco closed pid platform 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
to add watchdog timeout values for closed pid cisco platforms
#### How did you do it?
Added the list in watchdog.yml file

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
