### PR TITLE
Support multiple inventories in scripts `upgrade_image.py` and `get_dut_version.py`.

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -122,9 +122,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "-i", "--inventory",
-        type=str,
         dest="inventory",
-        required=True,
+        nargs="+",
         help="Ansible inventory file")
 
     parser.add_argument(

--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -211,9 +211,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "-i", "--inventory",
-        type=str,
+        nargs="+",
         dest="inventory",
-        required=True,
         help="Ansible inventory file")
 
     parser.add_argument(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Previously, scripts `upgrade_image.py` and `get_dut_version.py` only support passing one inventory. In this PR, modify the defination of argument `inventory` and it can support multiple inventories. Notice that different inventories are splitted using space, for example, `-i ../ansible/str ../ansible/veos`.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Previously, scripts `upgrade_image.py` and `get_dut_version.py` only support passing one inventory. In this PR, modify the defination of argument `inventory` and it can support multiple inventories. Notice that different inventories are splitted using space, for example, `-i ../ansible/str ../ansible/veos`.

#### How did you do it?
Modify the defination of argument `inventory` using `nargs`.

#### How did you verify/test it?
```
python ../.azure-pipelines/get_dut_version.py -i ../ansible/str ../ansible/veos -t vms7-t0-4600c-2 --log-level info
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
