### PR TITLE
Fix test_pfcwd_mmu_change

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -825,11 +825,11 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.peer_dev_list = dict()
         self.fake_storm = fake_storm
         self.storm_hndle = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         logger.info("---- Testing on port {} ----".format(port))
         self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True)
         self.rx_action = None
         self.tx_action = None
-        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         self.set_traffic_action(duthost, "drop")
         self.stats = PfcPktCntrs(self.dut, self.rx_action, self.tx_action)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix a code bug in `test_pfcwd_mmu_change`.
The variable `self.is_dualtor` is referenced in `setup_test_params`. Hence it must be initialized before `setup_test_params` is called.
https://github.com/sonic-net/sonic-mgmt/blob/6a69e34d64856fa60eafa31203afc0e9a86ea440/tests/pfcwd/test_pfcwd_function.py#L280-L296
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix a code bug in `test_pfcwd_mmu_change`.

#### How did you do it?
Initialize `self.is_dualtor` before `setup_test_params` is called.

#### How did you verify/test it?
Verified by running `test_pfcwd_mmu_change` on a T0 testbed.
```
collected 1 item                                                                                                                                                                            

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str2-msn4600c-acs-01-None]  PASSED                                                                                  [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
