### PR TITLE
Fix - 'ARPpopulate' object has no attribute 'exec_cmd_on_dut'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1519,7 +1519,7 @@ def duts_running_config_facts(duthosts):
     return cfg_facts
 
 @pytest.fixture(scope='class')
-def dut_test_params(duthosts, rand_one_dut_hostname, tbinfo, ptf_portmap_file, lower_tor_host):
+def dut_test_params(duthosts, rand_one_dut_hostname, tbinfo, ptf_portmap_file, lower_tor_host, creds):
     """
         Prepares DUT host test params
 
@@ -1549,7 +1549,9 @@ def dut_test_params(duthosts, rand_one_dut_hostname, tbinfo, ptf_portmap_file, l
                     ).vars['ansible_host'],
             "port_map_file": ptf_portmap_file,
             "sonic_asic_type": duthost.facts['asic_type'],
-            "sonic_version": duthost.os_version
+            "sonic_version": duthost.os_version,
+            "dut_username": creds['sonicadmin_user'],
+            "dut_password": creds['sonicadmin_password']
         }
     }
 

--- a/tests/saitests/sai_base_test.py
+++ b/tests/saitests/sai_base_test.py
@@ -45,6 +45,7 @@ class ThriftInterface(BaseTest):
             server = self.test_params['server']
         else:
             server = 'localhost'
+        self.server = server
 
         if self.test_params.has_key("port_map"):
             user_input = self.test_params['port_map']

--- a/tests/saitests/sai_base_test.py
+++ b/tests/saitests/sai_base_test.py
@@ -15,6 +15,7 @@ from ptf.base_tests import BaseTest
 from ptf import config
 import ptf.dataplane as dataplane
 import ptf.testutils as testutils
+import socket
 
 ################################################################
 #
@@ -26,6 +27,9 @@ import switch_sai_thrift.switch_sai_rpc as switch_sai_rpc
 from thrift.transport import TSocket
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
+import sys
+import paramiko
+from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 
 interface_to_front_mapping = {}
 
@@ -72,6 +76,39 @@ class ThriftInterface(BaseTest):
             self.dataplane.stop_pcap()
         BaseTest.tearDown(self)
         self.transport.close()
+
+    def exec_cmd_on_dut(self, hostname, username, password, cmd):
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        if isinstance(cmd, list):
+            cmd = ' '.join(cmd)
+
+        stdOut = stdErr = []
+        retValue = 1
+        try:
+            client.connect(hostname, username=username, password=password, allow_agent=False)
+            si, so, se = client.exec_command(cmd, timeout=20)
+            stdOut = so.readlines()
+            stdErr = se.readlines()
+            retValue = 0
+        except AuthenticationException as authenticationException:
+            print('SSH Authentication failure with message: %s' % authenticationException, file=sys.stderr)
+        except SSHException as sshException:
+            print('SSH Command failed with message: %s' % sshException, file=sys.stderr)
+        except BadHostKeyException as badHostKeyException:
+            print('SSH Authentication failure with message: %s' % badHostKeyException, file=sys.stderr)
+        except socket.timeout as e:
+            # The ssh session will timeout in case of a successful reboot
+            print('Caught exception socket.timeout: {}, {}, {}'.format(repr(e), str(e), type(e)), file=sys.stderr)
+            retValue = 255
+        except Exception as e:
+            print('Exception caught: {}, {}, type: {}'.format(repr(e), str(e), type(e)), file=sys.stderr)
+            print(sys.exc_info(), file=sys.stderr)
+        finally:
+            client.close()
+
+        return stdOut, stdErr, retValue
 
 class ThriftInterfaceDataPlane(ThriftInterface):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 'ARPpopulate' object has no attribute 'exec_cmd_on_dut'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This is only for 202012 branch. QoS SAI test failed with error:
"======================================================================",
    "ERROR: sai_qos_tests.ARPpopulate",
    "----------------------------------------------------------------------",
    "Traceback (most recent call last):",
    "  File \"saitests/sai_qos_tests.py\", line 365, in runTest",
    "    self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],",
    "AttributeError: 'ARPpopulate' object has no attribute 'exec_cmd_on_dut'",
This is a merge error.

#### How did you do it?
Merge the "exec_cmd_on_dut" code to 202012 branch.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
