### PR TITLE
[chassis] [platform] [test_link_down] give more time for T2 to boot up and when checking interfaces and services

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -47,5 +47,7 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical processes are healthy")
-    pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
+    is_chassis = duthost.get_facts().get("modular_chassis")
+    timeout = 400 if is_chassis else 300
+    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -47,7 +47,7 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical processes are healthy")
-    is_chassis = duthost.get_facts().get("modular_chassis")
+    is_chassis = dut.get_facts().get("modular_chassis")
     timeout = 400 if is_chassis else 300
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -7,7 +7,7 @@ import logging
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 
 
 def reset_timeout(duthost):

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -22,7 +22,7 @@ def reset_timeout(duthost):
     reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
-        reset_timeout = plt_reboot_ctrl['timeout']
+        reset_timeout = plt_reboot_ctrl.get('timeout', 300)
     return reset_timeout
 
 

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -11,6 +11,15 @@ from tests.common.utilities import wait_until
 
 
 def reset_timeout(duthost):
+    """
+    return: if timeout is specified in inventory file for this dut, return new timeout
+            if not specified, return 300 sec as default timeout
+    e.g.
+        processes_utils.py:
+          timeout: 400
+          wait: 60
+    """
+    reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl['timeout']

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -5,34 +5,32 @@ This script contains re-usable functions for checking status of critical service
 """
 import logging
 import time
-import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-
-TIMEOUT_TO_REBOOT = 300
+from tests.common.utilities import wait_until
 
 
-@pytest.fixture(scope='function')
-def set_timeout(duthost):
-    global TIMEOUT_TO_REBOOT
+def reset_timeout(duthost):
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
     if plt_reboot_ctrl:
-        TIMEOUT_TO_REBOOT = plt_reboot_ctrl['wait']
+        reset_timeout = plt_reboot_ctrl['timeout']
+    return reset_timeout
 
 
 def get_critical_processes_status(dut):
     processes_status = dut.all_critical_process_status()
-    for k, v in processes_status.items():
-        if v['status'] == False or len(v['exited_critical_process']) > 0:
+    for k, v in list(processes_status.items()):
+        if v['status'] is False or len(v['exited_critical_process']) > 0:
             return False, processes_status
 
     return True, processes_status
+
 
 def _all_critical_processes_healthy(dut):
     logging.info("Check critical processes status")
     status, _ = get_critical_processes_status(dut)
     return status
+
 
 def check_critical_processes(dut, watch_secs=0):
     """
@@ -49,11 +47,14 @@ def check_critical_processes(dut, watch_secs=0):
             time.sleep(min(5, watch_secs))
         watch_secs = watch_secs - 5
 
+
 def wait_critical_processes(dut):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
-    logging.info("Wait until all critical processes are healthy")
-    pytest_assert(wait_until(TIMEOUT_TO_REBOOT, 20, 0, _all_critical_processes_healthy, dut),
+    timeout = reset_timeout(dut)
+    logging.info("Wait until all critical processes are healthy in {} sec"
+                 .format(timeout))
+    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -20,7 +20,7 @@ def reset_timeout(duthost):
           wait: 60
     """
     reset_timeout = 300
-    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
+    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl['timeout']
     return reset_timeout

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -34,7 +34,7 @@ def set_max_to_reboot(duthost):
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
-        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['wait']
+        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['timeout']
 
 
 def multi_duts_and_ports(duthosts):

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -22,7 +22,7 @@ pytestmark = [
     pytest.mark.topology('t2'),
 ]
 
-MAX_TIME_TO_REBOOT = 120
+MAX_TIME_TO_REBOOT = 200
 
 
 @pytest.fixture(scope='function')

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -34,7 +34,7 @@ def set_max_to_reboot(duthost):
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
-        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['timeout']
+        MAX_TIME_TO_REBOOT = plt_reboot_ctrl.get('timeout', 120)
 
 
 def multi_duts_and_ports(duthosts):

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -28,7 +28,7 @@ MAX_TIME_TO_REBOOT = 120
 @pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
     """
-    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file, 
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
     to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
     """
     global MAX_TIME_TO_REBOOT

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -147,7 +147,7 @@ def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_
 
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
-                                 conn_graph_facts,
+                                 conn_graph_facts, set_max_to_reboot,
                                  fanouthosts, xcvr_skip_list):
     if len(duthosts.nodes) == 1:
         pytest.skip("Skip single-host dut for this test")
@@ -202,7 +202,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
 
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                    conn_graph_facts,
+                                    conn_graph_facts, set_max_to_reboot,
                                     fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -148,7 +148,7 @@ def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
                                  conn_graph_facts,
-                                 fanouthosts, tbinfo, xcvr_skip_list, set_max_to_reboot):
+                                 fanouthosts, xcvr_skip_list):
     if len(duthosts.nodes) == 1:
         pytest.skip("Skip single-host dut for this test")
 
@@ -203,7 +203,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
                                     conn_graph_facts,
-                                    fanouthosts, xcvr_skip_list, tbinfo, set_max_to_reboot):
+                                    fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname
 

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -22,11 +22,15 @@ pytestmark = [
     pytest.mark.topology('t2'),
 ]
 
-MAX_TIME_TO_REBOOT = 200
+MAX_TIME_TO_REBOOT = 120
 
 
 @pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
+    """
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file, 
+    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
+    """
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
@@ -197,10 +201,10 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     link_status_on_all_fanouts(localhost, fanouts_and_ports)
 
 
-def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostname,
+def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
                                     conn_graph_facts,
                                     fanouthosts, xcvr_skip_list, tbinfo, set_max_to_reboot):
-    duthost = duthosts[enum_frontend_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname
 
     # Before test, check all interfaces and services are up


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For T2 chassis, we now can overwrite timeout value if specified in inventory file, for this testbed.

1. We give 120sec in wait_for_startup, it is enough for any linecard/sup, but when sup reboot, we first start up sup, then startup each linecard ONE BY ONE, the checking order could be different from the linecard startup order, so we need to increase this timeout value
2. following in wait_critical_processes is also flaky base on pipeline powerfullness, e.g. multi-asic card on T2 chassis could take more than 300sec for all critical services to come back up, after SUP reboot
```
05/05/2023 22:35:25 utilities.wait_until                     L0127 DEBUG  | _all_critical_processes_healthy is False, wait 20 seconds and check again
05/05/2023 22:35:45 utilities.wait_until                     L0109 DEBUG  | Time elapsed: 285.117122 seconds
...
05/05/2023 22:35:54 utilities.wait_until                     L0127 DEBUG  | _all_critical_processes_healthy is False, wait 20 seconds and check again
05/05/2023 22:36:14 utilities.wait_until                     L0132 DEBUG  | _all_critical_processes_healthy is still False after 300 seconds, exit with False
05/05/2023 22:36:14 __init__._log_sep_line                   L0170 INFO   | ==================== platform_tests/test_link_down.py::test_link_status_on_host_reboot[str2-chassis-lc5-1] teardown ====================
```
3. use `enum_rand_one_per_hwsku_frontend_hostname` instead of `enum_frontend_dut_hostname` to avoid duplicate verification on linecard that has same hwsku

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
implement the same in processes_utils.py to support plt_reboot_ctrl

#### How did you verify/test it?
1. print MAX_TIME_TO_REBOOT in pdb
```
(Pdb) MAX_TIME_TO_REBOOT
300
```
2. Before, following is flaky to pass:
```

platform_tests/test_link_down.py::test_link_down_on_sup_reboot[str2-chassis-sup-1]
-------------------------------- live log call ---------------------------------
08:29:56 __init__.pytest_runtest_call L0040 ERROR | Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
self.ihook.pytest_pyfunc_call(pyfuncitem=self)
File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
return self._hookexec(self, self.get_hookimpls(), kwargs)
File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
return self._inner_hookexec(hook, methods, kwargs)
File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
return outcome.get_result()
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
_reraise(*ex) # noqa
File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
res = hook_impl.function(*args)
File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
testfunction(**testargs)
File "/azp/_work/27/s/tests/platform_tests/test_link_down.py", line 181, in test_link_down_on_sup_reboot
wait_for_startup(linecard, localhost, 0, MAX_TIME_TO_REBOOT)
File "/azp/_work/27/s/tests/common/reboot.py", line 164, in wait_for_startup
raise Exception('DUT {} did not startup'.format(hostname))
Exception: DUT str2-chassis-lc5-1 did not startup
```


After:
platform_tests/test_link_down.py::test_link_down_on_sup_reboot[str2-chassis-sup-1] PASSED [ 25%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
