### PR TITLE
[acl][m0] Add ipv6 support for m0_vlan scenario in test_acl

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -522,6 +522,36 @@
                                         "destination-ip-address": "20c0:a800:0:1::9/128"
                                     }
                                 }
+                            },
+                            "34": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 34
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000::6/128"
+                                    }
+                                }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -480,6 +480,36 @@
                                         "destination-ip-address": "20c0:a800:0:1::9/128"
                                     }
                                 }
+                            },
+                            "34": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 34
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000::6/128"
+                                    }
+                                }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -87,15 +87,15 @@ DOWNSTREAM_IP_TO_BLOCK_M0_L3 = {
 # Below M0_VLAN IPs are ip in vlan range
 DOWNSTREAM_DST_IP_M0_VLAN = {
     "ipv4": "192.168.0.253",
-    "ipv6": "20c0:a800::14"
+    "ipv6": "fc02:1000::5"
 }
 DOWNSTREAM_IP_TO_ALLOW_M0_VLAN = {
     "ipv4": "192.168.0.252",
-    "ipv6": "20c0:a800::1"
+    "ipv6": "fc02:1000::6"
 }
 DOWNSTREAM_IP_TO_BLOCK_M0_VLAN = {
     "ipv4": "192.168.0.251",
-    "ipv6": "20c0:a800::9"
+    "ipv6": "fc02:1000::7"
 }
 
 DOWNSTREAM_IP_PORT_MAP = {}
@@ -385,8 +385,6 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
 def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname, topo_scenario):
     if tbinfo["topo"]["type"] in ["t0", "mx"] and request.param == "ipv6":
         pytest.skip("IPV6 ACL test not currently supported on t0/mx testbeds")
-    if topo_scenario == "m0_vlan_scenario" and request.param == "ipv6":
-        pytest.skip("IPV6 ACL test not currently supported on m0_vlan")
 
     return request.param
 
@@ -434,6 +432,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
         for dut in duthosts:
             dut.command("sonic-clear fdb all")
             dut.command("sonic-clear arp")
+            dut.command("sonic-clear ndp")
             # Wait some time to ensure the async call of clear is completed
             time.sleep(20)
             for addr in addr_list:
@@ -448,6 +447,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
 
     duthost.command("sonic-clear fdb all")
     duthost.command("sonic-clear arp")
+    duthost.command("sonic-clear ndp")
 
 
 @pytest.fixture(scope="module", params=["ingress", "egress"])
@@ -928,6 +928,11 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 32
                 else:
                     rule_id = 30
+            elif topo_scenario == "m0_vlan_scenario":
+                if ip_version == "ipv6":
+                    rule_id = 34
+                else:
+                    rule_id = 2
             else:
                 rule_id = 2
         else:
@@ -949,6 +954,11 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 33
                 else:
                     rule_id = 31
+            elif topo_scenario == "m0_vlan_scenario":
+                if ip_version == "ipv6":
+                    rule_id = 35
+                else:
+                    rule_id = 15
             else:
                 rule_id = 15
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently ipv6 test for m0_vlan scenario is skipped in test_acl.

#### How did you do it?
Add support for m0_vlan scenario.
Because announce routes for m0 is different from t0/t1, I modify the test ipv6 addresses and add new acl rules.

#### How did you verify/test it?
Run tests.
On m0:
```
collected 1600 items
--- generated xml file: /var/src/sonic-mgmt-int/tests/logs/acl/test_acl.xml ----
=========================== short test summary info ============================
SKIPPED [800] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Egress ACLs are not currently supported on "broadcom" ASICs
SKIPPED [32] /var/src/sonic-mgmt-int/tests/acl/test_acl.py:893: Only run for egress
================== 768 passed, 832 skipped in 6870.74 seconds ==================
```

On t0:
```
collected 800 items
--- generated xml file: /var/src/sonic-mgmt-int/tests/logs/acl/test_acl.xml ----
=========================== short test summary info ============================
SKIPPED [200] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Egress ACLs are not currently supported on "broadcom" ASICs
SKIPPED [400] /var/src/sonic-mgmt-int/tests/acl/test_acl.py:389: IPV6 ACL test not currently supported on t0/mx testbeds
SKIPPED [8] /var/src/sonic-mgmt-int/tests/acl/test_acl.py:891: Only run for egress
================== 192 passed, 608 skipped in 2469.85 seconds ==================
```

On t1:
```
collected 800 items
--- generated xml file: /var/src/sonic-mgmt-int/tests/logs/acl/test_acl.xml ----
=========================== short test summary info ============================
SKIPPED [400] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Egress ACLs are not currently supported on "broadcom" ASICs
SKIPPED [16] /var/src/sonic-mgmt-int/tests/acl/test_acl.py:891: Only run for egress
================== 384 passed, 416 skipped in 3647.39 seconds ==================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
