### PR TITLE
remove iptable rule for eth1-midplane traffic from non-chassis's expected rule list

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -563,7 +563,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
         ip6tables_rules.append("-A INPUT -j DROP")
 
     # IP Table rule to allow eth1-midplane traffic for chassis
-    if asic_index is None:
+    if asic_index is not None:
         append_midplane_traffic_rules(duthost, iptables_rules)
 
     return iptables_rules, ip6tables_rules


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

For some T1 box device, case "cacl/test_cacl_application.py::test_cacl_application_nondualtor" fail

failure reason is 
```
    def verify_cacl(duthost, tbinfo, localhost, creds, docker_network, expected_dhcp_rules_for_standby = None, asic_index = None):
        expected_iptables_rules, expected_ip6tables_rules = generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
        logger.info('xuchen3 expected_iptables_rules {}'.format(expected_iptables_rules))
    
        stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
        actual_iptables_rules = stdout.strip().split("\n")
        logger.info('xuchen3 actual_iptables_rules {}'.format(actual_iptables_rules))
    
        # Ensure all expected iptables rules are present on the DuT
        logger.info("Number of expected iptable rules:{}, number of acutal iptables rules:{}".format(len(set(expected_iptables_rules)), len(set(actual_iptables_rules))))
        missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
>       pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables rules: {}".format(repr(missing_iptables_rules)))
E       Failed: Missing expected iptables rules: set(['-A INPUT -i eth1-midplane -j ACCEPT'])

```

RCA:
before generate iptable rule for midplane traffic for chassis device, need to check asic_index, as below:
```
    # IP Table rule to allow eth1-midplane traffic for chassis
    if asic_index is None:
        append_midplane_traffic_rules(duthost, iptables_rules)
```
according to code context, should use "asic_index is **not** None" as criteria of execution "append_midplane_traffic_rules()" for chassis device.
So, box device wrongly add iptable rule related eth1-midplane into expected rule list, and then caused case failure.

#### How did you do it?

correct criteria of execution "append_midplane_traffic_rules()" 
```
     # IP Table rule to allow eth1-midplane traffic for chassis
-    if asic_index is None:
+    if asic_index is not None:
         append_midplane_traffic_rules(duthost, iptables_rules)
```

#### How did you verify/test it?

pass local test on relevant T1 box device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
