### PR TITLE
[qos] fix arppopulate code conflict with multiasic

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -61,6 +61,7 @@ class ThriftInterface(BaseTest):
         else:
             self.dst_server_ip = self.src_server_ip
             dst_server_port = src_server_port
+        self.server = self.dst_server_ip
 
         if "port_map_file" in self.test_params:
             user_input = self.test_params['port_map_file']

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -350,6 +350,16 @@ def fill_leakout_plus_one(
             src_port_id, dst_port_id, pkt.__repr__()[0:180], queue))
     return False
 
+def get_peer_addresses(data):
+    def get_peer_addr(data, addr):
+        if isinstance(data, dict) and 'peer_addr' in data:
+            addr.add(data['peer_addr'])
+        elif isinstance(data, dict):
+            for val in data.values():
+                get_peer_addr(val, addr)
+    addresses = set()
+    get_peer_addr(data, addresses)
+    return list(addresses)
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
@@ -377,8 +387,6 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_vlan_3 = self.test_params['dst_port_3_vlan']
         self.test_port_ids = self.test_params.get("testPortIds", None)
         self.test_port_ips = self.test_params.get("testPortIps", None)
-        self.src_dut_index = self.test_params.get("src_dut_index", 0)
-        self.src_asic_inde = self.test_params.get("src_asic_inde", 0)
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -400,11 +408,10 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         send_packet(self, self.dst_port_3_id, arpreq_pkt)
 
         # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
-        if self.test_port_ids and self.test_port_ips:
-            for portid in self.test_port_ids:
+        if self.test_port_ips:
+            for ip in get_peer_addresses(self.test_port_ips):
                 self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
-                    'ping -q -c 3 {}'.format(
-                    self.test_port_ips[self.src_dut_index][self.src_asic_index][portid]['peer_addr']))
+                    'ping -q -c 3 {}'.format(ip))
 
         time.sleep(8)
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -377,6 +377,8 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_vlan_3 = self.test_params['dst_port_3_vlan']
         self.test_port_ids = self.test_params.get("testPortIds", None)
         self.test_port_ips = self.test_params.get("testPortIps", None)
+        self.src_dut_index = self.test_params.get("src_dut_index", 0)
+        self.src_asic_inde = self.test_params.get("src_asic_inde", 0)
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -401,7 +403,8 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         if self.test_port_ids and self.test_port_ips:
             for portid in self.test_port_ids:
                 self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
-                                     'ping -q -c 3 {}'.format(self.test_port_ips[portid]['peer_addr']))
+                    'ping -q -c 3 {}'.format(
+                    self.test_port_ips[self.src_dut_index][self.src_asic_index][portid]['peer_addr']))
 
         time.sleep(8)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

hit arppopulate issue:

```
======================================================================
ERROR: sai_qos_tests.ARPpopulate
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 404, in runTest
    'ping -q -c 3 {}'.format(self.test_port_ips[portid]['peer_addr']))
KeyError: 'peer_addr'

```

test_port_ips' structure changed to support mulit-asic.
need to acess peer_address using "self.test_port_ips[self.src_dut_index][self.src_asic_index][portid]['peer_addr']" instead of "self.test_port_ips[portid]['peer_addr']"


#### How did you do it?

follow date structure defined by multi-asic

#### How did you verify/test it?

pass local test


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
