### PR TITLE
Fix keyError from Qos param generator.

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -70,5 +70,9 @@ class QosParamCisco(object):
                      "dst_port_i": [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
                      "pkt_counts": [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1],
                      "shared_limit_bytes": 41943552}
-        self.qos_params["shared_res_size_1"].update(res_1)
-        self.qos_params["shared_res_size_2"].update(res_2)
+        try:
+            self.qos_params["shared_res_size_1"].update(res_1)
+            self.qos_params["shared_res_size_2"].update(res_2)
+        except KeyError:
+            self.qos_params["shared_res_size_1"] = res_1
+            self.qos_params["shared_res_size_2"] = res_2

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -70,9 +70,5 @@ class QosParamCisco(object):
                      "dst_port_i": [7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
                      "pkt_counts": [3527, 3527, 3527, 3527, 3527, 3527, 1798, 1798, 846, 687, 687, 328, 1],
                      "shared_limit_bytes": 41943552}
-        try:
-            self.qos_params["shared_res_size_1"].update(res_1)
-            self.qos_params["shared_res_size_2"].update(res_2)
-        except KeyError:
-            self.qos_params["shared_res_size_1"] = res_1
-            self.qos_params["shared_res_size_2"] = res_2
+        self.qos_params["shared_res_size_1"].update(res_1)
+        self.qos_params["shared_res_size_2"].update(res_2)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1153,9 +1153,17 @@ class QosSaiBase(QosBase):
             if sub_folder_dir not in sys.path:
                 sys.path.append(sub_folder_dir)
             import qos_param_generator
-            qpm = qos_param_generator.QosParamCisco(qosConfigs['qos_params'][dutAsic][dutTopo],
-                                                    duthost,
-                                                    bufferConfig)
+            topo = dutTopo
+            if (get_src_dst_asic_and_duts['src_dut_index'] == 
+                    get_src_dst_asic_and_duts['dst_dut_index'] and
+                get_src_dst_asic_and_duts['src_asic_index'] == 
+                    get_src_dst_asic_and_duts['dst_asic_index']):
+                topo = "topo-any"
+            qpm = qos_param_generator.QosParamCisco(
+                      qosConfigs['qos_params'][dutAsic][topo],
+                      duthost,
+                      bufferConfig)
+
             qosParams = qpm.run()
         else:
             qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]


### PR DESCRIPTION
In the cisco qos_param generator we have:
self.qos_params["shared_res_size_1"].update(res_1)
self.qos_params["shared_res_size_2"].update(res_2)

When the qos yaml file doesn't have the 2 keys shared_res_size_1 and 2, the above code fails. This PR is to fix this.