### PR TITLE
Added missed custom pytest markers into pytest.ini file

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -14,6 +14,13 @@ markers:
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
     supported_completeness_level: test supported levels of completeness (coverage) level (Debug, Basic, Confident, Thorough)
     skip_check_dut_health: skip default execution of check_dut_health_status fixture
+    skip_active_standby: skip_active_standby marker
+    enable_active_active: enable_active_active marker
+    macsec_required: macsec_required marker
+    nat_dynamic: nat_dynamic marker
+    nat_static: nat_static marker
+    dynamic_config: dynamic_config marker
+    static_config: static_config marker
 
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s


### PR DESCRIPTION
### Description of PR
Added missed custom pytest markers into pytest.ini file
Fix for: https://github.com/sonic-net/sonic-mgmt/issues/8319

Summary: Added missed custom pytest markers into pytest.ini file
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/8319

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/issues/8319

#### How did you do it?
Added missed markers

#### How did you verify/test it?
Run pytest: pytest --markers - check that new markers added

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
