### PR TITLE
[portchannel] Fix test_lag_member failed

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -187,7 +187,7 @@ def setup_ptf_lag(ptfhost, ptf_ports):
     time.sleep(10)
 
 
-def generate_port_config(duthost, tbinfo):
+def generate_port_config(duthost, tbinfo, most_common_port_speed):
     """
     Setup dut and ptf based on ports available in dut vlan
 
@@ -334,7 +334,7 @@ def ptf_dut_setup_and_teardown(duthost, ptfhost, tbinfo, most_common_port_speed)
         ptfhost: PTF host object
         tbinfo: fixture provides information about testbed
     """
-    dut_ports, ptf_ports, src_vlan_id, vlan = generate_port_config(duthost, tbinfo)
+    dut_ports, ptf_ports, src_vlan_id, vlan = generate_port_config(duthost, tbinfo, most_common_port_speed)
     try:
         setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id)
         setup_ptf_lag(ptfhost, ptf_ports)
@@ -399,7 +399,7 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
         ptfhost: PTF host object
     """
     ptf_lag = {
-        "port_list": ptf_ports[ATTR_PORT_BEHIND_LAG].values(),
+        "port_list": list(ptf_ports[ATTR_PORT_BEHIND_LAG].values()),
         "ip": ptf_ports["ip"]["lag"]
     }
     ptf_not_lag = ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There are some bugs in this PR: https://github.com/sonic-net/sonic-mgmt/pull/8405, to fix this issue.

#### How did you do it?
Add list() to dict_value.

#### How did you verify/test it?
Run tests.
```
collected 2 items                                                                                                                                                       

pc/test_lag_member.py::test_lag_member_status PASSED                                                                                                              [ 50%]
pc/test_lag_member.py::test_lag_member_traffic PASSED                                                                                                             [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
