### PR TITLE
[cacl/test_cacl_application.py] Add missing IP Table rule for eth1-midplane to test

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -355,7 +355,9 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
 def append_midplane_traffic_rules(duthost, iptables_rules):
     result = duthost.shell('ip link show | grep -w "eth1-midplane"', module_ignore_errors=True)['stdout']
     if result:
+        midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1', module_ignore_errors=True)['stdout']
         iptables_rules.append("-A INPUT -i eth1-midplane -j ACCEPT")
+        iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 
 
 def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby):

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -355,7 +355,8 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
 def append_midplane_traffic_rules(duthost, iptables_rules):
     result = duthost.shell('ip link show | grep -w "eth1-midplane"', module_ignore_errors=True)['stdout']
     if result:
-        midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1', module_ignore_errors=True)['stdout']
+        midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1',
+                                    module_ignore_errors=True)['stdout']
         iptables_rules.append("-A INPUT -i eth1-midplane -j ACCEPT")
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 


### PR DESCRIPTION
Summary:
Add missing IP Table rule for eth1-midplane corresponding to the CACL rule changes made in caclmgrd here: https://github.com/sonic-net/sonic-host-services/pull/42/
Fixes # 8448

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add missing IP Table rule for eth1-midplane for testing Sonic images that include https://github.com/sonic-net/sonic-host-services/pull/42/

#### How did you do it?

#### How did you verify/test it?
Ran the updated test against single and multi-asic DUTs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

