### PR TITLE
[Python3 migraiton]Fix test failure in test_escape_character.py

### DIFF
--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -3,6 +3,7 @@ import logging
 import time
 import re
 import pytest
+import six
 
 from tests.common.helpers.assertions import pytest_assert
 
@@ -19,5 +20,5 @@ def test_console_escape(duthost_console, duthost):
     time.sleep(5)
     child.sendcontrol('C')
     child.expect(r"\^C")
-    match = re.search(r'(\d) packets transmitted', child.read())
+    match = re.search(r'(\d) packets transmitted', six.ensure_text(child.read()))
     pytest_assert(int(match.group(1)) < TOTAL_PACKETS, "Escape Character does not work.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure in test_escape_character.py after Python3 migration

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failed after Python3 migration:
  File "/azp/_work/44/s/tests/dut_console/test_escape_character.py", line 22, in test_console_escape
    match = re.search(r'(\d) packets transmitted', child.read())
  File "/usr/lib/python3.8/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object

#### How did you do it?
Use six.ensure_text() to make Python2 and Python3 compatible

#### How did you verify/test it?
Manually run test in Python2 and Python3

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
