### PR TITLE
Bugfix for AttributeError in NDP responder

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -10,8 +10,8 @@ from fcntl import ioctl
 import logging
 import ptf.packet as scapy
 import scapy.all as scapy2
-import scapy.arch.pcapdnet
-scapy2.conf.use_pcap=True
+import scapy.arch.pcapdnet # noqa F401
+scapy2.conf.use_pcap = True
 
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -1,7 +1,3 @@
-import ptf.packet as scapy
-import scapy.all as scapy2
-scapy2.conf.use_pcap=True
-import scapy.arch.pcapdnet
 import binascii
 import socket
 import struct
@@ -12,6 +8,11 @@ import os.path
 from collections import defaultdict
 from fcntl import ioctl
 import logging
+import ptf.packet as scapy
+import scapy.all as scapy2
+scapy2.conf.use_pcap=True
+import scapy.arch.pcapdnet # noqa E402
+
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 
@@ -206,10 +207,9 @@ class ARPResponder(object):
         return eth_hdr + self.arp_chunk + local_mac + local_ip + remote_mac + remote_ip + self.arp_pad
 
     def generate_neigh_adv(self, local_mac, remote_mac, target_ip, remote_ip):
-        neigh_adv_pkt = Ether(src=local_mac, dst=remote_mac) / \
-            IPv6(src=target_ip, dst=remote_ip)
-        neigh_adv_pkt /= ICMPv6ND_NA(tgt=target_ip, R=0, S=1, O=1)
-        neigh_adv_pkt /= ICMPv6NDOptDstLLAddr(lladdr=local_mac)
+        neigh_adv_pkt = Ether(src=local_mac, dst=remote_mac) / IPv6(src=target_ip, dst=remote_ip) # noqa F821
+        neigh_adv_pkt /= ICMPv6ND_NA(tgt=target_ip, R=0, S=1, O=1)                                # noqa F821
+        neigh_adv_pkt /= ICMPv6NDOptDstLLAddr(lladdr=local_mac)                                   # noqa F821
 
         return neigh_adv_pkt
 

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -1,6 +1,7 @@
-import scapy.arch.pcapdnet
-import scapy.all as scapy2
 import ptf.packet as scapy
+import scapy.all as scapy2
+scapy2.conf.use_pcap=True
+import scapy.arch.pcapdnet
 import binascii
 import socket
 import struct
@@ -12,7 +13,7 @@ from collections import defaultdict
 from fcntl import ioctl
 import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-scapy2.conf.use_pcap = True
+
 
 NEIGH_SOLICIT_ICMP_MSG_TYPE = 135
 
@@ -205,10 +206,10 @@ class ARPResponder(object):
         return eth_hdr + self.arp_chunk + local_mac + local_ip + remote_mac + remote_ip + self.arp_pad
 
     def generate_neigh_adv(self, local_mac, remote_mac, target_ip, remote_ip):
-        neigh_adv_pkt = scapy.Ether(src=local_mac, dst=remote_mac) / \
-            scapy.IPv6(src=target_ip, dst=remote_ip)
-        neigh_adv_pkt /= scapy.ICMPv6ND_NA(tgt=target_ip, R=0, S=1, O=1)
-        neigh_adv_pkt /= scapy.ICMPv6NDOptDstLLAddr(lladdr=local_mac)
+        neigh_adv_pkt = Ether(src=local_mac, dst=remote_mac) / \
+            IPv6(src=target_ip, dst=remote_ip)
+        neigh_adv_pkt /= ICMPv6ND_NA(tgt=target_ip, R=0, S=1, O=1)
+        neigh_adv_pkt /= ICMPv6NDOptDstLLAddr(lladdr=local_mac)
 
         return neigh_adv_pkt
 

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -10,8 +10,8 @@ from fcntl import ioctl
 import logging
 import ptf.packet as scapy
 import scapy.all as scapy2
+import scapy.arch.pcapdnet
 scapy2.conf.use_pcap=True
-import scapy.arch.pcapdnet # noqa E402
 
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR #8049, Python style issues in `arp_responder.py` are fixed. However, it modified the import order of scapy related packages, which caused the NDP responder hit below issue:

```
Traceback (most recent call last):
  File "/opt/arp_responder.py", line 273, in <module>
    main()
  File "/opt/arp_responder.py", line 267, in main
    p.poll()
  File "/opt/arp_responder.py", line 88, in poll
    self.responder.action(self.mapping[handler])
  File "/opt/arp_responder.py", line 120, in action
    return self.reply_to_ndp(data, interface)
  File "/opt/arp_responder.py", line 159, in reply_to_ndp
    )][target_ip_str], remote_mac, target_ip_str, remote_ip_str)
  File "/opt/arp_responder.py", line 210, in generate_neigh_adv
    neigh_adv_pkt /= scapy.ICMPv6ND_NA(tgt=target_ip, R=0, S=1, O=1)
AttributeError: 'module' object has no attribute 'ICMPv6ND_NA'
```

In this PR, I recovered the import order and fixed this issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
This issue only happens on master branch, so no backport needed.

- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Bugfix for `AttributeError` in NDP responder.

#### How did you do it?
Recovered the import order of scapy related packages

#### How did you verify/test it?
Verified by testcases using ARP/NDP responder.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
