### PR TITLE
Update ansible tmp path at cfg file

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,7 @@
 inventory      = /etc/ansible/hosts
 library        = library:library/ixia
 module_utils   = module_utils
-remote_tmp     = /tmp/ansible-$USER
+remote_tmp     = /tmp/.ansible-$USER
 pattern        = *
 forks          = 5
 poll_interval  = 15

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,7 @@
 inventory      = /etc/ansible/hosts
 library        = library:library/ixia
 module_utils   = module_utils
-remote_tmp     = $HOME/.ansible/tmp
+remote_tmp     = /tmp/ansible-$USER
 pattern        = *
 forks          = 5
 poll_interval  = 15


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

update the tmp path at ansible cfg file, so that user other than root could have permissions to tmp folder

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach

#### What is the motivation for this PR?
It is necessary for Ansible scripts to work for users other than root.
As some servers don't use root access, other users should have permission for /tmp folder.

#### How did you do it?
change the cfg file

#### How did you verify/test it?
test it by running full community regression

#### Any platform-specific information?
no
