### PR TITLE
Use thermals specified in SKIP_MODULES in inventory to calculate the …

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -11,6 +11,7 @@ from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import skip_release
 from tests.common.platform.interface_utils import get_physical_port_indices
+from tests.platform_tests.cli.util import get_skip_mod_list
 from platform_api_test_base import PlatformApiTestBase
 
 ###################################################
@@ -405,7 +406,8 @@ class TestChassisApi(PlatformApiTestBase):
                 pytest.skip("No thermals found on device")
 
         if duthost.facts.get("chassis"):
-            expected_num_thermals = len(duthost.facts.get("chassis").get('thermals'))
+            thermal_skip_list = get_skip_mod_list(duthost, ['thermals'])
+            expected_num_thermals = len(duthost.facts.get("chassis").get('thermals')) - len(thermal_skip_list)
             pytest_assert(num_thermals == expected_num_thermals,
                           "Number of thermals ({}) does not match expected number ({})"
                           .format(num_thermals, expected_num_thermals))


### PR DESCRIPTION
### Description of PR
Fix for test_thermals in platform_tests/api/test_chassis.py fails on supervisor card in a chassis in which not all fabric cards are present.

This PR is the same as PR  https://github.com/sonic-net/sonic-mgmt/pull/7909/
Please see that PR for details

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_thermals in platform_tests/api/test_chassis.py fails on supervisor card in a chassis in which not all fabric cards are present.

#### How did you do it?
In platform.json file, we define a list of thermals present. For a supervisor card, the thermals includes thermal info for the fabric cards as well. However, this info is for all the fabric cards present in the chassis.

test_thermals uses this list of thermals in platform.json as the expected number of thermals present. If we do not have all the fabric cards populated in the chassis, then the thermal data for the absent fabric cards is missing. Thus, the test fails.
To fix the tests, we can define the thermals associated with fabric cards that are not present under 'thermals' under 'skip_modules' for the supervisor card in the inventory file. Example:


```
   ixre-cpm-chassis10:
       skip_modules:
         line-cards:
         fabric-cards:
           - FABRIC-CARD5 psus: thermals:
           - sfm6_1(fan) - sfm6_2 - sfm6_3 - sfm6_4(fan - sfm6_5(fan)
```

 
We can then use this data to calculate the expected number of thermals

#### How did you verify/test it?
Ran test against a chassis with not all fabric cards present.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
