### PR TITLE
[po2vlan] Skip po2vlan on dualtor testbeds

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -380,6 +380,11 @@ def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
 @pytest.fixture(scope="module", autouse=True)
 def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, ptfadapter,
                ports_list, tbinfo, vlan_intfs_dict, setup_acl_table):  # noqa F811
+
+    if "dualtor" in tbinfo["topo"]["name"]:
+        yield
+        return
+
     duthost = duthosts[rand_one_dut_hostname]
     # --------------------- Setup -----------------------
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
As the subject, `po2vlan` is not needed for dualtor tests.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
skip if topo if `dualtor`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
