### PR TITLE
Add UT for tacacs stop send request after first service reject user.

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -426,7 +426,7 @@ def test_stop_request_next_server_after_reject(
 
     skip_versions = ["201811", "201911", "202012", "202106", "202111", "202205", "202211"]
     skip_release(duthost, skip_versions)
-    
+
     # Use ptfhost ipv6 address as second ip address
     ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
     if 'ansible_hostv6' not in ptfhost_vars:

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -424,6 +424,7 @@ def test_stop_request_next_server_after_reject(
         tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    # not ignore on version >= 202305
     skip_versions = ["201811", "201911", "202012", "202106", "202111", "202205", "202211"]
     skip_release(duthost, skip_versions)
 


### PR DESCRIPTION
### Description of PR
Add UT for tacacs stop send request after first service reject user.

Summary:
Add UT for tacacs stop send request after first service reject user.
New UT is for code change in https://github.com/sonic-net/sonic-buildimage/pull/14249

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add new UT to test and protect 'TACACS stop send request after first service reject user' feature.

#### How did you do it?
Add second tacacs server IP address, and login with invalid account, then validate TACACS stop send request after first TACACS server reject user login.

#### How did you verify/test it?
Manually test new UT.
Pass PR validation.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
