### PR TITLE
[Double commit]Fix QoS test failure: brcm_sai_set_switch_attribute/updating switch mac addr failed

### DIFF
--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -72,12 +72,6 @@ def switch_init(clients):
             else:
                 print("unknown switch attribute", file=sys.stderr)
 
-        # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
-        # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
-        attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
-        attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
-        client.sai_thrift_set_switch_attribute(attr)
-
         # wait till the port are up
         time.sleep(10)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: (Cherry-pick from #8228 )
Fix test failure in qos/test_qos_sai.py
SAI_API_SWITCH:brcm_sai_set_switch_attribute:3852 updating switch mac addr failed with error -2

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During test_qos_sai.py, following error is seen:
Apr 21 11:15:31.453298 str2-7260cx3-acs-11 ERR syncd#syncd: message repeated 3 times: [ [none] SAI_API_SWITCH:brcm_sai_set_switch_attribute:3852 updating switch mac addr failed with error -2.]

#### How did you do it?
Remove old brcm_sai_set_switch_attribute code.

#### How did you verify/test it?
Manually run test case: qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
