### PR TITLE
Submitting topo-t2 addition to gb platform.

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3467,6 +3467,53 @@ qos_params:
                 lossless_weight: 30
             hdrm_pool_wm_multiplier: 1
             cell_size: 384
+        topo-t2:
+            100000_300m:
+                pkts_num_egr_mem: 6884
+                pg_drop:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_trig_pfc: 13660
+                    pkts_num_trig_ingr_drp: 14812
+                    pkts_num_margin: 375
+                    iterations: 100
+                pkts_num_leak_out: 8
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 10300
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 20
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 10300
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 20
+            400000_300m:
+                pkts_num_leak_out: 10
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 9923
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 20
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 9923
+                    pkts_num_trig_ingr_drp: 10589
+                    packet_size: 1350
+                    pkts_num_margin: 20
     jr2:
         topo-any:
             100000_300m:

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3468,6 +3468,16 @@ qos_params:
             hdrm_pool_wm_multiplier: 1
             cell_size: 384
         topo-t2:
+            shared_res_size_1:
+                ecn: 1
+                packet_size: 1350
+                cell_size: 384
+                pkts_num_margin: 1
+            shared_res_size_2:
+                ecn: 1
+                packet_size: 1350
+                cell_size: 384
+                pkts_num_margin: 1
             100000_300m:
                 pkts_num_egr_mem: 6884
                 pg_drop:


### PR DESCRIPTION
Adding topo-t2 for cisco-8000 in qos.yml file. This will be needed to run the multi-asic code in qos-sai for cisco-8000.