### PR TITLE
[ansible][nic_simulator] Re-generate gRPC python dependencies in deployment 

### DIFF
--- a/ansible/roles/vm_set/tasks/control_nic_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_nic_simulator.yml
@@ -50,12 +50,21 @@
     - name: Set nic simulator source directory
       set_fact:
         nic_simulator_dir: "{{ (playbook_dir, 'dualtor', 'nic_simulator') | path_join }}"
+        remote_nic_simulator_dir: "{{ (abs_root_path, 'nic_simulator') | path_join }}"
 
     - name: Copy nic simulator to test server
       copy:
         src: "{{ nic_simulator_dir }}"
         dest: "{{ abs_root_path }}"
         force: yes
+
+    - name: Generate gRPC dependencies from the protocol buffer definitions
+      shell:
+        cmd: python3 -m grpc.tools.protoc -I. --python_out=. --grpc_python_out=. {{ item }}
+        chdir: "{{ remote_nic_simulator_dir }}"
+      loop:
+       - nic_simulator_grpc_service.proto
+       - nic_simulator_grpc_mgmt_service.proto
 
     - name: Generate nic simulator systemd service file
       template:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Generate the `nic_simulator` gRPC Python dependencies in deployment.

Signed-off-by: Longxiang Lyu lolv@microsoft.com

#### How did you do it?


#### How did you verify/test it?
verified on `dualtor-aa` testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
