### PR TITLE
Stability of Voq tests (#4951, #4953)

### DIFF
--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -98,6 +98,9 @@ class FanoutHost(object):
 
         return self.host.no_shutdown(interface_name)
 
+    def check_intf_link_state(self, interface_name):
+        return self.host.check_intf_link_state(interface_name)
+
     def __str__(self):
         return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1273,6 +1273,10 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
 
         return True
 
+    def check_intf_link_state(self, interface_name):
+        intf_status = self.show_interface(command="status",interfaces=[interface_name])["ansible_facts"]['int_status']
+        return intf_status[interface_name]['oper_state'] == 'up'
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1274,7 +1274,7 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
         return True
 
     def check_intf_link_state(self, interface_name):
-        intf_status = self.show_interface(command="status",interfaces=[interface_name])["ansible_facts"]['int_status']
+        intf_status = self.show_interface(command="status", interfaces=[interface_name])["ansible_facts"]['int_status']
         return intf_status[interface_name]['oper_state'] == 'up'
 
     def get_bgp_neighbor_info(self, neighbor_ip):

--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -200,6 +200,10 @@ def delete_lag_members_ip(duthost, asic, portchannel_members,
     """
     deletes lag members and ip
     """
+    if portchannel_ip:
+        duthost.shell("config interface {} ip remove {} {}"
+                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
+
     logging.info('Deleting lag members {} from lag {} on dut {}'
                  .format(portchannel_members, portchannel, duthost.hostname))
     for member in portchannel_members:
@@ -207,9 +211,6 @@ def delete_lag_members_ip(duthost, asic, portchannel_members,
                       .format(asic.cli_ns_option, portchannel, member))
 
     if portchannel_ip:
-        duthost.shell("config interface {} ip remove {} {}"
-                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
-
         pytest_assert(wait_until(30, 5, 0, verify_lag_interface, duthost, asic, portchannel, expected=False),
                       'For deleted Portchannel {} ip link is not down'.format(portchannel))
 

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -688,7 +688,10 @@ class TestVoqIPFwd(object):
         check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_lb',
                      dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
 
-    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456), (1, 1456)])
+    @pytest.mark.parametrize('ttl, size', [(2, 64),
+                                           pytest.param(128, 64, marks=pytest.mark.express),
+                                           (255, 1456),
+                                           (1, 1456)])  # (1, 1500), ,(255, 1500), (128, 64), (128, 9000) (1, 1456)
     @pytest.mark.parametrize('version', [4, 6])
     @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
     def test_voq_inband_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts, tbinfo):

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -827,7 +827,7 @@ class LinkFlap(object):
         logging.info("status: %s", status)
         return status[dut_intf]['oper_state'] == exp_status
 
-    def check_fanout_link_state (self, fanout, fanout_port):
+    def check_fanout_link_state(self, fanout, fanout_port):
         return fanout.check_intf_link_state(fanout_port)
 
     def linkflap_down(self, fanout, fanport, dut, dut_intf):
@@ -913,7 +913,7 @@ class LinkFlap(object):
         if "portchannel" not in dut_intf.lower():
             # Wait for fanout port to be operationally up as well.
             fanout, fanport = fanout_switch_port_lookup(fanouthosts, dut.hostname, dut_intf)
-            pytest_assert(wait_until(30,1,0,self.check_fanout_link_state, fanout, fanport),
+            pytest_assert(wait_until(30, 1, 0, self.check_fanout_link_state, fanout, fanport),
                           "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
 
         time.sleep(2)
@@ -953,7 +953,7 @@ class TestNeighborLinkFlap(LinkFlap):
 
     def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                         enum_rand_one_frontend_asic_index, all_cfg_facts, setup, teardown,
-                                        nbrhosts, nbr_macs, established_arp):
+                                        nbrhosts, nbr_macs, established_arp, fanouthosts):
         """
         Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
 

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -827,6 +827,9 @@ class LinkFlap(object):
         logging.info("status: %s", status)
         return status[dut_intf]['oper_state'] == exp_status
 
+    def check_fanout_link_state (self, fanout, fanout_port):
+        return fanout.check_intf_link_state(fanout_port)
+
     def linkflap_down(self, fanout, fanport, dut, dut_intf):
         """
         Brings down an interface on a fanout and polls the DUT for the interface to be operationally down.
@@ -869,6 +872,8 @@ class LinkFlap(object):
             sleep_time = 90
         pytest_assert(wait_until(sleep_time, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        pytest_assert(wait_until(30, 1, 0, self.check_fanout_link_state, fanout, fanport),
+                      "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
 
     def localport_admindown(self, dut, asic, dut_intf):
         """
@@ -888,7 +893,7 @@ class LinkFlap(object):
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'down'),
                       "dut port {} didn't go down as expected".format(dut_intf))
 
-    def localport_adminup(self, dut, asic, dut_intf):
+    def localport_adminup(self, dut, asic, dut_intf, fanouthosts):
         """
         Admins up a port on the DUT and polls for oper status to be up.
 
@@ -905,6 +910,13 @@ class LinkFlap(object):
         asic.startup_interface(dut_intf)
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        if "portchannel" not in dut_intf.lower():
+            # Wait for fanout port to be operationally up as well.
+            fanout, fanport = fanout_switch_port_lookup(fanouthosts, dut.hostname, dut_intf)
+            pytest_assert(wait_until(30,1,0,self.check_fanout_link_state, fanout, fanport),
+                          "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
+
+        time.sleep(2)
 
 
 def pick_ports(cfg_facts):
@@ -995,7 +1007,7 @@ class TestNeighborLinkFlap(LinkFlap):
             try:
                 check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
             finally:
-                self.localport_adminup(per_host, asic, intf)
+                self.localport_adminup(per_host, asic, intf, fanouthosts)
 
             for neighbor in neighbors:
                 sonic_ping(asic, neighbor, verbose=True)

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 import pytest
-import time
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -910,9 +909,6 @@ def check_all_neighbors_present_remote(local_host, rem_host, rem_asic, neighs,
                     logger.debug("Asic neighbor encap for %s match: %s == %s", neighbor, encap_id,
                                  asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX'])
 
-
-#                pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX'] == "true",
-#                              "Encap impose is not true in asicDB")
                 pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL'] == "false",
                               "is local is not false in asicDB")
 

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import pytest
+import time
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -909,6 +910,9 @@ def check_all_neighbors_present_remote(local_host, rem_host, rem_asic, neighs,
                     logger.debug("Asic neighbor encap for %s match: %s == %s", neighbor, encap_id,
                                  asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX'])
 
+
+#                pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX'] == "true",
+#                              "Encap impose is not true in asicDB")
                 pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL'] == "false",
                               "is local is not false in asicDB")
 


### PR DESCRIPTION
### Description of PR
This is the same PR as PR# https://github.com/sonic-net/sonic-mgmt/pull/4951
Please see PR# 4951 and 4953 for details.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In VoQ tests against a T2 VoQ chassis we sometimes see 5-6 seconds delay before which the ping to the neighbor works after the port on the DUT is brought up as part of the voq link flap tests.

Currently, when we bring the link up on either the DUT or the fanout, we would only check if the link is up on the DUT.

What we see is that even though the DUT becomes operationally up, the remote peer doesn't become operationally up right away at the same time. It seems to take 2-6 seconds more than the DUT port. If the port is not up on the fanout, then the packets from the DUT is not forwarded to the testbed server, and thus the ping fails.

#### How did you do it?

#### How did you verify/test it?
Fix is to check the link status on the fanout port as well, whenever we bring a port up.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
