### PR TITLE
Revise dualtor PFC storm tests

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -55,6 +55,37 @@ def build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac,
     return pkt, exp_tunnel_pkt
 
 
+def get_queue_watermark(duthost, port, queue, clear_after_read=False):
+    """
+    Return the queue watermark for the given port and queue
+    """
+    # Wait a default interval (60 seconds)
+    time.sleep(60)
+    cmd = "show queue watermark unicast"
+    output = duthost.shell(cmd)['stdout_lines']
+    """
+        Egress shared pool occupancy per unicast queue:
+               Port    UC0    UC1    UC2    UC3    UC4    UC5    UC6    UC7
+        -----------  -----  -----  -----  -----  -----  -----  -----  -----
+          Ethernet0      0      0      0      0      0      0      0      0
+    """
+    port_line = None
+    for line in output:
+        if line.split()[0] == port:
+            port_line = line
+            break
+    assert port_line is not None, "Failed to find queue watermark line in output for port '{}'".format(port)
+    items = port_line.split()
+    index = queue + 1
+    assert index < len(items), "Index {} out of range for line:\n{}".format(index, port_line)
+    wmk_str = items[index]
+    assert wmk_str.isdigit(), "Invalid watermark string '{}' in line:\n{}".format(wmk_str, port_line)
+    wmk = int(items[index])
+    if clear_after_read:
+        duthost.shell("sonic-clear queue watermark unicast")
+    return wmk
+
+
 def get_queue_counter(duthost, port, queue, clear_before_read=False):
     """
     Return the counter for given queue in given port


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revises the dualtor PFC storm _active and _standby tests to use queue watermarks to detect congestion in response to the PFC frame storm generated via pfc_gen.py. 

The pfc_gen.py script is a CPU traffic generator that cannot reliably send the minimum fps needed to fully block an egress port. However, it should be sufficient to cause temporary congestion that can be more reliably detected from the queue watermark. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on T0 dualtor platform for Cisco-8000.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
