### PR TITLE
Fix test failure in test_proxy_arp_for_standby_neighbor

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -117,10 +117,10 @@ def test_proxy_arp_for_standby_neighbor(proxy_arp_enabled, ip_and_intf_info, res
 
     if ip_version == 'v4':
         pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
-        intf_name_cmd = "show arp | grep '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv4_addr)
+        intf_name_cmd = "show arp | grep -m 1 '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv4_addr)
     elif ip_version == 'v6':
         pytest_require(ptf_intf_ipv6_addr is not None, 'No IPv6 VLAN address configured on device')
-        intf_name_cmd = "show ndp | grep '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv6_addr)
+        intf_name_cmd = "show ndp | grep -m 1 '{}' | awk '{{ print $3 }}'".format(ptf_intf_ipv6_addr)
 
     # Find the interface on which the target IP is learned and set it to standby to force it to point to a tunnel route
     intf_name = upper_tor_host.shell(intf_name_cmd)['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test failure in test_proxy_arp_for_standby_neighbor

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test failed in Fix test failure in test_proxy_arp_for_standby_neighbor:
{"changed": true, "cmd": "sudo config mux mode standby Ethernet4\nEthernet216\nEthernet220\nEthernet224\nEthernet228\nEthernet232\nEthernet236\nEthernet240\nEthernet244\nEthernet248\nEthernet252",
"delta": "0:00:00.510204",
"end": "2023-03-17 23:05:41.244547",
"failed": true, "msg": "non-zero return code",
"rc": 127, "start": "2023-03-17 23:05:40.734343",
"stderr": "/bin/sh: 2: Ethernet216: not found
/bin/sh: 3: Ethernet220: not found
/bin/sh: 4: Ethernet224: not found
/bin/sh: 5: Ethernet228: not found
/bin/sh: 6: Ethernet232: not found
/bin/sh: 7: Ethernet236: not found
(omitted...)

#### How did you do it?
There are many interfaces given after "config mux mode standby".
Reduce the "grep" to only match the first one.

#### How did you verify/test it?
Manually run on 7260 dual tor testbed with 20201231 image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
