### PR TITLE
Increase the tolerance of noise packets in dualtor tunnel monitor queue check

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -98,7 +98,7 @@ def queue_stats_check(dut, exp_queue, packet_count):
     queue_counter = dut.shell('show queue counters | grep "UC"')['stdout']
     logging.debug('queue_counter:\n{}'.format(queue_counter))
     # In case of other noise packets
-    DIFF = 0.1
+    DIFF = max(10, packet_count * 0.1)
 
     """
     regex search will look for following pattern in queue_counter outpute
@@ -111,7 +111,7 @@ def queue_stats_check(dut, exp_queue, packet_count):
 
     if result:
         for number in result:
-            if int(number) <= packet_count * (1 + DIFF) and int(number) >= packet_count:
+            if int(number) <= packet_count + DIFF and int(number) >= packet_count:
                 logging.info("the expected Queue : {} received expected numbers of packet {}"
                              .format(exp_queue, number))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The noise packets are considered in the dualtor tunnel traffic monitor, but the tolerance is too small sometimes.
Currently the tolerance in queue_stats_check function is 10% of the total sent packets. 
If only a few packets are sent, the tolerance will be too small. For example, the default packets number is 10, in this case only 1 noise packet is allowed.
Sometimes dualtor tests fails due to noise packets.
So, increase the noise packets tolerance in queue check to at least 10 packets.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the statistical failure in the queue check of dualtor tunnel traffic monitor. 
#### How did you do it?
Increase the noise packets tolerance in queue check to at least 10 packets.
#### How did you verify/test it?
By automation, all related tests passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
