### PR TITLE
Avoid error if collect SSH cipher cases when DUT is offline

### DIFF
--- a/tests/ssh/conftest.py
+++ b/tests/ssh/conftest.py
@@ -36,6 +36,11 @@ def generate_ssh_ciphers(request, typename):
         remote_cmd = "ssh -Q kex"
         permitted_list = PERMITTED_KEXS
 
+    # If --collect-only is specified, return the permitted list directly. Otherwise, pytest will try to
+    # connect to DUT. If DUT is not online, pytest will fail with collecting test items.
+    if hasattr(request.config.option, "collectonly") and request.config.option.collectonly:
+        return permitted_list
+
     testbed_name = request.config.option.testbed
     testbed_file = request.config.option.testbed_file
     testbed_module = imp.load_source('testbed', 'common/testbed.py')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The SSH cipher tests are parameterized based on supported SSH ciphers on DUT. In test item collection phase, scripts need to run commands on DUT to get the supported ciphers. If we just want to run pytest with "--collect-only", the collection will fail if DUT is offline.

#### How did you do it?
This change is to enhance parameterization of the SSH cipher tests. Before connecting to DUT, firstly check if the `--collect-only` pytest argument is specified. If yes, do not try to connect to DUT. Just return default supported ciphers list. Then pytest collection will not raise error if DUT is offline.

#### How did you verify/test it?
Test run pytest with `--collect-only` argument when DUT is offline.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
