### PR TITLE
Fix test_replace_mtu failure on topologies without portchannel

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -72,7 +72,9 @@ def get_ethernet_port_not_in_portchannel(duthost):
     ports = list(config_facts['PORT'].keys())
     port_channel_members = []
     if 'PORTCHANNEL_MEMBER' not in config_facts:
-        return ports[0]
+        if len(ports) > 0:
+            port_name = ports[0]
+        return port_name
     port_channel_member_facts = config_facts['PORTCHANNEL_MEMBER']
     for port_channel in list(port_channel_member_facts.keys()):
         for member in list(port_channel_member_facts[port_channel].keys()):

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -71,6 +71,8 @@ def get_ethernet_port_not_in_portchannel(duthost):
     port_name = ""
     ports = list(config_facts['PORT'].keys())
     port_channel_members = []
+    if 'PORTCHANNEL_MEMBER' not in config_facts:
+        return ports[0]
     port_channel_member_facts = config_facts['PORTCHANNEL_MEMBER']
     for port_channel in list(port_channel_member_facts.keys()):
         for member in list(port_channel_member_facts[port_channel].keys()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test_replace_mtu failure on the topologies without portchannel.
For example, on Mx topology, we got below error on `test_replace_mtu`:

```
generic_config_updater/test_eth_interface.py::test_replace_mtu 
-------------------------------- live log call ---------------------------------
18:07:51 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/azp/_work/13/s/tests/generic_config_updater/test_eth_interface.py", line 148, in test_replace_mtu
    port_name = get_ethernet_port_not_in_portchannel(duthost)
  File "/azp/_work/13/s/tests/generic_config_updater/test_eth_interface.py", line 72, in get_ethernet_port_not_in_portchannel
    port_channel_member_facts = config_facts['PORTCHANNEL_MEMBER']
KeyError: 'PORTCHANNEL_MEMBER'
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix test_replace_mtu failure on the topologies without portchannel.

#### How did you do it?
If the topology doesn't contain any portchannel, return the first port from port list directly.

#### How did you verify/test it?
Verified on `Mx` topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
