### PR TITLE
[auto-techsupport] Fixed issue on slow CPUs(mostly on DPUs) when we have failure due to 2 techsupport processes running but only one expected

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -636,7 +636,7 @@ def is_techsupport_generation_in_expected_state(duthost, expected_in_progress=Tr
         num_of_process = len(duthost.shell(get_running_tech_procs_cmd)['stdout_lines']) - processes_to_be_ignored
         logger.info('Number of running autotechsupport processes: {}'.format(num_of_process))
 
-        if num_of_process == 1:
+        if num_of_process >= 1:
             techsupport_in_progress = True
 
         is_in_expected_state = False


### PR DESCRIPTION
### Description of PR
Fixed issue on slow CPUs(mostly on DPUs) when we have failure due to 2 techsupport processes running but only one expected

The problem happens only on slow CPU devices(observed on DPU devices with ARM CPU). Auto-techsupport tries to trigger a new techsupport process - which checks if the existing process is running and if the process already running it exits immediately, but in slow CPU devices - it exits not immediately, and as result we may see 2 techsupport processes running(second one will exit in few sec). Fixed test logic - now we check that we have 1 or more processes running. If we have more processes running - at the end of the test we will do validation for new techsupport files(we still expect only one new techsupport dump file).

Summary: Fixed issue on slow CPUs(mostly on DPUs) when we have failure due to 2 techsupport processes running but only one expected
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fixed issue on slow CPUs(mostly on DPUs) when we have failure due to 2 techsupport processes running but only one expected

#### How did you do it?
See code and explanation abowe

#### How did you verify/test it?
Executed test case few times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
