### PR TITLE
Update test_telemetry.py

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -84,8 +84,12 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
             "Skipping test as no Ethernet0 frontpanel port on supervisor")
     logger.info('start telemetry output testing')
     dut_ip = duthost.mgmt_ip
-    cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt COUNTERS_DB \
-           -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT)
+    cfg_facts = duthost.get_running_config_facts()
+    up_ports = [p for p, v in cfg_facts['PORT'].items() if v.get('admin_status', None) == 'up']
+    v_port = sorted(up_ports)[0]
+    logging.warning("v_port={}".format(v_port))
+    cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/{2} -xt COUNTERS_DB \
+           -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT, v_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     logger.info("GNMI Server output")
     logger.info(show_gnmi_out)
@@ -171,6 +175,7 @@ def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, p
     skip_201911_and_older(duthost)
     cmd = generate_client_cli(
         duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE, update_count=3)
+    logging.warning("cmd={}".format(cmd))
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     result = str(show_gnmi_out)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -87,7 +87,6 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     cfg_facts = duthost.get_running_config_facts()
     up_ports = [p for p, v in cfg_facts['PORT'].items() if v.get('admin_status', None) == 'up']
     v_port = sorted(up_ports)[0]
-    logging.warning("v_port={}".format(v_port))
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/{2} -xt COUNTERS_DB \
            -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT, v_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
@@ -175,7 +174,6 @@ def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, p
     skip_201911_and_older(duthost)
     cmd = generate_client_cli(
         duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE, update_count=3)
-    logging.warning("cmd={}".format(cmd))
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     result = str(show_gnmi_out)
 


### PR DESCRIPTION
Update test_telemetry.py so that it can test the Dut whose panel port serial number starts from 1 instead of 0

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (7142)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Although Dut does not have Ethernet0, I would like to be able to test Ethernet1 and pass this test case. Because some devices have a card type that is not supervisor, but its panel port is not start with Ethernet0, but Ethernet1.
#### How did you do it?
Dynamically obtain the panel port and select the first UP port
#### How did you verify/test it?
Verified on a testbed under a Dut whose panel port numbers start at 1 instead of 0, and test is passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
