### PR TITLE
add dualtor flag for pfcwd cases

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -173,4 +173,37 @@ def setup_pfc_test(
 
     # set poll interval
     duthost.command("pfcwd interval {}".format(setup_info['pfc_timers']['pfc_wd_poll_time']))
+
+    logger.info("setup_info : {}".format(setup_info))
     yield setup_info
+
+@pytest.fixture(scope="module")
+def setup_dut_test_params(
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, conn_graph_facts, tbinfo,     # noqa F811
+    enum_frontend_asic_index
+):
+    """
+    Sets up all the parameters needed for the PFCWD tests
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+        ptfhost: AnsibleHost instance for PTF
+        conn_graph_facts: fixture that contains the parsed topology info
+
+    Yields:
+        dut_info: dictionary containing dut information
+    """
+    dut_test_params = {'basicParams': {'is_dualtor': False}}
+    if "dualtor" in tbinfo["topo"]["name"]:
+        dut_test_params["basicParams"]["is_dualtor"] = True
+        vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+        if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
+            default_vlan_name = vlan_cfgs['default_vlan_config']
+            if default_vlan_name:
+                for vlan in list(vlan_cfgs[default_vlan_name].values()):
+                    if 'mac' in vlan and vlan['mac']:
+                        dut_test_params["basicParams"]["def_vlan_mac"] = vlan['mac']
+                        break
+
+    logger.info("dut_test_params : {}".format(dut_test_params))
+    yield dut_test_params

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -177,6 +177,7 @@ def setup_pfc_test(
     logger.info("setup_info : {}".format(setup_info))
     yield setup_info
 
+
 @pytest.fixture(scope="module")
 def setup_dut_test_params(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, conn_graph_facts, tbinfo,     # noqa F811

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -277,7 +277,7 @@ class PfcPktCntrs(object):
 
 class SetupPfcwdFunc(object):
     """ Test setup per port """
-    def setup_test_params(self, port, vlan, init=False, mmu_params=False, is_dualtor=False):
+    def setup_test_params(self, port, vlan, init=False, mmu_params=False):
         """
         Sets up test parameters associated with a DUT port
 
@@ -290,7 +290,7 @@ class SetupPfcwdFunc(object):
         self.setup_port_params(port, init=init)
         if mmu_params:
             self.setup_mmu_params(port)
-        self.resolve_arp(vlan, is_dualtor)
+        self.resolve_arp(vlan, self.is_dualtor)
         if not self.pfc_wd['fake_storm']:
             self.storm_setup(init=init)
 
@@ -744,12 +744,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.storm_hndle = None
         self.rx_action = None
         self.tx_action = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
 
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx,
-                                   is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+            self.setup_test_params(port, setup_info['vlan'], init=not idx)
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),
@@ -826,10 +826,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fake_storm = fake_storm
         self.storm_hndle = None
         logger.info("---- Testing on port {} ----".format(port))
-        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True,
-                               is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True)
         self.rx_action = None
         self.tx_action = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         self.set_traffic_action(duthost, "drop")
         self.stats = PfcPktCntrs(self.dut, self.rx_action, self.tx_action)
 
@@ -904,13 +904,14 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.storm_hndle = None
         self.rx_action = None
         self.tx_action = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         action = "dontcare"
 
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing port toggling with PFCWD enabled on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx,
-                                   is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+            self.setup_test_params(port, setup_info['vlan'], init=not idx)
+
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -277,7 +277,7 @@ class PfcPktCntrs(object):
 
 class SetupPfcwdFunc(object):
     """ Test setup per port """
-    def setup_test_params(self, port, vlan, init=False, mmu_params=False):
+    def setup_test_params(self, port, vlan, init=False, mmu_params=False, is_dualtor=False):
         """
         Sets up test parameters associated with a DUT port
 
@@ -290,7 +290,7 @@ class SetupPfcwdFunc(object):
         self.setup_port_params(port, init=init)
         if mmu_params:
             self.setup_mmu_params(port)
-        self.resolve_arp(vlan)
+        self.resolve_arp(vlan, is_dualtor)
         if not self.pfc_wd['fake_storm']:
             self.storm_setup(init=init)
 
@@ -368,7 +368,7 @@ class SetupPfcwdFunc(object):
             PfcCmd.update_alpha(self.dut, port, self.pg_profile, self.alpha)
         time.sleep(2)
 
-    def resolve_arp(self, vlan):
+    def resolve_arp(self, vlan, is_dualtor=False):
         """
         Populate ARP info for the DUT vlan port
 
@@ -382,7 +382,11 @@ class SetupPfcwdFunc(object):
                 ptf_port += (constants.VLAN_SUB_INTERFACE_SEPARATOR + self.pfc_wd['test_port_vlan_id'])
             self.ptf.command("ifconfig {} {}".format(ptf_port, self.pfc_wd['test_neighbor_addr']))
             self.ptf.command("ping {} -c 10".format(vlan['addr']))
-            self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))
+
+            if is_dualtor:
+                self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']), module_ignore_errors=True)
+            else:
+                self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))
 
     def storm_setup(self, init=False):
         """
@@ -711,7 +715,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.rx_action = action
         self.tx_action = action
 
-    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts,  # noqa F811
+    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         PFCwd functional test
@@ -727,6 +731,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
+        setup_dut_info = setup_dut_test_params
         self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
@@ -743,7 +748,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx)
+            self.setup_test_params(port, setup_info['vlan'], init=not idx, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),
@@ -774,7 +779,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     logger.info("--- Stop PFC WD ---")
                     self.dut.command("pfcwd stop")
 
-    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
+    def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Tests if mmu changes impact Pfcwd functionality
@@ -805,6 +810,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
+        setup_dut_info = setup_dut_test_params
         self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
@@ -819,7 +825,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fake_storm = fake_storm
         self.storm_hndle = None
         logger.info("---- Testing on port {} ----".format(port))
-        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True)
+        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
         self.rx_action = None
         self.tx_action = None
         self.set_traffic_action(duthost, "drop")
@@ -856,7 +862,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             logger.info("--- Stop PFC WD ---")
             self.dut.command("pfcwd stop")
 
-    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, enum_fanout_graph_facts,  # noqa F811
+    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                                tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Test PfCWD functionality after toggling port
@@ -883,6 +889,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         setup_info = setup_pfc_test
+        setup_dut_info = setup_dut_test_params
         self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
@@ -900,7 +907,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing port toggling with PFCWD enabled on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx)
+            self.setup_test_params(port, setup_info['vlan'], init=not idx, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -384,7 +384,7 @@ class SetupPfcwdFunc(object):
             self.ptf.command("ping {} -c 10".format(vlan['addr']))
 
             if is_dualtor:
-                self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']), module_ignore_errors=True)
+                self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']), module_ignore_errors=True)  # noqa: E501
             else:
                 self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))
 
@@ -748,7 +748,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+            self.setup_test_params(port, setup_info['vlan'], init=not idx,
+                                   is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),
@@ -825,7 +826,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fake_storm = fake_storm
         self.storm_hndle = None
         logger.info("---- Testing on port {} ----".format(port))
-        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True,
+                               is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
         self.rx_action = None
         self.tx_action = None
         self.set_traffic_action(duthost, "drop")
@@ -907,7 +909,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing port toggling with PFCWD enabled on {} ---".format(port))
-            self.setup_test_params(port, setup_info['vlan'], init=not idx, is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
+            self.setup_test_params(port, setup_info['vlan'], init=not idx,
+                                   is_dualtor=setup_dut_info['basicParams']['is_dualtor'])
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PFCWD cases on dualtor failed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PFCWD cases on dualtor failed

#### How did you do it?
resolve_arp function needs to call the CMD "docker exec -i swss arping ...", but it would failed on standby dualtor

#### How did you verify/test it?
Run original case, no such failure

#### Any platform specific information?
Dualtor testbeds.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
