### PR TITLE
Fix arp_responder - support VLAN tagged ARP request

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -105,6 +105,9 @@ class ARPResponder(object):
     def action(self, interface):
         data = interface.recv()
         eth_type = struct.unpack('!H', data[12:14])[0]
+        # Retrieve the correct ethertype if the packet is VLAN tagged
+        if eth_type == 0x8100:  # 802.1Q, VLAN tagged
+            eth_type = struct.unpack('!H', data[16:18])[0]
 
         if eth_type == 0x0806:  # ARP
             if len(data) <= self.ARP_PKT_LEN:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is to fix arp_responder.


Summary:
This PR is to fix arp_responder script. 
PR https://github.com/sonic-net/sonic-mgmt/pull/8153 introduced logic to check the ethertype. Only packets with ethertype = 0x0806/0x86DD are accepted.
However, there are VLAN tagged ARP request whose ethertype is 0x8100 is also dropped by mistake.
```
0000   ff ff ff ff ff ff 1c 34 da 1d e4 00 81 00 0b b9   .......4........
0010   08 06 00 01 08 00 06 04 00 01 1c 34 da 1d e4 00   ...........4....
0020   1e 01 0a 01 00 00 00 00 00 00 1e 01 0a 65 00 00   .............e..
0030   00 00 00 00 00 00 00 00 00 00 00 00               ............
```
This PR addressed the issue by checking the 802.1Q type first. If the ethertype is 0x8100, then retrieve the inner ethertype from offset [16:18].

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix arp_responder script. 

#### How did you do it?
This PR addressed the issue by checking the 802.1Q type first. If the ethertype is 0x8100, then retrieve the inner ethertype from offset [16:18].

#### How did you verify/test it?
Verified by running `test_vnet_vxlan`. 
The test cases can pass after this change.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
