### PR TITLE
[Python3 migration]Fix import error and misuse of global keyword

### DIFF
--- a/tests/fdb/test_fdb_flush.py
+++ b/tests/fdb/test_fdb_flush.py
@@ -7,7 +7,7 @@ import os
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.ptf_runner import ptf_runner
-from utils import fdb_cleanup
+from .utils import fdb_cleanup
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx')

--- a/tests/macsec/test_interop_wan_isis.py
+++ b/tests/macsec/test_interop_wan_isis.py
@@ -3,9 +3,9 @@ import logging
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from macsec_platform_helper import get_portchannel
-from macsec_platform_helper import find_portchannel_from_member
-from macsec_config_helper import enable_macsec_port, disable_macsec_port
+from .macsec_platform_helper import get_portchannel
+from .macsec_platform_helper import find_portchannel_from_member
+from .macsec_config_helper import enable_macsec_port, disable_macsec_port
 
 
 logger = logging.getLogger(__name__)

--- a/tests/wan/isis/test_isis_ecmp.py
+++ b/tests/wan/isis/test_isis_ecmp.py
@@ -66,7 +66,7 @@ def common_setup_teardown(duthosts):
 
 
 def test_isis_ecmp(duthosts, nbrhosts, common_setup_teardown):
-
+    global path
     path = 0
     run_cmds = ["clear counters"]
     for _, nbr in list(nbrhosts.items()):
@@ -83,7 +83,6 @@ def test_isis_ecmp(duthosts, nbrhosts, common_setup_teardown):
     time.sleep(15)
     run_cmds = ["show interfaces counters incoming |grep Po1|awk '{print $3}'"]
     for _, nbr in list(nbrhosts.items()):
-        global path
         output = nbr['host'].eos_command(commands=run_cmds)
         if int(output["stdout"][0]) > 2:
             path += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes import error and misuse of global keyword

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix import error and misuse of global keyword in following files:
test_fdb_flush.py
test_interop_wan_isis.py
test_isis_ecmp.py

#### How did you do it?
Use relative import and move the global declaration at the beginning of function's definition.

#### How did you verify/test it?
Manually run test_fdb_flush.py
N/A for test_interop_wan_isis.py and test_isis_ecmp.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
