### PR TITLE
[Python3 migration][stress_acl] Fix stress acl test failure in python3

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -76,7 +76,7 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port,
 
     for acl_id in acl_rule_list:
         ip_addr1 = acl_id % 256
-        ip_addr2 = acl_id / 256
+        ip_addr2 = int(acl_id / 256)
 
         src_ip_addr = "20.0.{}.{}".format(ip_addr2, ip_addr1)
         dst_ip_addr = "10.0.0.1"
@@ -136,7 +136,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
         else:
             readd_id = loops + ACL_RULE_NUMS
             ip_addr1 = readd_id % 256
-            ip_addr2 = readd_id / 256
+            ip_addr2 = int(readd_id / 256)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB hset "ACL_RULE|STRESS_ACL| RULE_{}" \
                                     "SRC_IP" "20.0.{}.{}/32" "PACKET_ACTION" "DROP" "PRIORITY" "{}"'
                                     .format(readd_id, ip_addr2, ip_addr1, readd_id))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In python3, slash operator ("/") does true division for all types including integers, but in stress acl test, we only expect integer
#### How did you do it?
Add (int) before ("/")
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
