### PR TITLE
[qos] learn arp for each testcase, and fix DscpMappingPB failure (double commit PR#8121)

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1152,6 +1152,10 @@ class QosSaiBase(QosBase):
         if saiQosTest:
             testParams = dutTestParams["basicParams"]
             testParams.update(dutConfig["testPorts"])
+            testParams.update({
+                "testPortIds": dutConfig["testPortIds"],
+                "testPortIps": dutConfig["testPortIps"]
+            })
             self.runPtfTest(
                 ptfhost, testCase=saiQosTest, testParams=testParams
             )

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -341,6 +341,8 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_port_3_ip = self.test_params['dst_port_3_ip']
         self.dst_port_3_mac = self.dataplane.get_mac(0, self.dst_port_3_id)
         self.dst_vlan_3 = self.test_params['dst_port_3_vlan']
+        self.test_port_ids = self.test_params.get("testPortIds", None)
+        self.test_port_ips = self.test_params.get("testPortIps", None)
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -356,6 +358,13 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         send_packet(self, self.dst_port_2_id, arpreq_pkt)
         arpreq_pkt = construct_arp_pkt('ff:ff:ff:ff:ff:ff', self.dst_port_3_mac, 1, self.dst_port_3_ip, '192.168.0.1', '00:00:00:00:00:00', self.dst_vlan_3)
         send_packet(self, self.dst_port_3_id, arpreq_pkt)
+
+        # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
+        if self.test_port_ids and self.test_port_ips:
+            for portid in self.test_port_ids:
+                self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
+                                     'ping -q -c 3 {}'.format(self.test_port_ips[portid]['peer_addr']))
+
         time.sleep(8)
 
 


### PR DESCRIPTION
…ure (double commit PR #8121)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
double commit PR #8121 to 202012 branch
In testQosSaiSeparatedDscpQueueMapping, encounter below case failure:
```
sai_qos_tests.DscpMappingPB ... dst_port_id: 20, src_port_id: 44
actual dst_port_id: 20
dst_port_mac: 8a:52:64:f3:b0:14, src_port_mac: 76:2a:8e:f0:53:2c, src_port_ip: 10.0.0.45, dst_port_ip: 10.0.0.13
port list {0: 4294967330, 1: 4294967331, 62: 4294967374, 61: 4294967373, 60: 4294967372, 50: 4294967412, 52: 4294967404, 21: 4294967399, 34: 4294967338, 58: 4294967370, 44: 4294967311, 16: 4294967376, 5: 4294967335, 17: 4294967377, 45: 4294967312, 54: 4294967406, 46: 4294967344, 47: 4294967345, 53: 4294967405, 37: 4294967341, 55: 4294967407, 36: 4294967340, 4: 4294967334, 42: 4294967307, 20: 4294967398, 38: 4294967303, 39: 4294967304, 63: 4294967375}
dscp: 0, calling send_packet()
END OF TEST
FAIL

======================================================================
FAIL: sai_qos_tests.DscpMappingPB
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 388, in runTest
    dst_port_id, cnt, result.format()))
    AssertionError: Expected packet was not received on port 20. Total received: 0.
========== RECEIVED ==========
0 total packets.
==============================
```
RCA:
before execute get_rx_port() to get actuall dst port in portchannel, arp table is not existing relevant dst ip address.
so there is a timing issue: during broadcast arp, possible get wrong dst port result in get_rx_port()

#### How did you do it?

before execute qos sai ptf test code, send a icmp to trigger arp learning in arppopulate() function

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
