### PR TITLE
Fix string escape issue for patch_rsyslog

### DIFF
--- a/ansible/devutil/sonic_helpers.py
+++ b/ansible/devutil/sonic_helpers.py
@@ -89,8 +89,8 @@ def patch_rsyslog(sonichosts):
             path=conf_file,
             state="present",
             insertafter="# Define a custom template",
-            line='$template RemoteSONiCFileFormat,"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% '
-                 '%PROCID% %MSGID% [origin swVersion="{}"] %msg%\n"'.format(sonic_build_version),
+            line=r'$template RemoteSONiCFileFormat,"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% '
+                 r'%PROCID% %MSGID% [origin swVersion=\"{}\"] %msg%\n"'.format(sonic_build_version),
             module_attrs={"become": True}
         )
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The patch_rsyslog is to add an extra log format to include image version information in syslog messages sent out to syslog server.

While porting this code from ansible playbook to python, the pattern string needs update because python has slightly different behavior of interpreting string escape with ansible playbook.

#### How did you do it?
This change fixed the string escape in devutil/sonic_helpers.py.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
