### PR TITLE
Add a field `ASIC` in the return value of script `get_dut_version.py`.

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -20,20 +20,21 @@ logger = logging.getLogger(__name__)
 RC_INIT_FAILED = 1
 RC_GET_DUT_VERSION_FAILED = 2
 
-ASIC_NAME_PATH = '/../ansible/group_vars/sonic/variables'
+ASIC_NAME_PATH = '../ansible/group_vars/sonic/variables'
 
 
 def read_asic_name(hwsku):
-    asic_name_file = os.path.dirname(__file__) + ASIC_NAME_PATH
+    asic_name_file = os.path.join(os.path.dirname(__file__), ASIC_NAME_PATH)
     try:
         with open(asic_name_file) as f:
             asic_name = yaml.safe_load(f)
 
-        for key, value in list(asic_name.copy().items()):
-            if ('td' not in key) and ('th' not in key) and ('spc' not in key):
-                asic_name.pop(key)
+        asic_name_dict = {}
+        for key, value in asic_name.items():
+            if "hwskus" in key:
+                asic_name_dict[key] = value
 
-        for name, hw in list(asic_name.items()):
+        for name, hw in asic_name_dict.items():
             if hwsku in hw:
                 return name.split('_')[1]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Priviously, the return value of script `get_dut_version.py` contains a field called `ASIC`, but actually it is the asic type. In this PR, I rename this value, and add a field `ASIC` which is the actually asic of dut. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Priviously, the return value of script `get_dut_version.py` contains a field called `ASIC`, but actually it is the asic type. In this PR, I rename this value, and add a field `ASIC` which is actually the asic of dut. 

#### How did you do it?
Read the asic from file `ansible/group_vars/sonic/variables`, and add it into the return value of script `get_dut_version.py`. Meanwhile, rename the `ASIC` in pervious return value. 

#### How did you verify/test it?
```
python ../.azure-pipelines/get_dut_version.py -i ../ansible/str3 -t vms63-t1-4600-5 --log-level info

{u'str3-msn4600c-acs-05': {u'Kernel': u'5.10.0-18-2-amd64', u'Uptime': u'07:54:13 up  1:30,  2 users,  load average: 1.17, 1.00, 0.83', u'Build commit': u'5e3b9620e9', u'Build date': u'Mon May  8 19:56:10 UTC 2023', u'ASIC Count': u'1', 'ASIC TYPE': u'mellanox', 'Docker images': [{'TAG': u'20220531.27', 'IMAGE ID': u'd12f6430f030', 'REPOSITORY': u'docker-syncd-mlnx', 'SIZE': u'841MB'}, {'TAG': u'latest', 'IMAGE ID': u'd12f6430f030', 'REPOSITORY': u'docker-syncd-mlnx', 'SIZE': u'841MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'd36c2f1d0641', 'REPOSITORY': u'docker-orchagent', 'SIZE': u'361MB'}, {'TAG': u'latest', 'IMAGE ID': u'd36c2f1d0641', 'REPOSITORY': u'docker-orchagent', 'SIZE': u'361MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'67432031932d', 'REPOSITORY': u'docker-teamd', 'SIZE': u'344MB'}, {'TAG': u'latest', 'IMAGE ID': u'67432031932d', 'REPOSITORY': u'docker-teamd', 'SIZE': u'344MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'4e3b0c2c5c84', 'REPOSITORY': u'docker-fpm-frr', 'SIZE': u'373MB'}, {'TAG': u'latest', 'IMAGE ID': u'4e3b0c2c5c84', 'REPOSITORY': u'docker-fpm-frr', 'SIZE': u'373MB'}, {'TAG': u'latest', 'IMAGE ID': u'ebf252866186', 'REPOSITORY': u'docker-dhcp-relay', 'SIZE': u'340MB'}, {'TAG': u'latest', 'IMAGE ID': u'c80e456d48f0', 'REPOSITORY': u'docker-macsec', 'SIZE': u'346MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'8a1eb62256ca', 'REPOSITORY': u'docker-platform-monitor', 'SIZE': u'764MB'}, {'TAG': u'latest', 'IMAGE ID': u'8a1eb62256ca', 'REPOSITORY': u'docker-platform-monitor', 'SIZE': u'764MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'30a2223208bd', 'REPOSITORY': u'docker-snmp', 'SIZE': u'377MB'}, {'TAG': u'latest', 'IMAGE ID': u'30a2223208bd', 'REPOSITORY': u'docker-snmp', 'SIZE': u'377MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'e634b3046463', 'REPOSITORY': u'docker-lldp', 'SIZE': u'370MB'}, {'TAG': u'latest', 'IMAGE ID': u'e634b3046463', 'REPOSITORY': u'docker-lldp', 'SIZE': u'370MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'cdd355282d8d', 'REPOSITORY': u'docker-database', 'SIZE': u'328MB'}, {'TAG': u'latest', 'IMAGE ID': u'cdd355282d8d', 'REPOSITORY': u'docker-database', 'SIZE': u'328MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'f32471b85f31', 'REPOSITORY': u'docker-mux', 'SIZE': u'376MB'}, {'TAG': u'latest', 'IMAGE ID': u'f32471b85f31', 'REPOSITORY': u'docker-mux', 'SIZE': u'376MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'4be9f3a3f8ce', 'REPOSITORY': u'docker-acms', 'SIZE': u'375MB'}, {'TAG': u'latest', 'IMAGE ID': u'4be9f3a3f8ce', 'REPOSITORY': u'docker-acms', 'SIZE': u'375MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'8da9291b32b4', 'REPOSITORY': u'docker-sonic-telemetry', 'SIZE': u'408MB'}, {'TAG': u'latest', 'IMAGE ID': u'8da9291b32b4', 'REPOSITORY': u'docker-sonic-telemetry', 'SIZE': u'408MB'}, {'TAG': u'20220531.27', 'IMAGE ID': u'766db3d9c965', 'REPOSITORY': u'docker-router-advertiser', 'SIZE': u'328MB'}, {'TAG': u'latest', 'IMAGE ID': u'766db3d9c965', 'REPOSITORY': u'docker-router-advertiser', 'SIZE': u'328MB'}], 'ASIC': 'spc3', u'Model Number': u'MSN4600-CS2FO', u'Platform': u'x86_64-mlnx_msn4600c-r0', u'Serial Number': u'MT2021X01037', u'HwSKU': u'Mellanox-SN4600C-C64', u'Hardware Revision': u'A1', u'Built by': u'cloudtest@8529b447c000001', u'Date': u'Wed 17 May 2023 07:54:13', u'SONiC Software Version': u'SONiC.20220531.27', u'SONiC OS Version': u'11', u'Distribution': u'Debian 11.7'}}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
