### PR TITLE
fix port_config_gen.py issue

### DIFF
--- a/ansible/roles/fanout/library/port_config_gen.py
+++ b/ansible/roles/fanout/library/port_config_gen.py
@@ -94,7 +94,7 @@ class PortConfigGenerator(object):
             for line in machine_conf:
                 if not line:
                     continue
-                if "platform" in line:
+                if "platform" in line and "build_platform" not in line:
                     return line.split("=")[1].strip()
         raise ValueError("Failed to retrieve platform from '%s'" %
                          self.MACHINE_CONF)


### PR DESCRIPTION
Summary:
fix port_config_gen.py get platform issue, need get onie_platform info, not onie_build_platform

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix get platform issue, need get platform info not build platform info.
On some DUT, /host/machine.conf contains both build_platform and platform info.
Original code logic always search 'platform' keyword which is not right. 

#### How did you do it?
Add check for platform and build_platform

#### How did you verify/test it?
run ansible-playbook fanout.yml -i *** --limit ***  -b --vault-password-file ***

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
