### PR TITLE
Improved auto-techsupport test case, fixed #8192 

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -950,6 +950,7 @@ def get_new_techsupport_files_list(duthost, available_tech_support_files):
     :return: list of new techsupport files
     """
     try:
+        duthost.shell('ls -lh /var/dump/')  # print into logs full folder content(for debug purpose)
         new_available_tech_support_files = duthost.shell('ls /var/dump/*.tar.gz')['stdout_lines']
     except RunAnsibleModuleFail:
         new_available_tech_support_files = []
@@ -1233,6 +1234,10 @@ def clear_folders(duthost):
     Clear auto-techsupport related folders
     :param duthost: duthost object
     """
+    # print into logs folders content(for debug purpose) before remove
+    duthost.shell('sudo ls -lh /var/core/')
+    duthost.shell('sudo ls -lh /var/dump/')
+
     duthost.shell('sudo rm -rf /var/core/*')
     duthost.shell('sudo rm -rf /var/dump/*')
 
@@ -1266,11 +1271,13 @@ def get_random_physical_port_non_po_member(minigraph_facts):
     :return: string, port name
     """
     po_members = []
+    test_port = None
     for po_iface, po_data in list(minigraph_facts['minigraph_portchannels'].items()):
         po_members += po_data['members']
     all_ports = list(minigraph_facts['minigraph_ports'].keys())
     non_po_ports = [port for port in all_ports if port not in po_members]
-    test_port = random.choice(non_po_ports)
+    if non_po_ports:
+        test_port = random.choice(non_po_ports)
     return test_port
 
 


### PR DESCRIPTION
### Description of PR
Improved auto-techsupport test case, fixed #8192 

- Fixed issue: https://github.com/sonic-net/sonic-mgmt/issues/8192
- Added execution of the command: "ls -lh /var/dump/" in the case when we get list of dumps, it will allow us to see all available files in the folder(not only .tar.gz but also .tar)

Summary: Improved auto-techsupport test case, fixed #8192 
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/8192

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/issues/8192

#### How did you do it?
See code

#### How did you verify/test it?
Executed auto-techsupport tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

