### PR TITLE
Fix a typo in tests/dualtor_io/test_heartbeat_failure.py

### DIFF
--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -33,7 +33,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
 
 def test_active_tor_heartbeat_failure_upstream(
-    toggle_all_simulator_ports_to_upper_tor, pper_tor_host, lower_tor_host,     # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,     # noqa F811
     send_server_to_t1_with_action, shutdown_tor_heartbeat, cable_type           # noqa F811
 ):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is a typo in the fixture name "pper_tor_host"(should be "upper_tor_host") of test case test_active_tor_heartbeat_failure_upstream, fix it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix a typo in test.
#### How did you do it?

#### How did you verify/test it?
Run test passed on dualtor test bed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
