### PR TITLE
[202012] Enable pfcwd testruns on dual tor platforms

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -32,14 +32,6 @@ def pytest_addoption(parser):
     parser.addoption('--two-queues', action='store_true', default=True,
                      help='Run test with sending traffic to both queues [3, 4]')
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_pfcwd_test_dualtor(tbinfo):
-    if 'dualtor' in tbinfo['topo']['name']:
-        pytest.skip("Pfcwd tests skipped on dual tor testbed")
-
-    yield
-
-
 @pytest.fixture(scope="module")
 def two_queues(request):
     """

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -296,17 +296,6 @@ def test_update_saithrift_ptf(request, ptfhost):
     logging.info("Python saithrift package installed successfully")
 
 
-def test_stop_pfcwd(duthosts, enum_dut_hostname, tbinfo):
-    '''
-     Stop pfcwd on dual tor testbeds
-    '''
-    if 'dualtor' not in tbinfo['topo']['name']:
-        pytest.skip("Skip this test on non dualTOR testbeds")
-
-    dut = duthosts[enum_dut_hostname]
-    dut.command('pfcwd stop')
-
-
 def test_generate_running_golden_config(duthosts):
     """
     Generate running golden config after pre test.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Pfcwd testcases were initially skipped on dual tor setups because of incomplete MMU configs. Reenabling those testcases through this change
