### PR TITLE
[console] Fix failed in test_console_rate

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -24,15 +24,14 @@ def is_sonic_console(conn_graph_facts, dut_hostname):
 
 
 def test_console_baud_rate_config(duthost):
-    global pass_config_test
-    pass_config_test = False
     platform = duthost.facts["platform"]
     expected_baud_rate = BAUD_RATE_MAP[platform] if platform in BAUD_RATE_MAP else BAUD_RATE_MAP["default"]
-    res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2",
-                        module_ignore_errors=True)
-    pytest_assert(res["rc"] == 0 and res["stdout"] == expected_baud_rate, "Baud rate {} is unexpected!"
-                  .format(res["stdout"]))
-    pass_config_test = True
+    res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
+    pytest_require(res["stdout"] != "", "Cannot get baud rate")
+    if res["stdout"] != expected_baud_rate:
+        global pass_config_test
+        pass_config_test = False
+        pytest.fail("Baud rate {} is unexpected!".format(res["stdout"]))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some DUT cannot get baud rate via 'cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2', skip test in this scenario.
```
admin~$ cat /proc/cmdline
reboot=p console=ttyS0 acpi=on Aboot=Aboot-norcal7-7.2.0-pcie2x4-6128821 block_flash=pci0000:00/0000:00:1f.2/.*host./target0:0:0/.*$ block_drive=pci0000:00/0000:00:1f.2/.*host./target2:0:0/.*$ net_ma2=pci0000:00/0000:00:01.0/.*$ net_ma1=pci0000:00/0000:00:01.1/.*$ block_usb2=pci0000:00/0000:00:14.0/\(usb3/3-2\|usb4/4-2\)/.*$ block_usb1=pci0000:00/0000:00:14.0/\(usb3/3-3\|usb4/4-5\)/.*$ platform=rook scd.lpc_irq=7 scd.lpc_res_addr=0xb0000000 scd.lpc_res_size=0x10000 sid=Gardena cmdline-aboot-end tsc=reliable pcie_ports=native rhash_entries=1 usb-storage.delay_use=0 reassign_prefmem iommu=on intel_iommu=on intel_idle.max_cstate=0 varlog_size=4096 sonic.mode=fixed log_buf_len=1M security=apparmor apparmor=1 rw net.ifnames=0 systemd.unified_cgroup_hierarchy=0 quiet systemd.show_status=auto hwaddr_ma1=98:5d:82:23:b2:f8 root=UUID=f7a4638f-b3ba-4a1f-b784-8dd0bb5050f9 loop=image-20201231.87/fs.squashfs loopfstype=squashfs
```

#### How did you do it?
Skip test if cannot get baud rate.

#### How did you verify/test it?
Run tests.
```
collected 3 items                                                              

dut_console/test_console_baud_rate.py::test_console_baud_rate_config SKIPPED [ 33%]
dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect SKIPPED [ 66%]
dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect SKIPPED [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
