### PR TITLE
[202205] Revert cherry-pick [tests/configlet] Remove -n in apply-patch in add_rack test (#6146)

### DIFF
--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -16,7 +16,7 @@ else:
     from tests.common.utilities import wait_until
 
 CMD_APPLY_HACK = "config apply-patch -n -i '' -v {}"
-CMD_APPLY = "config apply-patch -v {}"
+CMD_APPLY = "config apply-patch -n -v {}"
 
 # HACKS summary:
 #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #6146 was cherry-picked to sonic-mgmt 202205 branch before this PR (https://github.com/sonic-net/sonic-buildimage/pull/11894) is backported to sonic-buildimage 202205 branch.

This caused consistent failure of running add-rack test on 202205 image.

#### How did you do it?
Revert #6146 cherry-picked to 202205 branch.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
