### PR TITLE
[loganalyzer] ignore some syslog errors during link down test

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -47,5 +47,7 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical processes are healthy")
-    pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
+    is_chassis = duthost.get_facts().get("modular_chassis")
+    timeout = 400 if is_chassis else 300
+    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -47,7 +47,7 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical processes are healthy")
-    is_chassis = duthost.get_facts().get("modular_chassis")
+    is_chassis = dut.get_facts().get("modular_chassis")
     timeout = 400 if is_chassis else 300
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -7,7 +7,7 @@ import logging
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 
 
 def reset_timeout(duthost):

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -22,7 +22,7 @@ def reset_timeout(duthost):
     reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
-        reset_timeout = plt_reboot_ctrl['timeout']
+        reset_timeout = plt_reboot_ctrl.get('timeout', 300)
     return reset_timeout
 
 

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -11,6 +11,15 @@ from tests.common.utilities import wait_until
 
 
 def reset_timeout(duthost):
+    """
+    return: if timeout is specified in inventory file for this dut, return new timeout
+            if not specified, return 300 sec as default timeout
+    e.g.
+        processes_utils.py:
+          timeout: 400
+          wait: 60
+    """
+    reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl['timeout']

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -5,34 +5,32 @@ This script contains re-usable functions for checking status of critical service
 """
 import logging
 import time
-import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-
-TIMEOUT_TO_REBOOT = 300
+from tests.common.utilities import wait_until
 
 
-@pytest.fixture(scope='function')
-def set_timeout(duthost):
-    global TIMEOUT_TO_REBOOT
+def reset_timeout(duthost):
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
     if plt_reboot_ctrl:
-        TIMEOUT_TO_REBOOT = plt_reboot_ctrl['wait']
+        reset_timeout = plt_reboot_ctrl['timeout']
+    return reset_timeout
 
 
 def get_critical_processes_status(dut):
     processes_status = dut.all_critical_process_status()
-    for k, v in processes_status.items():
-        if v['status'] == False or len(v['exited_critical_process']) > 0:
+    for k, v in list(processes_status.items()):
+        if v['status'] is False or len(v['exited_critical_process']) > 0:
             return False, processes_status
 
     return True, processes_status
+
 
 def _all_critical_processes_healthy(dut):
     logging.info("Check critical processes status")
     status, _ = get_critical_processes_status(dut)
     return status
+
 
 def check_critical_processes(dut, watch_secs=0):
     """
@@ -49,11 +47,14 @@ def check_critical_processes(dut, watch_secs=0):
             time.sleep(min(5, watch_secs))
         watch_secs = watch_secs - 5
 
+
 def wait_critical_processes(dut):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
-    logging.info("Wait until all critical processes are healthy")
-    pytest_assert(wait_until(TIMEOUT_TO_REBOOT, 20, 0, _all_critical_processes_healthy, dut),
+    timeout = reset_timeout(dut)
+    logging.info("Wait until all critical processes are healthy in {} sec"
+                 .format(timeout))
+    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -20,7 +20,7 @@ def reset_timeout(duthost):
           wait: 60
     """
     reset_timeout = 300
-    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py')
+    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl['timeout']
     return reset_timeout

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -25,6 +25,30 @@ pytestmark = [
 MAX_TIME_TO_REBOOT = 120
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_hostname, loganalyzer):
+    """
+    Ignore following syslog errors, when loganalyzer is enabled
+    """
+    ignore_regex_dict = [
+            ".*ERR lldp[0-9]*#lldpmgrd.*Port init timeout reached (300 seconds), resuming lldpd.*",
+            ".*ERR monit.*",
+    ]
+
+    impacted_duts = []
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_supervisor_node():
+        impacted_duts = duthosts
+    else:
+        impacted_duts = [duthost]
+
+    logger.info("Impacted DUTs: '{}'".format(impacted_duts))
+
+    if loganalyzer:
+        for a_dut in impacted_duts:
+            loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex_dict)
+
+
 @pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
     """

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -20,33 +20,10 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t2'),
+    pytest.mark.disable_loganalyzer,
 ]
 
 MAX_TIME_TO_REBOOT = 120
-
-
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_hostname, loganalyzer):
-    """
-    Ignore following syslog errors, when loganalyzer is enabled
-    """
-    ignore_regex_dict = [
-            ".*ERR lldp[0-9]*#lldpmgrd.*Port init timeout reached (300 seconds), resuming lldpd.*",
-            ".*ERR monit.*",
-    ]
-
-    impacted_duts = []
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if duthost.is_supervisor_node():
-        impacted_duts = duthosts
-    else:
-        impacted_duts = [duthost]
-
-    logger.info("Impacted DUTs: '{}'".format(impacted_duts))
-
-    if loganalyzer:
-        for a_dut in impacted_duts:
-            loganalyzer[a_dut.hostname].ignore_regex.extend(ignore_regex_dict)
 
 
 @pytest.fixture(scope='function')

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -136,7 +136,7 @@ def links_up(fanout, ports):
     return fanout.links_status_up(ports)
 
 
-def link_status_on_host(localhost, fanouts_and_ports, up=True):
+def link_status_on_host(fanouts_and_ports, up=True):
     for fanout, ports in list(fanouts_and_ports.items()):
         hostname = fanout.hostname
         # Assumption here is all fanouts are healthy.
@@ -152,14 +152,14 @@ def link_status_on_host(localhost, fanouts_and_ports, up=True):
     return True
 
 
-def link_status_on_all_fanouts(localhost, fanouts_and_ports, up=True):
+def link_status_on_all_fanouts(fanouts_and_ports, up=True):
     """
     Return:
         True: if up=True, and all links on all fanout hosts are up
               or
               if up=False, and all link on all fanout hosts are down
     """
-    link_status_on_host(localhost, fanouts_and_ports, up)
+    link_status_on_host(fanouts_and_ports, up)
     logger.info("All interfaces on all fanouts are {}!".format('up' if up else 'down'))
     return True
 
@@ -194,7 +194,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, duts_and_ports)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_all_fanouts(localhost, fanouts_and_ports)
+    link_status_on_all_fanouts(fanouts_and_ports)
 
     # Get a dut uptime before reboot
     dut_uptime_before = duthost.get_up_time()
@@ -203,7 +203,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     reboot(duthost, localhost, wait_for_ssh=False)
 
     # Also make sure fanout hosts' links are down
-    link_status_on_all_fanouts(localhost, fanouts_and_ports, up=False)
+    link_status_on_all_fanouts(fanouts_and_ports, up=False)
 
     # Wait for ssh port to open up on the SUP
     wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
@@ -222,7 +222,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
         duthosts, conn_graph_facts, xcvr_skip_list)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_all_fanouts(localhost, fanouts_and_ports)
+    link_status_on_all_fanouts(fanouts_and_ports)
 
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
@@ -239,7 +239,7 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
     fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, dut_ports)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_host(localhost, fanouts_and_ports)
+    link_status_on_host(fanouts_and_ports)
 
     # Get a dut uptime before reboot
     dut_uptime_before = duthost.get_up_time()
@@ -248,7 +248,7 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
     reboot(duthost, localhost, wait_for_ssh=False)
 
     # After reboot, immediately check if all links on all fanouts are down
-    link_status_on_host(localhost, fanouts_and_ports, up=False)
+    link_status_on_host(fanouts_and_ports, up=False)
 
     # Wait for ssh port to open up on the DUT
     wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
@@ -264,4 +264,4 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
         duthost, conn_graph_facts["device_conn"][hostname], xcvr_skip_list)
 
     # Also make sure fanout hosts' links are up
-    link_status_on_host(localhost, fanouts_and_ports)
+    link_status_on_host(fanouts_and_ports)

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -34,7 +34,7 @@ def set_max_to_reboot(duthost):
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
-        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['wait']
+        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['timeout']
 
 
 def multi_duts_and_ports(duthosts):

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -22,7 +22,7 @@ pytestmark = [
     pytest.mark.topology('t2'),
 ]
 
-MAX_TIME_TO_REBOOT = 120
+MAX_TIME_TO_REBOOT = 200
 
 
 @pytest.fixture(scope='function')

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -34,7 +34,7 @@ def set_max_to_reboot(duthost):
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
-        MAX_TIME_TO_REBOOT = plt_reboot_ctrl['timeout']
+        MAX_TIME_TO_REBOOT = plt_reboot_ctrl.get('timeout', 120)
 
 
 def multi_duts_and_ports(duthosts):

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -28,7 +28,7 @@ MAX_TIME_TO_REBOOT = 120
 @pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
     """
-    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file, 
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
     to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
     """
     global MAX_TIME_TO_REBOOT

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -147,7 +147,7 @@ def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_
 
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
-                                 conn_graph_facts,
+                                 conn_graph_facts, set_max_to_reboot,
                                  fanouthosts, xcvr_skip_list):
     if len(duthosts.nodes) == 1:
         pytest.skip("Skip single-host dut for this test")
@@ -202,7 +202,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
 
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                    conn_graph_facts,
+                                    conn_graph_facts, set_max_to_reboot,
                                     fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -148,7 +148,7 @@ def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
                                  conn_graph_facts,
-                                 fanouthosts, tbinfo, xcvr_skip_list, set_max_to_reboot):
+                                 fanouthosts, xcvr_skip_list):
     if len(duthosts.nodes) == 1:
         pytest.skip("Skip single-host dut for this test")
 
@@ -203,7 +203,7 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
                                     conn_graph_facts,
-                                    fanouthosts, xcvr_skip_list, tbinfo, set_max_to_reboot):
+                                    fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname
 

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -22,11 +22,15 @@ pytestmark = [
     pytest.mark.topology('t2'),
 ]
 
-MAX_TIME_TO_REBOOT = 200
+MAX_TIME_TO_REBOOT = 120
 
 
 @pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
+    """
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file, 
+    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
+    """
     global MAX_TIME_TO_REBOOT
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
     if plt_reboot_ctrl:
@@ -197,10 +201,10 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
     link_status_on_all_fanouts(localhost, fanouts_and_ports)
 
 
-def test_link_status_on_host_reboot(duthosts, localhost, enum_frontend_dut_hostname,
+def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
                                     conn_graph_facts,
                                     fanouthosts, xcvr_skip_list, tbinfo, set_max_to_reboot):
-    duthost = duthosts[enum_frontend_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostname = duthost.hostname
 
     # Before test, check all interfaces and services are up


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This test issues reboot on sup and linecards, when duts are down, there will be syslog errors showing that `monit check failed: container xxx is down`, which is expected, we want to ignore those syslog errors caused by reboot to avoid false alarm in pipeline runs


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
