### PR TITLE
[tests/copp]: Update copp mgmt tests to support new rate-limits

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -322,7 +322,7 @@ class DHCPTopoT1Test(PolicyTest):
         return packet
 
 
-# SONIC configuration has no policer limiting for DHCP
+# SONIC config contains policer CIR=300 for DHCP
 class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -356,7 +356,7 @@ class DHCPTest(PolicyTest):
         return packet
 
 
-# SONIC configuration has no policer limiting for DHCPv6
+# SONIC config contains policer CIR=300 for DHCPv6
 class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -408,9 +408,8 @@ class DHCP6TopoT1Test(PolicyTest):
 
         return packet
 
-# SONIC configuration has no policer limiting for LLDP
 
-
+# SONIC config contains policer CIR=300 for LLDP
 class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -431,7 +430,7 @@ class LLDPTest(PolicyTest):
         return packet
 
 
-# SONIC configuration has no policer limiting for UDLD
+# SONIC config contains policer CIR=300 for UDLD
 class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -457,7 +456,7 @@ class UDLDTest(PolicyTest):
         return packet
 
 
-# SONIC configuration has no policer limiting for BGP
+# SONIC config contains policer CIR=6000 for BGP
 class BGPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -480,7 +479,7 @@ class BGPTest(PolicyTest):
         return packet
 
 
-# SONIC configuration has no policer limiting for LACP
+# SONIC config contains policer CIR=6000 for LACP
 class LACPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -238,34 +238,6 @@ class ControlPlaneBaseTest(BaseTest):
         self.log('RX PPS = %d' % rx_pps)
 
 
-class NoPolicyTest(ControlPlaneBaseTest):
-    def __init__(self):
-        ControlPlaneBaseTest.__init__(self)
-        self.needPreSend = False
-
-    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
-        pkt_rx_limit = send_count * 0.90
-
-        self.log("")
-        self.log("Checking constraints (NoPolicy):")
-        self.log(
-            "rx_pps (%d) > NO_POLICER_LIMIT (%d): %s" %
-            (int(rx_pps), int(self.NO_POLICER_LIMIT),
-             str(rx_pps > self.NO_POLICER_LIMIT))
-        )
-        self.log(
-            "recv_count (%d) > pkt_rx_limit (%d): %s" %
-            (int(recv_count), int(pkt_rx_limit), str(recv_count > pkt_rx_limit))
-        )
-
-        if self.has_trap:
-            assert (rx_pps > self.NO_POLICER_LIMIT)
-            assert (recv_count > pkt_rx_limit)
-        else:
-            assert (rx_pps < self.NO_POLICER_LIMIT)
-            assert (recv_count < pkt_rx_limit)
-
-
 class PolicyTest(ControlPlaneBaseTest):
     def __init__(self):
         ControlPlaneBaseTest.__init__(self)
@@ -351,9 +323,9 @@ class DHCPTopoT1Test(PolicyTest):
 
 
 # SONIC configuration has no policer limiting for DHCP
-class DHCPTest(NoPolicyTest):
+class DHCPTest(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("DHCPTest")
@@ -385,9 +357,9 @@ class DHCPTest(NoPolicyTest):
 
 
 # SONIC configuration has no policer limiting for DHCPv6
-class DHCP6Test(NoPolicyTest):
+class DHCP6Test(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("DHCP6Test")
@@ -439,9 +411,9 @@ class DHCP6TopoT1Test(PolicyTest):
 # SONIC configuration has no policer limiting for LLDP
 
 
-class LLDPTest(NoPolicyTest):
+class LLDPTest(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("LLDPTest")
@@ -460,9 +432,9 @@ class LLDPTest(NoPolicyTest):
 
 
 # SONIC configuration has no policer limiting for UDLD
-class UDLDTest(NoPolicyTest):
+class UDLDTest(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("UDLDTest")
@@ -486,9 +458,9 @@ class UDLDTest(NoPolicyTest):
 
 
 # SONIC configuration has no policer limiting for BGP
-class BGPTest(NoPolicyTest):
+class BGPTest(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("BGPTest")
@@ -509,9 +481,9 @@ class BGPTest(NoPolicyTest):
 
 
 # SONIC configuration has no policer limiting for LACP
-class LACPTest(NoPolicyTest):
+class LACPTest(PolicyTest):
     def __init__(self):
-        NoPolicyTest.__init__(self)
+        PolicyTest.__init__(self)
 
     def runTest(self):
         self.log("LACPTest")

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -74,7 +74,13 @@ class TestCOPP(object):
     @pytest.mark.parametrize("protocol", ["ARP",
                                           "IP2ME",
                                           "SNMP",
-                                          "SSH"])
+                                          "SSH",
+                                          "DHCP",
+                                          "DHCP6",
+                                          "BGP",
+                                          "LACP",
+                                          "LLDP",
+                                          "UDLD"])
     def test_policer(self, protocol, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                      ptfhost, copp_testbed, dut_type):
         """
@@ -82,27 +88,6 @@ class TestCOPP(object):
 
             Checks that the policer enforces the rate limit for protocols
             that have a set rate limit.
-        """
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        _copp_runner(duthost,
-                     ptfhost,
-                     protocol,
-                     copp_testbed,
-                     dut_type)
-
-    @pytest.mark.parametrize("protocol", ["BGP",
-                                          "DHCP",
-                                          "DHCP6",
-                                          "LACP",
-                                          "LLDP",
-                                          "UDLD"])
-    def test_no_policer(self, protocol, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                        ptfhost, copp_testbed, dut_type):
-        """
-            Validates that non-rate-limited COPP groups work as expected.
-
-            Checks that the policer does not enforce a rate limit for protocols
-            that do not have any set rate limit.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         _copp_runner(duthost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
* Rate limits are being set for bgp, lacp, dhcp, lldp, udld and macsec via a copp cfg change via sonic-buildimage PR 
   https://github.com/sonic-net/sonic-buildimage/pull/14859. This is the corresponding sonic-mgmt change to make sure that copp tests don't fail with the updated rate limits.

* This change is dependent on the the sonic-buildimage PR above and will be committed after the buildimage PR is merged.

Summary:
Fixes # 17964421

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
It was observed that a flood of DHCP packets without rate-limiting can cause BGP flaps or lacp keepalive losses.
#### How did you do it?
Enable rate-limiting for all traffic types to prevent such BGP flaps.
#### How did you verify/test it?
By injecting DHCP traffic at a fast enough rate and verifying that they are indeed throttled.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
