### PR TITLE
Making Arp clear conditional for T2 in qos_sai_test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1291,7 +1291,7 @@ class QosSaiBase(QosBase):
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
 
-        if 'dualtor' in tbinfo['topo']['name']:
+        if 't2' not in tbinfo['topo']['name']:
             dut_asic.command('sonic-clear fdb all')
             dut_asic.command('sonic-clear arp')
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1295,7 +1295,6 @@ class QosSaiBase(QosBase):
             dut_asic.command('sonic-clear fdb all')
             dut_asic.command('sonic-clear arp')
 
-
         saiQosTest = None
         if dutTestParams["topo"] in self.SUPPORTED_T0_TOPOS:
             saiQosTest = "sai_qos_tests.ARPpopulate"

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1291,8 +1291,10 @@ class QosSaiBase(QosBase):
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
 
-        dut_asic.command('sonic-clear fdb all')
-        dut_asic.command('sonic-clear arp')
+        if 'dualtor' in tbinfo['topo']['name']:
+            dut_asic.command('sonic-clear fdb all')
+            dut_asic.command('sonic-clear arp')
+
 
         saiQosTest = None
         if dutTestParams["topo"] in self.SUPPORTED_T0_TOPOS:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is impacted by the PR # https://github.com/sonic-net/sonic-mgmt/pull/7819 

For T2 topology the arp table is not getting refreshed/updated with the dynamic Arp entries after arp clear on the DUT.

The Apr populate test broadcast the arp packet and sleep for 8 seconds. Within this time frame no arp is learnt on the DUT side & fails at qos test run with below error as the port_ip's are missing in Arp table:

"Traceback (most recent call last):", "  File \"saitests/py3/sai_qos_tests.py\", line 3934, in runTest", "    self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan", "  File \"saitests/py3/sai_qos_tests.py\", line 198, in get_rx_port", "    result.port, result.format()))", "AssertionError: Expected packet was not received. Received on port:None ========== EXPECTED =========="

Summary:
For  T2-topology, in ARPpopulate  test, found below issues -
1.After arp clear, even if the sleep time is increased to 30 secs on the Arppopulate test the Arp is not learnt. We observed that the arp packets sent in test are dropped on the DUT during the run.
2.In the test, since there is no return value, the arp entries left unverified on the DUT before the qos test run.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
Since the PR# https://github.com/sonic-net/sonic-mgmt/pull/7819 resolve the dualtor's issue
The step to clear arp & fdb are made conditional for topo type as dualtor only

#### What is the motivation for this PR?
Since all the qos test were impacted by the ArpPopulate change, all test cases failed with error -

"Traceback (most recent call last):", "  File \"saitests/py3/sai_qos_tests.py\", line 3934, in runTest", "    self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan", "  File \"saitests/py3/sai_qos_tests.py\", line 198, in get_rx_port", "    result.port, result.format()))", "AssertionError: Expected packet was not received. Received on port:None ========== EXPECTED ==========" 

#### How did you do it?
The step to clear arp & fdb are made conditional for topo type as dualtor only.

#### How did you verify/test it?
Re-run the  qos  test suite
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
