### PR TITLE
Update advanced-reboot ptf test to support 70K packets

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -241,7 +241,14 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
+<<<<<<< df9a1d710e33f71fd06293c17275c41a97d038ba:ansible/roles/test/files/ptftests/py3/advanced-reboot.py
         self.sent_packet_count = 0
+=======
+        # How many packets to be sent in send_in_background method
+        self.packets_to_send = min(
+            int(self.time_to_listen / (self.send_interval + 0.0015)), 70000)
+
+>>>>>>> Update advanced-reboot ptf test to support 70K packets:ansible/roles/test/files/ptftests/advanced-reboot.py
         # Thread pool for background watching operations
         self.pool = ThreadPool(processes=3)
 

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -185,7 +185,7 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
-        self.check_param('num_of_packets', int(self.time_to_listen / (self.send_interval + 0.0015)) , required=False)
+        self.check_param('num_of_packets', int(self.time_to_listen / (self.send_interval + 0.0015)), required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -216,6 +216,9 @@ class ReloadTest(BaseTest):
 
         self.packets_list = []
         self.vnet = self.test_params['vnet']
+        self.num_of_packets = self.test_params['num_of_packets']
+        if self.test_params['asic_type'] == "mellanox":
+            self.num_of_packets = 70000
         if (self.vnet):
             self.packets_list = json.load(open(self.test_params['vnet_pkts']))
 
@@ -639,7 +642,6 @@ class ReloadTest(BaseTest):
         self.dut_mac = self.test_params['dut_mac']
         self.vlan_mac = self.test_params['vlan_mac']
         self.lo_prefix = self.test_params['lo_prefix']
-        self.num_of_packets = self.test_params['num_of_packets']
         if self.vlan_mac != self.dut_mac:
             self.is_dualtor = True
         else:

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -185,7 +185,7 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
-	self.check_param('num_of_packets', int(self.time_to_listen / (self.send_interval + 0.0015)) , required=False)
+        self.check_param('num_of_packets', int(self.time_to_listen / (self.send_interval + 0.0015)) , required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,7 +180,12 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
-        self.check_param('num_of_packets', 45000, required=False)
+        # Listen for more then 240 seconds, to be used in sniff_in_background method.
+        self.time_to_listen = 240.0
+        #   Inter-packet interval, to be used in send_in_background method.
+        #   Improve this interval to gain more precision of disruptions.
+        self.send_interval = 0.0035
+	self.check_param('num_of_packets', int(self.time_to_listen / (self.send_interval + 0.0015)) , required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':
@@ -245,14 +250,10 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
-<<<<<<< df9a1d710e33f71fd06293c17275c41a97d038ba:ansible/roles/test/files/ptftests/py3/advanced-reboot.py
         self.sent_packet_count = 0
-=======
         # How many packets to be sent in send_in_background method
-        self.packets_to_send = min(
-            int(self.time_to_listen / (self.send_interval + 0.0015)), self.num_of_packets)
+        self.packets_to_send = self.num_of_packets
 
->>>>>>> Update advanced-reboot ptf test to support 70K packets:ansible/roles/test/files/ptftests/advanced-reboot.py
         # Thread pool for background watching operations
         self.pool = ThreadPool(processes=3)
 

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,7 +180,7 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
-        self.check_param('num_of_packets', 70000, required=False)
+        self.check_param('num_of_packets', 45000, required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,6 +180,7 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
+        self.check_param('num_of_packets', 70000, required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':
@@ -246,7 +247,7 @@ class ReloadTest(BaseTest):
 =======
         # How many packets to be sent in send_in_background method
         self.packets_to_send = min(
-            int(self.time_to_listen / (self.send_interval + 0.0015)), 70000)
+            int(self.time_to_listen / (self.send_interval + 0.0015)), self.num_of_packets)
 
 >>>>>>> Update advanced-reboot ptf test to support 70K packets:ansible/roles/test/files/ptftests/advanced-reboot.py
         # Thread pool for background watching operations
@@ -638,6 +639,7 @@ class ReloadTest(BaseTest):
         self.dut_mac = self.test_params['dut_mac']
         self.vlan_mac = self.test_params['vlan_mac']
         self.lo_prefix = self.test_params['lo_prefix']
+        self.num_of_packets = self.test_params['num_of_packets']
         if self.vlan_mac != self.dut_mac:
             self.is_dualtor = True
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
improve advanced-reboot script to use 70k packets in the case when we run a fast/warm reboot upgrade
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Improve advanced-reboot script to use 70k packets in case when we run fast/warm reboot upgrade,
45000 packets could be to little packets sometimes and packets could be finished being sent before reboot even starts

#### How did you do it?
just increase the packets number, 70k seemed to be enough packets according to our checks

#### How did you verify/test it?
run the tests several times on each platform

#### Any platform specific information?
no
