### PR TITLE
Disable Loganalyzer in config reload testcases in dualtor_io folder

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -420,6 +420,7 @@ def test_active_link_admin_down_config_reload_downstream(
             upper_tor_host.shell("config save -y")
 
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_upstream(
@@ -472,6 +473,7 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
             upper_tor_host.shell("config save -y")
 
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_downstream_standby(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Disable Loganalyzer in config reload testcases in dualtor_io folder

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Some testcases, which would do config reload, didn't disable loganalyzer. So teardown error occurred.

#### How did you do it?
Add pytest mark to disable loganalyzer in config reload testcases under dualtor_io folder.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
