### PR TITLE
[Python3 migration]Fix test failure in test_orch_stress.py

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -290,10 +290,10 @@ def apply_dual_tor_neigh_entries(cleanup_mocked_configs, rand_selected_dut, tbin
     for ip, mac in list(mock_server_ip_mac_map.items()):
         # Use `ip neigh replace` in case entries already exist for the target IP
         # If there are no pre-existing entries, equivalent to `ip neigh add`
-        cmds.append('ip -4 neigh replace {} lladdr {} dev {}'.format(ip, mac.decode(), vlan))
+        cmds.append('ip -4 neigh replace {} lladdr {} dev {}'.format(ip, mac, vlan))
 
     for ipv6, mac in list(mock_server_ipv6_mac_map.items()):
-        cmds.append('ip -6 neigh replace {} lladdr {} dev {}'.format(ipv6, mac.decode(), vlan))
+        cmds.append('ip -6 neigh replace {} lladdr {} dev {}'.format(ipv6, mac, vlan))
     dut.shell_cmds(cmds=cmds)
 
     return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in test_orch_stress.py after Python3 migration

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed after Python3 migration. The error is:
        for ip, mac in list(mock_server_ip_mac_map.items()):
            # Use `ip neigh replace` in case entries already exist for the target IP
            # If there are no pre-existing entries, equivalent to `ip neigh add`
-            cmds.append('ip -4 neigh replace {} lladdr {} dev {}'.format(ip, mac.decode(), vlan))
E           AttributeError: 'str' object has no attribute 'decode'

#### How did you do it?
Remove decode() as the variable mac is a string in Python3.

#### How did you verify/test it?
Manually run test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
