### PR TITLE
Fix caching issue status in conditional mark

### DIFF
--- a/tests/common/plugins/conditional_mark/issue.py
+++ b/tests/common/plugins/conditional_mark/issue.py
@@ -70,7 +70,7 @@ class GitHubIssueChecker(IssueCheckerBase):
             bool: False if the issue is closed else True.
         """
         try:
-            response = requests.get(self.api_url, auth=(self.user, self.api_token))
+            response = requests.get(self.api_url, auth=(self.user, self.api_token), timeout=10)
             response.raise_for_status()
             issue_data = response.json()
             if issue_data.get('state', '') == 'closed':
@@ -138,4 +138,4 @@ def check_issues(issues):
     for proc in check_procs:
         proc.join(timeout=60)
 
-    return check_results
+    return dict(check_results)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The conditional mark plugin supports querying Github for issues status to determine adding a mark or not.
When there is network issue, querying Github for issue status will fail after connection timeout. PR #6313 added caching for issue status. However, the caching seems not really working because multiprocessing is used for querying issue status. The returned result is a proxy to Manager object, not really a dict expected by the caching code.

#### How did you do it?
This fix casted the issue querying result to dict before returning it back to the caching code.
This change also added timeout value for sending requests to Github querying issue status.

#### How did you verify/test it?
Run pytest with --collect-only in sonic-mgmt container has no Internet access.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
