### PR TITLE
[Snappi] Update MAC address for portchannel interfaces

### DIFF
--- a/tests/common/snappi/snappi_fixtures.py
+++ b/tests/common/snappi/snappi_fixtures.py
@@ -82,7 +82,7 @@ def __gen_pc_mac(id):
     Returns:
         MAC address (string)
     """
-    return '11:22:33:44:55:{:02d}'.format(id)
+    return '10:22:33:44:55:{:02d}'.format(id)
 
 
 def __valid_ipv4_addr(ip):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Known MAC issue with Cisco switches where the 1 in the lsb of the most significant octet makes this a multicast address and the switch will drop it. This was causing packet drops on Cisco switches on the portchannel interfaces for any traffic that is sent to the portchannel interface from the traffic generator. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Test cases failing for portchannel interface

#### How did you do it?
Changed the MAC address to be a 0 in the LSB of the most significant octet.

#### How did you verify/test it?
Tested on lab switch and traffic generator.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
