### PR TITLE
Ignore RP asic if None

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -82,7 +82,8 @@ class MultiAsicSonicHost(object):
                 if config_facts['FEATURE'][service]['state'] == "disabled":
                     self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
         for asic in active_asics:
-            service_list += asic.get_critical_services()
+            if asic:
+                service_list += asic.get_critical_services()
         self.sonichost.reset_critical_services_tracking_list(service_list)
 
     def get_default_critical_services_list(self):

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -875,7 +875,12 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
+        if dutAsic == "gb" and topo == "t2":
+            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+                dutTopo = dutTopo + "any"
+            else:
+                dutTopo = dutTopo + topo
+        elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -875,12 +875,7 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutAsic == "gb" and topo == "t2":
-            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
-                dutTopo = dutTopo + "any"
-            else:
-                dutTopo = dutTopo + topo
-        elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
+        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any


### PR DESCRIPTION
For cisco-8000, the RP presents an asic for every fabric card that is present. If there is no fabric card in a slot, the asic is returned as None. It is ok to ignore that, since it is not used by RP anyways.