### PR TITLE
Enhance get_crm_resources_fdb_and_ip_route for multi-asic Issue #8425

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -454,7 +454,7 @@ def get_crm_resources_fdb_and_ip_route(duthost, asic_ix):
     for line in output['stdout_lines']:
         if line:
             line = line.split()
-            if duthost.sonichost.is_multi_asic and asic_matched == False:
+            if duthost.sonichost.is_multi_asic and asic_matched is False:
                 if line[0] == asic_str:
                     asic_matched = True
                 continue

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -583,27 +583,28 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         routes_num = get_entries_num(new_crm_stats_route_used, new_crm_stats_route_available)
         if ip_ver == "4":
             routes_list_raw = [str(ipaddress.IPv4Address(u'2.0.0.1') + item) + "/32"
-                for item in range(1, routes_num + 1)]
+                               for item in range(1, routes_num + 1)]
         elif ip_ver == "6":
             routes_list_raw = [str(ipaddress.IPv6Address(u'2001::') + item) + "/128"
-                for item in range(1, routes_num + 1)]
+                               for item in range(1, routes_num + 1)]
         else:
-             pytest.fail("Incorrect IP version specified - {}".format(ip_ver))
+            pytest.fail("Incorrect IP version specified - {}".format(ip_ver))
         # Group commands to avoid command line too long errors
         num_cmds_to_run_at_once = 100
         routes_list_list = [" ".join(routes_list_raw[i:i+num_cmds_to_run_at_once])
-              for i in range(0, len(routes_list_raw), num_cmds_to_run_at_once)]
+                            for i in range(0, len(routes_list_raw), num_cmds_to_run_at_once)]
         # Store CLI command to delete all created neighbours if test case will fail
         for routes_list in routes_list_list:
             RESTORE_CMDS["test_crm_route"].append(
                 del_routes_template.render(routes_list=routes_list,
-                  interface=crm_interface[0],  namespace = asichost.namespace))
+                                           interface=crm_interface[0],
+                                           namespace=asichost.namespace))
 
         # Add test routes entries to correctly calculate used CRM resources in percentage
         for routes_list in routes_list_list:
             duthost.shell(add_routes_template.render(routes_list=routes_list,
-                                             interface=crm_interface[0],
-                                             namespace=asichost.namespace))
+                                                     interface=crm_interface[0],
+                                                     namespace=asichost.namespace))
         logger.info("Waiting {} seconds for SONiC to update resources...".format(SONIC_RES_UPDATE_TIME))
         # Make sure SONIC configure expected entries
         time.sleep(SONIC_RES_UPDATE_TIME)
@@ -905,28 +906,31 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             elif i == 1:
                 ports = ",".join(tmp_ports[24:26])
             elif i == 2:
-                ports = ",".join([tmp_ports[20],tmp_ports[25]])
+                ports = ",".join([tmp_ports[20], tmp_ports[25]])
             recreate_acl_table(duthost, ports)
-            verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector)
+            verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
+                                 enum_frontend_asic_index, asic_collector)
             # Rebind DATA ACL at end to recover original config
             recreate_acl_table(duthost, ports)
             apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
             duthost.command("acl-loader delete")
     else:
-        verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector)
+        verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
+                             enum_frontend_asic_index, asic_collector)
 
     pytest_assert(crm_stats_checker,
                   "\"crm_stats_acl_entry_used\" counter was not decremented or "
                   "\"crm_stats_acl_entry_available\" counter was not incremented")
 
-def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, asic_collector):
+
+def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
+                         enum_frontend_asic_index, asic_collector):
     apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
                             crm_stats_acl_entry_used \
                             crm_stats_acl_entry_available"\
-                            .format(db_cli=asichost.sonic_db_cli,
-                            acl_tbl_key=acl_tbl_key)
+                            .format(db_cli=asichost.sonic_db_cli, acl_tbl_key=acl_tbl_key)
     RESTORE_CMDS["crm_threshold_name"] = "acl_entry"
     crm_stats_acl_entry_used = 0
     crm_stats_acl_entry_available = 0
@@ -935,7 +939,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     new_crm_stats_acl_entry_used, new_crm_stats_acl_entry_available = get_crm_stats(get_acl_entry_stats, duthost)
     # Verify "crm_stats_acl_entry_used" counter was incremented
     pytest_assert(new_crm_stats_acl_entry_used - crm_stats_acl_entry_used == 2,
-                    "\"crm_stats_acl_entry_used\" counter was not incremented")
+                  "\"crm_stats_acl_entry_used\" counter was not incremented")
 
     crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used
 
@@ -958,12 +962,12 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
                             crm_stats_acl_entry_used \
                             crm_stats_acl_entry_available"\
-                            .format(db_cli=asichost.sonic_db_cli,
-                            acl_tbl_key=acl_tbl_key)
+                            .format(db_cli=asichost.sonic_db_cli, acl_tbl_key=acl_tbl_key)
     global crm_stats_checker
     crm_stats_checker = wait_until(30, 5, 0, check_crm_stats, get_acl_entry_stats, duthost,
-                                    crm_stats_acl_entry_used,
-                                    crm_stats_acl_entry_available,"==", ">=")
+                                   crm_stats_acl_entry_used,
+                                   crm_stats_acl_entry_available, "==", ">=")
+
 
 def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, collector):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION

### Description of PR
crm/test_crm.py::test_crm_route test failure for multi-asic/chassis platforms.
The test checks for crm route used entires before and after adding 64 routes, the crm show resources output shows the increased used entires.

But the newly added API get_crm_resources_fdb_and_ip_route https://github.com/sonic-net/sonic-mgmt/pull/7564 does not check the correct asic / ipv4_route, this fails all the tests using other than ASIC0.

Summary:
Fixes #8425

### Type of change
Added code to check in get_crm_resources_fdb_and_ip_route to see if this is multi asic instance and use asic index in matching the correct block of the crm show resources output. to get the correct used and available entries for various resources.


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Verified running sonic-mgmt/crm/test_crm.py::test_crm_route test for v4 and v6 across various LCs and Asics.

============================================================================== PASSES ==============================================================================
________________________________________________________________ test_crm_route[sfd-vt2-lc2-1-ipv4] ________________________________________________________________
--------------------------- generated xml file: /data/tests/logs/crm/raj.py::test_crm_route[sfd-vt2-lc2-1-ipv4]_2023-05-30-23-50-58.xml ----------------------------
INFO:root:Can not get Allure report URL. Please check logs
---------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------
23:59:57 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================== short test summary info ======================================================================
PASSED crm/raj.py::test_crm_route[sfd-vt2-lc2-1-ipv4]
==================================================================== 1 passed in 536.86 seconds ====================================================================