### PR TITLE
[dualtor][active-active] Support `test_bgp_update_timer`

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -13,10 +13,14 @@ from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.mux_simulator_control import mux_server_url  # noqa F401
+from tests.common.dualtor.dual_tor_common import active_active_ports                    # noqa F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup    # noqa F401
+from tests.common.dualtor.mux_simulator_control import mux_server_url                   # noqa F401
 from tests.common.dualtor.mux_simulator_control import \
-    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m   # noqa F401
+    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m               # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+
 
 pytestmark = [
     pytest.mark.topology("any"),
@@ -282,6 +286,7 @@ def test_bgp_update_timer_single_route(
     duthosts,
     enum_rand_one_per_hwsku_frontend_hostname,
     toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,      # noqa F811
+    validate_active_active_dualtor_setup                                        # noqa F811
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
@@ -380,6 +385,7 @@ def test_bgp_update_timer_session_down(
     duthosts,
     enum_rand_one_per_hwsku_frontend_hostname,
     toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,      # noqa F811
+    validate_active_active_dualtor_setup                                        # noqa F811
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -524,7 +524,9 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(duthosts, enum_rand_one_per_hwsku_frontend_hostname, mux_server_url, tbinfo): # noqa F811
+def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, mux_server_url, tbinfo, active_standby_ports               # noqa F811
+):
     """
     A function level fixture to toggle all ports to enum_rand_one_per_hwsku_frontend_hostname.
 
@@ -532,7 +534,7 @@ def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(duthos
     After test is done, restore all mux cables to 'auto' mode on all ToRs in teardown phase.
     """
     # Skip on non dualtor testbed
-    if 'dualtor' not in tbinfo['topo']['name']:
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
         yield
         return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Support `test_bgp_update_timer` on `dualtor-aa` testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. for `toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m`, let's skip toggle if no `active-standby` mux ports are defined.
2. stop `arp_responder` and `garp_service` if running during setup, so DUTs could learn the correct ARP entries for the configured BGP neighbors' addresses.

#### How did you verify/test it?
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[svcstr-7050-acs-2-default] PASSED                                                                                                                                   [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[svcstr-7050-acs-2-default] PASSED                                                                                                                                   [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
