### PR TITLE
[acl][mx] Add ipv6 support for mx in test_acl

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -85,15 +85,15 @@ DOWNSTREAM_IP_TO_BLOCK_M0_L3 = {
 }
 
 # Below M0_VLAN IPs are ip in vlan range
-DOWNSTREAM_DST_IP_M0_VLAN = {
+DOWNSTREAM_DST_IP_VLAN = {
     "ipv4": "192.168.0.253",
     "ipv6": "fc02:1000::5"
 }
-DOWNSTREAM_IP_TO_ALLOW_M0_VLAN = {
+DOWNSTREAM_IP_TO_ALLOW_VLAN = {
     "ipv4": "192.168.0.252",
     "ipv6": "fc02:1000::6"
 }
-DOWNSTREAM_IP_TO_BLOCK_M0_VLAN = {
+DOWNSTREAM_IP_TO_BLOCK_VLAN = {
     "ipv4": "192.168.0.251",
     "ipv6": "fc02:1000::7"
 }
@@ -254,12 +254,16 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     # Need to refresh below constants for two scenarios of M0
     global DOWNSTREAM_DST_IP, DOWNSTREAM_IP_TO_ALLOW, DOWNSTREAM_IP_TO_BLOCK
 
+    if topo == "mx":
+        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN
+        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN
+        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN
     # Announce routes for m0 is something different from t1/t0
     if topo_scenario == "m0_vlan_scenario":
         topo = "m0_vlan"
-        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_VLAN
-        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_M0_VLAN
-        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_VLAN
+        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN
+        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN
+        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN
     elif topo_scenario == "m0_l3_scenario":
         topo = "m0_l3"
         DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_L3
@@ -382,8 +386,8 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
 
 
 @pytest.fixture(scope="module", params=["ipv4", "ipv6"])
-def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname, topo_scenario):
-    if tbinfo["topo"]["type"] in ["t0", "mx"] and request.param == "ipv6":
+def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
+    if tbinfo["topo"]["type"] in ["t0"] and request.param == "ipv6":
         pytest.skip("IPV6 ACL test not currently supported on t0/mx testbeds")
 
     return request.param
@@ -913,8 +917,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(7)
 
-    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version,
-                                     topo_scenario):
+    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
@@ -923,12 +926,12 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
-            if topo_scenario == "m0_l3_scenario":
+            if setup["topo"] == "m0_l3":
                 if ip_version == "ipv6":
                     rule_id = 32
                 else:
                     rule_id = 30
-            elif topo_scenario == "m0_vlan_scenario":
+            elif setup["topo"] in ["m0_vlan", "mx"]:
                 if ip_version == "ipv6":
                     rule_id = 34
                 else:
@@ -939,8 +942,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             rule_id = 3
         counters_sanity_check.append(rule_id)
 
-    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version,
-                                   topo_scenario):
+    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
@@ -949,12 +951,12 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
-            if topo_scenario == "m0_l3_scenario":
+            if setup["topo"] == "m0_l3":
                 if ip_version == "ipv6":
                     rule_id = 33
                 else:
                     rule_id = 31
-            elif topo_scenario == "m0_vlan_scenario":
+            elif setup["topo"] in ["m0_vlan", "mx"]:
                 if ip_version == "ipv6":
                     rule_id = 35
                 else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently ipv6 acl test is not supported in mx.

#### How did you do it?
Add support for mx.

#### How did you verify/test it?
Run tests on m0 and mx, all passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
