### PR TITLE
Fixes for voq_nbr test failures

### DIFF
--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -762,6 +762,12 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
         # Check neighbor on local linecard
         logger.info("*" * 60)
         logger.info("Verify initial neighbor: %s, port %s", neighbor, local_port)
+        if ":" in neighbor:
+            logger.info("Force neighbor solicitation for IPV6.")
+            asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
+        else:
+            logger.info("Force neighbor solicitation for IPV4.")
+            asic_cmd(asic, "arping -c 1 %s" % neighbor)
         pytest_assert(wait_until(60, 2, 0, check_arptable_mac,
                                  per_host, asic, neighbor, original_mac, checkstate=False),
                       "MAC {} didn't change in ARP table".format(original_mac))

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -705,7 +705,7 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     Test Steps
 
     * Change the MAC address on a remote host that is already present in the ARP table.
-    * Without clearing the entry in the DUT, allow the existing entry to time out and the new reply to have the new MAC
+    * Without clearing the entry in the DUT, do the neighbor discovery and get the new reply to have the new MAC
       address.
     * On local linecard:
         * Verify table entries in local ASIC, APP, and host ARP table are updated with new MAC.
@@ -778,8 +778,11 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
 
         for neighbor in nbr_to_test:
             if ":" in neighbor:
-                logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
+                logger.info("Force neighbor solicitation for IPV6.")
                 asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
+            else:
+                logger.info("Force neighbor solicitation for IPV4.")
+                asic_cmd(asic, "arping -c 1 %s" % (neighbor))
             pytest_assert(wait_until(60, 2, 0, check_arptable_mac,
                                      per_host, asic, neighbor, NEW_MAC, checkstate=False),
                           "MAC {} didn't change in ARP table".format(NEW_MAC))
@@ -796,8 +799,11 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
         change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], original_mac)
         for neighbor in nbr_to_test:
             if ":" in neighbor:
-                logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
+                logger.info("Force neighbor solicitation for IPV6.")
                 asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
+            else:
+                logger.info("Force neighbor solicitation for IPV4.")
+                asic_cmd(asic, "arping -c 1 %s" % (neighbor))
             pytest_assert(
                 wait_until(60, 2, 0, check_arptable_mac, per_host, asic, neighbor, original_mac, checkstate=False),
                 "MAC {} didn't change in ARP table".format(original_mac))
@@ -1215,6 +1221,7 @@ class TestGratArp(object):
                 logger.info("Will Restore ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
                             nbrinfo['shell_intf'], nbrinfo['vm'])
                 change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], original_mac)
+                self.send_grat_pkt(original_mac, neighbor, int(tb_port))
 
                 if ":" in neighbor:
                     logger.info("Force neighbor solicitation to workaround long IPV6 timer.")

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -379,7 +379,7 @@ def ping_all_dut_local_nbrs(duthosts):
                 node_results.append(sonic_ping(asic, neighbor, verbose=True))
         results[node.hostname] = node_results
 
-    parallel_run(_ping_all_local_nbrs, [], {}, duthosts.frontend_nodes, timeout=120)
+    parallel_run(_ping_all_local_nbrs, [], {}, duthosts.frontend_nodes, timeout=300)
 
 
 def ping_all_neighbors(duthosts, all_cfg_facts, neighbors):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- voq/test_voq_nbr.py test cases '_test_neighbor_hw_mac_change_' and '_test_gratarp_macchange_' 
- Above two test cases fail for IPV4 neighbor case where the neighbor MAC is not changed in DUT's arp table.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- This PR helps to fix '_test_neighbor_hw_mac_change_' and '_test_gratarp_macchange_' voq-nbr test cases.
- Tests fail for IPV4 neighbor, when its mac change is not updated in the DUT's arp table.

#### How did you do it?
- For _test_neighbor_hw_mac_change_, by doing neighbor solicitation for IPV4 neighbor using arping as it is done for IPV6 neighbor during test call as well during restoration in finally block.
- For '_test_gratarp_macchange_', after test call is done, during restoration 'original_mac' is sent in gratuitous arp to update the arp table on DUT.

#### How did you verify/test it?
- Ran all the VOQ neighbor test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![Voq-May15](https://github.com/sonic-net/sonic-mgmt/assets/114024719/474161ce-05b7-4ba5-a9a7-29c2d76b3fa0)
