### PR TITLE
Skip some drop_counter test if the leaf fanout is running SONiC OS

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -81,7 +81,10 @@ def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
     # Check that class to handle fanout config is implemented
     if "mellanox" == duthost.facts["asic_type"]:
         fanout = get_fanout_obj(conn_graph_facts, duthost, fanouthosts)
-        if not is_mellanox_fanout(duthost, localhost):
+        # if the leaf fanout switch is Mellanox, but running SONiC OS
+        # then we have to skip some test cases because some operation (like the openflow)
+        # ia only supported on the Mellanox onyx
+        if not is_mellanox_fanout(duthost, localhost) or fanout.os == "sonic":
             fanout = None
 
     yield fanout

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -83,7 +83,7 @@ def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
         fanout = get_fanout_obj(conn_graph_facts, duthost, fanouthosts)
         # if the leaf fanout switch is Mellanox, but running SONiC OS
         # then we have to skip some test cases because some operation (like the openflow)
-        # ia only supported on the Mellanox onyx
+        # is only supported on the Mellanox onyx
         if not is_mellanox_fanout(duthost, localhost) or fanout.os == "sonic":
             fanout = None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some test cases in `test_drop_counters.py` requires Mellanox leaf fanout switch with Onyx OS.
Before this PR, we only check if the asic_type of leaf fanout. The OS is not checked.
Therefore, we saw some issue when we began to deploy Mellanox switch with SONiC OS as leaf fanout switch. 
This PR is to address the issue by checking the OS of leaf fanout as well.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to check the OS  of leaf fanout. Some test cases that require Mellanox leaf fanout are skipped if the leaf fanout is Mellanox platform, but running SONiC OS. 

#### How did you do it?
Check the OS of leaf fanout.

#### How did you verify/test it?
Verified on a SN4600 testbed.

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
