### PR TITLE
[Fixbug]: No IPv4 neighbor is configured

### DIFF
--- a/ansible/roles/sonic/tasks/vsonic.yml
+++ b/ansible/roles/sonic/tasks/vsonic.yml
@@ -24,6 +24,7 @@
           sonic-cfggen -H -k Force10-S6000 --preset empty
           | jq '.DEVICE_METADATA.localhost.hostname="{{ hostname }}"'
           | jq '.DEVICE_METADATA.localhost.bgp_asn="{{ configuration[hostname]['bgp']['asn'] }}"'
+          | jq '.DEVICE_METADATA.localhost.deployment_id="1"'
           > config-metadata.json
   when: hostname in configuration
 

--- a/ansible/roles/sonic/templates/configdb-t0-leaf.j2
+++ b/ansible/roles/sonic/templates/configdb-t0-leaf.j2
@@ -49,7 +49,7 @@
             "holdtime": "10",
             "keepalive": "3",
             "local_addr": "{{ host['interfaces']['Port-Channel1']['ipv6' if peer | ipv6 else 'ipv4'].split('/')[0] | lower }}",
-            "name": "{{ hostname }}",
+            "name": "{{ duts_name }}",
             "nhopself": "0",
             "rrclient": "0"
         },
@@ -73,6 +73,13 @@
             "name": "exabgp_v6",
             "nhopself": "0",
             "rrclient": "0"
+        }
+    },
+    "DEVICE_NEIGHBOR_METADATA": {
+        "{{ duts_name }}": {
+                "hwsku": "SONiC-VM",
+                "mgmt_addr": "{{ hostvars[duts_name]['ansible_host'] }}",
+                "type": "TorRouter"
         }
     },
 {% set separator = joiner(",") %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In some SONiC image, the DEVICE_NEIGHBOR_METADATA section and deployment_id are required, Otherwise the bgp session will not be loaded into FRR to the neighbor device with SONiC.

#### How did you do it?
Add deployment_id and DEVICE_NEIGHBOR_METADATA to config_db.json at `add_topo` stage.

#### How did you verify/test it?
Check it in internal testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Please merge this PR to 202205 after the PR(https://github.com/sonic-net/sonic-mgmt/pull/7894) was merged to 202205
