### PR TITLE
Added skip for ip invalid checksum for Onyx fanout

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_column_positions
 from tests.common.portstat_utilities import parse_portstat
+from tests.drop_packets.drop_packets import is_mellanox_fanout
 
 
 pytestmark = [
@@ -322,13 +323,16 @@ class TestIPPacket(object):
                       "DUT forwarded {} packets, but {} packets matched expected format, not in expected range"
                       .format(tx_ok, match_cnt))
 
-    def test_forward_ip_packet_with_0xffff_chksum_drop(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                       ptfadapter, common_param):
+    def test_forward_ip_packet_with_0xffff_chksum_drop(self, duthosts, localhost,
+                                                       enum_rand_one_per_hwsku_frontend_hostname, ptfadapter,
+                                                       common_param):
         # GIVEN a ip packet with checksum 0x0000(compute from scratch)
         # WHEN manually set checksum as 0xffff and send the packet to DUT
         # THEN DUT should drop packet with 0xffff and add drop count
 
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        if is_mellanox_fanout(duthost, localhost):
+            pytest.skip("Not supported at Mellanox fanout")
         (peer_ip_ifaces_pair, rif_rx_ifaces, rif_support, ptf_port_idx,
          pc_ports_map, ptf_indices, ingress_router_mac) = common_param
         pkt = testutils.simple_ip_packet(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_forward_ip_packet_with_0xffff_chksum_drop not supported on Onyx fanouts

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Onyx fanouts did not support test_forward_ip_packet_with_0xffff_chksum_drop 
#### How did you do it?
Add skip base at OS installed at Fanout
#### How did you verify/test it?
Run test_forward_ip_packet_with_0xffff_chksum_drop, TC skipped
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
