### PR TITLE
[Snappi] Skip warm and fast reboot RDMA test cases for Cisco devices

### DIFF
--- a/tests/snappi/files/helper.py
+++ b/tests/snappi/files/helper.py
@@ -5,7 +5,7 @@ from tests.common.cisco_data import is_cisco_device
 
 def skip_warm_reboot(duthost, reboot_type):
     """
-    Skip warm reboot tests for TD2 asics
+    Skip warm/fast reboot tests for TD2 asics and Cisco devices
 
     Args:
         duthost (pytest fixture): device under test
@@ -16,20 +16,10 @@ def skip_warm_reboot(duthost, reboot_type):
     """
     SKIP_LIST = ["td2"]
     asic_type = duthost.get_asic_name()
-    pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type),
-                   "Warm reboot is not supported on {}".format(asic_type))
-
-
-def skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type):
-    """
-    Skip warm and fast reboot tests for Cisco devices
-
-    Args:
-        duthost (pytest fixture): device under test
-        reboot_type (string): type of reboot (can be warm, cold, fast)
-    """
     reboot_case_supported = True
     if (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
+        reboot_case_supported = False
+    elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
         reboot_case_supported = False
     pytest_require(reboot_case_supported, "Reboot type {} is not supported on {} switches".
                    format(reboot_type, duthost.facts['asic_type']))

--- a/tests/snappi/files/helper.py
+++ b/tests/snappi/files/helper.py
@@ -1,5 +1,6 @@
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.helpers.assertions import pytest_require
+from tests.common.cisco_data import is_cisco_device
 
 
 def skip_warm_reboot(duthost, reboot_type):
@@ -17,3 +18,18 @@ def skip_warm_reboot(duthost, reboot_type):
     asic_type = duthost.get_asic_name()
     pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type),
                    "Warm reboot is not supported on {}".format(asic_type))
+
+
+def skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type):
+    """
+    Skip warm and fast reboot tests for Cisco devices
+
+    Args:
+        duthost (pytest fixture): device under test
+        reboot_type (string): type of reboot (can be warm, cold, fast)
+    """
+    reboot_case_supported = True
+    if (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
+        reboot_case_supported = False
+    pytest_require(reboot_case_supported, "Reboot type {} is not supported on {} switches".
+                   format(reboot_type, duthost.facts['asic_type']))

--- a/tests/snappi/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -12,6 +12,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossl
 from tests.common.reboot import reboot
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
+from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -172,8 +173,11 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
 
     testbed_config, port_config_list = snappi_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
-    lossless_prio = int(lossless_prio)
 
+    skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
+
+    lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
     test_prio_list = [lossless_prio]
     bg_prio_list = [p for p in all_prio_list]
@@ -243,6 +247,10 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
 
     testbed_config, port_config_list = snappi_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
+
+    skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
+
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
     bg_prio_list = lossy_prio_list

--- a/tests/snappi/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -12,7 +12,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossl
 from tests.common.reboot import reboot
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
-from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
+from tests.snappi.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +175,6 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     duthost = duthosts[rand_one_dut_hostname]
 
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
@@ -249,7 +248,6 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
     duthost = duthosts[rand_one_dut_hostname]
 
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list

--- a/tests/snappi/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -11,7 +11,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossl
     lossy_prio_list                         # noqa F401
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
-from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
+from tests.snappi.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,6 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,                 # noqa F
 
     duthost = duthosts[rand_one_dut_hostname]
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
     testbed_config, port_config_list = snappi_testbed_config
     lossy_prio = int(lossy_prio)
 
@@ -246,7 +245,6 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,                  # noqa F
     duthost = duthosts[rand_one_dut_hostname]
 
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list

--- a/tests/snappi/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -11,7 +11,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossl
     lossy_prio_list                         # noqa F401
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
-from tests.snappi.files.helper import skip_warm_reboot
+from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +172,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,                 # noqa F
 
     duthost = duthosts[rand_one_dut_hostname]
     skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
     testbed_config, port_config_list = snappi_testbed_config
     lossy_prio = int(lossy_prio)
 
@@ -243,6 +244,10 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,                  # noqa F
 
     testbed_config, port_config_list = snappi_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
+
+    skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
+
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list

--- a/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -10,7 +10,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, lossless_prio_list  
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
 from .files.pfcwd_basic_helper import run_pfcwd_basic_test
-from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
+from tests.snappi.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,6 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
 
     duthost = duthosts[rand_one_dut_hostname]
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     testbed_config, port_config_list = snappi_testbed_config
     lossless_prio = int(lossless_prio)
@@ -223,7 +222,6 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
 
     duthost = duthosts[rand_one_dut_hostname]
     skip_warm_reboot(duthost, reboot_type)
-    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     testbed_config, port_config_list = snappi_testbed_config
 

--- a/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -10,7 +10,7 @@ from tests.common.snappi.qos_fixtures import prio_dscp_map, lossless_prio_list  
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
 from .files.pfcwd_basic_helper import run_pfcwd_basic_test
-from tests.snappi.files.helper import skip_warm_reboot
+from tests.snappi.files.helper import skip_warm_and_fast_reboot_on_cisco_devices, skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +159,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
 
     duthost = duthosts[rand_one_dut_hostname]
     skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     testbed_config, port_config_list = snappi_testbed_config
     lossless_prio = int(lossless_prio)
@@ -221,6 +222,8 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                    "Port is not mapped to the expected DUT")
 
     duthost = duthosts[rand_one_dut_hostname]
+    skip_warm_reboot(duthost, reboot_type)
+    skip_warm_and_fast_reboot_on_cisco_devices(duthost, reboot_type)
 
     testbed_config, port_config_list = snappi_testbed_config
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Cisco devices do not support warm or fast reboot operations. If such an operation is performed, it leaves the switch in a bad state, resulting in failures. This change skips all cases with warm and fast reboots for cisco devices.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Lots of failures related to ARP were seen with warm and fast reboot RDMA cases in cisco switches. Cisco switches currently do not support warm and fast reboots, so these failures are expected. Hence, these test cases will be skipped if it is a cisco switch, 

#### How did you do it?
Check device's asic type and skip the appropriate cases. 

#### How did you verify/test it?
Test cases are skipped on lab switch. 

#### Any platform specific information?
Cisco-8000

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
