### PR TITLE
[chassis] read timeout from inventory if any when check_interfaces_and_services

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -8,16 +8,14 @@ This script is to cover the test case 'Reload configuration' in the SONiC platfo
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
-import re
 import time
-
-from datetime import datetime
-
 import pytest
 
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-from tests.common.reboot import *
+from tests.common.reboot import sync_reboot_history_queue_with_dut, reboot, check_reboot_cause,\
+    check_reboot_cause_history, reboot_ctrl_dict, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
+    REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_POWEROFF, REBOOT_TYPE_WATCHDOG
 from tests.common.platform.transceiver_utils import check_transceiver_basic
 from tests.common.platform.interface_utils import check_all_interface_information, get_port_map
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
@@ -29,8 +27,11 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+logger = logging.getLogger(__name__)
+
 MAX_WAIT_TIME_FOR_INTERFACES = 300
 MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120
+
 
 @pytest.fixture
 def set_max_time_for_interfaces(duthost):
@@ -45,17 +46,19 @@ def set_max_time_for_interfaces(duthost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts, xcvr_skip_list):
+def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts, xcvr_skip_list):      # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     yield
 
-    logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
+    logging.info(
+        "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list)
 
 
-def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
+def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
+                     reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
     """
     Perform the specified type of reboot and check platform status.
     @param localhost: The Localhost object.
@@ -67,11 +70,13 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REB
     @param reboot_kwargs: The argument used by reboot_helper
     """
 
-    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
+    logging.info(
+        "Sync reboot cause history queue with DUT reboot cause history queue")
     sync_reboot_history_queue_with_dut(dut)
 
     logging.info("Run %s reboot on DUT" % reboot_type)
-    reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
+    reboot(dut, localhost, reboot_type=reboot_type,
+           reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")
@@ -80,7 +85,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REB
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 
 
-def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_for_interfaces, reboot_type = None):
+def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_for_interfaces, reboot_type=None):
     """
     Perform a further check after reboot-cause, including transceiver status, interface status
     @param localhost: The Localhost object.
@@ -93,7 +98,8 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
     if dut.is_supervisor_node():
         logging.info("skipping interfaces related check for supervisor")
     else:
-        logging.info("Wait {} seconds for all the transceivers to be detected".format(MAX_WAIT_TIME_FOR_INTERFACES))
+        logging.info("Wait {} seconds for all the transceivers to be detected".format(
+            MAX_WAIT_TIME_FOR_INTERFACES))
         result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, 0, check_all_interface_information, dut, interfaces,
                             xcvr_skip_list)
         assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
@@ -103,8 +109,10 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
         for asic_index in dut.get_frontend_asic_ids():
             # Get the interfaces pertaining to that asic
             interface_list = get_port_map(dut, asic_index)
-            interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
-            check_transceiver_basic(dut, asic_index, interfaces_per_asic, xcvr_skip_list)
+            interfaces_per_asic = {k: v for k, v in list(
+                interface_list.items()) if k in interfaces}
+            check_transceiver_basic(
+                dut, asic_index, interfaces_per_asic, xcvr_skip_list)
 
         logging.info("Check pmon daemon status")
         assert check_pmon_daemon_status(dut), "Not all pmon daemons running."
@@ -126,60 +134,67 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
             "got reboot-cause failed after rebooted by %s" % reboot_type
 
         if "201811" in dut.os_version or "201911" in dut.os_version:
-            logging.info("Skip check reboot-cause history for version before 202012")
+            logging.info(
+                "Skip check reboot-cause history for version before 202012")
         else:
             logger.info("Check reboot-cause history")
             assert wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 0, check_reboot_cause_history, dut,
-                              REBOOT_TYPE_HISTOYR_QUEUE), "Check reboot-cause history failed after rebooted by %s" % reboot_type
+                              REBOOT_TYPE_HISTOYR_QUEUE), \
+                "Check reboot-cause history failed after rebooted by %s" % reboot_type
         if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
-            logging.info("Further checking skipped for %s test which intends to verify reboot-cause only" % reboot_type)
+            logging.info(
+                "Further checking skipped for %s test which intends to verify reboot-cause only" % reboot_type)
             return
 
-def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                     conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):
+
+def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    import pdb; pdb.set_trace()
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
+                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
 
 
-def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
+def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform soft reboot and check platform status
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    soft_reboot_supported = duthost.command('which soft-reboot', module_ignore_errors=True)["stdout"]
+    soft_reboot_supported = duthost.command(
+        'which soft-reboot', module_ignore_errors=True)["stdout"]
     if "" == soft_reboot_supported:
-        pytest.skip("Soft-reboot is not supported on this DUT, skip this test case")
+        pytest.skip(
+            "Soft-reboot is not supported on this DUT, skip this test case")
 
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting soft reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
+                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT)
 
 
-def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
+def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform fast reboot and check platform status
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    sonic_hwsku = duthost.sonichost.facts["hwsku"]
-    if "SN3800" in sonic_hwsku:
-        pytest.skip("Not supported on Mellanox 3800")
-
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting fast reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
+                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST)
 
 
-def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
+def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform warm reboot and check platform status
     """
@@ -194,9 +209,11 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn
     if asic_type in ["mellanox"]:
         issu_capability = duthost.command("show platform mlnx issu")["stdout"]
         if "disabled" in issu_capability:
-            pytest.skip("ISSU is not supported on this DUT, skip this test case")
+            pytest.skip(
+                "ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
+                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM)
 
 
 def _power_off_reboot_helper(kwargs):
@@ -219,7 +236,9 @@ def _power_off_reboot_helper(kwargs):
         pdu_ctrl.turn_on_outlet(outlet)
 
 
-def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list, pdu_controller, power_off_delay):
+def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                          localhost, conn_graph_facts, xcvr_skip_list,      # noqa F811
+                          pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
@@ -232,15 +251,19 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     UNSUPPORTED_ASIC_TYPE = ["cisco-8000"]
     if duthost.facts["asic_type"] in UNSUPPORTED_ASIC_TYPE:
-        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform".format(duthost.facts["asic_type"]))
+        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform".format(
+            duthost.facts["asic_type"]))
     pdu_ctrl = pdu_controller
     if pdu_ctrl is None:
-        pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+        pytest.skip(
+            "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
 
     all_outlets = pdu_ctrl.get_outlet_status()
     # If PDU supports returning output_watts, making sure that all outlets has power.
-    no_power = [item for item in all_outlets if int(item.get('output_watts', '1')) == 0]
-    pytest_assert(not no_power, "Not all outlets have power output: {}".format(no_power))
+    no_power = [item for item in all_outlets if int(
+        item.get('output_watts', '1')) == 0]
+    pytest_assert(
+        not no_power, "Not all outlets have power output: {}".format(no_power))
 
     # Purpose of this list is to control sequence of turning on PSUs in power off testing.
     # If there are 2 PSUs, then 3 scenarios would be covered:
@@ -262,7 +285,8 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
             poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
-            reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+            reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+                             xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                              _power_off_reboot_helper, poweroff_reboot_kwargs)
     except Exception as e:
         logging.debug("Restore power after test failure")
@@ -275,29 +299,36 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
         raise e
 
 
-def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                         set_max_time_for_interfaces, conn_graph_facts, xcvr_skip_list):
+def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                         localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    watchdogutil_status_result = duthost.command("watchdogutil status", module_ignore_errors=True)
+    watchdogutil_status_result = duthost.command(
+        "watchdogutil status", module_ignore_errors=True)
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
-        pytest.skip("Watchdog is not supported on this DUT, skip this test case")
+        pytest.skip(
+            "Watchdog is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
+    reboot_and_check(localhost, duthost,
+                     conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
 
 
-def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                           set_max_time_for_interfaces, conn_graph_facts, xcvr_skip_list):
+def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+                           localhost, conn_graph_facts, xcvr_skip_list):        # noqa F811
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    ls_starting_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
+    ls_starting_out = set(duthost.shell(
+        "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     for i in range(3):
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
-    ls_ending_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
+                         [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
+    ls_ending_out = set(duthost.shell(
+        "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     pytest_assert(ls_ending_out == ls_starting_out,
-            "Console devices have changed: expected console devices: {}, got: {}".format(", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))
+                  "Console devices have changed: expected console devices: {}, got: {}"
+                  .format(", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -85,7 +85,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 
 
-def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_for_interfaces, reboot_type=None):
+def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=None):
     """
     Perform a further check after reboot-cause, including transceiver status, interface status
     @param localhost: The Localhost object.
@@ -147,7 +147,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
             return
 
 
-def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
+def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname, set_max_time_for_interfaces,
                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform cold reboot and check platform status
@@ -300,7 +300,7 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -317,7 +317,7 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                           localhost, conn_graph_facts, xcvr_skip_list):        # noqa F811
+                           localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):        # noqa F811
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -8,14 +8,16 @@ This script is to cover the test case 'Reload configuration' in the SONiC platfo
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
+import re
 import time
+
+from datetime import datetime
+
 import pytest
 
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-from tests.common.reboot import sync_reboot_history_queue_with_dut, reboot, check_reboot_cause,\
-    check_reboot_cause_history, reboot_ctrl_dict, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
-    REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_POWEROFF, REBOOT_TYPE_WATCHDOG
+from tests.common.reboot import *
 from tests.common.platform.transceiver_utils import check_transceiver_basic
 from tests.common.platform.interface_utils import check_all_interface_information, get_port_map
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
@@ -27,11 +29,8 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-logger = logging.getLogger(__name__)
-
 MAX_WAIT_TIME_FOR_INTERFACES = 300
 MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120
-
 
 @pytest.fixture
 def set_max_time_for_interfaces(duthost):
@@ -46,19 +45,17 @@ def set_max_time_for_interfaces(duthost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     yield
 
-    logging.info(
-        "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
+    logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list)
 
 
-def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
-                     reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
+def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
     """
     Perform the specified type of reboot and check platform status.
     @param localhost: The Localhost object.
@@ -70,13 +67,11 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     @param reboot_kwargs: The argument used by reboot_helper
     """
 
-    logging.info(
-        "Sync reboot cause history queue with DUT reboot cause history queue")
+    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
     sync_reboot_history_queue_with_dut(dut)
 
     logging.info("Run %s reboot on DUT" % reboot_type)
-    reboot(dut, localhost, reboot_type=reboot_type,
-           reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
+    reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")
@@ -85,7 +80,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 
 
-def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_for_interfaces, reboot_type=None):
+def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_for_interfaces, reboot_type = None):
     """
     Perform a further check after reboot-cause, including transceiver status, interface status
     @param localhost: The Localhost object.
@@ -98,8 +93,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
     if dut.is_supervisor_node():
         logging.info("skipping interfaces related check for supervisor")
     else:
-        logging.info("Wait {} seconds for all the transceivers to be detected".format(
-            MAX_WAIT_TIME_FOR_INTERFACES))
+        logging.info("Wait {} seconds for all the transceivers to be detected".format(MAX_WAIT_TIME_FOR_INTERFACES))
         result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, 0, check_all_interface_information, dut, interfaces,
                             xcvr_skip_list)
         assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
@@ -109,10 +103,8 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
         for asic_index in dut.get_frontend_asic_ids():
             # Get the interfaces pertaining to that asic
             interface_list = get_port_map(dut, asic_index)
-            interfaces_per_asic = {k: v for k, v in list(
-                interface_list.items()) if k in interfaces}
-            check_transceiver_basic(
-                dut, asic_index, interfaces_per_asic, xcvr_skip_list)
+            interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
+            check_transceiver_basic(dut, asic_index, interfaces_per_asic, xcvr_skip_list)
 
         logging.info("Check pmon daemon status")
         assert check_pmon_daemon_status(dut), "Not all pmon daemons running."
@@ -134,67 +126,60 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, set_max_time_
             "got reboot-cause failed after rebooted by %s" % reboot_type
 
         if "201811" in dut.os_version or "201911" in dut.os_version:
-            logging.info(
-                "Skip check reboot-cause history for version before 202012")
+            logging.info("Skip check reboot-cause history for version before 202012")
         else:
             logger.info("Check reboot-cause history")
             assert wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 0, check_reboot_cause_history, dut,
-                              REBOOT_TYPE_HISTOYR_QUEUE), \
-                "Check reboot-cause history failed after rebooted by %s" % reboot_type
+                              REBOOT_TYPE_HISTOYR_QUEUE), "Check reboot-cause history failed after rebooted by %s" % reboot_type
         if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
-            logging.info(
-                "Further checking skipped for %s test which intends to verify reboot-cause only" % reboot_type)
+            logging.info("Further checking skipped for %s test which intends to verify reboot-cause only" % reboot_type)
             return
 
-
-def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                     conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
-                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
+    import pdb; pdb.set_trace()
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
 
 
-def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform soft reboot and check platform status
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    soft_reboot_supported = duthost.command(
-        'which soft-reboot', module_ignore_errors=True)["stdout"]
+    soft_reboot_supported = duthost.command('which soft-reboot', module_ignore_errors=True)["stdout"]
     if "" == soft_reboot_supported:
-        pytest.skip(
-            "Soft-reboot is not supported on this DUT, skip this test case")
+        pytest.skip("Soft-reboot is not supported on this DUT, skip this test case")
 
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting soft reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
-                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT)
 
 
-def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform fast reboot and check platform status
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    sonic_hwsku = duthost.sonichost.facts["hwsku"]
+    if "SN3800" in sonic_hwsku:
+        pytest.skip("Not supported on Mellanox 3800")
+
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting fast reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
-                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST)
 
 
-def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                     localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform warm reboot and check platform status
     """
@@ -209,11 +194,9 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if asic_type in ["mellanox"]:
         issu_capability = duthost.command("show platform mlnx issu")["stdout"]
         if "disabled" in issu_capability:
-            pytest.skip(
-                "ISSU is not supported on this DUT, skip this test case")
+            pytest.skip("ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
-                     [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM)
 
 
 def _power_off_reboot_helper(kwargs):
@@ -236,9 +219,7 @@ def _power_off_reboot_helper(kwargs):
         pdu_ctrl.turn_on_outlet(outlet)
 
 
-def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                          localhost, conn_graph_facts, xcvr_skip_list,      # noqa F811
-                          pdu_controller, power_off_delay):
+def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list, pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
@@ -251,19 +232,15 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     UNSUPPORTED_ASIC_TYPE = ["cisco-8000"]
     if duthost.facts["asic_type"] in UNSUPPORTED_ASIC_TYPE:
-        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform".format(
-            duthost.facts["asic_type"]))
+        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform".format(duthost.facts["asic_type"]))
     pdu_ctrl = pdu_controller
     if pdu_ctrl is None:
-        pytest.skip(
-            "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+        pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
 
     all_outlets = pdu_ctrl.get_outlet_status()
     # If PDU supports returning output_watts, making sure that all outlets has power.
-    no_power = [item for item in all_outlets if int(
-        item.get('output_watts', '1')) == 0]
-    pytest_assert(
-        not no_power, "Not all outlets have power output: {}".format(no_power))
+    no_power = [item for item in all_outlets if int(item.get('output_watts', '1')) == 0]
+    pytest_assert(not no_power, "Not all outlets have power output: {}".format(no_power))
 
     # Purpose of this list is to control sequence of turning on PSUs in power off testing.
     # If there are 2 PSUs, then 3 scenarios would be covered:
@@ -285,8 +262,7 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
             poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
-            reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
-                             xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+            reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                              _power_off_reboot_helper, poweroff_reboot_kwargs)
     except Exception as e:
         logging.debug("Restore power after test failure")
@@ -299,36 +275,29 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
         raise e
 
 
-def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                         set_max_time_for_interfaces, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    watchdogutil_status_result = duthost.command(
-        "watchdogutil status", module_ignore_errors=True)
+    watchdogutil_status_result = duthost.command("watchdogutil status", module_ignore_errors=True)
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
-        pytest.skip(
-            "Watchdog is not supported on this DUT, skip this test case")
+        pytest.skip("Watchdog is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost,
-                     conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
 
 
-def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                           localhost, conn_graph_facts, xcvr_skip_list):        # noqa F811
+def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                           set_max_time_for_interfaces, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    ls_starting_out = set(duthost.shell(
-        "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
+    ls_starting_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     for i in range(3):
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"]
-                         [duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
-    ls_ending_out = set(duthost.shell(
-        "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
+    ls_ending_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     pytest_assert(ls_ending_out == ls_starting_out,
-                  "Console devices have changed: expected console devices: {}, got: {}"
-                  .format(", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))
+            "Console devices have changed: expected console devices: {}, got: {}".format(", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR allows that, if `test_reboot.py` or `cold` has specified timeout in inventory file, take that timeout for check_interfaces _and_services, otherwise use default value `300`.
This is to accommodate for some T2 chassis that is heavier.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
