### PR TITLE
[dualtor][active-active][202205] Support `test_server_failure`

### DIFF
--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -2,6 +2,8 @@
 import json
 import pytest
 
+from tests.common.helpers.assertions import pytest_require
+
 
 __all__ = [
     'cable_type',
@@ -28,7 +30,7 @@ class ActiveActivePortID(object):
 
 
 @pytest.fixture(params=[CableType.active_standby, CableType.active_active])
-def cable_type(request, active_active_ports, active_standby_ports):
+def cable_type(request, active_active_ports, active_standby_ports, tbinfo):
     """Dualtor cable type."""
     cable_type = request.param
     has_enable_active_active_marker = False
@@ -38,6 +40,8 @@ def cable_type(request, active_active_ports, active_standby_ports):
             has_enable_active_active_marker = True
         elif marker.name == "skip_active_standby":
             skip_active_standby_marker = True
+
+    pytest_require('dualtor' in tbinfo['topo']['name'], skip_message="Skip on non-dualtor testbed")
 
     if ((not has_enable_active_active_marker) and (cable_type == CableType.active_active)):
         pytest.skip("Skip cable type 'active-active'")

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -31,7 +31,7 @@ from tests.common.dualtor.dual_tor_common import active_standby_ports           
 from tests.common.dualtor.dual_tor_common import active_active_ports                                            # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import mux_config                                                     # lgtm[py/unused-import]
 from tests.common.helpers.generators import generate_ip_through_default_route
-from tests.common.utilities import dump_scapy_packet_show_output, get_intf_by_sub_intf, is_ipv4_address
+from tests.common.utilities import dump_scapy_packet_show_output, get_intf_by_sub_intf, is_ipv4_address, wait_until
 from tests.ptf_runner import ptf_runner
 
 

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -11,6 +11,7 @@ from tests.common.dualtor.dual_tor_common import cable_type                     
 from tests.common.dualtor.dual_tor_common import mux_config                             # noqa F401
 from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER, RESET
 
@@ -237,7 +238,7 @@ def toggle_simulator_port_to_upper_tor(url, tbinfo):
             target: "upper_tor" or "lower_tor"
         """
         # Skip on non dualtor testbed
-        if 'dualtor' not in tbinfo['topo']['name']:
+        if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
             return
         server_url = url(interface_name)
         data = {"active_side": UPPER_TOR}

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -31,7 +31,9 @@ __all__ = [
     "set_drop_active_active",
     "TrafficDirection",
     "ForwardingState",
-    "toggle_active_active_simulator_ports"
+    "toggle_active_active_simulator_ports",
+    "stop_nic_grpc_server",
+    "simulator_server_down_active_active"
 ]
 
 logger = logging.getLogger(__name__)
@@ -267,9 +269,13 @@ def set_drop_active_active(mux_config, nic_simulator_client):
     def _call_set_drop_nic_simulator(nic_addresses, portids, directions, recover=False):
         drop_requests = []
         for portid, direction in zip(portids, directions):
+            if not isinstance(portid, list):
+                portid = [portid]
+            if not isinstance(direction, list):
+                direction = [direction]
             drop_request = nic_simulator_grpc_service_pb2.DropRequest(
-                portid=[portid],
-                direction=[direction],
+                portid=portid,
+                direction=direction,
                 recover=recover
             )
             drop_requests.append(drop_request)
@@ -353,3 +359,58 @@ def toggle_active_active_simulator_ports(active_active_ports_config, nic_simulat
                 raise ValueError("failed to toggle port %s, portid %s, state %s" % (mux_port, portid, state))
 
     return _toggle_active_active_simulator_ports
+
+
+@pytest.fixture(scope="function")
+def stop_nic_grpc_server(mux_config, nic_simulator_client, restart_nic_simulator):      # noqa F811
+    """Return a helper function to simulate grpc failure for active-active ports."""
+
+    def _call_set_nic_server_admin_state_nic_simulator(nic_addresses, admin_state):
+        request = nic_simulator_grpc_mgmt_service_pb2.ListOfNiCServerAdminStateRequest(
+            nic_addresses=list(nic_addresses),
+            admin_states=[admin_state for _ in nic_addresses]
+        )
+        client_stub = nic_simulator_client()
+        response = call_grpc(client_stub.SetNicServerAdminState, args=(request,))
+        logging.debug("stop nic grpc server response:\n%s", response)
+        for nic_address, success in zip(response.nic_addresses, response.successes):
+            if not success:
+                raise ValueError("failed to stop grpc server %s" % nic_address)
+
+    def _stop_nic_grpc_server(interface_names):
+        """Stop the grpc servers."""
+        nic_addresses = []
+        for interface_name in interface_names:
+            nic_address = mux_config[interface_name]["SERVER"]["soc_ipv4"].split("/")[0]
+            logger.debug("Stop grpc server on port %s, address %s", interface_name, nic_address)
+            nic_addresses.append(nic_address)
+
+        _call_set_nic_server_admin_state_nic_simulator(nic_addresses, False)
+
+    yield _stop_nic_grpc_server
+
+    restart_nic_simulator()
+
+
+@pytest.fixture
+def simulator_server_down_active_active(active_active_ports, set_drop_active_active):       # noqa F811
+    """Simulate server down scenario for active-active mux ports."""
+
+    def _simulate_server_down(interface_name):
+        if interface_name not in active_active_ports:
+            raise ValueError("%s is not a valid active-active mux port" % interface_name)
+        portids = [[ActiveActivePortID.UPPER_TOR, ActiveActivePortID.LOWER_TOR]]
+        # set upstream drop for both upper and lower ToR
+        set_drop_active_active(
+            [interface_name],
+            portids,
+            [[TrafficDirection.UPSTREAM, TrafficDirection.UPSTREAM]]
+        )
+        # set downstream drop for both upper and lower ToR
+        set_drop_active_active(
+            [interface_name],
+            portids,
+            [[TrafficDirection.DOWNSTREAM, TrafficDirection.DOWNSTREAM]]
+        )
+
+    return _simulate_server_down

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -4,9 +4,16 @@ import random
 
 from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, \
                                                        simulator_flap_counter, simulator_server_down    # noqa F401
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status                                    # noqa: F401
-from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa: F401
+from tests.common.dualtor.dual_tor_common import active_active_ports                                    # noqa F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa F401
+from tests.common.dualtor.dual_tor_common import cable_type                                             # noqa F401
+from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                    # noqa F401
+from tests.common.dualtor.dual_tor_utils import upper_tor_host                                          # noqa F401
+from tests.common.dualtor.dual_tor_utils import lower_tor_host                                          # noqa F401
+from tests.common.dualtor.nic_simulator_control import simulator_server_down_active_active              # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                                      # noqa: F401
 from tests.common.utilities import wait_until
@@ -17,20 +24,24 @@ pytestmark = [
     pytest.mark.usefixtures('run_garp_service', 'run_icmp_responder')
 ]
 
-@pytest.fixture(autouse=True, scope='module')
-def skip_if_non_dualtor_topo(tbinfo):
-    pytest_require('dualtor' in tbinfo['topo']['name'], "Only run on dualtor testbed")
 
-
-def test_server_down(duthosts, tbinfo, active_standby_ports, simulator_flap_counter,                # noqa F811
-                     simulator_server_down, toggle_simulator_port_to_upper_tor, loganalyzer):       # noqa F811
+@pytest.mark.enable_active_active
+def test_server_down(cable_type, duthosts, tbinfo, active_active_ports, active_standby_ports,               # noqa F811
+                     simulator_flap_counter, simulator_server_down, toggle_simulator_port_to_upper_tor,     # noqa F811
+                     loganalyzer, validate_active_active_dualtor_setup, upper_tor_host, lower_tor_host,     # noqa F811
+                     simulator_server_down_active_active):                                                  # noqa F811
     """
     Verify that mux cable is not toggled excessively.
     """
+    def upper_tor_mux_state_verification(state, health):
+        mux_state_upper_tor = show_muxcable_status(upper_tor_host)
+        return (mux_state_upper_tor[test_iface]['status'] == state and
+                mux_state_upper_tor[test_iface]['health'] == health)
 
-    pytest_require(active_standby_ports, "No active-standby ports are found in the dualtor topology")
-    test_iface = random.choice(active_standby_ports)
-    logging.info("Selected active-standby interface %s to test", test_iface)
+    def lower_tor_mux_state_verfication(state, health):
+        mux_state_lower_tor = show_muxcable_status(lower_tor_host)
+        return (mux_state_lower_tor[test_iface]['status'] == state and
+                mux_state_lower_tor[test_iface]['health'] == health)
 
     if loganalyzer:
         for analyzer in list(loganalyzer.values()):
@@ -38,37 +49,44 @@ def test_server_down(duthosts, tbinfo, active_standby_ports, simulator_flap_coun
                 r".*ERR swss#orchagent: :- setState: State transition from active to active is not-handled"
             )
 
-    upper_tor = duthosts[tbinfo['duts'][0]]
-    lower_tor = duthosts[tbinfo['duts'][1]]
+    if cable_type == CableType.active_standby:
+        test_iface = random.choice(active_standby_ports)
+        logging.info("Selected %s interface %s to test", cable_type, test_iface)
+        # Set upper_tor as active
+        toggle_simulator_port_to_upper_tor(test_iface)
+        pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy'),
+                      "mux_cable status is unexpected. Should be (active, healthy). Test can't proceed. ")
+        mux_flap_counter_0 = simulator_flap_counter(test_iface)
 
-    def upper_tor_mux_state_verification(state, health):
-        mux_state_upper_tor = show_muxcable_status(upper_tor)
-        return (mux_state_upper_tor[test_iface]['status'] == state and
-                mux_state_upper_tor[test_iface]['health'] == health)
+        simulator_server_down(test_iface)
 
-    def lower_tor_mux_state_verfication(state, health):
-        mux_state_lower_tor = show_muxcable_status(lower_tor)
-        return (mux_state_lower_tor[test_iface]['status'] == state and
-                mux_state_lower_tor[test_iface]['health'] == health)
+        # Verify mux_cable state on upper_tor is active
+        pytest_assert(wait_until(20, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'),
+                      "mux_cable status is unexpected. Should be (active, unhealthy)")
+        # Verify mux_cable state on lower_tor is standby
+        pytest_assert(wait_until(30, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'),
+                      "mux_cable status is unexpected. Should be (standby, unhealthy)")
+        # Verify that mux_cable flap_counter should be no larger than 3
+        # lower_tor(standby) -> active -> standby
+        # upper_tor(active) -> active
+        # The toggle from both tor may be overlapped and invisible
+        mux_flap_counter_1 = simulator_flap_counter(test_iface)
+        pytest_assert(mux_flap_counter_1 - mux_flap_counter_0 <= 3,
+                      "The mux_cable flap count should be no larger than 3 ({})"
+                      .format(mux_flap_counter_1 - mux_flap_counter_0))
 
-    # Set upper_tor as active
-    toggle_simulator_port_to_upper_tor(test_iface)
-    pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy'),
-                  "mux_cable status is unexpected. Should be (active, healthy). Test can't proceed. ")
-    mux_flap_counter_0 = simulator_flap_counter(test_iface)
-    # Server down
-    simulator_server_down(test_iface)
-    # Verify mux_cable state on upper_tor is active
-    pytest_assert(wait_until(20, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'),
-                    "mux_cable status is unexpected. Should be (active, unhealthy)")
-    # Verify mux_cable state on lower_tor is standby
-    pytest_assert(wait_until(30, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'),
-                  "mux_cable status is unexpected. Should be (standby, unhealthy)")
-    # Verify that mux_cable flap_counter should be no larger than 3
-    # lower_tor(standby) -> active -> standby
-    # upper_tor(active) -> active
-    # The toggle from both tor may be overlapped and invisible
-    mux_flap_counter_1 = simulator_flap_counter(test_iface)
-    pytest_assert(mux_flap_counter_1 - mux_flap_counter_0 <= 3,
-                    "The mux_cable flap count should be no larger than 3 ({})".format(mux_flap_counter_1 - mux_flap_counter_0))
+    elif cable_type == CableType.active_active:
+        test_iface = random.choice(active_active_ports)
+        logging.info("Selected %s interface %s to test", cable_type, test_iface)
 
+        pytest_assert(upper_tor_mux_state_verification('active', 'healthy'),
+                      "mux_cable status is unexpected. Should be (active, healthy)")
+        pytest_assert(lower_tor_mux_state_verfication('active', 'healthy'),
+                      "mux_cable status is unexpected. Should be (active, healthy)")
+
+        simulator_server_down_active_active(test_iface)
+
+        pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'standby', 'unhealthy'),
+                      "mux_cable status is unexpected. Should be (standby, unhealthy)")
+        pytest_assert(wait_until(30, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'),
+                      "mux_cable status is unexpected. Should be (standby, unhealthy)")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry-pick into 202205
Cover the server failure scenario for active-active dualtor

Signed-off-by: Longxiang Lyu lolv@microsoft.com


#### How did you do it?
add server failure simulate fixture
add testcase to verify that after the server failure, both ToRs should become standby and unhealthy. 

#### How did you verify/test it?
run on both dualtor and dualtor-aa testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
