### PR TITLE
[test_port_toggle] disable_loganalyzer for specific test

### DIFF
--- a/tests/platform_tests/test_port_toggle.py
+++ b/tests/platform_tests/test_port_toggle.py
@@ -8,7 +8,8 @@ from tests.common import port_toggle
 
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology("any"),
+    pytest.mark.disable_loganalyzer,
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Main goal for test_port_toggle is to shutdown/startup ports and see if there is any unexpected up/down ports. 
During the testing when toggling ports, there'll be some syslog errors complaining about monit status fail, which is expected to see.
```
E Match Messages:
E May 11 15:00:50.350333 chassis-lc3-1 ERR monit[557]: 'routeCheck' status failed (255) -- Failure res
```
Also considering that this test does not depend on syslog to test, we should ignore syslog errors.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
