### PR TITLE
[202205] Integrate po2vlan testcases into general qualification pipeline

### DIFF
--- a/tests/common/checkpoint.py
+++ b/tests/common/checkpoint.py
@@ -1,0 +1,91 @@
+import logging
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHECKPOINT_NAME = "backup"
+
+
+def list_checkpoints(duthost):
+    """List checkpoint on target duthost
+
+    Args:
+        duthost: Device Under Test (DUT)
+        cp: checkpoint filename
+    """
+    cmds = 'config list-checkpoints'
+
+    logger.info("Commands: {}".format(cmds))
+    output = duthost.shell(cmds, module_ignore_errors=True)
+
+    pytest_assert(
+        not output['rc'],
+        "Failed to list all checkpoint file"
+    )
+
+    return output
+
+
+def verify_checkpoints_exist(duthost, cp):
+    """Check if checkpoint file exist in duthost
+    """
+    output = list_checkpoints(duthost)
+    return '"{}"'.format(cp) in output['stdout']
+
+
+def create_checkpoint(duthost, cp=DEFAULT_CHECKPOINT_NAME):
+    """Run checkpoint on target duthost
+
+    Args:
+        duthost: Device Under Test (DUT)
+        cp: checkpoint filename
+    """
+    cmds = 'config checkpoint {}'.format(cp)
+
+    logger.info("Commands: {}".format(cmds))
+    output = duthost.shell(cmds, module_ignore_errors=True)
+
+    pytest_assert(
+        not output['rc']
+        and "Checkpoint created successfully" in output['stdout']
+        and verify_checkpoints_exist(duthost, cp),
+        "Failed to config a checkpoint file: {}".format(cp)
+    )
+
+
+def delete_checkpoint(duthost, cp=DEFAULT_CHECKPOINT_NAME):
+    """Run checkpoint on target duthost
+
+    Args:
+        duthost: Device Under Test (DUT)
+        cp: checkpoint filename
+    """
+    pytest_assert(
+        verify_checkpoints_exist(duthost, cp),
+        "Failed to find the checkpoint file: {}".format(cp)
+    )
+
+    cmds = 'config delete-checkpoint {}'.format(cp)
+
+    logger.info("Commands: {}".format(cmds))
+    output = duthost.shell(cmds, module_ignore_errors=True)
+
+    pytest_assert(
+        not output['rc'] and "Checkpoint deleted successfully" in output['stdout'],
+        "Failed to delete a checkpoint file: {}".format(cp)
+    )
+
+
+def rollback(duthost, cp=DEFAULT_CHECKPOINT_NAME):
+    """Run rollback on target duthost
+
+    Args:
+        duthost: Device Under Test (DUT)
+        cp: rollback filename
+    """
+    cmds = 'config rollback {}'.format(cp)
+
+    logger.info("Commands: {}".format(cmds))
+    output = duthost.shell(cmds, module_ignore_errors=True)
+
+    return output

--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -1,0 +1,398 @@
+import pytest
+import ptf.testutils as testutils
+import collections
+import ipaddress
+import time
+import sys
+from netaddr import valid_ipv4
+
+from tests.common.helpers.assertions import pytest_require
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
+from tests.common.fixtures.duthost_utils import ports_list   # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig          # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add
+from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
+from tests.common.checkpoint import create_checkpoint, rollback
+
+
+# TODO: Remove this once we no longer support Python 2
+if sys.version_info.major >= 3:
+    UNICODE_TYPE = str
+else:
+    UNICODE_TYPE = unicode      # noqa F821
+
+SETUP_ENV_CP = "test_setup_checkpoint"
+PTF_LAG_NAME = "bond1"
+DUT_LAG_NAME = "PortChannel1"
+ATTR_PORT_BEHIND_LAG = "port_behind_lag"
+ATTR_PORT_TEST = "port_for_test"
+ATTR_PORT_NO_TEST = "port_not_for_test"
+
+
+def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
+                      src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
+
+    pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
+                                       eth_dst=dst_mac,
+                                       eth_src=src_mac,
+                                       dl_vlan_enable=False if vlan_id == 0 else True,
+                                       vlan_vid=vlan_id,
+                                       vlan_pcp=0,
+                                       ip_src=src_ip,
+                                       ip_dst=dst_ip,
+                                       ip_ttl=ttl)
+    return pkt
+
+
+def populate_fdb(ptfadapter, vlan_ports_list, vlan_intfs_dict):
+    # send icmp packet from each tagged and untagged port in each test vlan to populate fdb
+    for vlan in vlan_intfs_dict:
+        for vlan_port in vlan_ports_list:
+            if vlan in vlan_port['permit_vlanid']:
+                # vlan_id: 0 - untagged, vlan = tagged
+                vlan_id = 0 if vlan == vlan_port['pvid'] else vlan
+                port_id = vlan_port['port_index'][0]
+                src_mac = ptfadapter.dataplane.get_mac(0, port_id)
+                pkt = build_icmp_packet(vlan_id=vlan_id, src_mac=src_mac)
+                testutils.send(ptfadapter, port_id, pkt)
+
+
+def ptf_teardown(ptfhost, ptf_lag_map):
+    """
+    Restore ptf configuration
+
+    Args:
+        ptfhost: PTF host object
+        ptf_lag_map: imformation about lag in ptf
+    """
+    ptfhost.set_dev_no_master(PTF_LAG_NAME)
+
+    for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
+        ptfhost.set_dev_no_master(ptf_lag_member)
+        ptfhost.set_dev_up_or_down(ptf_lag_member, True)
+
+    ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
+    ptfhost.ptf_nn_agent()
+
+
+def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
+    """
+    Setup dut lag
+
+    Args:
+        duthost: DUT host object
+        dut_ports: ports need to configure
+        vlan: information about vlan configuration
+        src_vlan_id: original vlan id
+
+    Returns:
+        information about dut lag
+    """
+    # Port in acl table can't be added to port channel, and acl table can only be updated by json file
+    duthost.remove_acl_table("EVERFLOW")
+    duthost.remove_acl_table("EVERFLOWV6")
+    # Create port channel
+    duthost.shell("config portchannel add {}".format(DUT_LAG_NAME))
+
+    lag_port_list = []
+    port_list_idx = 0
+    port_list = list(dut_ports[ATTR_PORT_BEHIND_LAG].values())
+    # Add ports to port channel
+    for port_list_idx in range(0, len(dut_ports[ATTR_PORT_BEHIND_LAG])):
+        port_name = port_list[port_list_idx]
+        duthost.del_member_from_vlan(src_vlan_id, port_name)
+        duthost.shell("config portchannel member add {} {}".format(DUT_LAG_NAME, port_name))
+        lag_port_list.append(port_name)
+        port_list_idx += 1
+    port_list = list(dut_ports[ATTR_PORT_NO_TEST].values())
+    # Remove ports from vlan
+    for port_list_idx in range(0, len(dut_ports[ATTR_PORT_NO_TEST])):
+        port_name = port_list[port_list_idx]
+        duthost.del_member_from_vlan(src_vlan_id, port_name)
+
+    duthost.shell("config vlan add {}".format(vlan["id"]))
+    duthost.shell("config interface ip add Vlan{} {}".format(vlan["id"], vlan["ip"]))
+    duthost.add_member_to_vlan(vlan["id"], DUT_LAG_NAME, True)
+    duthost.add_member_to_vlan(src_vlan_id, DUT_LAG_NAME, True)
+
+    lag_port_map = {}
+    lag_port_map[DUT_LAG_NAME] = lag_port_list
+    lag_port_map["vlan"] = vlan
+    return lag_port_map
+
+
+def setup_ptf_lag(ptfhost, ptf_ports, vlan):
+    """
+    Setup ptf lag
+
+    Args:
+        ptfhost: PTF host object
+        ptf_ports: ports need to configure
+        vlan: information about vlan configuration
+
+    Returns:
+        information about ptf lag
+    """
+    ip_splits = vlan["ip"].split("/")
+    vlan_ip = ipaddress.ip_address(UNICODE_TYPE(ip_splits[0]))
+    lag_ip = "{}/{}".format(vlan_ip + 1, ip_splits[1])
+    # Add lag
+    ptfhost.create_lag(PTF_LAG_NAME, lag_ip, "802.3ad")
+
+    port_list = []
+    # Add member to lag
+    for _, port_name in list(ptf_ports[ATTR_PORT_BEHIND_LAG].items()):
+        ptfhost.add_intf_to_lag(PTF_LAG_NAME, port_name)
+        port_list.append(port_name)
+
+    lag_port_map = {}
+    lag_port_map[PTF_LAG_NAME] = {
+        "port_list": port_list,
+    }
+
+    ptfhost.startup_lag(PTF_LAG_NAME)
+    ptfhost.ptf_nn_agent()
+    # Wait for lag sync
+    time.sleep(10)
+
+    return lag_port_map
+
+
+def setup_dut_ptf(ptfhost, duthost, tbinfo, vlan_intfs_dict):
+    """
+    Setup dut and ptf based on ports available in dut vlan
+
+    Args:
+        ptfhost: PTF host object
+        duthost: DUT host object
+        tbinfo: fixture provides information about testbed
+
+    Returns:
+        information about lag of ptf and dut
+    """
+    number_of_lag_member = 2
+    number_of_test_ports = 4
+
+    # Get id of vlan that concludes enough up ports as src_vlan_id, port in this vlan is used for testing
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+    src_vlan_id = get_vlan_id(cfg_facts, number_of_lag_member)
+    pytest_require(src_vlan_id != -1, "Can't get usable vlan concluding enough member")
+
+    dut_ports = {
+        ATTR_PORT_BEHIND_LAG: {},
+        ATTR_PORT_TEST: {},
+        ATTR_PORT_NO_TEST: {},
+    }
+    src_vlan_members = cfg_facts["VLAN_MEMBER"]["Vlan{}".format(src_vlan_id)]
+    # Get the port correspondence between DUT and PTF
+    port_index_map = cfg_facts["port_index_map"]
+    # Get dut_ports (behind / not behind lag) used for creating dut lag by src_vlan_members and port_index_map
+    for port_name, _ in list(src_vlan_members.items()):
+        port_id = port_index_map[port_name]
+        if len(dut_ports[ATTR_PORT_BEHIND_LAG]) < number_of_lag_member:
+            dut_ports[ATTR_PORT_BEHIND_LAG][port_id] = port_name
+        elif len(dut_ports[ATTR_PORT_TEST]) < number_of_test_ports:
+            dut_ports[ATTR_PORT_TEST][port_id] = port_name
+        else:
+            dut_ports[ATTR_PORT_NO_TEST][port_id] = port_name
+
+    ptf_ports = {
+        ATTR_PORT_BEHIND_LAG: {},
+    }
+    duts_map = tbinfo["duts_map"]
+    dut_indx = duts_map[duthost.hostname]
+    # Get available port in PTF
+    host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+    ptf_ports_available_in_topo = {}
+    for key in host_interfaces:
+        ptf_ports_available_in_topo[host_interfaces[key]] = "eth{}".format(key)
+
+    # Get ptf_ports (behind / not behind lag) used for creating ptf lag by ptf_ports_available_in_topo and dut_ports
+    for port_id in ptf_ports_available_in_topo:
+        if port_id in dut_ports[ATTR_PORT_BEHIND_LAG]:
+            ptf_ports[ATTR_PORT_BEHIND_LAG][port_id] = ptf_ports_available_in_topo[port_id]
+
+    pytest_require(len(ptf_ports[ATTR_PORT_BEHIND_LAG]) == len(dut_ports[ATTR_PORT_BEHIND_LAG]),
+                   "Can't get enough ports in ptf")
+
+    vlan = {}
+    for k, v in vlan_intfs_dict.items():
+        if v['orig'] is False:
+            vlan['id'] = k
+            vlan['ip'] = v['ip']
+            break
+    dut_lag_map = setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id)
+    ptf_lag_map = setup_ptf_lag(ptfhost, ptf_ports, vlan)
+    return dut_lag_map, ptf_lag_map, src_vlan_id
+
+
+def get_vlan_id(cfg_facts, number_of_lag_member):
+    """
+    Determine if Vlan have enough port members needed
+
+    Args:
+        cfg_facts: DUT config facts
+        number_of_lag_member: number of lag members needed for test
+    """
+    port_status = cfg_facts["PORT"]
+    src_vlan_id = -1
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        # Number of members in vlan is insufficient
+        if len(members) < number_of_lag_member + 1:
+            continue
+
+        # Get count of available port in vlan
+        count = 0
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+
+            count += 1
+            if count == number_of_lag_member + 1:
+                src_vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if src_vlan_id != -1:
+            break
+    return src_vlan_id
+
+
+def running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list): # noqa F811
+    """
+    Read running config facts and get vlan ports list
+
+    Args:
+        duthosts: DUT host object
+        rand_one_dut_hostname: random one dut hostname
+        rand_selected_dut: random selected dut
+        tbinfo: fixture provides information about testbed
+        ports_list: list of ports
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    vlan_ports_list = []
+    config_ports = {k: v for k, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', 'down') == 'up'}
+    config_portchannels = cfg_facts.get('PORTCHANNEL_MEMBER', {})
+    config_port_indices = {k: v for k, v in list(mg_facts['minigraph_ptf_indices'].items()) if k in config_ports}
+    config_ports_vlan = collections.defaultdict(list)
+    vlan_members = cfg_facts.get('VLAN_MEMBER', {})
+    # key is dev name, value is list for configured VLAN member.
+    for k, v in list(cfg_facts['VLAN'].items()):
+        vlanid = v['vlanid']
+        for addr in cfg_facts['VLAN_INTERFACE']['Vlan'+vlanid]:
+            # address could be IPV6 and IPV4, only need IPV4 here
+            if addr and valid_ipv4(addr.split('/')[0]):
+                ip = addr
+                break
+        else:
+            continue
+        if k not in vlan_members:
+            continue
+        for port in vlan_members[k]:
+            if 'tagging_mode' not in vlan_members[k][port]:
+                continue
+            mode = vlan_members[k][port]['tagging_mode']
+            config_ports_vlan[port].append({'vlanid': int(vlanid), 'ip': ip, 'tagging_mode': mode})
+
+    if config_portchannels:
+        for po in config_portchannels:
+            vlan_port = {
+                'dev': po,
+                'port_index': [config_port_indices[member] for member in list(config_portchannels[po].keys())],
+                'permit_vlanid': []
+            }
+            if po in config_ports_vlan:
+                vlan_port['pvid'] = 0
+                for vlan in config_ports_vlan[po]:
+                    if 'vlanid' not in vlan or 'ip' not in vlan or 'tagging_mode' not in vlan:
+                        continue
+                    if vlan['tagging_mode'] == 'untagged':
+                        vlan_port['pvid'] = vlan['vlanid']
+                    vlan_port['permit_vlanid'].append(vlan['vlanid'])
+            if 'pvid' in vlan_port:
+                vlan_ports_list.append(vlan_port)
+
+    for i, port in enumerate(ports_list):
+        vlan_port = {
+            'dev': port,
+            'port_index': [config_port_indices[port]],
+            'permit_vlanid': []
+        }
+        if port in config_ports_vlan:
+            vlan_port['pvid'] = 0
+            for vlan in config_ports_vlan[port]:
+                if 'vlanid' not in vlan or 'ip' not in vlan or 'tagging_mode' not in vlan:
+                    continue
+                if vlan['tagging_mode'] == 'untagged':
+                    vlan_port['pvid'] = vlan['vlanid']
+                vlan_port['permit_vlanid'].append(vlan['vlanid'])
+        if 'pvid' in vlan_port:
+            vlan_ports_list.append(vlan_port)
+
+    return vlan_ports_list
+
+
+@pytest.fixture(scope="module")
+def cfg_facts(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    return duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+
+
+@pytest.fixture(scope="module")
+def vlan_intfs_dict(tbinfo, utils_vlan_intfs_dict_orig):        # noqa F811
+    vlan_intfs_dict = utils_vlan_intfs_dict_orig
+    # For t0 topo, will add VLAN for test.
+    # Need to make sure vlan id is unique, and avoid vlan ip network overlapping.
+    # For example, ip prefix is 192.168.0.1/21 for VLAN 1000,
+    # Below ip prefix overlaps with 192.168.0.1/21, and need to skip:
+    # 192.168.0.1/24, 192.168.1.1/24, 192.168.2.1/24, 192.168.3.1/24,
+    # 192.168.4.1/24, 192.168.5.1/24, 192.168.6.1/24, 192.168.7.1/24
+    vlan_intfs_dict = utils_vlan_intfs_dict_add(vlan_intfs_dict, 1)
+    return vlan_intfs_dict
+
+
+@pytest.fixture(scope="module")
+def acl_rule_cleanup(duthost, tbinfo):
+    """Cleanup all the existing DATAACL rules"""
+    # remove all rules under the ACL_RULE table
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.shell('acl-loader delete')
+
+    yield
+
+
+@pytest.fixture(scope="module")
+def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
+    """ Remove the DATAACL table prior to the test and recreate it at the end"""
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.command('config acl remove table DATAACL')
+
+    yield
+
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.command('config acl remove table DATAACL')
+        # rebind with new set of ports
+        bind_acl_table(duthost, tbinfo)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, ptfadapter,
+               ports_list, tbinfo, vlan_intfs_dict, setup_acl_table):  # noqa F811
+    duthost = duthosts[rand_one_dut_hostname]
+    # --------------------- Setup -----------------------
+    try:
+        create_checkpoint(duthost, SETUP_ENV_CP)
+        dut_lag_map, ptf_lag_map, src_vlan_id = setup_dut_ptf(ptfhost, duthost, tbinfo, vlan_intfs_dict)
+
+        vp_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
+        populate_fdb(ptfadapter, vp_list, vlan_intfs_dict)
+        bind_acl_table(duthost, tbinfo)
+        apply_acl_rules(duthost, tbinfo)
+    # --------------------- Testing -----------------------
+        yield
+    # --------------------- Teardown -----------------------
+    finally:
+        rollback(duthost, SETUP_ENV_CP)
+        ptf_teardown(ptfhost, ptf_lag_map)

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -3,7 +3,7 @@ import pytest
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from ptf.mask import Mask
-
+from collections import defaultdict
 import time
 import itertools
 import logging
@@ -21,6 +21,14 @@ from tests.common.dualtor.mux_simulator_control import mux_server_url, \
                                                        toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.dualtor.dual_tor_common import active_active_ports        # noqa F401
 from .utils import fdb_cleanup, send_eth, send_arp_request, send_arp_reply, send_recv_eth
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig          # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add           # noqa F401
+from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table        # noqa F401
+from tests.common.fixtures.duthost_utils import ports_list            # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_acl_table  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup # noqa F401
+from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx'),
@@ -38,6 +46,7 @@ PKT_TYPES = ["ethernet", "arp_request", "arp_reply", "cleanup"]
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(scope="module")
 def get_dummay_mac_count(tbinfo):
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
@@ -50,6 +59,7 @@ def get_dummay_mac_count(tbinfo):
         logger.info("Use dummy mac count {} on topo {}\n".format(DUMMY_MAC_COUNT, tbinfo["topo"]["name"]))
         return DUMMY_MAC_COUNT
 
+
 def simple_eth_packet(
     pktlen=60,
     eth_dst="00:01:02:03:04:05",
@@ -61,14 +71,15 @@ def simple_eth_packet(
     if vlan_vid or vlan_pcp:
         pktlen += 4
         pkt /= scapy.Dot1Q(vlan=vlan_vid, prio=vlan_pcp)
-        pkt[scapy.Dot1Q : 1].type = DEFAULT_FDB_ETHERNET_TYPE
+        pkt[scapy.Dot1Q: 1].type = DEFAULT_FDB_ETHERNET_TYPE
     else:
         pkt.type = DEFAULT_FDB_ETHERNET_TYPE
     pkt = pkt / ("0" * (pktlen - len(pkt)))
 
     return pkt
 
-def send_eth(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
+
+def send_eth(ptfadapter, source_port, source_mac, dest_mac, vlan_id):       # noqa F811
     """
     send ethernet packet
     :param ptfadapter: PTF adapter object
@@ -83,11 +94,12 @@ def send_eth(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
         eth_src=source_mac,
         vlan_vid=vlan_id
     )
-    logger.debug('send packet source port id {} smac: {} dmac: {} vlan: {}'.format(source_port, source_mac, dest_mac, vlan_id))
+    logger.debug('send packet source port id {} smac: {} dmac: {} vlan: {}'
+                 .format(source_port, source_mac, dest_mac, vlan_id))
     testutils.send(ptfadapter, source_port, pkt)
 
 
-def send_arp_request(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
+def send_arp_request(ptfadapter, source_port, source_mac, dest_mac, vlan_id):       # noqa F811
     """
     send arp request packet
     :param ptfadapter: PTF adapter object
@@ -98,20 +110,22 @@ def send_arp_request(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
     :return:
     """
     pkt = testutils.simple_arp_packet(pktlen=60,
-                eth_dst=dest_mac,
-                eth_src=source_mac,
-                vlan_vid=vlan_id,
-                vlan_pcp=0,
-                arp_op=1,
-                ip_snd='10.10.1.3',
-                ip_tgt='10.10.1.2',
-                hw_snd=source_mac,
-                hw_tgt='ff:ff:ff:ff:ff:ff',
-                )
-    logger.debug('send ARP request packet source port id {} smac: {} dmac: {} vlan: {}'.format(source_port, source_mac, dest_mac, vlan_id))
+                                      eth_dst=dest_mac,
+                                      eth_src=source_mac,
+                                      vlan_vid=vlan_id,
+                                      vlan_pcp=0,
+                                      arp_op=1,
+                                      ip_snd='10.10.1.3',
+                                      ip_tgt='10.10.1.2',
+                                      hw_snd=source_mac,
+                                      hw_tgt='ff:ff:ff:ff:ff:ff',
+                                      )
+    logger.debug('send ARP request packet source port id {} smac: {} dmac: {} vlan: {}'
+                 .format(source_port, source_mac, dest_mac, vlan_id))
     testutils.send(ptfadapter, source_port, pkt)
 
-def send_arp_reply(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
+
+def send_arp_reply(ptfadapter, source_port, source_mac, dest_mac, vlan_id):     # noqa F811
     """
     send arp reply packet
     :param ptfadapter: PTF adapter object
@@ -122,20 +136,22 @@ def send_arp_reply(ptfadapter, source_port, source_mac, dest_mac, vlan_id):
     :return:
     """
     pkt = testutils.simple_arp_packet(eth_dst=dest_mac,
-                eth_src=source_mac,
-                vlan_vid=vlan_id,
-                vlan_pcp=0,
-                arp_op=2,
-                ip_snd='10.10.1.2',
-                ip_tgt='10.10.1.3',
-                hw_tgt=dest_mac,
-                hw_snd=source_mac,
-                )
-    logger.debug('send ARP reply packet source port id {} smac: {} dmac: {} vlan: {}'.format(source_port, source_mac, dest_mac, vlan_id))
+                                      eth_src=source_mac,
+                                      vlan_vid=vlan_id,
+                                      vlan_pcp=0,
+                                      arp_op=2,
+                                      ip_snd='10.10.1.2',
+                                      ip_tgt='10.10.1.3',
+                                      hw_tgt=dest_mac,
+                                      hw_snd=source_mac,
+                                      )
+    logger.debug('send ARP reply packet source port id {} smac: {} dmac: {} vlan: {}'
+                 .format(source_port, source_mac, dest_mac, vlan_id))
     testutils.send(ptfadapter, source_port, pkt)
 
 
-def send_recv_eth(duthost, ptfadapter, source_ports, source_mac, dest_ports, dest_mac, src_vlan, dst_vlan):
+def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                # noqa F811
+                  dest_ports, dest_mac, src_vlan, dst_vlan):
     """
     send ethernet packet and verify it on dest_port
     :param ptfadapter: PTF adapter object
@@ -162,8 +178,8 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac, dest_ports, des
         # need to use Mask to ignore the priority field.
         exp_pkt = Mask(exp_pkt)
         exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
-    logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}'.format(
-        source_ports, source_mac, dest_mac, src_vlan, dest_ports))
+    logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}'
+                 .format(source_ports, source_mac, dest_mac, src_vlan, dest_ports))
 
     # fdb test will send lots of pkts between paired ports, it's hard to guarantee there is no congestion
     # on server side during this period. So tolerant to retry 3 times before complain the assert.
@@ -175,11 +191,13 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac, dest_ports, des
             ptfadapter.dataplane.flush()
             testutils.send(ptfadapter, source_ports[0], pkt, count=pkt_count)
             if len(dest_ports) == 1:
-                testutils.verify_packet(ptfadapter, exp_pkt, dest_ports[0], timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
+                testutils.verify_packet(ptfadapter, exp_pkt, dest_ports[0],
+                                        timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
             else:
-                testutils.verify_packet_any_port(ptfadapter, exp_pkt, dest_ports, timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
+                testutils.verify_packet_any_port(ptfadapter, exp_pkt, dest_ports,
+                                                 timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
             break
-        except:
+        except Exception:
             # Send 10 pkts in retry to make this test case to be more tolerent of congestion on server/ptf
             pkt_count = 10
             pass
@@ -187,7 +205,9 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac, dest_ports, des
         result = duthost.command("show mac", module_ignore_errors=True)
         logger.info("Dest MAC is {}, show mac results {}".format(dest_mac, result['stdout']))
         pytest_assert(False, "Expected packet was not received on ports {}"
-                             "Dest MAC in fdb is {}".format(dest_ports, dest_mac.lower() in result['stdout'].lower()))
+                             "Dest MAC in fdb is {}"
+                             .format(dest_ports, dest_mac.lower() in result['stdout'].lower()))
+
 
 def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):
     """
@@ -216,7 +236,7 @@ def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):
             send_eth(ptfadapter, port_index, mac, router_mac, vlan_id)
 
             # put in learned MAC
-            fdb[port_index] = { mac }
+            fdb[port_index] = {mac}
 
             # Send packets to switch to populate the layer 2 table with dummy MACs for each port
             # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
@@ -284,6 +304,7 @@ def setup_active_active_ports(active_active_ports, rand_selected_dut, rand_unsel
 
 
 @pytest.mark.bsl
+@pytest.mark.po2vlan
 def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type,
              toggle_all_simulator_ports_to_rand_selected_tor_m, record_mux_status,              # noqa F811
              setup_active_active_ports, get_dummay_mac_count):                                  # noqa F811
@@ -298,32 +319,33 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
     2. verify show mac command on DUT for learned mac.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    conf_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+    conf_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
 
     # reinitialize data plane due to above changes on PTF interfaces
     ptfadapter.reinit()
 
     router_mac = duthost.facts['router_mac']
 
-    port_index_to_name = { v: k for k, v in conf_facts['port_index_map'].items() }
+    port_index_to_name = {v: k for k, v in list(conf_facts['port_index_map'].items())}
 
     configured_dummay_mac_count = get_dummay_mac_count
     # Only take interfaces that are in ptf topology
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
     available_ports_idx = []
-    for idx, name in ptf_ports_available_in_topo.items():
-        if idx in port_index_to_name and conf_facts['PORT'][port_index_to_name[idx]].get('admin_status', 'down') == 'up':
+    for idx, name in list(ptf_ports_available_in_topo.items()):
+        if idx in port_index_to_name and \
+                conf_facts['PORT'][port_index_to_name[idx]].get('admin_status', 'down') == 'up':
             available_ports_idx.append(idx)
 
     vlan_table = {}
     interface_table = defaultdict(set)
     config_portchannels = conf_facts.get('PORTCHANNEL', {})
 
-    for name, vlan in conf_facts['VLAN'].items():
+    for name, vlan in list(conf_facts['VLAN'].items()):
         vlan_id = int(vlan['vlanid'])
         vlan_table[vlan_id] = []
 
-        for ifname in conf_facts['VLAN_MEMBER'][name].keys():
+        for ifname in list(conf_facts['VLAN_MEMBER'][name].keys()):
             if 'tagging_mode' not in conf_facts['VLAN_MEMBER'][name][ifname]:
                 continue
             tagging_mode = conf_facts['VLAN_MEMBER'][name][ifname]['tagging_mode']
@@ -335,12 +357,12 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
                 if port_index:
                     interface_table[ifname].add(vlan_id)
             elif conf_facts['port_index_map'][ifname] in available_ports_idx:
-                    port_index.append(conf_facts['port_index_map'][ifname])
-                    interface_table[ifname].add(vlan_id)
+                port_index.append(conf_facts['port_index_map'][ifname])
+                interface_table[ifname].add(vlan_id)
             if port_index:
-                vlan_table[vlan_id].append({'port_index':port_index, 'tagging_mode':tagging_mode})
+                vlan_table[vlan_id].append({'port_index': port_index, 'tagging_mode': tagging_mode})
 
-    vlan_member_count = sum([ len(members) for members in vlan_table.values() ])
+    vlan_member_count = sum([len(members) for members in list(vlan_table.values())])
 
     fdb = setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, configured_dummay_mac_count)
     for vlan in vlan_table:
@@ -362,8 +384,8 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
 
     dummy_mac_count = 0
     total_mac_count = 0
-    for k, vl in fdb_fact.items():
-        assert validate_mac(k) == True
+    for k, vl in list(fdb_fact.items()):
+        assert validate_mac(k) is True
         for v in vl:
             assert v['port'] in interface_table
             assert v['vlan'] in interface_table[v['port']]
@@ -405,5 +427,4 @@ def test_self_mac_not_learnt(ptfadapter, rand_selected_dut, pkt_type,
     time.sleep(5)
     # Verify that self mac is not learnt
     fdb_facts = rand_selected_dut.fdb_facts()['ansible_facts']
-    pytest_assert(self_mac not in fdb_facts,
-                    "Self-mac {} is not supposed to be learnt".format(self_mac))
+    pytest_assert(self_mac not in fdb_facts, "Self-mac {} is not supposed to be learnt".format(self_mac))

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,6 +2,7 @@
 markers:
     acl: ACL tests
     bsl: BSL tests
+    po2vlan: Portchannel to VLAN tests
     reboot: tests which perform SONiC reboot
     port_toggle: tests which toggle ports
     disable_loganalyzer: make to disable automatic loganalyzer

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -4,11 +4,19 @@ import logging
 import pprint
 import time
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # lgtm[py/unused-import]
-from tests.common.fixtures.duthost_utils import ports_list, utils_vlan_ports_list
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.snmp_helpers import get_snmp_facts
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig          # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add           # noqa F401
+from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table        # noqa F401
+from tests.common.fixtures.duthost_utils import ports_list            # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_acl_table  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup # noqa F401
+from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
+from tests.common.helpers.portchannel_to_vlan import running_vlan_ports_list
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +29,14 @@ PTF_PORT_MAPPING_MODE = "use_orig_interface"
 
 DUMMY_MAC_PREFIX = "02:11:22:33"
 
+
 def get_fdb_dynamic_mac_count(duthost):
     res = duthost.command('show mac')
-    logger.info('"show mac" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
+    logger.info('"show mac" output on DUT:\n{}'.format(
+        pprint.pformat(res['stdout_lines'])))
     total_mac_count = 0
-    for l in res['stdout_lines']:
-        if "dynamic" in l.lower() and DUMMY_MAC_PREFIX in l.lower():
+    for mac in res['stdout_lines']:
+        if "dynamic" in mac.lower() and DUMMY_MAC_PREFIX in mac.lower():
             total_mac_count += 1
     return total_mac_count
 
@@ -42,41 +52,51 @@ def fdb_cleanup(duthost):
         return
     else:
         duthost.command('sonic-clear fdb all')
-        assert wait_until(20, 2, 0, fdb_table_has_no_dynamic_macs, duthost), "FDB Table Cleanup failed"
+        assert wait_until(20, 2, 0, fdb_table_has_no_dynamic_macs,
+                          duthost), "FDB Table Cleanup failed"
 
 
 def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
-                        src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
+                      src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
 
     pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
-                                eth_dst=dst_mac,
-                                eth_src=src_mac,
-                                dl_vlan_enable=False if vlan_id == 0 else True,
-                                vlan_vid=vlan_id,
-                                vlan_pcp=0,
-                                ip_src=src_ip,
-                                ip_dst=dst_ip,
-                                ip_ttl=ttl)
+                                       eth_dst=dst_mac,
+                                       eth_src=src_mac,
+                                       dl_vlan_enable=False if vlan_id == 0 else True,
+                                       vlan_vid=vlan_id,
+                                       vlan_pcp=0,
+                                       ip_src=src_ip,
+                                       ip_dst=dst_ip,
+                                       ip_ttl=ttl)
     return pkt
 
 
 @pytest.mark.bsl
-def test_snmp_fdb_send_tagged(ptfadapter, utils_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m, duthost, localhost, creds_all_duts):
+@pytest.mark.po2vlan
+def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,          # noqa F811
+                              toggle_all_simulator_ports_to_rand_selected_tor_m,    # noqa F811
+                              rand_selected_dut, tbinfo, ports_list, localhost, creds_all_duts): # noqa F811
     """
     Send tagged packets from each port.
     Verify SNMP FDB entry
     """
-    cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+    duthost = duthosts[rand_one_dut_hostname]
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")[
+        'ansible_facts']
     config_portchannels = cfg_facts.get('PORTCHANNEL', {})
     send_cnt = 0
     send_portchannels_cnt = 0
-    for vlan_port in utils_vlan_ports_list:
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
+    for vlan_port in vlan_ports_list:
         port_index = vlan_port["port_index"][0]
         for permit_vlanid in map(int, vlan_port["permit_vlanid"]):
-            dummy_mac = '{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, (port_index>>8)&0xFF, port_index&0xFF)
+            dummy_mac = '{}:{:02x}:{:02x}'.format(
+                DUMMY_MAC_PREFIX, (port_index >> 8) & 0xFF, port_index & 0xFF)
             pkt = build_icmp_packet(permit_vlanid, dummy_mac)
-            logger.info("Send tagged({}) packet from {} ...".format(permit_vlanid, port_index))
-            logger.info(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
+            logger.info("Send tagged({}) packet from {} ...".format(
+                permit_vlanid, port_index))
+            logger.info(pkt.sprintf(
+                "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
             testutils.send(ptfadapter, port_index, pkt)
             send_cnt += 1
             if vlan_port['dev'] in config_portchannels:
@@ -85,8 +105,11 @@ def test_snmp_fdb_send_tagged(ptfadapter, utils_vlan_ports_list, toggle_all_simu
     ptfadapter.dataplane.flush()
 
     time.sleep(10)
-    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+    snmp_facts = get_snmp_facts(
+        localhost, host=hostip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     assert 'snmp_fdb' in snmp_facts
     assert 'snmp_interfaces' in snmp_facts
     dummy_mac_cnt = 0

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -3,20 +3,17 @@ import ptf.packet as scapy
 import ptf.testutils as testutils
 from ptf.mask import Mask
 
-import itertools
 import logging
-import pprint
-import time
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # lgtm[py/unused-import]
-from tests.common.config_reload import config_reload
-from tests.common.utilities import wait_until
-from tests.common.fixtures.duthost_utils import ports_list, utils_vlan_ports_list
-from tests.common.fixtures.duthost_utils import utils_create_test_vlans
-from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig
-from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add
-from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig          # noqa F401
+from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add           # noqa F401
+from tests.common.fixtures.duthost_utils import ports_list            # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_acl_table  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup # noqa F401
+from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F401
+from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
+from tests.common.helpers.portchannel_to_vlan import running_vlan_ports_list
 
 logger = logging.getLogger(__name__)
 
@@ -27,205 +24,19 @@ pytestmark = [
 # Use original ports intead of sub interfaces for ptfadapter if it's t0-backend
 PTF_PORT_MAPPING_MODE = "use_orig_interface"
 
-# Only test the first 2 portchannels
-PORTCHANNELS_TEST_NUM = 2
-
-
-@pytest.fixture(scope="module")
-def cfg_facts(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    return duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-
-@pytest.fixture(scope="module")
-def vlan_intfs_dict(tbinfo, utils_vlan_intfs_dict_orig):
-    vlan_intfs_dict = utils_vlan_intfs_dict_orig
-    # For t0 topo, will add 2 VLANs for test.
-    # Need to make sure vlan id is unique, and avoid vlan ip network overlapping.
-    # For example, ip prefix is 192.168.0.1/21 for VLAN 1000,
-    # Below ip prefix overlaps with 192.168.0.1/21, and need to skip:
-    # 192.168.0.1/24, 192.168.1.1/24, 192.168.2.1/24, 192.168.3.1/24,
-    # 192.168.4.1/24, 192.168.5.1/24, 192.168.6.1/24, 192.168.7.1/24
-    if tbinfo['topo']['name'] != 't0-56-po2vlan':
-        vlan_intfs_dict = utils_vlan_intfs_dict_add(vlan_intfs_dict, 2)
-    return vlan_intfs_dict
-
-
-@pytest.fixture(scope="module")
-def work_vlan_ports_list(rand_selected_dut, tbinfo, cfg_facts, ports_list, utils_vlan_ports_list, vlan_intfs_dict, pc_num=PORTCHANNELS_TEST_NUM):
-    if tbinfo['topo']['name'] == 't0-56-po2vlan':
-        return utils_vlan_ports_list
-
-    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
-    work_vlan_ports_list = []
-    config_ports = {k: v for k,v in cfg_facts['PORT'].items() if v.get('admin_status', 'down') == 'up'}
-    config_portchannels = cfg_facts.get('PORTCHANNEL', {})
-    config_port_indices = {k: v for k, v in mg_facts['minigraph_ptf_indices'].items() if k in config_ports}
-
-    # For t0 topo, will add port to new VLAN, use 'orig' field to identify new VLAN.
-    vlan_id_list = [k for k, v in vlan_intfs_dict.items() if v['orig'] == False]
-    pvid_cycle = itertools.cycle(vlan_id_list)
-    # when running on t0 we can use the portchannel members
-    if config_portchannels:
-        portchannel_cnt = 0
-        for po in config_portchannels:
-            vlan_port = {
-                'dev' : po,
-                'port_index' : [config_port_indices[member] for member in config_portchannels[po]['members']],
-                'permit_vlanid' : []
-            }
-            # Add 2 portchannels for test
-            if portchannel_cnt < pc_num:
-                portchannel_cnt += 1
-                vlan_port['pvid'] = pvid_cycle.next()
-                vlan_port['permit_vlanid'] = vlan_id_list[:]
-            if 'pvid' in vlan_port:
-                work_vlan_ports_list.append(vlan_port)
-        assert portchannel_cnt == pc_num, 'Need 2 portchannels for test'
-
-    for i, port in enumerate(ports_list):
-        vlan_port = {
-            'dev' : port,
-            'port_index' : [config_port_indices[port]],
-            'permit_vlanid' : []
-        }
-        # Add 4 ports for test
-        if i < 4:
-            vlan_port['pvid'] = pvid_cycle.next()
-            vlan_port['permit_vlanid'] = vlan_id_list[:]
-        if 'pvid' in vlan_port:
-            work_vlan_ports_list.append(vlan_port)
-
-    return work_vlan_ports_list
-
-@pytest.fixture(scope="module")
-def acl_rule_cleanup(duthost, tbinfo):
-    """Cleanup all the existing DATAACL rules"""
-    # remove all rules under the ACL_RULE table
-    if "t0-backend" in tbinfo["topo"]["name"]:
-        duthost.shell('acl-loader delete')
-
-    yield
-
-@pytest.fixture(scope="module")
-def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
-   """ Remove the DATAACL table prior to the test and recreate it at the end"""
-   if "t0-backend" in tbinfo["topo"]["name"]:
-       duthost.command('config acl remove table DATAACL')
-
-   yield
-
-   if "t0-backend" in tbinfo["topo"]["name"]:
-       duthost.command('config acl remove table DATAACL')
-       # rebind with new set of ports
-       bind_acl_table(duthost, tbinfo)
-
-def shutdown_portchannels(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TEST_NUM):
-    cmds = []
-    cnt = 0
-    logger.info("Shutdown lags, flush IP addresses")
-    for portchannel, ips in portchannel_interfaces.items():
-        cmds.append('config interface shutdown {}'.format(portchannel))
-        for ip in ips:
-            cmds.append('config interface ip remove {} {}'.format(portchannel, ip))
-        cnt += 1
-        if cnt >= pc_num:
-            break
-
-    duthost.shell_cmds(cmds=cmds)
-
-
-def check_portchannels_down(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TEST_NUM):
-    '''
-    After shutdown portchannels, check redis to make sure router interface is removed.
-    '''
-    cnt = 0
-    oid_list = []
-    # Get oid list for first 2 portchannels
-    for portchannel in portchannel_interfaces:
-        res = duthost.shell("sonic-db-cli COUNTERS_DB hget COUNTERS_LAG_NAME_MAP {}".format(portchannel))
-        oid_list.append(res['stdout'])
-        cnt += 1
-        if cnt >= pc_num:
-            break
-    res = duthost.shell("sonic-db-cli ASIC_DB keys *ROUTER_INTERFACE*")
-    for line in res['stdout_lines']:
-        get_res = duthost.shell("sonic-db-cli ASIC_DB hget {} SAI_ROUTER_INTERFACE_ATTR_PORT_ID".format(line))
-        if 'oid' not in get_res['stdout']:
-            continue
-        if get_res['stdout'] in oid_list:
-            return False
-    return True
-
-
-def create_test_vlans(duthost, cfg_facts, work_vlan_ports_list, vlan_intfs_dict):
-    utils_create_test_vlans(duthost, cfg_facts, work_vlan_ports_list, vlan_intfs_dict, delete_untagged_vlan=True)
-
-def startup_portchannels(duthost, portchannel_interfaces, pc_num=PORTCHANNELS_TEST_NUM):
-    cmds = []
-    cnt = 0
-    logger.info("Bringup lags")
-    for portchannel in portchannel_interfaces:
-        cmds.append('config interface startup {}'.format(portchannel))
-        cnt += 1
-        if cnt >= pc_num:
-            break
-
-    duthost.shell_cmds(cmds=cmds)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_ports_list, vlan_intfs_dict, cfg_facts, setup_acl_table):
-    duthost = duthosts[rand_one_dut_hostname]
-    # --------------------- Setup -----------------------
-    try:
-        if tbinfo['topo']['name'] != 't0-56-po2vlan':
-            portchannel_interfaces = cfg_facts.get('PORTCHANNEL_INTERFACE', {})
-
-            shutdown_portchannels(duthost, portchannel_interfaces)
-
-            # Must wait for orchagent to remove related router interface
-            start_time = time.time()
-            assert wait_until(120, 2, 0, check_portchannels_down, duthost, portchannel_interfaces), "Shutdown portchannels failed"
-            end_time = time.time()
-            logger.info('Take {} seconds to shutdown portchannels'.format(end_time-start_time))
-
-            create_test_vlans(duthost, cfg_facts, work_vlan_ports_list, vlan_intfs_dict)
-
-            startup_portchannels(duthost, portchannel_interfaces)
-
-            res = duthost.command('show int portchannel')
-            logger.info('"show int portchannel" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
-
-            populate_fdb(ptfadapter, work_vlan_ports_list, vlan_intfs_dict)
-            bind_acl_table(duthost, tbinfo)
-            apply_acl_rules(duthost, tbinfo)
-    # --------------------- Testing -----------------------
-        yield
-    # --------------------- Teardown -----------------------
-    finally:
-        tearDown(duthost, tbinfo)
-
-
-def tearDown(duthost, tbinfo):
-
-    logger.info("VLAN test ending ...")
-
-    if tbinfo['topo']['name'] != 't0-56-po2vlan':
-        config_reload(duthost)
-
 
 def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
-                        src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
+                      src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
 
     pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
-                                eth_dst=dst_mac,
-                                eth_src=src_mac,
-                                dl_vlan_enable=False if vlan_id == 0 else True,
-                                vlan_vid=vlan_id,
-                                vlan_pcp=0,
-                                ip_src=src_ip,
-                                ip_dst=dst_ip,
-                                ip_ttl=ttl)
+                                       eth_dst=dst_mac,
+                                       eth_src=src_mac,
+                                       dl_vlan_enable=False if vlan_id == 0 else True,
+                                       vlan_vid=vlan_id,
+                                       vlan_pcp=0,
+                                       ip_src=src_ip,
+                                       ip_dst=dst_ip,
+                                       ip_ttl=ttl)
     return pkt
 
 
@@ -233,12 +44,12 @@ def build_qinq_packet(outer_vlan_id, vlan_id,
                       src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                       src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
     pkt = testutils.simple_qinq_tcp_packet(eth_dst=dst_mac,
-                             eth_src=src_mac,
-                             dl_vlan_outer=outer_vlan_id,
-                             vlan_vid=vlan_id,
-                             ip_src=src_ip,
-                             ip_dst=dst_ip,
-                             ip_ttl=ttl)
+                                           eth_src=src_mac,
+                                           dl_vlan_outer=outer_vlan_id,
+                                           vlan_vid=vlan_id,
+                                           ip_src=src_ip,
+                                           ip_dst=dst_ip,
+                                           ip_ttl=ttl)
     return pkt
 
 
@@ -248,7 +59,7 @@ def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], d
                                    timeout=timeout, exp_pkt=pkt)
         if isinstance(result, test.dataplane.PollFailure):
             test.fail("Expected packet was not received on device %d, port %r.\n%s"
-                    % (device_number, port, result.format()))
+                      % (device_number, port, result.format()))
 
     for port_group in portchannel_ports:
         for port in port_group:
@@ -258,10 +69,10 @@ def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], d
                 break
         else:
             test.fail("Expected packet was not received on device %d, ports %s.\n"
-                    % (device_number, str(port_group)))
+                      % (device_number, str(port_group)))
 
 
-def verify_icmp_packets(ptfadapter, send_pkt, work_vlan_ports_list, vlan_port, vlan_id):
+def verify_icmp_packets(ptfadapter, send_pkt, vlan_ports_list, vlan_port, vlan_id):
     untagged_pkt = build_icmp_packet(0)
     tagged_pkt = build_icmp_packet(vlan_id)
     untagged_dst_ports = []
@@ -272,8 +83,9 @@ def verify_icmp_packets(ptfadapter, send_pkt, work_vlan_ports_list, vlan_port, v
     masked_tagged_pkt = Mask(tagged_pkt)
     masked_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
 
-    logger.info("Verify untagged packets from ports " + str(vlan_port["port_index"][0]))
-    for port in work_vlan_ports_list:
+    logger.info("Verify untagged packets from ports " +
+                str(vlan_port["port_index"][0]))
+    for port in vlan_ports_list:
         if vlan_port["port_index"] == port["port_index"]:
             # Skip src port
             continue
@@ -282,7 +94,7 @@ def verify_icmp_packets(ptfadapter, send_pkt, work_vlan_ports_list, vlan_port, v
                 untagged_dst_pc_ports.append(port["port_index"])
             else:
                 untagged_dst_ports += port["port_index"]
-        elif vlan_id in map(int, port["permit_vlanid"]):
+        elif vlan_id in list(map(int, port["permit_vlanid"])):
             if len(port["port_index"]) > 1:
                 tagged_dst_pc_ports.append(port["port_index"])
             else:
@@ -311,20 +123,10 @@ def verify_unicast_packets(ptfadapter, send_pkt, exp_pkt, src_port, dst_ports, t
         raise
 
 
-def populate_fdb(ptfadapter, work_vlan_ports_list, vlan_intfs_dict):
-    # send icmp packet from each tagged and untagged port in each test vlan to populate fdb
-    for vlan in vlan_intfs_dict:
-        for vlan_port in work_vlan_ports_list:
-            if vlan in vlan_port['permit_vlanid']:
-                vlan_id = 0 if vlan == vlan_port['pvid'] else vlan  # vlan_id: 0 - untagged, vlan = tagged
-                port_id = vlan_port['port_index'][0]
-                src_mac = ptfadapter.dataplane.get_mac(0, port_id)
-                pkt = build_icmp_packet(vlan_id=vlan_id, src_mac=src_mac)
-                testutils.send(ptfadapter, port_id, pkt)
-
-
 @pytest.mark.bsl
-def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc1_send_untagged(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo,
+                                ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
     """
     Test case #1
     Verify packets egress without tag from ports whose PVID same with ingress port
@@ -333,25 +135,33 @@ def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_sim
 
     logger.info("Test case #1 starting ...")
 
-    for vlan_port in work_vlan_ports_list:
-        pkt = build_icmp_packet(0)
-        logger.info("Send untagged packet from {} ...".format(vlan_port["port_index"][0]))
-        logger.info(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
+    untagged_pkt = build_icmp_packet(0)
+    # Need a tagged packet for set_do_not_care_scapy
+    tagged_pkt = build_icmp_packet(4095)
+    exp_pkt = Mask(tagged_pkt)
+    exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
+    for vlan_port in vlan_ports_list:
+        logger.info("Send untagged packet from {} ...".format(
+            vlan_port["port_index"][0]))
+        logger.info(untagged_pkt.sprintf(
+            "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
         if vlan_port['pvid'] != 0:
-            verify_icmp_packets(ptfadapter, pkt, work_vlan_ports_list, vlan_port, vlan_port["pvid"])
+            verify_icmp_packets(
+                ptfadapter, untagged_pkt, vlan_ports_list, vlan_port, vlan_port["pvid"])
         else:
-            exp_pkt = Mask(pkt)
-            exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
             dst_ports = []
-            for port in work_vlan_ports_list:
+            for port in vlan_ports_list:
                 dst_ports += port["port_index"] if port != vlan_port else []
-            testutils.send(ptfadapter, vlan_port["port_index"][0], pkt)
+            testutils.send(ptfadapter, vlan_port["port_index"][0], untagged_pkt)
             logger.info("Check on " + str(dst_ports) + "...")
             testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
 
 
 @pytest.mark.bsl
-def test_vlan_tc2_send_tagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc2_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo,
+                              ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):   # noqa F811
     """
     Test case #2
     Send tagged packets from each port.
@@ -361,17 +171,23 @@ def test_vlan_tc2_send_tagged(ptfadapter, work_vlan_ports_list, toggle_all_simul
 
     logger.info("Test case #2 starting ...")
 
-    for vlan_port in work_vlan_ports_list:
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
+    for vlan_port in vlan_ports_list:
         for permit_vlanid in map(int, vlan_port["permit_vlanid"]):
             pkt = build_icmp_packet(permit_vlanid)
-            logger.info("Send tagged({}) packet from {} ...".format(permit_vlanid, vlan_port["port_index"][0]))
-            logger.info(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
+            logger.info("Send tagged({}) packet from {} ...".format(
+                permit_vlanid, vlan_port["port_index"][0]))
+            logger.info(pkt.sprintf(
+                "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
 
-            verify_icmp_packets(ptfadapter, pkt, work_vlan_ports_list, vlan_port, permit_vlanid)
+            verify_icmp_packets(
+                ptfadapter, pkt, vlan_ports_list, vlan_port, permit_vlanid)
 
 
 @pytest.mark.bsl
-def test_vlan_tc3_send_invalid_vid(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc3_send_invalid_vid(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo,
+                                   ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """
     Test case #3
     Send packets with invalid VLAN ID
@@ -380,122 +196,150 @@ def test_vlan_tc3_send_invalid_vid(ptfadapter, work_vlan_ports_list, toggle_all_
 
     logger.info("Test case #3 starting ...")
 
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     invalid_tagged_pkt = build_icmp_packet(4095)
     masked_invalid_tagged_pkt = Mask(invalid_tagged_pkt)
     masked_invalid_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
-    for vlan_port in work_vlan_ports_list:
+    for vlan_port in vlan_ports_list:
         dst_ports = []
         src_port = vlan_port["port_index"][0]
-        for port in work_vlan_ports_list:
+        for port in vlan_ports_list:
             dst_ports += port["port_index"] if port != vlan_port else []
-        logger.info("Send invalid tagged packet " + " from " + str(src_port) + "...")
-        logger.info(invalid_tagged_pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
+        logger.info("Send invalid tagged packet " +
+                    " from " + str(src_port) + "...")
+        logger.info(invalid_tagged_pkt.sprintf(
+            "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
         testutils.send(ptfadapter, src_port, invalid_tagged_pkt)
         logger.info("Check on " + str(dst_ports) + "...")
-        testutils.verify_no_packet_any(ptfadapter, masked_invalid_tagged_pkt, dst_ports)
+        testutils.verify_no_packet_any(
+            ptfadapter, masked_invalid_tagged_pkt, dst_ports)
 
 
 @pytest.mark.bsl
-def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc4_tagged_unicast(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut,
+                                 tbinfo, vlan_intfs_dict, ports_list,                   # noqa F811
+                                 toggle_all_simulator_ports_to_rand_selected_tor_m):    # noqa F811
     """
     Test case #4
     Send packets w/ src and dst specified over tagged ports in vlan
     Verify that bidirectional communication between two tagged ports work
     """
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for tagged_test_vlan in vlan_intfs_dict:
         ports_for_test = []
 
-        for vlan_port in work_vlan_ports_list:
+        for vlan_port in vlan_ports_list:
             if vlan_port['pvid'] != tagged_test_vlan and tagged_test_vlan in vlan_port['permit_vlanid']:
                 ports_for_test.append(vlan_port['port_index'])
         if len(ports_for_test) < 2:
             continue
 
-        #take two tagged ports for test
+        # take two tagged ports for test
         src_port = ports_for_test[0]
         dst_port = ports_for_test[-1]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
-        transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
-        return_transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
+        transmit_tagged_pkt = build_icmp_packet(
+            vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
+        return_transmit_tagged_pkt = build_icmp_packet(
+            vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
 
-        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(tagged_test_vlan, src_port, dst_port))
+        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(
+            tagged_test_vlan, src_port, dst_port))
 
         verify_unicast_packets(
             ptfadapter, transmit_tagged_pkt, transmit_tagged_pkt, src_port[0],
             dst_port, timeout=5)
 
         logger.info("One Way Tagged Packet Transmission Works")
-        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(tagged_test_vlan, src_port, dst_port))
+        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
+            tagged_test_vlan, src_port, dst_port))
 
-        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(tagged_test_vlan, dst_port, src_port))
+        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(
+            tagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_tagged_pkt,
                                return_transmit_tagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Tagged Packet Transmission Works")
-        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(tagged_test_vlan, dst_port[0], src_port))
+        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
+            tagged_test_vlan, dst_port[0], src_port))
 
 
 @pytest.mark.bsl
-def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc5_untagged_unicast(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut,
+                                   tbinfo, vlan_intfs_dict, ports_list,                 # noqa F811
+                                   toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """
     Test case #5
     Send packets w/ src and dst specified over untagged ports in vlan
     Verify that bidirectional communication between two untagged ports work
     """
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for untagged_test_vlan in vlan_intfs_dict:
 
         ports_for_test = []
 
-        for vlan_port in work_vlan_ports_list:
+        for vlan_port in vlan_ports_list:
             if vlan_port['pvid'] == untagged_test_vlan:
                 ports_for_test.append(vlan_port['port_index'])
         if len(ports_for_test) < 2:
             continue
 
-        #take two untagged ports for test
+        # take two untagged ports for test
         src_port = ports_for_test[0]
         dst_port = ports_for_test[-1]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
-        transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
-        return_transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
+        transmit_untagged_pkt = build_icmp_packet(
+            vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
+        return_transmit_untagged_pkt = build_icmp_packet(
+            vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
-        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(untagged_test_vlan, src_port, dst_port))
+        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(
+            untagged_test_vlan, src_port, dst_port))
 
         verify_unicast_packets(
             ptfadapter, transmit_untagged_pkt, transmit_untagged_pkt, src_port[0],
             dst_port, timeout=5)
 
         logger.info("One Way Untagged Packet Transmission Works")
-        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(untagged_test_vlan, src_port, dst_port))
+        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(
+            untagged_test_vlan, src_port, dst_port))
 
-        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(untagged_test_vlan, dst_port, src_port))
+        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(
+            untagged_test_vlan, dst_port, src_port))
 
         verify_unicast_packets(ptfadapter, return_transmit_untagged_pkt,
                                return_transmit_untagged_pkt, dst_port[0], src_port, timeout=5)
 
         logger.info("Two Way Untagged Packet Transmission Works")
-        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(untagged_test_vlan, dst_port, src_port))
+        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(
+            untagged_test_vlan, dst_port, src_port))
 
 
 @pytest.mark.bsl
-def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut,
+                                          tbinfo, vlan_intfs_dict, ports_list,                  # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor_m):   # noqa F811
     """
     Test case #6
     Send packets w/ src and dst specified over tagged port and untagged port in vlan
     Verify that bidirectional communication between tagged port and untagged port work
     """
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for test_vlan in vlan_intfs_dict:
         untagged_ports_for_test = []
         tagged_ports_for_test = []
 
-        for vlan_port in work_vlan_ports_list:
+        for vlan_port in vlan_ports_list:
             if test_vlan not in vlan_port['permit_vlanid']:
                 continue
             if vlan_port['pvid'] == test_vlan:
@@ -507,61 +351,77 @@ def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan
         if not tagged_ports_for_test:
             continue
 
-        #take two ports for test
+        # take two ports for test
         src_port = untagged_ports_for_test[0]
         dst_port = tagged_ports_for_test[0]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
-        transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
-        exp_tagged_pkt = build_icmp_packet(vlan_id=test_vlan, src_mac=src_mac, dst_mac=dst_mac)
+        transmit_untagged_pkt = build_icmp_packet(
+            vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
+        exp_tagged_pkt = build_icmp_packet(
+            vlan_id=test_vlan, src_mac=src_mac, dst_mac=dst_mac)
         exp_tagged_pkt = Mask(exp_tagged_pkt)
         exp_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
 
-        return_transmit_tagged_pkt = build_icmp_packet(vlan_id=test_vlan, src_mac=dst_mac, dst_mac=src_mac)
-        exp_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
+        return_transmit_tagged_pkt = build_icmp_packet(
+            vlan_id=test_vlan, src_mac=dst_mac, dst_mac=src_mac)
+        exp_untagged_pkt = build_icmp_packet(
+            vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
-        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(test_vlan, src_port, dst_port))
+        logger.info("Untagged({}) packet to be sent from port {} to port {}".format(
+            test_vlan, src_port, dst_port))
 
-        verify_unicast_packets(ptfadapter, transmit_untagged_pkt, exp_tagged_pkt, src_port[0], dst_port)
+        verify_unicast_packets(
+            ptfadapter, transmit_untagged_pkt, exp_tagged_pkt, src_port[0], dst_port)
 
         logger.info("One Way Untagged Packet Transmission Works")
-        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(test_vlan, src_port, dst_port))
+        logger.info("Untagged({}) packet successfully sent from port {} to port {}".format(
+            test_vlan, src_port, dst_port))
 
-        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(test_vlan, dst_port, src_port))
+        logger.info("Tagged({}) packet to be sent from port {} to port {}".format(
+            test_vlan, dst_port, src_port))
 
-        verify_unicast_packets(ptfadapter, return_transmit_tagged_pkt, exp_untagged_pkt, dst_port[0], src_port)
+        verify_unicast_packets(
+            ptfadapter, return_transmit_tagged_pkt, exp_untagged_pkt, dst_port[0], src_port)
 
         logger.info("Two Way tagged Packet Transmission Works")
-        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(test_vlan, dst_port, src_port))
+        logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(
+            test_vlan, dst_port, src_port))
 
 
-def test_vlan_tc7_tagged_qinq_switch_on_outer_tag(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, duthost, toggle_all_simulator_ports_to_rand_selected_tor_m):
+@pytest.mark.po2vlan
+def test_vlan_tc7_tagged_qinq_switch_on_outer_tag(ptfadapter, duthosts, rand_one_dut_hostname, rand_selected_dut,
+                                                  tbinfo, vlan_intfs_dict, duthost, ports_list,         # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor_m):   # noqa F811
     """
     Test case #7
     Send qinq packets w/ src and dst specified over tagged ports in vlan
     Verify that the qinq packet is switched based on outer vlan tag + src/dst mac
     """
-
+    vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for tagged_test_vlan in vlan_intfs_dict:
         ports_for_test = []
-        for vlan_port in work_vlan_ports_list:
+        for vlan_port in vlan_ports_list:
             if vlan_port['pvid'] != tagged_test_vlan and tagged_test_vlan in vlan_port['permit_vlanid']:
                 ports_for_test.append(vlan_port['port_index'])
         if len(ports_for_test) < 2:
             continue
 
-        #take two tagged ports for test
+        # take two tagged ports for test
         src_port = ports_for_test[0]
         dst_port = ports_for_test[-1]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
-        transmit_qinq_pkt = build_qinq_packet(outer_vlan_id=tagged_test_vlan, vlan_id=250, src_mac=src_mac, dst_mac=dst_mac)
-        logger.info ("QinQ({}) packet to be sent from port {} to port {}".format(tagged_test_vlan, src_port, dst_port))
+        transmit_qinq_pkt = build_qinq_packet(
+            outer_vlan_id=tagged_test_vlan, vlan_id=250, src_mac=src_mac, dst_mac=dst_mac)
+        logger.info("QinQ({}) packet to be sent from port {} to port {}".format(
+            tagged_test_vlan, src_port, dst_port))
 
-        verify_unicast_packets(ptfadapter, transmit_qinq_pkt, transmit_qinq_pkt, src_port[0], dst_port)
+        verify_unicast_packets(ptfadapter, transmit_qinq_pkt,
+                               transmit_qinq_pkt, src_port[0], dst_port)
 
-        logger.info ("QinQ packet switching worked successfully...")
+        logger.info("QinQ packet switching worked successfully...")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Integrate po2vlan testcases into general qualification pipeline

#### How did you do it?
Update po2vlan related test cases, create new portchannel and add it to two VLANs.

#### How did you verify/test it?
Run end to end test on t0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
