### PR TITLE
[qos][gcu] Add GCU testcase for ecn parameter tuning

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -1,0 +1,101 @@
+import ast
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
+from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
+from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
+from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+logger = logging.getLogger(__name__)
+
+READ_ASICDB_TIMEOUT = 20
+READ_ASICDB_INTERVAL = 5
+WRED_MAPPING = {'green_min_threshold': 'SAI_WRED_ATTR_GREEN_MIN_THRESHOLD',
+                'green_max_threshold': 'SAI_WRED_ATTR_GREEN_MAX_THRESHOLD',
+                'green_drop_probability': 'SAI_WRED_ATTR_GREEN_DROP_PROBABILITY'}
+
+
+@pytest.fixture(scope="function")
+def ensure_dut_readiness(duthost):
+    """
+    Setup/teardown fixture ecn config update tst
+
+    Args:
+        duthost: DUT host object
+    """
+    verify_orchagent_running_or_assert(duthost)
+    create_checkpoint(duthost)
+
+    yield
+
+    try:
+        verify_orchagent_running_or_assert(duthost)
+        logger.info("Rolled back to original checkpoint")
+        rollback_or_reload(duthost)
+    finally:
+        delete_checkpoint(duthost)
+
+
+def ensure_application_of_updated_config(duthost, configdb_field, values):
+    """
+    Ensures application of the JSON patch config update
+
+    Args:
+        duthost: DUT host object
+        configdb_field: config db field(s) under test
+        values: expected value(s) of configdb_field
+    """
+    def _confirm_value_in_asic_db():
+        table_name = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
+        wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(table_name))["stdout"]
+        wred_data = ast.literal_eval(wred_data)
+        for field, value in zip(configdb_field.split(','), values.split(',')):
+            if value != wred_data[WRED_MAPPING[field]]:
+                return False
+        return True
+
+    logger.info("Validating fields in ASIC DB...")
+    pytest_assert(
+        wait_until(READ_ASICDB_TIMEOUT, READ_ASICDB_INTERVAL, 0, _confirm_value_in_asic_db),
+        "ASIC DB does not properly reflect newly configured field(s): {} expected value(s): {}"
+        .format(configdb_field, values)
+    )
+
+
+@pytest.mark.parametrize("configdb_field", ["green_min_threshold", "green_max_threshold", "green_drop_probability",
+                         "green_min_threshold,green_max_threshold,green_drop_probability"])
+@pytest.mark.parametrize("operation", ["replace"])
+def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, operation):
+    tmpfile = generate_tmpfile(duthost)
+    logger.info("tmpfile {} created for json patch of field: {} and operation: {}"
+                .format(tmpfile, configdb_field, operation))
+
+    json_patch = list()
+    values = list()
+    ecn_data = duthost.shell('sonic-db-cli CONFIG_DB hgetall "WRED_PROFILE|AZURE_LOSSLESS"')['stdout']
+    ecn_data = ast.literal_eval(ecn_data)
+    for field in configdb_field.split(','):
+        value = int(ecn_data[field]) + 1
+        values.append(str(value))
+
+        logger.info("value to be added to json patch: {}, operation: {}, field: {}"
+                    .format(value, operation, field))
+
+        json_patch.append(
+                          {"op": "{}".format(operation),
+                           "path": "/WRED_PROFILE/AZURE_LOSSLESS/{}".format(field),
+                           "value": "{}".format(value)})
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+        ensure_application_of_updated_config(duthost, configdb_field, ",".join(values))
+    finally:
+        delete_tmpfile(duthost, tmpfile)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 8237

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Added GCU testcase for ECN parameter tuning

#### How did you verify/test it?
Testcases have passed
```
nejo@d1ee8b2d31c4:/var/nejo/tests$ ./run_tests.sh -n vms7-t0-dx010-4 -i ../ansible/str,../ansible/veos -e "--skip_sanity --disable_loganalyzer --pdb" -t t0,any -c generic_config_updater/test_ecn_config_update.py -u
=== Running tests in groups ===
Running: pytest generic_config_updater/test_ecn_config_update.py --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-acs-4 --testbed vms7-t0-dx010-4 --testbed_file /var/nejo/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t0,any --skip_sanity --disable_loganalyzer --pdb
  from cryptography.exceptions import InvalidSignature
========================================================================================================== test session starts ==========================================================================================================
platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/nejo/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, ansible-2.2.4, celery-4.4.7, xdist-1.28.0, html-1.22.1, allure-pytest-2.8.22, repeat-0.9.1
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: 
collected 4 items                                                                                                                                                                                                                       

generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold] PASSED                                                                                                                     [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_max_threshold] PASSED                                                                                                                     [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_drop_probability] PASSED                                                                                                                  [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold,green_max_threshold,green_drop_probability] PASSED                                                                          [100%]

-------------------------------------------------------------------------------------------- generated xml file: /var/nejo/tests/logs/tr.xml --------------------------------------------------------------------------------------------
====================================================================================================== 4 passed in 391.59 seconds =======================================================================================================