### PR TITLE
[cacl/test_cacl_application.py] Add missing IP Table rule for eth1-midplane to test

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -338,7 +338,9 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
 def append_midplane_traffic_rules(duthost, iptables_rules):
     result = duthost.shell('ip link show | grep -w "eth1-midplane"', module_ignore_errors=True)['stdout']
     if result:
+        midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1', module_ignore_errors=True)['stdout']
         iptables_rules.append("-A INPUT -i eth1-midplane -j ACCEPT")
+        iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 
 def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby):
     iptables_rules = []


### PR DESCRIPTION

### Description of PR
<!--
This PR fixes https://github.com/sonic-net/sonic-mgmt/issues/8448 by adding the missing IP Table rule.

Change https://github.com/sonic-net/sonic-host-services/pull/42/files is required.
-->

Summary:
Fixes # 8448

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add the missing rule for testing image that includes https://github.com/sonic-net/sonic-host-services/pull/42/files

#### How did you do it?

#### How did you verify/test it?
Ran the updated test against single and multi-asic DUTs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

