### PR TITLE
skip generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -460,6 +460,12 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
     conditions:
       - "platform in ['x86_64-kvm_x86_64-r0']"
 
+generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
+  skip:
+    reason: "Skip asym pfc on unsupported platforms"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+      
 generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33-True]:
   skip:
     reason: 'Skipping test on mellanox platform due to bug of https://github.com/sonic-net/sonic-mgmt/issues/7733'
@@ -467,12 +473,6 @@ generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/7733
 
-generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
-  skip:
-    reason: "Skip asym pfc on unsupported platforms"
-    conditions:
-      - "asic_type in ['cisco-8000']"
-      
 generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
   skip:
     reason: "This test was not run on this hwsku type currently"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -465,7 +465,7 @@ generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
     reason: "Skip asym pfc on unsupported platforms"
     conditions:
       - "asic_type in ['cisco-8000']"
-      
+
 generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33-True]:
   skip:
     reason: 'Skipping test on mellanox platform due to bug of https://github.com/sonic-net/sonic-mgmt/issues/7733'

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -467,6 +467,12 @@ generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/7733
 
+generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
+  skip:
+    reason: "Skip asym pfc on unsupported platforms"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+      
 generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
   skip:
     reason: "This test was not run on this hwsku type currently"


### PR DESCRIPTION
### Description of PR

Skip generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym for unsupported platforms
 


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205


#### How did you verify/test it?

 Verified by running the mgmt test script test_eth_interface.py::test_toggle_pfc_asym

