### PR TITLE
[pretest] add gbsyncd in DEFAULT_ASIC_SERVICES

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -456,11 +456,13 @@ class MultiAsicSonicHost(object):
                 service_name = asic.get_docker_name(feature)
                 if service_name in self.sonichost.critical_services:
                     services.append(service_name)
-
+        logger.info("wenyi: services: {}".format(services))
         for docker in services:
             # This is to avoid gbsyncd check fo VS
             # because VS gbsyncd docker's critical_processes has gbsyncdmgrd
             # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS
+            logger.info("wenyi: asic_type: {}, docker: {}, docker_type: {}, is_gbsyncd: {}, "
+                        .format(self.get_facts()['asic_type'], docker, type(docker), ("gbsyncd" in docker)))
             if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
                 continue
             cmd_disable_rate_limit = (

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -458,9 +458,11 @@ class MultiAsicSonicHost(object):
                     services.append(service_name)
 
         for docker in services:
-            # This is to avoid gbsyncd check fo VS
-            #if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
-            #    continue
+            # This is to avoid gbsyncd check fo VS test_disable_rsyslog_rate_limit
+            # we are still getting whatever enabled feature in test_disable_rsyslog_rate_limit
+            # and gbsyncd feature will be added to services
+            if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
+                continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -460,7 +460,7 @@ class MultiAsicSonicHost(object):
         for docker in services:
             # This is to avoid gbsyncd check fo VS
             # because VS gbsyncd docker's critical_processes has gbsyncdmgrd
-            # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS 
+            # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS
             if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
                 continue
             cmd_disable_rate_limit = (

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -449,15 +449,18 @@ class MultiAsicSonicHost(object):
         Disable Rate limit for a given service
         """
         services = [feature]
+
         if (feature in self.sonichost.DEFAULT_ASIC_SERVICES):
             services = []
             for asic in self.asics:
                 service_name = asic.get_docker_name(feature)
                 if service_name in self.sonichost.critical_services:
                     services.append(service_name)
-        logger.info("wenyi: DEFAULT_ASIC_SERVICES:{}\n critical_services: {} \n services: {}"
-                    .format(self.sonichost.DEFAULT_ASIC_SERVICES, self.sonichost.critical_services, services))
+
         for docker in services:
+            # This is to avoid gbsyncd check for multi-asic, only check gbsyncd0/1/..
+            if self.sonichost.is_multi_asic and docker == "gbsyncd":
+                continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -461,7 +461,7 @@ class MultiAsicSonicHost(object):
             # This is to avoid gbsyncd check fo VS
             # because VS gbsyncd docker's critical_processes has gbsyncdmgrd
             # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS 
-            if self.get_facts()['asic_type'] == 'vs' and docker == "gbsyncd":
+            if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
                 continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -449,14 +449,14 @@ class MultiAsicSonicHost(object):
         Disable Rate limit for a given service
         """
         services = [feature]
-
         if (feature in self.sonichost.DEFAULT_ASIC_SERVICES):
             services = []
             for asic in self.asics:
                 service_name = asic.get_docker_name(feature)
                 if service_name in self.sonichost.critical_services:
                     services.append(service_name)
-
+        logger.info("wenyi: DEFAULT_ASIC_SERVICES:{}\n critical_services: {} \n services: {}"
+                    .format(self.sonichost.DEFAULT_ASIC_SERVICES, self.sonichost.critical_services, services))
         for docker in services:
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -458,8 +458,10 @@ class MultiAsicSonicHost(object):
                     services.append(service_name)
 
         for docker in services:
-            # This is to avoid gbsyncd check for multi-asic, only check gbsyncd0/1/..
-            if self.sonichost.is_multi_asic and docker == "gbsyncd":
+            # This is to avoid gbsyncd check fo VS
+            # because VS gbsyncd docker's critical_processes has gbsyncdmgrd
+            # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS 
+            if self.get_facts()['asic_type'] == 'vs' and docker == "gbsyncd":
                 continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -456,15 +456,11 @@ class MultiAsicSonicHost(object):
                 service_name = asic.get_docker_name(feature)
                 if service_name in self.sonichost.critical_services:
                     services.append(service_name)
-        logger.info("wenyi: services: {}".format(services))
+
         for docker in services:
             # This is to avoid gbsyncd check fo VS
-            # because VS gbsyncd docker's critical_processes has gbsyncdmgrd
-            # while VS is missing gearbox_config.json file, so gbsyncdmgrd would not be running inside gbsyncd on VS
-            logger.info("wenyi: asic_type: {}, docker: {}, docker_type: {}, is_gbsyncd: {}, "
-                        .format(self.get_facts()['asic_type'], docker, type(docker), ("gbsyncd" in docker)))
-            if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
-                continue
+            #if self.get_facts()['asic_type'] == 'vs' and "gbsyncd" in docker:
+            #    continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -458,9 +458,6 @@ class MultiAsicSonicHost(object):
                     services.append(service_name)
 
         for docker in services:
-            # TODO: https://github.com/sonic-net/sonic-mgmt/issues/5970
-            if self.sonichost.is_multi_asic and docker == "gbsyncd":
-                continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -35,7 +35,6 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
-    DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
     """
     setting either one of shell_user/shell_pw or ssh_user/ssh_passwd pair should yield the same result.
@@ -45,7 +44,7 @@ class SonicHost(AnsibleHostBase):
                  ssh_user=None, ssh_passwd=None):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
 
-        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
+        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
 
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,10 +82,10 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
         # Append gbsyncd only for non-VS to avoid pretest check for gbsyncd
         # e.g. in test_feature_status, test_disable_rsyslog_rate_limit
-        if gbsyncd_enabled and self.get_facts()['asic_type'] != 'vs':
+        gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
+        if gbsyncd_enabled and self.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,7 +82,7 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled':
+        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled' and duthost.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -35,7 +35,7 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
-    DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
+    DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
     """
     setting either one of shell_user/shell_pw or ssh_user/ssh_passwd pair should yield the same result.
@@ -45,7 +45,7 @@ class SonicHost(AnsibleHostBase):
                  ssh_user=None, ssh_passwd=None):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
 
-        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
+        self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']
@@ -81,6 +81,9 @@ class SonicHost(AnsibleHostBase):
         self._os_version = self._get_os_version()
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
+        feature_status = self.get_feature_status()
+        if 'gbsyncd' in feature_status.keys() and feature_status['gbsyncd']['status'] == 'enabled':
+            self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False
         self._kernel_version = self._get_kernel_version()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -35,6 +35,7 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
+    DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
 
     """
     setting either one of shell_user/shell_pw or ssh_user/ssh_passwd pair should yield the same result.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -83,6 +83,7 @@ class SonicHost(AnsibleHostBase):
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
         gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
+        logger.info("Wenyi : asic_type: {}".format(self.facts["asic_type"]))
         if gbsyncd_enabled and self.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,7 +82,8 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled' and duthost.facts["asic_type"] != "vs":
+        gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
+        if gbsyncd_enabled and duthost.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -83,7 +83,7 @@ class SonicHost(AnsibleHostBase):
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
         gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
-        if gbsyncd_enabled and duthost.facts["asic_type"] != "vs":
+        if gbsyncd_enabled and self.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,8 +82,7 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
-        if gbsyncd_enabled and self.facts["asic_type"] != "vs":
+        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled':
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -83,7 +83,6 @@ class SonicHost(AnsibleHostBase):
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
         gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
-        logger.info("Wenyi : asic_type: {}".format(self.facts["asic_type"]))
         if gbsyncd_enabled and self.facts["asic_type"] != "vs":
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1438,8 +1438,8 @@ Totals               6450                 6449
             command_output = self.shell(cmd, module_ignore_errors=True)
             if command_output['rc'] == 0:
                 break
-        else:
-            return feature_status, False
+            else:
+                return feature_status, False
 
         features_stdout = command_output['stdout_lines']
         lines = features_stdout[2:]

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,7 +82,10 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled':
+        gbsyncd_enabled = 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled'
+        # Append gbsyncd only for non-VS to avoid pretest check for gbsyncd
+        # e.g. in test_feature_status, test_disable_rsyslog_rate_limit
+        if gbsyncd_enabled and self.get_facts()['asic_type'] != 'vs':
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1437,8 +1437,8 @@ Totals               6450                 6449
             command_output = self.shell(cmd, module_ignore_errors=True)
             if command_output['rc'] == 0:
                 break
-            else:
-                return feature_status, False
+        else:
+            return feature_status, False
 
         features_stdout = command_output['stdout_lines']
         lines = features_stdout[2:]

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -82,7 +82,7 @@ class SonicHost(AnsibleHostBase):
         if 'router_type' in self.facts and self.facts['router_type'] == 'spinerouter':
             self.DEFAULT_ASIC_SERVICES.append("macsec")
         feature_status = self.get_feature_status()
-        if 'gbsyncd' in feature_status.keys() and feature_status['gbsyncd']['status'] == 'enabled':
+        if 'gbsyncd' in feature_status[0].keys() and feature_status[0]['gbsyncd'] == 'enabled':
             self.DEFAULT_ASIC_SERVICES.append("gbsyncd")
         self._sonic_release = self._get_sonic_release()
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. add gbsyncd in DEFAULT_ASIC_SERVICES to accommodate for multi-asic use cases, when gbsyncd feature is enabled
2. avoid gbsyncd check fo VS, VS's gbsyncd critical processes is gbsyncdmgrd, while VS don't have gearbox_config.json file, so gbsyncdmgrd is not running on gbsyncd
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
=========================== short test summary info ============================
SKIPPED [1] /var/src/private/sonic-mgmt-int/tests/test_pretest.py:304: No URL specified for python saithrift package
SKIPPED [1] /var/src/private/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skip updating templates for C.20220531.26
==================== 11 passed, 2 skipped in 312.50 seconds ====================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
