### PR TITLE
Improvising qos tests by tunning the qos params for single_asic, single_dut_multi_asic and  multi_dut

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -157,9 +157,9 @@ qos_params:
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
+                    pg: 0
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 3500
                 wm_pg_shared_lossless:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -2,7 +2,7 @@ qos_params:
     j2c+:
         topo-any:
             100000_300m:
-                pkts_num_leak_out: 51
+                pkts_num_leak_out: 5
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
@@ -51,11 +51,11 @@ qos_params:
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 8
+                    dscp: 7
                     ecn: 1
-                    pg: 0
+                    pg: 1
                     pkts_num_trig_egr_drp: 2396745
-                    pkts_num_margin: 20
+                    pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
@@ -157,9 +157,9 @@ qos_params:
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 8
+                    dscp: 7
                     ecn: 1
-                    pg: 0
+                    pg: 1
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 3500
                 wm_pg_shared_lossless:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -51,9 +51,9 @@ qos_params:
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
+                    pg: 0
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -179,7 +179,6 @@ class ThriftInterface(BaseTest):
                     cmd, self.src_asic_index, self.src_server_ip)
 
 
-
     def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             # need to enable watchdog on the source asic using cint script

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -167,6 +167,7 @@ class ThriftInterface(BaseTest):
         return stdOut, stdErr, retValue
 
     def sai_thrift_port_tx_enable(self, client, asic_type, port_list, target='dst', last_port=True):
+        sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
         if self.platform_asic and self.platform_asic == "broadcom-dnx" and last_port:
             # need to enable watchdog on the source asic using cint script
             cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog enable\"".format(self.src_asic_index)
@@ -177,7 +178,7 @@ class ThriftInterface(BaseTest):
             assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(
                     cmd, self.src_asic_index, self.src_server_ip)
 
-        sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
+
 
     def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
         if self.platform_asic and self.platform_asic == "broadcom-dnx":

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -167,6 +167,7 @@ class ThriftInterface(BaseTest):
         return stdOut, stdErr, retValue
 
     def sai_thrift_port_tx_enable(self, client, asic_type, port_list, target='dst', last_port=True):
+        inc = 0
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
         if self.platform_asic and self.platform_asic == "broadcom-dnx" and last_port:
             # need to enable watchdog on the source asic using cint script
@@ -175,11 +176,22 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(
-                    cmd, self.src_asic_index, self.src_server_ip)
+            if retValue != 0:
+                # Retry credit-wd command max 3 times on failure
+                while inc < 3 and retValue != 0:
+                    print("Retrying credit_wd_enable")
+                    time.sleep(5)
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
+                                                                    self.test_params['dut_username'],
+                                                                    self.test_params['dut_password'],
+                                                                    cmd)
+                    inc += 1
+            assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0,\
+                "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,self.src_server_ip)
 
 
     def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
+        inc = 0
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             # need to enable watchdog on the source asic using cint script
             cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog disable\"".format(self.src_asic_index)
@@ -187,8 +199,19 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(
-                    cmd, self.src_asic_index, self.src_server_ip)
+            if retValue != 0:
+                # Retry credit-wd command max 3 times on failure
+                while inc < 3 and retValue != 0:
+                    print("Retrying credit_wd_enable")
+                    time.sleep(5)
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
+                                                                    self.test_params['dut_username'],
+                                                                    self.test_params['dut_password'],
+                                                                    cmd)
+                    inc += 1
+            assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0, \
+                "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
+
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -168,7 +168,7 @@ class ThriftInterface(BaseTest):
         return stdOut, stdErr, retValue
 
     def sai_thrift_port_tx_enable(self, client, asic_type, port_list, target='dst', last_port=True):
-        inc = 0
+        count = 0
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
         if self.platform_asic and self.platform_asic == "broadcom-dnx" and last_port:
             # need to enable watchdog on the source asic using cint script
@@ -177,21 +177,23 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            if retValue != 0:
+            if retValue != 0 or 'Success rv = 0' not in stdOut[1]:
                 # Retry credit-wd command max 3 times on failure
-                while inc < 3 and retValue != 0:
+                while count < 3:
                     print("Retrying credit_wd_enable")
                     time.sleep(5)
                     stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
                                                                     self.test_params['dut_username'],
                                                                     self.test_params['dut_password'],
                                                                     cmd)
-                    inc += 1
+                    if stdOut and 'Success rv = 0' in stdOut[1]:
+                        break
+                    count += 1
             assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0,\
                 "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
 
     def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
-        inc = 0
+        count = 0
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             # need to enable watchdog on the source asic using cint script
             cmd = "bcmcmd -n {} \"BCMSAI credit-watchdog disable\"".format(self.src_asic_index)
@@ -199,16 +201,18 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            if retValue != 0:
+            if retValue != 0 or 'Success rv = 0' not in stdOut[1]:
                 # Retry credit-wd command max 3 times on failure
-                while inc < 3 and retValue != 0:
+                while count < 3:
                     print("Retrying credit_wd_enable")
                     time.sleep(5)
                     stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip,
                                                                     self.test_params['dut_username'],
                                                                     self.test_params['dut_password'],
                                                                     cmd)
-                    inc += 1
+                    if stdOut and 'Success rv = 0' in stdOut[1]:
+                        break
+                    count += 1
             assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0, \
                 "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -11,6 +11,7 @@ from ptf import config
 import ptf.testutils as testutils
 import json
 import socket
+import time
 
 ################################################################
 #
@@ -187,8 +188,7 @@ class ThriftInterface(BaseTest):
                                                                     cmd)
                     inc += 1
             assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0,\
-                "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,self.src_server_ip)
-
+                "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
 
     def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
         inc = 0

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -351,7 +351,6 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         dual_tor = self.test_params.get('dual_tor', None)
         leaf_downstream = self.test_params.get('leaf_downstream', None)
         asic_type = self.test_params['sonic_asic_type']
-        platform_asic = self.test_params['platform_asic']
         exp_ip_id = 101
         exp_ttl = 63
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
@@ -457,11 +456,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # queue 3/4  1                 1               1                                                1                                         1                         # noqa E501
             # queue 5    1                 1               1                                                1                                         1                         # noqa E501
             # queue 7    0                 1               1                                                1                                         1                         # noqa E501
-            if platform_asic and platform_asic == "broadcom-dnx":
-                # LACP packets go to queue0 in dnx
-                assert (queue_results[QUEUE_0] >= 1 + queue_results_base[QUEUE_0])
-            else:
-                assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
+            assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
             assert (queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
             assert (queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
             assert (queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
@@ -3096,7 +3091,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                                                xmit_counters_base, self, src_port_id, pkt, 10)
                 pkts_num_leak_out = 0
 
-            # send packets short of triggering egress drop
+           # send packets short of triggering egress drop
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3091,7 +3091,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                                                xmit_counters_base, self, src_port_id, pkt, 10)
                 pkts_num_leak_out = 0
 
-           # send packets short of triggering egress drop
+            # send packets short of triggering egress drop
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3082,14 +3082,14 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (fill_leakout_plus_one(self, src_port_id, dst_port_id,
                                               pkt, int(self.test_params['pg']), asic_type))
 
-            # send packets short of triggering egress drop
-            if check_leackout_compensation_support(asic_type, hwsku):
-                send_packet(self, src_port_id, pkt, pkts_num_leak_out)
-                time.sleep(5)
-                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
-                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
-                                               xmit_counters_base, self, src_port_id, pkt, 10)
-                pkts_num_leak_out = 0
+            if platform_asic and platform_asic == "broadcom-dnx":
+                if check_leackout_compensation_support(asic_type, hwsku):
+                    send_packet(self, src_port_id, pkt, pkts_num_leak_out)
+                    time.sleep(5)
+                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_base, self, src_port_id, pkt, 10)
+                    pkts_num_leak_out = 0
 
             # send packets short of triggering egress drop
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3083,6 +3083,15 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                                               pkt, int(self.test_params['pg']), asic_type))
 
             # send packets short of triggering egress drop
+            if check_leackout_compensation_support(asic_type, hwsku):
+                send_packet(self, src_port_id, pkt, pkts_num_leak_out)
+                time.sleep(5)
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_base, self, src_port_id, pkt, 10)
+                pkts_num_leak_out = 0
+
+           # send packets short of triggering egress drop
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +
@@ -3111,7 +3120,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             assert (recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
             for cntr in ingress_counters:
-                assert (recv_counters[cntr] == recv_counters_base[cntr])
+                if platform_asic and platform_asic == "broadcom-dnx" and cntr == 1:
+                    assert(recv_counters[cntr] == recv_counters_base[cntr])
             # xmit port no egress drop
             for cntr in egress_counters:
                 assert (xmit_counters[cntr] == xmit_counters_base[cntr])


### PR DESCRIPTION
### Description of PR
This PR is in continuation of PR# https://github.com/sonic-net/sonic-mgmt/pull/8149
which was originally part of PR# https://github.com/sonic-net/sonic-mgmt/pull/6946

The existing QoS (test_qos_sai.py) is written to accommodate a single asic on a single Dut. But, we require the same tests to be executed against a T2 chassis (with single/multi-asic linecards) and multi-asic pizza boxes.

Summary:
 This PR is in continuation to above PR's mentioned

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
1.Qos test cases failed with intermittent errors
#### How did you do it?
Two issues are addressed here :

1.The dscp queue mapping for LossyQueue Test changed in config file to map to queue 1 of traffic-class instead of  0  since disabling the tx and filling up the queue 0  prevents the lacp packets going out and port channel goes down

2.During Qos test on transmission disable and enable, sometimes on test failure the port dangles in a transmission disable state and did not recover. Switching the step to enable the transmission port before the BCMSAI credit-watchdog enable , eradicate the test failure due to bad port state.  
#### How did you verify/test it?

Executed qos testcases  on for single_asic ,single_dut_multi_asic & multi_dut
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
