### PR TITLE
Avoid using http proxy during announce-routes

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -5,9 +5,10 @@ import os
 import yaml
 import re
 import requests
-import time
 import ipaddress
+import json
 import sys
+import socket
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -98,11 +99,14 @@ def wait_for_http(host_ip, http_port, timeout=10):
     """
     started = False
     tries = 0
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(2)
     while not started and tries < timeout:
-        if os.system("curl {}:{}".format(host_ip, http_port)) == 0:
+        try:
+            s.connect((host_ip, http_port))
             started = True
-        tries += 1
-        time.sleep(1)
+        except socket.error:
+            tries += 1
 
     return started
 
@@ -144,8 +148,18 @@ def change_routes(action, ptf_ip, port, routes):
     wait_for_http(ptf_ip, port, timeout=60)
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
-    r = requests.post(url, data=data, timeout=90)
-    assert r.status_code == 200
+    r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
+    if r.status_code != 200:
+        raise Exception(
+            "Change routes failed: url={}, data={}, r.status_code={}, r.reason={}, r.headers={}, r.text={}".format(
+                url,
+                json.dumps(data),
+                r.status_code,
+                r.reason,
+                r.headers,
+                r.text
+            )
+        )
 
 
 # AS path from Leaf router for T0 topology


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The announce-routes step is to populate the exabgp processes running in PTF container with predefined routes by sending HTTP POST request from sonic-mgmt container to PTF container. The python requests tool is used for sending HTTP requests. In case http_proxy or https_proxy environment variables are set, the requests tool will use the proxy to send the request. However, the proxy is not needed in this case because usually sonic-mgmt container has direct access to PTF container.

#### How did you do it?
This change disables the proxy by explicitly setting proxies to None while calling the `requests.post` method.

Another change is to use socket instead of "curl" command to wait for the http port of exabgp processes running in PTF container to be ready.

#### How did you verify/test it?
Tested `testbed-cli.sh announce-routes` with and without http_proxy environment variable.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
