### PR TITLE
[Testbed] Support config extra mgmt IP on PTF

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -86,6 +86,7 @@
             ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
             ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
             ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
+            ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
             mgmt_bridge: "{{ mgmt_bridge }}"
             vm_names: ""
           become: yes
@@ -138,6 +139,7 @@
         ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
         ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
         ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
+        ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
         ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
         ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
         mgmt_bridge: "{{ mgmt_bridge }}"
@@ -208,6 +210,7 @@
       ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
       ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
       ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
+      ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
       ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
       ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
       mgmt_bridge: "{{ mgmt_bridge }}"

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -37,6 +37,7 @@
   ptf: ptf-unknown
   ptf_ip: 10.255.0.178/24
   ptf_ipv6:
+  ptf_extra_mgmt_ip: []
   server: server_1
   vm_base: VM0100
   dut:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support config extra MGMT IP addresses on PTF while add-topo. The extra IPs are used for non-routable traffic inside testbed.

**How to use this feature**
To configure multi MGMT IP addresses on PTF, update the `testbed.yaml` and add your extra MGMT addresses in the key `ptf_extra_mgmt_ip`. For example:

```
- conf-name: vms-sn2700-t1
  group-name: vms1-1
  topo: t1
  ptf_image_name: docker-ptf
  ptf: ptf-unknown
  ptf_ip: 10.255.0.178/23
  ptf_ipv6:
  ptf_extra_mgmt_ip: ["172.16.188.178/17", "172.16.188.179/17"]
  server: server_1
  vm_base: VM0100
  dut:
    - str-msn2700-01
  inv_name: lab
  auto_recover: 'True'
  comment: Tests Mellanox SN2700 vms
```

After add-topo, we can find 3 IP addresses configured on the mgmt port:

```
root@bafc741834e8:~# ip addr show mgmt
23843: mgmt@if23844: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 5a:be:4d:b5:4e:04 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.255.0.178/23 scope global mgmt
       valid_lft forever preferred_lft forever
    inet 172.16.188.178/17 scope global mgmt
       valid_lft forever preferred_lft forever
    inet 172.16.188.179/17 scope global secondary mgmt
       valid_lft forever preferred_lft forever
```

To keep backward compatibility, key `ptf_extra_mgmt_ip` is not required.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Support config extra MGMT IP addresses on PTF while add-topo.

#### How did you do it?
Updated `add-topo` related ansible playbooks and `testbed-cli.sh` to support this feature.

#### How did you verify/test it?
Verified on below situations:
* Testbed without key `ptf_extra_mgmt_ip`.
* Testbed with `ptf_extra_mgmt_ip: []`.
* Testbed with `ptf_extra_mgmt_ip: [<a-single-extra-ip>]`.
* Testbed with `ptf_extra_mgmt_ip: [<extra-ip-1>, <extra-ip-2>]`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
