### PR TITLE
[202205] Fix blocking operation of queue in advanced-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1021,7 +1021,7 @@ class ReloadTest(BaseTest):
         # wait until all bgp session are established
         self.log("Wait until bgp routing is up on all devices")
         for _, q in self.ssh_jobs:
-            q.put('quit')
+            self.put_nowait(q, 'quit')
 
         def wait_for_ssh_threads(signal):
             while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
@@ -1103,7 +1103,7 @@ class ReloadTest(BaseTest):
         # wait until all bgp session are established
         self.log("Wait until bgp routing is up on all devices")
         for _, q in self.ssh_jobs:
-            q.put('quit')
+            self.put_nowait(q, 'quit')
 
         def wait_for_ssh_threads(signal):
             while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
@@ -1437,7 +1437,7 @@ class ReloadTest(BaseTest):
                 self.put_nowait(q, 'cpu_going_down')
             if self.cpu_state.get() == 'down':
                 for _, q in self.ssh_jobs:
-                    q.put('cpu_down')
+                    self.put_nowait(q, 'cpu_down')
                 break
             time.sleep(self.TIMEOUT)
 
@@ -1447,7 +1447,7 @@ class ReloadTest(BaseTest):
                 self.put_nowait(q, 'cpu_going_up')
             if self.cpu_state.get() == 'up':
                 for _, q in self.ssh_jobs:
-                    q.put('cpu_up')
+                    self.put_nowait(q, 'cpu_up')
                 break
             time.sleep(self.TIMEOUT)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix issue in `advanced-reboot.py`.
We found that fast-reboot and warm-reboot tests are failing with exception
```
TimeoutError: DUT hasn't shutdown in 300 seconds
```
By checking log, we found DUT had been rebooted successfully.
```
2023-05-23 18:57:15 : Schedule to reboot the remote switch in 10 sec
2023-05-23 18:57:15 : Wait until Control plane is down
2023-05-23 18:57:25 : Sniffer started at 2023-05-23 18:57:25.933862
2023-05-23 18:57:25 : Rebooting remote side
2023-05-23 18:57:35 : Sender started at 2023-05-23 18:57:35.982221
2023-05-23 18:57:56 : return code from fast-reboot: 255
2023-05-23 18:58:32 : Control plane state transition from up to down

2023-05-23 18:58:56 : VLAN ARP state transition from up to down
2023-05-23 18:59:13 : VLAN ARP state transition from down to up
2023-05-23 18:59:15 : Control plane state transition from down to up
2023-05-23 18:59:29 : VLAN ARP state transition from up to down
```  
The reason is the `q.put()` operation blocked `wait_until_cpu_port_down` from exiting. As a result, the timeout is always happening.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix the blocking issue in `advanced-reboot.py`.

#### How did you do it?
Replace `q.put()` with `self.put_nowait`.

#### How did you verify/test it?
Verified by running fast-reboot test. The test can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
