### PR TITLE
Fix config reload error

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -115,7 +115,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
 
     elif config_source == 'config_db':
         cmd = 'config reload -y &>/dev/null'
-        if config_force_option_supported(duthost):
+        if config_force_option_supported(sonic_host):
             cmd = 'config reload -y -f &>/dev/null'
         sonic_host.shell(cmd, executable="/bin/bash")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes config reload error during test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test cases failed due to config reload error:
E                 File "/var/src/sonic-mgmt-int/tests/common/config_reload.py", line 118, in config_reload
E                   if config_force_option_supported(duthost):
E               NameError: global name 'duthost' is not defined

#### How did you do it?
Fix code merge error

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
