### PR TITLE
[fixbug]: Fix neighbor recover failure

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -56,19 +56,20 @@ def config_force_option_supported(duthost):
 
 
 @ignore_loganalyzer
-def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
+def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
                   safe_reload=False, wait_before_force_reload=0,
-                  check_intf_up_ports=False, traffic_shift_away=False, override_config=False):
+                  check_intf_up_ports=False, traffic_shift_away=False, override_config=False, is_dut = True):
     """
     reload SONiC configuration
-    :param duthost: DUT host object
+    :param sonic_host: SONiC host object
     :param config_source: configuration source is 'config_db', 'minigraph' or 'running_golden_config'
-    :param wait: wait timeout for DUT to initialize after configuration reload
+    :param wait: wait timeout for sonic_host to initialize after configuration reload
     :param override_config: override current config with '/etc/sonic/golden_config_db.json'
+    :param is_dut: True if the host is DUT, False if the host may be neighbor device
     :return:
     """
     def _config_reload_cmd_wrapper(cmd, executable):
-        out = duthost.shell(cmd, executable=executable)
+        out = sonic_host.shell(cmd, executable=executable)
         if out['rc'] == 0:
             return True
         else:
@@ -82,12 +83,13 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
 
     logger.info('reloading {}'.format(config_source))
 
-    # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
-    ignore_t2_syslog_msgs(duthost)
+    if is_dut:
+        # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
+        ignore_t2_syslog_msgs(sonic_host)
 
     if config_source == 'minigraph':
-        if start_dynamic_buffer and duthost.facts['asic_type'] == 'mellanox':
-            output = duthost.shell('redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model',
+        if start_dynamic_buffer and sonic_host.facts['asic_type'] == 'mellanox':
+            output = sonic_host.shell('redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model',
                                    module_ignore_errors=True)
             is_buffer_model_dynamic = (output and output.get('stdout') == 'dynamic')
         else:
@@ -97,31 +99,31 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
             cmd += ' -t'
         if override_config:
             cmd += ' -o'
-        duthost.shell(cmd, executable="/bin/bash")
+        sonic_host.shell(cmd, executable="/bin/bash")
         time.sleep(60)
         if start_bgp:
-            duthost.shell('config bgp startup all')
+            sonic_host.shell('config bgp startup all')
         if is_buffer_model_dynamic:
-            duthost.shell('enable-dynamic-buffer.py')
-        duthost.shell('config save -y')
+            sonic_host.shell('enable-dynamic-buffer.py')
+        sonic_host.shell('config save -y')
 
     elif config_source == 'config_db':
         cmd = 'config reload -y &>/dev/null'
         reloading = False
-        if config_force_option_supported(duthost):
+        if config_force_option_supported(sonic_host):
             if wait_before_force_reload:
                 reloading = wait_until(wait_before_force_reload, 10, 0, _config_reload_cmd_wrapper, cmd, "/bin/bash")
             cmd = 'config reload -y -f &>/dev/null'
         if not reloading:
-            duthost.shell(cmd, executable="/bin/bash")
+            sonic_host.shell(cmd, executable="/bin/bash")
 
     elif config_source == 'running_golden_config':
         cmd = 'config reload -y -l /etc/sonic/running_golden_config.json &>/dev/null'
-        if config_force_option_supported(duthost):
+        if config_force_option_supported(sonic_host):
             cmd = 'config reload -y -f -l /etc/sonic/running_golden_config.json &>/dev/null'
-        duthost.shell(cmd, executable="/bin/bash")
+        sonic_host.shell(cmd, executable="/bin/bash")
 
-    modular_chassis = duthost.get_facts().get("modular_chassis")
+    modular_chassis = sonic_host.get_facts().get("modular_chassis")
     wait = max(wait, 240) if modular_chassis else wait
 
     if safe_reload:
@@ -129,15 +131,15 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         # time it takes for containers to come back up. Therefore, add 5
         # minutes to the maximum wait time. If it's ready sooner, then the
         # function will return sooner.
-        pytest_assert(wait_until(wait + 300, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
                       "All critical services should be fully started!")
-        wait_critical_processes(duthost)
+        wait_critical_processes(sonic_host)
         if config_source == 'minigraph':
-            pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, duthost),
+            pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, sonic_host),
                           "PFC_WD is missing in CONFIG-DB")
 
         if check_intf_up_ports:
-            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, sonic_host),
                           "Not all ports that are admin up on are operationally up")
     else:
         time.sleep(wait)

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -107,7 +107,7 @@ def _neighbor_vm_recover_bgpd(node=None, results=None):
 
 def _neighbor_vm_recover_config(node=None, results=None):
     if isinstance(node["host"], SonicHost):
-        config_reload(node["host"])
+        config_reload(node["host"], is_dut = False)
     return results
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The PR(https://github.com/sonic-net/sonic-mgmt/pull/6056) introduced the following error when we need to recover the neighbor device as SONiC.

```python
E               Failed: Processes "['_neighbor_vm_recover_config--<SonicHost VM0101>']" failed with exit code "1"
E               Exception:
E               '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'topo_type'
E               Traceback:
E               Traceback (most recent call last):
E                 File "/var/src/sonic-mgmt/tests/common/helpers/parallel.py", line 31, in run
E                   Process.run(self)
E                 File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/var/src/sonic-mgmt/tests/common/plugins/sanity_check/recover.py", line 110, in _neighbor_vm_recover_config
E                   config_reload(node["host"])
E                 File "/var/src/sonic-mgmt/tests/common/plugins/loganalyzer/utils.py", line 24, in decorated
E                   res = func(*args, **kwargs)
E                 File "/var/src/sonic-mgmt/tests/common/config_reload.py", line 90, in config_reload
E                   ignore_t2_syslog_msgs(duthost)
E                 File "/var/src/sonic-mgmt/tests/common/helpers/dut_utils.py", line 300, in ignore_t2_syslog_msgs
E                   if duthost.topo_type == "t2" and duthost.facts.get('platform_asic') == "broadcom-dnx":
E                 File "/var/src/sonic-mgmt/tests/common/devices/base.py", line 50, in __getattr__
E                   "'%s' object has no attribute '%s'" % (self.__class__, module_name)
E               AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'topo_type'
```

#### How did you do it?
Refactor the common function, config_reload, to avoid accessing the attribute,topo_type, that was only defined for DUT when SONiC neighbor was recovered.

#### How did you verify/test it?
Check it locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
