### PR TITLE
[202205][portchannel] Fix test_lag_member failed (#8405)

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -347,7 +347,7 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
         ptfhost: PTF host object
     """
     ptf_lag = {
-        "port_list": ptf_ports[ATTR_PORT_BEHIND_LAG].values(),
+        "port_list": list(ptf_ports[ATTR_PORT_BEHIND_LAG].values()),
         "ip": ptf_ports["ip"]["lag"]
     }
     ptf_not_lag = ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PRs: https://github.com/sonic-net/sonic-mgmt/pull/8405, https://github.com/sonic-net/sonic-mgmt/pull/8419

#### How did you do it?
Add ping from ptf before run traffic test to ensure that arp table in DUT has been refreshed.
Split ptf/dut setup and generate, adding try/exception to avoid exception in setup period cause teardown failed.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
