### PR TITLE
[Mellanox] Adjust PSU power threshold exceeding test case for SN5600 test

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1299,9 +1299,9 @@ class PsuPowerThresholdMocker(object):
 
     def mock_power_threshold(self, number_psus):
         self.mock_helper.mock_value(
-            self.AMBIENT_TEMP_WARNING_THRESHOLD, 65000, True)
+            self.AMBIENT_TEMP_WARNING_THRESHOLD, 38000, True)
         self.mock_helper.mock_value(
-            self.AMBIENT_TEMP_CRITICAL_THRESHOLD, 75000, True)
+            self.AMBIENT_TEMP_CRITICAL_THRESHOLD, 40000, True)
 
         max_power = None
         for i in range(number_psus):
@@ -1313,7 +1313,7 @@ class PsuPowerThresholdMocker(object):
             self.mock_helper.mock_value(
                 self.PSU_POWER_CAPACITY.format(i + 1), max_power, True)
             self.mock_helper.mock_value(
-                self.PSU_POWER_SLOPE.format(i + 1), 2000, True)
+                self.PSU_POWER_SLOPE.format(i + 1), 30, True)
 
         # Also mock ambient temperatures
         self.mock_helper.mock_value(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adjust PSU power threshold exceeding test case for SN5600 test

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Adjust PSU power threshold exceeding test case for SN5600 test

#### How did you do it?

1. Update the formula to calculate the warning threshold
2. Ignore the error caused by mocking ambient sensors
3. Remove "-ti" option when executing docker commands

#### How did you verify/test it?
Run regression test cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
