### PR TITLE
Fixed warning message "... is used prior to global declaration"

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -36,6 +36,8 @@ PORT_STATUS_CHECK_INTERVAL = 10
 # To avoid getting candidate test ports again and again, use a global variable
 # to save all candidate test ports.
 # Key: dut host name, value: a dictionary of candidate ports tuple with dut port name as key
+global all_ports_by_dut
+global fanout_original_port_states
 all_ports_by_dut = {}
 fanout_original_port_states = {}
 
@@ -55,7 +57,6 @@ def check_image_version(duthost):
 
 def save_fanout_port_state(portinfo):
     key = "{}|{}".format(portinfo['dutname'], portinfo['port'])
-    global fanout_original_port_states
     if key not in fanout_original_port_states:
         dutname, portname = portinfo['dutname'], portinfo['port']
         duthost, dut_port, fanout, fanout_port = all_ports_by_dut[dutname][portname]
@@ -99,9 +100,6 @@ def recover_ports(duthosts, fanouthosts):
         enum_dut_portname_module_fixture (str): DUT port name
         fanouthosts: Fanout objects
     """
-    global all_ports_by_dut
-    global fanout_original_port_states
-
     logger.info('Collecting existing port configuration for DUT and fanout...')
     for duthost in duthosts:
         # Only do the sampling when there are no candidates


### PR DESCRIPTION
### Description of PR
Fixed warning message
```
10:27:19  platform_tests/test_auto_negotiation.py:57
10:27:19    /data/sonic-mgmt/tests/platform_tests/test_auto_negotiation.py:57: SyntaxWarning: name 'fanout_original_port_states' is used prior to global declaration
10:27:19      global fanout_original_port_states
```

Summary: Fixed warning message "... is used prior to global declaration"
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fixed warning message "... is used prior to global declaration"

#### How did you do it?
See code

#### How did you verify/test it?
Executed test test_auto_negotiation.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
