### PR TITLE
[Python3 migration]Make test_nbr_health.py Python2 and Python3 compatible

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -67,7 +67,7 @@ def check_eos_bgp_facts(hostname, host):
     logger.info("Check neighbor {} bgp facts".format(hostname))
     res = host.eos_command(commands=['show ip bgp sum'])
     logger.info("bgp: {}".format(res))
-    if 'stdout_lines' not in res or 'BGP summary' not in res['stdout_lines'][0][0]:
+    if 'stdout_lines' not in res or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
 
@@ -75,7 +75,7 @@ def check_sonic_bgp_facts(hostname, host):
     logger.info("Check neighbor {} bgp facts".format(hostname))
     res = host.command('vtysh -c "show ip bgp sum"')
     logger.info("bgp: {}".format(res))
-    if 'stdout_lines' not in res or 'Unicast Summary' not in "\n".join(res['stdout_lines']):
+    if 'stdout_lines' not in res or u'Unicast Summary' not in "\n".join(res['stdout_lines']):
         return "neighbor {} bgp not configured correctly".format(hostname)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Make test_nbr_health.py Python2 and Python3 compatible

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During Python3 migration, some code are changed to not support Python2 again.

#### How did you do it?
Change test_nbr_health.py compatible both in Python2 and Python3.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
