### PR TITLE
Add PR test job to collect all pytest cases

### DIFF
--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -5,14 +5,18 @@ steps:
   displayName: 'checkout sonic-mgmt repo'
 
 - script: |
-    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
-    sudo docker run -dt -v $(pwd):/var/src/sonic-mgmt --name sonic-mgmt-collect \
-      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest /bin/bash
+    set -x
+    /usr/bin/docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    /usr/bin/docker run -dt --name sonic-mgmt-collect \
+      -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
+      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
+      /bin/bash
   displayName: 'Prepare sonic-mgmt docker container'
 
 - script: |
-    docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
-      sudo pytest --inventory ../ansible/veos_vtb --host-pattern all \
+    set -x
+    /usr/bin/docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+      pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \
       --ignore scripts --ignore k8s --ignore sai_qualify --ignore common \

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -11,8 +11,8 @@ steps:
 
 - script: |
     set -x
-    docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
-    docker run -dt --name sonic-mgmt-collect \
+    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    sudo docker run -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash
@@ -20,7 +20,7 @@ steps:
 
 - script: |
     set -x
-    docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+    sudo docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
       pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -1,8 +1,13 @@
 steps:
 
+- task: DockerInstaller@0
+  inputs:
+    dockerVersion: '20.10.23'
+  displayName: 'Install Docker'
+
 - checkout: self
   clean: true
-  displayName: 'checkout sonic-mgmt repo'
+  displayName: 'Checkout sonic-mgmt repo'
 
 - script: |
     set -x

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -1,0 +1,21 @@
+steps:
+
+- checkout: self
+  clean: true
+  displayName: 'checkout sonic-mgmt repo'
+
+- script: |
+    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    sudo docker run -dt -v $(pwd):/var/src/sonic-mgmt --name sonic-mgmt-collect \
+      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest /bin/bash
+  displayName: 'Prepare sonic-mgmt docker container'
+
+- script: |
+    docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+      sudo pytest --inventory ../ansible/veos_vtb --host-pattern all \
+      --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
+      --ignore saitests --ignore ptftests --ignore acstests \
+      --ignore scripts --ignore k8s --ignore sai_qualify --ignore common \
+      --ignore-conditional-mark \
+      --color=no --collect-only --continue-on-collection-errors
+  displayName: 'Run pytest --collect-only'

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -11,8 +11,11 @@ steps:
 
 - script: |
     set -x
-    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
-    sudo docker run -dt --name sonic-mgmt-collect \
+
+    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker pull \
+      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+
+    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker run -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash
@@ -20,7 +23,8 @@ steps:
 
 - script: |
     set -x
-    sudo docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+
+    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
       pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -1,8 +1,19 @@
 steps:
 
-- task: DockerInstaller@0
-  inputs:
-    dockerVersion: '20.10.23'
+- script: |
+    sudo apt-get update
+    sudo apt-get install \
+      ca-certificates \
+      curl \
+      gnupg \
+      lsb-release -y
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor \
+      -o /usr/share/keyrings/docker-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+      https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install docker-ce docker-ce-cli containerd.io -y
   displayName: 'Install Docker'
 
 - checkout: self
@@ -12,10 +23,9 @@ steps:
 - script: |
     set -x
 
-    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker pull \
-      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
 
-    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker run -dt --name sonic-mgmt-collect \
+    sudo docker run -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash
@@ -24,7 +34,7 @@ steps:
 - script: |
     set -x
 
-    sudo /agent/_work/_tool/docker-stable/20.10.23/x64/docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+    sudo docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
       pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \

--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -11,8 +11,8 @@ steps:
 
 - script: |
     set -x
-    /usr/bin/docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
-    /usr/bin/docker run -dt --name sonic-mgmt-collect \
+    docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    docker run -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash
@@ -20,7 +20,7 @@ steps:
 
 - script: |
     set -x
-    /usr/bin/docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
+    docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
       pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,14 @@ stages:
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
+  - job: collect_only
+    displayName: "collect_only"
+    timeoutInMinutes: 20
+    continueOnError: false
+    pool: ubuntu-20.04
+    steps:
+    - template: .azure-pipelines/pytest-collect-only.yml
+
 - stage: Test
   dependsOn: Pre_test
   condition: and(succeeded(), in(dependencies.Pre_test.result, 'Succeeded'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,18 +24,19 @@ stages:
   - group: Testbed-Tools
   - group: GIT_SECRETS
   jobs:
-  - job: pre_commit
-    displayName: "pre-commit-check"
+  - job: static_analysis
+    displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
     pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
-  - job: collect_only
-    displayName: "collect_only"
+  - job: validate_test_cases
+    displayName: "Validate Test Cases"
     timeoutInMinutes: 20
     continueOnError: false
+    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,6 @@ stages:
     displayName: "collect_only"
     timeoutInMinutes: 20
     continueOnError: false
-    pool: ubuntu-20.04
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Traditionally, if we run pretest using mark option like `-m pretest`, then all test scripts in the repository are collected to find out which tests have mark `pretest`. If any of the script in repository has importing issue, the issue would be exposed while collecting the test.
Currently, the PR testing does not run the pretest by mark. It runs the test_pretest.py script as an ordinary script. Then if a script has importing issue, the issue cannot be detected.

#### How did you do it?
This change added a PR test job to run pytest command with `--collect-only` option. Then pytest will try to collect all the test only without actually executing any of them.
In case any script has import issue, this collect only check is able to detect it.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
