### PR TITLE
[202205] Skip test_ecn_config_updates on m0 and mx topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -439,6 +439,12 @@ generic_config_updater:
     conditions:
       - "'t2' in topo_name"
 
+generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
+  skip:
+    reason: "M0 and Mx don't support ecn config update"
+    conditions:
+      - "topo_type in ['m0', 'mx']"
+
 generic_config_updater/test_eth_interface.py:
   xfail:
     reason: 'Xfail this script due to many failures found'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Backport #8403 to 202205 branch.
Skip test_ecn_config_updates on M0 and Mx topology. M0 and Mx topo don't support ecn config update.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Skip test_ecn_config_updates on M0 and Mx topology. M0 and Mx topo don't support ecn config update.

#### How did you do it?
Skip the testcase via conditional mark.

#### How did you verify/test it?
Verified on M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
