### PR TITLE
[dualtor][active-active][vlan] Fix test setup error on dualtor-aa topo testbed

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -9,7 +9,6 @@ import requests
 from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                             # noqa F401
 from tests.common.dualtor.dual_tor_common import mux_config                             # noqa F401
-from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
@@ -501,7 +500,7 @@ def toggle_all_simulator_ports_to_another_side(mux_server_url, tbinfo):
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, tbinfo, rand_one_dut_hostname):
+def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, tbinfo, rand_one_dut_hostname, active_standby_ports):
     """
     A function level fixture to toggle all ports to randomly selected tor.
 
@@ -510,6 +509,8 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
     """
     # Skip on non dualtor testbed or dualtor testbed without active-standby ports
     if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
+        logger.debug('active_standby_ports: {}'.format(active_standby_ports))
+        logger.info('Skipping toggle on non-dualtor testbed or active-active dualtor topo.')
         yield
         return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Noticed some vlan tests are failing on dualtor-aa topology testbed at the step of test setup. 
The error messages are: 
```
        if not is_toggle_done and \
                not utilities.wait_until(120, 10, 0, _check_toggle_done, duthosts, target_dut_hostname, probe=True):
>           pytest_assert(False, "Failed to toggle all ports to {} from mux simulator".format(target_dut_hostname))
E           Failed: Failed to toggle all ports to xxxxxxxxxxxx from mux simulator
```

The toggle wasn't skipped as expected because fixture  `active_standby_ports` fixture wasn't "requested" and executed in fixture `toggle_all_simulator_ports_to_rand_selected_tor_m`. Type of `active_standby_ports` was  `<type 'function'>` hence `not active_standby_ports` will always be False. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix Vlan tests setup failure on dualtor-aa testbed. 

#### How did you do it?
Request `active_standby_ports` fixture in the toggle fixture. 

#### How did you verify/test it?
Run the test. The toggle error was resolved. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
