### PR TITLE
Correct scapy pcapdnet import order and skip LACP session collection on kvm

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -228,7 +228,7 @@ class ReloadTest(BaseTest):
         self.nr_pc_pkts = 100
         self.nr_tests = 3
         self.reboot_delay = 10
-        self.task_timeout = 300   # Wait up to 5 minutes for tasks to complete
+        self.task_timeout = 500   # Wait up to 5 minutes for tasks to complete
         self.max_nr_vl_pkts = 500  # FIXME: should be 1000.
         # But ptf is not fast enough + swss is slow for FDB and ARP entries insertions
         self.timeout_thr = None

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -228,7 +228,7 @@ class ReloadTest(BaseTest):
         self.nr_pc_pkts = 100
         self.nr_tests = 3
         self.reboot_delay = 10
-        self.task_timeout = 500   # Wait up to 5 minutes for tasks to complete
+        self.task_timeout = 300   # Wait up to 5 minutes for tasks to complete
         self.max_nr_vl_pkts = 500  # FIXME: should be 1000.
         # But ptf is not fast enough + swss is slow for FDB and ARP entries insertions
         self.timeout_thr = None

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -156,11 +156,12 @@ def get_report_summary(duthost, analyze_result, reboot_type, reboot_oper, base_o
         if lacp_sessions_dict and "lacp_sessions" in lacp_sessions_dict else None
     controlplane_summary = {"downtime": "",
                             "arp_ping": "", "lacp_session_max_wait": ""}
-    if lacp_sessions_waittime and len(lacp_sessions_waittime) > 0:
-        max_lacp_session_wait = max(list(lacp_sessions_waittime.values()))
-        analyze_result.get(
-            "controlplane", controlplane_summary).update(
-                {"lacp_session_max_wait": max_lacp_session_wait})
+    if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
+        if lacp_sessions_waittime and len(lacp_sessions_waittime) > 0:
+            max_lacp_session_wait = max(list(lacp_sessions_waittime.values()))
+            analyze_result.get(
+                "controlplane", controlplane_summary).update(
+                    {"lacp_session_max_wait": max_lacp_session_wait})
 
     result_summary = {
         "reboot_type": "{}-{}".format(reboot_type, reboot_oper) if reboot_oper else reboot_type,

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -10,8 +10,8 @@ from fcntl import ioctl
 import logging
 import ptf.packet as scapy
 import scapy.all as scapy2
-import scapy.arch.pcapdnet # noqa F401
 scapy2.conf.use_pcap = True
+import scapy.arch.pcapdnet # noqa F401
 
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -10,7 +10,7 @@ from fcntl import ioctl
 import logging
 import ptf.packet as scapy
 import scapy.all as scapy2
-scapy2.conf.use_pcap = True
+scapy2.conf.use_pcap = True        # Do not move this import. use_pcap import needs to be enabled before import pcapdnet
 import scapy.arch.pcapdnet # noqa F401
 
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -10,8 +10,8 @@ from fcntl import ioctl
 import logging
 import ptf.packet as scapy
 import scapy.all as scapy2
-scapy2.conf.use_pcap = True
 import scapy.arch.pcapdnet # noqa F401
+scapy2.conf.use_pcap = True
 
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix import in arp_responder.py and Skip lacp collection on kvm
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Setting scapy.all.conf.use_pcap = True enables the use of pcap-based packet capturing. The import statement import scapy.arch.pcapdnet likely relies on this configuration being set correctly in order to work as intended.
#### How did you do it?

#### How did you verify/test it?
ElasticTest:

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
