### PR TITLE
cisco: masic: Update qos param gen to topo-any for single-asic

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -875,7 +875,12 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
+        if dutAsic == "gb" and topo == "t2":
+            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+                dutTopo = dutTopo + "any"
+            else:
+                dutTopo = dutTopo + topo
+        elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -875,12 +875,7 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutAsic == "gb" and topo == "t2":
-            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
-                dutTopo = dutTopo + "any"
-            else:
-                dutTopo = dutTopo + topo
-        elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
+        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1321,9 +1321,17 @@ class QosSaiBase(QosBase):
             if sub_folder_dir not in sys.path:
                 sys.path.append(sub_folder_dir)
             import qos_param_generator
-            qpm = qos_param_generator.QosParamCisco(qosConfigs['qos_params'][dutAsic][dutTopo],
-                                                    duthost,
-                                                    bufferConfig)
+            topo = dutTopo
+            if (get_src_dst_asic_and_duts['src_dut_index'] ==
+                    get_src_dst_asic_and_duts['dst_dut_index'] and
+                get_src_dst_asic_and_duts['src_asic_index'] ==
+                    get_src_dst_asic_and_duts['dst_asic_index']):
+                topo = "topo-any"
+            qpm = qos_param_generator.QosParamCisco(
+                      qosConfigs['qos_params'][dutAsic][topo],
+                      duthost,
+                      bufferConfig)
+
             qosParams = qpm.run()
         else:
             qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]


### PR DESCRIPTION
In the cisco qos_param generator we have:
self.qos_params["shared_res_size_1"].update(res_1)
self.qos_params["shared_res_size_2"].update(res_2)

When the qos yaml file doesn't have the 2 keys shared_res_size_1 and 2, the above code fails. The qos.yaml doesn't have details for topo-t2 currently, and so the above code fails. The fix is to use topo-any for single-asic mode. When we work on multi-asic mode, we will incorporate the above values for topo-t2.