### PR TITLE
Fix hard coded PSUs in conn_graph_facts

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -505,12 +505,13 @@ class Parse_Lab_Graph():
         """
         if hostname in self.devices:
             ret = {}
-            for key in ['PSU1', 'PSU2', 'PSU3', 'PSU4']:
-                try:
-                    ret.update(
-                        {key: self.devices[self.pdulinks[hostname][key]['peerdevice']]})
-                except KeyError:
-                    pass
+            if hostname in self.pdulinks:
+                for key in self.pdulinks[hostname].keys():
+                    try:
+                        ret.update(
+                            {key: self.devices[self.pdulinks[hostname][key]['peerdevice']]})
+                    except KeyError:
+                        pass
             return ret
         else:
             # Please be noted that an empty dict is returned when hostname is not found


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The conn_graph_facts.py module hard coded PSUs of a devices as:
    ['PSU1', 'PSU2', 'PSU3', 'PSU4']
This assumes that a device can have at most 4 PSUs. For chassis devices, this is not true. A chassis device may have more than 4 PSUs.

#### How did you do it?
This change fixed the issue by dynamically get configured PSUs from connection graph.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
