### PR TITLE
[copp tables] validate copp tables during in/cross-branch upgrades

### DIFF
--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -4,7 +4,8 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot
 from tests.common.reboot import get_reboot_cause
 from tests.common.reboot import REBOOT_TYPE_COLD
-from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version, get_reboot_command
+from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version,\
+    get_reboot_command, check_copp_config
 from tests.upgrade_path.upgrade_helpers import restore_image            # noqa F401
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
 from tests.platform_tests.verify_dut_health import verify_dut_health    # noqa F401
@@ -80,6 +81,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
             pytest_assert(reboot_cause == upgrade_type,
                           "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
             check_services(duthost)
+            check_copp_config(duthost)
 
 
 @pytest.mark.device_type('vs')

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -2,6 +2,8 @@ import pytest
 import logging
 import time
 import ipaddress
+import json
+import re
 from six.moves.urllib.parse import urlparse
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot
@@ -117,3 +119,51 @@ def check_reboot_cause(duthost, expected_cause):
     reboot_cause = get_reboot_cause(duthost)
     logging.info("Checking cause from dut {} to expected {}".format(reboot_cause, expected_cause))
     return reboot_cause == expected_cause
+
+
+def check_copp_config(duthost):
+    logging.info("Comparing CoPP configuration from copp_cfg.json to COPP_TABLE")
+    copp_tables = json.loads(duthost.shell("sonic-db-dump -n APPL_DB -k COPP_TABLE* -y")["stdout"])
+    copp_cfg = json.loads(duthost.shell("cat /etc/sonic/copp_cfg.json")["stdout"])
+    feature_status = duthost.shell("show feature status")["stdout"]
+    copp_tables_formatted = get_copp_table_formatted_dict(copp_tables)
+    copp_cfg_formatted = get_copp_cfg_formatted_dict(copp_cfg, feature_status)
+    pytest_assert(copp_tables_formatted == copp_cfg_formatted,
+                  "There is a difference between CoPP config and CoPP tables. CoPP config: {}\nCoPP tables:"
+                  " {}".format(copp_tables_formatted, copp_cfg_formatted))
+
+
+def get_copp_table_formatted_dict(copp_tables):
+    """
+    Format the copp tables output to "copp_group":{"values"} only
+    """
+    formatted_dict = {}
+    for queue_group, queue_group_value in copp_tables.items():
+        new_queue_group = queue_group.replace("COPP_TABLE:", "")
+        formatted_dict.update({new_queue_group: queue_group_value["value"]})
+    logging.debug("Formatted copp tables dictionary: {}".format(formatted_dict))
+    return formatted_dict
+
+
+def get_copp_cfg_formatted_dict(copp_cfg, feature_status):
+    """
+    Format the copp_cfg.json output to compare with copp tables
+    """
+    formatted_dict = {}
+    for trap_name, trap_value in copp_cfg["COPP_TRAP"].items():
+        pattern = r"{}\s+enabled".format(trap_name)
+        trap_enabled = re.search(pattern, feature_status)
+        if trap_value.get("always_enabled", "") or trap_enabled:
+            trap_group = trap_value["trap_group"]
+            if trap_group in formatted_dict:
+                exist_trap_ids = formatted_dict[trap_group]["trap_ids"].split(",")
+                additional_trap_ids = trap_value["trap_ids"].split(",")
+                trap_ids = exist_trap_ids + additional_trap_ids
+                trap_ids.sort()
+                formatted_dict[trap_group].update({"trap_ids": ",".join(trap_ids)})
+            else:
+                formatted_dict.update({trap_group: copp_cfg["COPP_GROUP"][trap_group]})
+                formatted_dict[trap_group].update({"trap_ids": trap_value["trap_ids"]})
+    formatted_dict.update({"default": copp_cfg["COPP_GROUP"]["default"]})
+    logging.debug("Formatted copp_cfg.json dictionary: {}".format(formatted_dict))
+    return formatted_dict


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update the test test_upgrade_path.py to support validation of the copp tables after in/cross-branch upgrades.
Added validation after upgrade, to compare copp tables with copp_cfg.json file.
Fixes #8085 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Add validation of copp tables after improvement of fast-reboot

#### How did you do it?
Added validation of copp tables after upgrade 

#### How did you verify/test it?
executed test _test_upgrade_path_ with _base_image=**201911**, target_image=**202205**, upgrade_type=**fast**_

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
