### PR TITLE
Fix for fwd_ip_packet #7954  - test_ip_packet.py

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -323,7 +323,7 @@ class TestIPPacket(object):
                       .format(tx_ok, match_cnt))
 
     def test_forward_ip_packet_with_0xffff_chksum_drop(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                       ptfadapter, common_param):
+                                                       ptfadapter, common_param, tbinfo):
         # GIVEN a ip packet with checksum 0x0000(compute from scratch)
         # WHEN manually set checksum as 0xffff and send the packet to DUT
         # THEN DUT should drop packet with 0xffff and add drop count
@@ -378,6 +378,13 @@ class TestIPPacket(object):
         tx_ok = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_ok")
         tx_drp = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_err = TestIPPacket.sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
+
+        # For t2 max topology, increase the tolerance value from 0.1 to 0.2
+        # Set the tolerance value to 0.2 if the topology is T2 max, PKT_NUM_ZERO would be set to 200
+        vms_num = len(tbinfo['topo']['properties']['topology']['VMs'])
+        if tbinfo['topo']['type'] == "t2" and vms_num > 8:
+            logger.info("Setting PKT_NUM_ZERO for t2 max topology with 0.2 tolerance")
+            self.PKT_NUM_ZERO = self.PKT_NUM * 0.2
 
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- Issue #7954, for T2 testing with DNX chassis.
- Fixes `tx_ok `count issue due to background traffic.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- _ip/test_forward_ip_packet_with_0xffff_chksum_drop_ test case in _test_ip_packet.py_ was failing in `tx_ok `count check.
- The issue was flaky in T2 testing with DNX chassis.

#### How did you do it?
- Test actually validates the expected packets are not egressing out from the DUT.
- '`out_ifaces`' retrieved as part of the test for T2 max topology has more interfaces than T2 min topology DUT.
- Once the 1000 packets are sent from ptf, test waits for 5 seconds followed by portstat command on DUT.
- During this wait time, there are background traffic on the '`out_ifaces`' which adds to the `tx_ok `count and it crosses "_PKT_NUM_MIN_" number 100 for T2 max chassis.
- Hence for T2 max topo chassis, tolerance value has been increased from 0.1 to 0.2 and "_PKT_NUM_MIN_" will be at 200.

#### How did you verify/test it?
- Ran all the `TestIPPacket `test cases against a multi-asic line card in a T2 chassis with both min and max topo
![fwd-ip-packet-chksum](https://github.com/sonic-net/sonic-mgmt/assets/114024719/6caac200-d81f-4805-a0c4-14c0259f6178)
.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
