### PR TITLE
Install different version docker-py based on py2 or py3

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -86,7 +86,7 @@
 - name: Update python3 packages
   block:
   - name: remove old python packages
-    pip: name=docker state=absent executable={{ pip_executable }}
+    pip: name=docker-py state=absent executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
     ignore_errors: yes

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -83,7 +83,7 @@
     environment: "{{ proxy_env | default({}) }}"
   when: pip_executable=="pip"
 
-- name: Update python2 packages
+- name: Update python3 packages
   block:
   - name: remove old python packages
     pip: name=docker-py state=absent executable={{ pip_executable }}

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -70,13 +70,28 @@
   become: yes
   environment: "{{ proxy_env | default({}) }}"
 
-- name: remove old python packages
-  pip: name=docker-py state=absent executable={{ pip_executable }}
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
-  ignore_errors: yes
+- name: Update python2 packages
+  block:
+  - name: remove old python packages
+    pip: name=docker-py state=absent executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+    ignore_errors: yes
+  - name: Install python packages
+    pip: name=docker version=4.1.0 state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+  when: pip_executable=="pip"
 
-- name: Install python packages
-  pip: name=docker version=4.1.0 state=forcereinstall executable={{ pip_executable }}
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
+- name: Update python2 packages
+  block:
+  - name: remove old python packages
+    pip: name=docker-py state=absent executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+    ignore_errors: yes
+  - name: Install python packages
+    pip: name=docker version=6.1.0 state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+  when: pip_executable=="pip3"

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -86,7 +86,7 @@
 - name: Update python3 packages
   block:
   - name: remove old python packages
-    pip: name=docker-py state=absent executable={{ pip_executable }}
+    pip: name=docker state=absent executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
     ignore_errors: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For servers running Ubuntu 20.04 or higher, we are using python3 env. Recently it hit below issue while removing topo:

```
Error connecting: Error while fetching server API version: request() got an unexpected keyword argument 'chunked'
```

In this PR, I updated the ansible playbook to install `docker==6.1.0` for python3 env. For python2 env, it'll remain `docker==4.1.0`.

Below is the whole error log for reference:

```
TASK [vm_set : Wait for removal of cEOS containers] ***************************************************************************************************************************
Monday 08 May 2023  05:30:17 +0000 (0:00:02.353)       0:00:39.711 ************
failed: [BJW-CAN-SERV-12] (item={u'vm_name': u'VM72030', 'ansible_loop_var': u'vm_name', u'ansible_job_id': u'134548411564.181976', u'started': 1, 'changed': True, 'failed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/134548411564.181976'}) => {"ansible_job_id": "134548411564.181976", "ansible_loop_var": "async_remove_ceos_result_item", "async_remove_ceos_result_item": {"ansible_job_id": "134548411564.181976", "ansible_loop_var": "vm_name", "changed": true, "failed": false, "finished": 0, "results_file": "/root/.ansible_async/134548411564.181976", "started": 1, "vm_name": "VM72030"}, "attempts": 1, "changed": false, "finished": 1, "msg": "Error connecting: Error while fetching server API version: request() got an unexpected keyword argument 'chunked'", "stderr": "/home/azure/.ansible/tmp/ansible-tmp-1683523814.78-74969-162024352963681/AnsiballZ_docker_container.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\n", "stderr_lines": ["/home/azure/.ansible/tmp/ansible-tmp-1683523814.78-74969-162024352963681/AnsiballZ_docker_container.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses", "  import imp"]}
```



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix `docker-py` issue while removing topology.

#### How did you do it?
Updated the ansible playbook to install `docker==6.1.0` for python3 env. For python2 env, it'll remain `docker==4.1.0`.

#### How did you verify/test it?

Verified on Ubuntu 18.04 (py2) and 20.04 (py3) servers.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
