### PR TITLE
[202205][add-topo] add option to disble updategraph service during testbed deployment

### DIFF
--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -79,8 +79,20 @@ class SerialSession(object):
         return
 
 def session(new_params):
-    seq = [
-        ('while true; do if [ $(systemctl is-active swss) == "active" ]; then break; fi; echo $(systemctl is-active swss); sleep 1; done', [r'#'], 180),
+    if new_params['disable_updategraph']:
+        seq = [
+            ('while true; do if [ $(systemctl is-active swss) == "active" ]; then break; fi; '
+             'echo $(systemctl is-active swss); '
+             'sed -i -e "s/enabled=true/enabled=false/" /etc/sonic/updategraph.conf; '
+             'systemctl restart updategraph; sleep 1; done', [r'#'], 180),
+        ]
+    else:
+        seq = [
+            ('while true; do if [ $(systemctl is-active swss) == "active" ]; then break; fi; '
+             'echo $(systemctl is-active swss); sleep 1; done', [r'#'], 180),
+        ]
+
+    seq.extend([
         ('pkill dhclient', [r'#']),
         ('hostname %s' % str(new_params['hostname']), [r'#']),
         ('sed -i s:sonic:%s: /etc/hosts' % str(new_params['hostname']), [r'#']),
@@ -89,7 +101,7 @@ def session(new_params):
         ('ip route add 0.0.0.0/0 via %s table default' % str(new_params['mgmt_gw']), [r'#']),
         ('ip route', [r'#']),
         ('echo %s:%s | chpasswd' % (str(new_params['login']), str(new_params['new_password'])), [r'#']),
-    ]
+    ])
     # For multi-asic VS there is no default config generated.
     # interfaces-config service will not add eth0 IP address as there
     # no default config. Multiple SWSS service will not start until
@@ -124,6 +136,7 @@ def main():
         mgmt_gw = dict(required=True),
         new_password = dict(required=True),
         num_asic = dict(required=True),
+        disable_updategraph = dict(required=True, type='bool'),
     ))
 
     try:

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -4,6 +4,10 @@
   when: respin_vms is not defined
 
 - set_fact:
+    disable_updategraph: False
+  when: disable_updategraph is not defined
+
+- set_fact:
     skip_this_vm: True
 
 - set_fact:
@@ -61,6 +65,7 @@
               mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
               new_password={{ sonic_password }}
               num_asic={{ num_asic }}
+              disable_updategraph={{ disable_updategraph }}
     register: kickstart_output
     until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code == 0'
     retries: 5
@@ -92,6 +97,7 @@
               mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
               new_password={{ sonic_password }}
               num_asic={{ num_asic }}
+              disable_updategraph={{ disable_updategraph }}
     register: kickstart_output_final
     until: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code == 0'
     retries: 5

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -2,6 +2,10 @@
     sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
     when: sonic_vm_storage_location is not defined
 
+- set_fact:
+    disable_updategraph: False
+  when: disable_updategraph is not defined
+
 - name: Create directory for vm images and vm disks
   file: path={{ item }} state=directory mode=0755
   with_items:
@@ -62,6 +66,7 @@
              mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
              new_password={{ sonic_password }}
              num_asic={{ num_asic }}
+             disable_updategraph={{ disable_updategraph }}
   register: kickstart_output
 
 - name: Fail if kickstart gives error for {{ dut_name }}

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -52,6 +52,7 @@ function usage
   echo "To deploy topology for specified testbed on a server: $0 add-topo 'testbed-name' ~/.password"
   echo "    Optional argument for add-topo:"
   echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
+  echo "        -e disable_updategraph=<true|false>    # Disable updategraph service when deploying testbed"
   echo "To remove topology for specified testbed on a server: $0 remove-topo 'testbed-name' ~/.password"
   echo "To remove topology and keysight-api-server container for specified testbedon a server:"
   echo "        $0 remove-topo 'testbed-name' ~/.password remove_keysight_api_server"


### PR DESCRIPTION
cherry-picking #8260 

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
If SONiC image was built with ENABLE_DHCP_GRAPH_SERVICE=y option, the image will boot up waiting for configuraion to be pushed down from DHCP. When starting such image, waiting for swss to become active would timeout and thus fail the testbed deployment.

#### How did you do it?
Adding option to disable updategraph service during testbed deployment.

#### How did you verify/test it?
With regular kvm image, both following deployment succeeded:
```
./testbed-cli.sh  -t vtestbed.csv -m veos_vtb -k ceos redeploy-topo vms-kvm-t1-lag password.txt -e disable_updategraph=True
./testbed-cli.sh  -t vtestbed.csv -m veos_vtb -k ceos redeploy-topo vms-kvm-t1-lag password.txt
```

With image built with ENABLE_DHCP_GRAPH_SERVICE=y option, first command succeeded and second failed.