### PR TITLE
[T2 chassis] Accommodate timeout for bgpMon peer connection to establish base on inventory file

### DIFF
--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -19,8 +19,20 @@ pytestmark = [
 
 BGP_PORT = 179
 BGP_CONNECT_TIMEOUT = 121
+MAX_TIME_FOR_BGPMON = 180
 ZERO_ADDR = r'0.0.0.0/0'
 logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def set_timeout_for_bgpmon(duthost):
+    """
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
+    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
+    """
+    global MAX_TIME_FOR_BGPMON
+    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_bgpmon.py', 'cold')
+    if plt_reboot_ctrl:
+        MAX_TIME_FOR_BGPMON = plt_reboot_ctrl.get('timeout', 180)
 
 
 def get_default_route_ports(host, tbinfo):
@@ -130,7 +142,7 @@ def build_syn_pkt(local_addr, peer_addr):
 
 
 def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_index,
-                common_setup_teardown, ptfadapter, ptfhost):
+                common_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """
     Add a bgp monitor on ptf and verify that DUT is attempting to establish connection to it
     """
@@ -176,7 +188,7 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
     try:
         pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
                       "Failed to start bgp monitor session on PTF")
-        pytest_assert(wait_until(180, 5, 0, bgpmon_peer_connected, duthost, peer_addr),
+        pytest_assert(wait_until(MAX_TIME_FOR_BGPMON, 5, 0, bgpmon_peer_connected, duthost, peer_addr),
                       "BGPMon Peer connection not established")
     finally:
         ptfhost.exabgp(name=BGP_MONITOR_NAME, state="absent")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Accommodate timeout for bgpMon peer connection to establish, if timeout is specified in inventory file for this test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Call getter function in utilities.py to get timeout for this specific test case
#### How did you verify/test it?
Before:
```
07/05/2023 01:18:51 utilities.wait_until                     L0127 DEBUG  | bgpmon_peer_connected is False, wait 5 seconds and check again
07/05/2023 01:18:56 utilities.wait_until                     L0132 DEBUG  | bgpmon_peer_connected is still False after 180 seconds, exit with False
07/05/2023 01:18:56 base._run                               
```
```
pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
"Failed to start bgp monitor session on PTF")
>           pytest_assert(wait_until(180, 5, 0, bgpmon_peer_connected, duthost, peer_addr),"BGPMon Peer connection not established")
E           Failed: BGPMon Peer connection not established
```
After:
```
22:53:27 test_bgpmon.test_bgpmon                  L0164 INFO   | Configured bgpmon and verifying packet on [15, 12, 13, 14, 10, 11, 8, 9, 4, 5, 2, 3, 0, 1, 24, 25, 26, 27]
PASSED                                                                                                                                                                                       [100%]
---------------------------------------------------------------------------------------- live log teardown --------------------------------
-------------------------------------------------------------- generated xml file: /var/src/private/sonic-mgmt-int/tests/logs/tr.xml ---------------------------------------------------------------
-------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
22:54:33 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 1 passed in 190.67 seconds ==========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
