### PR TITLE
[tests/route]: Add an option to test max ASIC route scale limit

### DIFF
--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -10,6 +10,9 @@ def pytest_addoption(parser):
     route_group.addoption("--num_routes", action="store", default=None, type=int,
                           help="Number of routes for add/delete")
 
+    route_group.addoption("--max_scale", action="store_true",
+                          help="Test with maximum possible route scale")
+
 
 @pytest.fixture(scope='module')
 def get_function_conpleteness_level(pytestconfig):

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -281,9 +281,12 @@ def test_perf_add_remove_routes(
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    max_scale = request.config.getoption("--max_scale")
     # Number of routes for test
     set_num_routes = request.config.getoption("--num_routes")
-    if set_num_routes is None:
+    if max_scale and set_num_routes is not None:
+        raise Exception("--max_scale and --num_routes are mutually exclusive")
+    elif not max_scale and set_num_routes is None:
         topo_name = tbinfo["topo"]["name"]
         if topo_name in ["m0", "mx"]:
             set_num_routes = DEAFULT_M0_MX_NUM_ROUTES
@@ -310,7 +313,10 @@ def test_perf_add_remove_routes(
         ),
     )
 
-    num_routes = min(avail_routes_count, set_num_routes)
+    if (max_scale):
+        num_routes = avail_routes_count
+    else:
+        num_routes = min(avail_routes_count, set_num_routes)
     logger.info(
         "IP route utilization before test start: Used: {}, Available: {}, Test count: {}".format(
             used_routes_count, avail_routes_count, num_routes


### PR DESCRIPTION
 * The default route scale of 10000 routes in this test may not be sufficient to test route scaling on different platforms/skus. A more robust option is to test the maximum possible route scale limit by leveraging CRM counters instead of a hard-coded value

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (16225112)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To improve route scaling tests and avoid table full errors in production
#### How did you do it?
Increase test scale based on topology and check for certain necessary config parameters
#### How did you verify/test it?
By running this sonic-mgmt on testbeds with different topologies
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
