### PR TITLE
Fix TestQosSai test failure - 'float' object cannot be interpreted as an integer

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2285,7 +2285,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 pkt_cnt = pkts_num_trig_pfc // self.pkt_size_factor
                 send_packet(
-                    self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, pkt_cnt)
+                    self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, int(pkt_cnt))
 
                 time.sleep(8)   # wait pfc counter refresh
                 self.show_port_counter(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix TestQosSai test failure - 'float' object cannot be interpreted as an integer

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
TestQosSai test failure - 'float' object cannot be interpreted as an integer
====================================================================== 
ERROR: sai_qos_tests.HdrmPoolSizeTest 
---------------------------------------------------------------------- 
Traceback (most recent call last): 
  File \"saitests/py3/sai_qos_tests.py\", line 2287, in runTest 
    self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, pkt_cnt) 
  File \"/root/env-python3/lib/python3.7/site-packages/ptf/testutils.py\", line 3202, in send_packet 
    for n in range(count): 
TypeError: 'float' object cannot be interpreted as an integer 

#### How did you do it?
Use int to make sure the pkt_cnt is integer

#### How did you verify/test it?
Manually run test case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
