### PR TITLE
[Fanout] Support config TPID for marvell-armhf SONiC fanout switches

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -1,7 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
-            "hwsku": "{{ fanout_hwsku}}",
+            "hwsku": "{{ fanout_hwsku }}",
             "hostname": "{{ inventory_hostname }}"
         }
     },
@@ -18,8 +18,10 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if 'broadcom' in fanout_sonic_version["asic_type"] and port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] %}
+        {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"] == "Access" %}
             "tpid": "0x9100",
+        {% endif %}
     {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -1,9 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
-        {% if fanout_hwsku in ("Nokia-7215", "Arista-720DT-G48S4") %}
             "default_pfcwd_status": "disable",
-        {% endif %}
             "hwsku": "{{ fanout_hwsku }}",
             "hostname": "{{ inventory_hostname }}"
         }

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -1,6 +1,9 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
+        {% if fanout_hwsku in ("Nokia-7215", "Arista-720DT-G48S4") %}
+            "default_pfcwd_status": "disable",
+        {% endif %}
             "hwsku": "{{ fanout_hwsku }}",
             "hostname": "{{ inventory_hostname }}"
         }
@@ -67,6 +70,49 @@
         }
     },
 
+    "VERSIONS": {
+        "DATABASE": {
+            "VERSION": "version_1_0_1"
+        }
+    },
+
+{% if fanout_hwsku in ("Nokia-7215", "Arista-720DT-G48S4") %}
+
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "BUFFER_POOL_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PORT_BUFFER_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "RIF": {
+            "FLEX_COUNTER_STATUS": "disable"
+        }
+    },
+
+{% else %}
+
     "FLEX_COUNTER_TABLE": {
         "PFCWD": {
             "FLEX_COUNTER_STATUS": "enable"
@@ -115,12 +161,6 @@
         }
     },
 
-    "VERSIONS": {
-        "DATABASE": {
-            "VERSION": "version_1_0_1"
-        }
-    },
-
     "PFC_WD": {
         "GLOBAL": {
             "POLL_INTERVAL": "200"
@@ -166,6 +206,8 @@
             "weight": "15"
         }
     },
+
+{% endif %}
 
     "FEATURE": {
         "acms": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Support config TPID for marvell-armhf SONiC fanout switches
2. Add other necessary configuration for Nokia-7215 and Arista-720DT SONiC fanout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
1. Support config TPID for Marvell SONiC fanout switches
2. Add other necessary configuration for Nokia-7215 and Arista-720DT SONiC fanout.

#### How did you do it?
Update the config_db template for SONiC 202205 fanout.

#### How did you verify/test it?
Verified on Nokia-7215 fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
