### PR TITLE
cisco-8000: qos-sai: Skip LossyQueueVoq and pgShared watermark for  t2 for time-being.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -555,6 +555,8 @@ class QosSaiBase(QosBase):
             "dst_asic": dst_asic,
             "src_dut": src_dut,
             "dst_dut": dst_dut,
+            "single_asic_test": (src_dut == dst_dut and
+                src_asic == dst_asic),
             "all_asics": all_asics,
             "all_duts": all_duts
         }

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1035,8 +1035,8 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         if not get_src_dst_asic_and_duts['single_asic_test']:
-             pytest.skip("This test is not applicable when "
-                 "src and dst ASICs are different.")
+             pytest.skip("LossyQueueVoq: This test is skipped for now, will"
+                 " be re-enabled for RH cards.")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         flow_config = qosConfig[LossyVoq]["flow_config"]
@@ -1373,8 +1373,8 @@ class TestQosSai(QosSaiBase):
                 dutTestParams["basicParams"].get("platform_asic", None) \
                     == "cisco-8000":
                 pytest.skip(
-                    "Lossy test is not applicable in multiple ASIC case"
-                    " in cisco-8000 platform.")
+                    "PGSharedWatermark: Lossy test is not applicable in "
+                    "multiple ASIC case in cisco-8000 platform.")
 
             pktsNumFillShared = int(qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
@@ -1570,6 +1570,12 @@ class TestQosSai(QosSaiBase):
                 qosConfig = dutQosConfig["param"][portSpeedCableLength]
             triggerDrop = qosConfig[queueProfile]["pkts_num_trig_ingr_drp"]
         else:
+            if not get_src_dst_asic_and_duts['single_asic_test'] and \
+                dutTestParams["basicParams"].get("platform_asic", None) \
+                    == "cisco-8000":
+                pytest.skip(
+                    "Lossy test is not applicable in multiple ASIC case"
+                    " in cisco-8000 platform.")
             if queueProfile in dutQosConfig["param"][portSpeedCableLength].keys():
                 qosConfig = dutQosConfig["param"][portSpeedCableLength]
             else:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -541,8 +541,8 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         if not get_src_dst_asic_and_duts['single_asic_test']:
-             pytest.skip("This test is not applicable when "
-                 "src and dst ASICs are different.")
+             pytest.skip("This test needs to be revisited later, for the case "
+                 "where src and dst ASICs are different.")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and \
                 'backend' not in dutTestParams['topo']:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -540,6 +540,9 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
+        if not get_src_dst_asic_and_duts['single_asic_test']:
+             pytest.skip("This test is not applicable when "
+                 "src and dst ASICs are different.")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and \
                 'backend' not in dutTestParams['topo']:
@@ -1031,8 +1034,9 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000":
-            pytest.skip("Lossy Queue Voq test is not supported")
+        if not get_src_dst_asic_and_duts['single_asic_test']:
+             pytest.skip("This test is not applicable when "
+                 "src and dst ASICs are different.")
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         flow_config = qosConfig[LossyVoq]["flow_config"]
@@ -1365,6 +1369,13 @@ class TestQosSai(QosSaiBase):
         if "wm_pg_shared_lossless" in pgProfile:
             pktsNumFillShared = qosConfig[pgProfile]["pkts_num_trig_pfc"]
         elif "wm_pg_shared_lossy" in pgProfile:
+            if not get_src_dst_asic_and_duts['single_asic_test'] and \
+                dutTestParams["basicParams"].get("platform_asic", None) \
+                    == "cisco-8000":
+                pytest.skip(
+                    "Lossy test is not applicable in multiple ASIC case"
+                    " in cisco-8000 platform.")
+
             pktsNumFillShared = int(qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)


### PR DESCRIPTION
There are several testcases that are not applicable, or not work as they are written, when run on multiple-ASIC(or multi-DUT). We need to skip them for cisco-8000. These are:

1. LossyQueueVoq
           voq1 ==> split voq (not applicable for T2) or fair voq  (applicable for T2 downlink LC)
           voq2 ==> default voq so we need to add on uplink LC (need to add back)
    So we need to add it back as enhancement. 

2. PG Shared Watermark Lossy for multi-asic and multi-dut scenarion
    Reason for skip: In packet chassis lossy traffic will get dropped at egress ASIC so we cannot validate PG Watermark on ingress ASIC