### PR TITLE
[202205][m0][mx] Fix test_override_config_table failed in m0/mx (#8368)

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -812,3 +812,31 @@ def convert_scapy_packet_to_bytes(packet):
         return str(packet)
     else:
         return bytes(packet)
+
+
+def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
+    """
+    Set default_pfcwd_status in the specified file with parameter default_pfcwd_value
+    The path is expected to be one of:
+    - /etc/sonic/init_cfg.json
+    - /etc/sonic/config_db.json
+
+    Args:
+        duthost (AnsibleHost): instance
+        default_pfcwd_value: value of default_pfcwd_status, enable or disable
+
+    Returns:
+        original value of default_pfcwd_status
+    """
+    output = duthost.shell("cat {} | grep default_pfcwd_status".format(filepath))['stdout']
+    matched = re.search('"default_pfcwd_status": "(.*)"', output)
+    if matched:
+        original_value = matched.group(1)
+    else:
+        pytest.fail("There is no default_pfcwd_status in /etc/sonic/init_cfg.json.")
+
+    sed_command = ("sed -i \'s/\"default_pfcwd_status\": \"{}\"/\"default_pfcwd_status\": \"{}\"/g\' {}"
+                   .format(original_value, default_pfcwd_value, filepath))
+    duthost.shell(sed_command)
+
+    return original_value

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -2,12 +2,12 @@ import json
 import os
 import pytest
 import logging
-import re
 import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.config_reload import config_reload
+from tests.common.utilities import update_pfcwd_default_state
 
 logger = logging.getLogger(__name__)
 
@@ -115,32 +115,6 @@ def cfg_setup(setup_pfc_test, duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     logger.info("--- Clean up config dir from DUT ---")
     cfg_teardown(duthost)
 
-
-def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
-    """
-    Set default_pfcwd_status in the specified file with parameter default_pfcwd_value
-    The path is expected to be one of:
-    - /etc/sonic/init_cfg.json
-    - /etc/sonic/config_db.json
-
-    Args:
-        duthost (AnsibleHost): instance
-        default_pfcwd_value: value of default_pfcwd_status, enable or disable
-
-    Returns:
-        original value of default_pfcwd_status
-    """
-    output = duthost.shell("cat {} | grep default_pfcwd_status".format(filepath))['stdout']
-    matched = re.search('"default_pfcwd_status": "(.*)"', output)
-    if matched:
-        original_value = matched.group(1)
-    else:
-        pytest.fail("There is no default_pfcwd_status in /etc/sonic/init_cfg.json.")
-
-    sed_command = "sed -i \'s/\"default_pfcwd_status\": \"{}\"/\"default_pfcwd_status\": \"{}\"/g\' {}".format(original_value, default_pfcwd_value, filepath)
-    duthost.shell(sed_command)
-
-    return original_value
 
 @pytest.fixture(scope='class')
 def mg_cfg_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/8368
test_override_config_table failed in m0/mx because default_pfcwd_status is enabled.

#### How did you do it?
Disable pfcwd before test and restore it after test.

#### How did you verify/test it?
Run tests on m0/mx/t1 topo, all pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
