### PR TITLE
Skip ipinip hash test on mlnx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -439,17 +439,11 @@ fdb/test_fdb_mac_expire.py:
 #######################################
 #####            fib              #####
 #######################################
-fib/test_fib.py::test_ipinip_hash[ipv4]:
+fib/test_fib.py::test_ipinip_hash:
   skip:
-    reason: "The inner IP header is not used as hash keys."
+    reason: 'ipinip hash test is not fully supported on mellanox platform (case#00581265)'
     conditions:
-      "asic_type in ['mellanox']"
-
-fib/test_fib.py::test_ipinip_hash[ipv6]:
-  skip:
-    reason: "The inner IP header is not used as hash keys."
-    conditions:
-      "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox']"
 
 #######################################
 #####   generic_config_updater    #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -437,6 +437,21 @@ fdb/test_fdb_mac_expire.py:
       - "topo_type not in ['t0', 'm0', 'mx']"
 
 #######################################
+#####            fib              #####
+#######################################
+fib/test_fib.py::test_ipinip_hash[ipv4]:
+  skip:
+    reason: "The inner IP header is not used as hash keys."
+    conditions:
+      "asic_type in ['mellanox']"
+
+fib/test_fib.py::test_ipinip_hash[ipv6]:
+  skip:
+    reason: "The inner IP header is not used as hash keys."
+    conditions:
+      "asic_type in ['mellanox']"
+
+#######################################
 #####   generic_config_updater    #####
 #######################################
 generic_config_updater:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip `test_ipinip_hash` on `Mellanox` platform.

Case No. 00581265

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip `test_ipinip_hash` on `Mellanox` platform.

#### How did you do it?
Update the `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### How did you verify/test it?
Verified on an SN4600 T1 testbed. The case is skipped now.

#### Any platform specific information?
`Mellanox` platform specific.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
