### PR TITLE
[portchannel][dualtor] Skip dualtor in test_lag_member

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -675,6 +675,12 @@ pc/test_lag_2.py::test_lag_db_status_with_po_update:
     conditions:
         - "topo_name not in ['t1-lag'] and 't2' not in topo_name"
 
+pc/test_lag_member.py:
+  skip:
+    reason: "Not support dualtor topo"
+    conditions:
+        - "'dualtor' in topo_name"
+
 pc/test_po_cleanup.py:
   skip:
     reason: "Skip test due to there is no portchannel exists in current topology."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_lag_member doesn't support dualtor topo.

#### How did you do it?
Add skip for dualtor in this test.

#### How did you verify/test it?
Run test.
```
collected 2 items                                                              

pc/test_lag_member.py::test_lag_member_status SKIPPED (Not support d...) [ 50%]
pc/test_lag_member.py::test_lag_member_traffic SKIPPED (Not support ...) [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
