### PR TITLE
Added marker "dependency" into pytest.ini file to prevent warning message

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -20,6 +20,7 @@ markers:
     nat_static: nat_static marker
     dynamic_config: dynamic_config marker
     static_config: static_config marker
+    dependency: dependency marker
 
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s


### PR DESCRIPTION
### Description of PR
Added marker "dependency" into pytest.ini file
Fixed warning:
```
10:27:19  /usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:334
10:27:19    /usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:334: PytestUnknownMarkWarning: Unknown pytest.mark.dependency - is this a typo?  You can register custom marks to avoid this warning - for details, see [https://docs.pytest.org/en/latest/mark.html](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.pytest.org%2Fen%2Flatest%2Fmark.html&data=05%7C01%7Cpetrop%40nvidia.com%7C8aa0fe9d139949c2aa7508db57b04773%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C638200186985704318%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=lgKlGsoN2jay15fTMX3VHPorKMkxdQo4JLtzAoMY4qk%3D&reserved=0)
10:27:19      PytestUnknownMarkWarning,
10:27:19  
10:27:19  -- Docs: [https://docs.pytest.org/en/latest/warnings.html](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.pytest.org%2Fen%2Flatest%2Fwarnings.html&data=05%7C01%7Cpetrop%40nvidia.com%7C8aa0fe9d139949c2aa7508db57b04773%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C638200186985704318%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=26xZpcRrWlMnBU3ichoYPH0eODiIT29Ap8Dqyc43Dk0%3D&reserved=0)
```

Summary: Added marker "dependency" into pytest.ini file
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix for warning

#### How did you do it?
see code

#### How did you verify/test it?
Run tests, and checked that no warnings

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
