### PR TITLE
fix print syntax issue in python2

### DIFF
--- a/tests/saitests/sai_base_test.py
+++ b/tests/saitests/sai_base_test.py
@@ -27,6 +27,7 @@ import switch_sai_thrift.switch_sai_rpc as switch_sai_rpc
 from thrift.transport import TSocket
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
+import socket
 import sys
 import paramiko
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
@@ -94,18 +95,18 @@ class ThriftInterface(BaseTest):
             stdErr = se.readlines()
             retValue = 0
         except AuthenticationException as authenticationException:
-            print('SSH Authentication failure with message: %s' % authenticationException, file=sys.stderr)
+            sys.stderr.write('SSH Authentication failure with message: %s' % authenticationException)
         except SSHException as sshException:
-            print('SSH Command failed with message: %s' % sshException, file=sys.stderr)
+            sys.stderr.write('SSH Command failed with message: %s' % sshException)
         except BadHostKeyException as badHostKeyException:
-            print('SSH Authentication failure with message: %s' % badHostKeyException, file=sys.stderr)
+            sys.stderr.write('SSH Authentication failure with message: %s' % badHostKeyException)
         except socket.timeout as e:
             # The ssh session will timeout in case of a successful reboot
-            print('Caught exception socket.timeout: {}, {}, {}'.format(repr(e), str(e), type(e)), file=sys.stderr)
+            sys.stderr.write('Caught exception socket.timeout: {}, {}, {}'.format(repr(e), str(e), type(e)))
             retValue = 255
         except Exception as e:
-            print('Exception caught: {}, {}, type: {}'.format(repr(e), str(e), type(e)), file=sys.stderr)
-            print(sys.exc_info(), file=sys.stderr)
+            sys.stderr.write('Exception caught: {}, {}, type: {}'.format(repr(e), str(e), type(e)))
+            sys.stderr.write(sys.exc_info())
         finally:
             client.close()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

hit below syntax error in 202012 branch:

```
"stderr": "Traceback (most recent call last):\n  File \"/usr/bin/ptf\", line 522, in <module>\n    test_modules = load_test_modules(config)\n  File \"/usr/bin/ptf\", line 413, in load_test_modules\n    mod = imp.load_module(modname, *imp.find_module(modname, [root]))\n  File \"saitests/pfc_asym.py\", line 14, in <module>\n    from sai_base_test import *\n  File \"saitests/sai_base_test.py\", line 97\n    print('SSH Authentication failure with message: %s' % authenticationException, file=sys.stderr)\n                                                                                       ^\nSyntaxError: invalid syntax",
  "stderr_lines": [
    "Traceback (most recent call last):",
    "  File \"/usr/bin/ptf\", line 522, in <module>",
    "    test_modules = load_test_modules(config)",
    "  File \"/usr/bin/ptf\", line 413, in load_test_modules",
    "    mod = imp.load_module(modname, *imp.find_module(modname, [root]))",
    "  File \"saitests/pfc_asym.py\", line 14, in <module>",
    "    from sai_base_test import *",
    "  File \"saitests/sai_base_test.py\", line 97",
    "    print('SSH Authentication failure with message: %s' % authenticationException, file=sys.stderr)",
    "                                                                                       ^",
    "SyntaxError: invalid syntax"
  ],
```

RCA:
in python2, print('message', file=sys.stderr)" is incorrect syntax.
should use "print >> sys.stderr, 'message' "
or use sys module's write api


#### How did you do it?
use sys module, it can work in both python3 and python2

#### How did you verify/test it?
pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
