### PR TITLE
Improve devutils to specify output file

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -145,12 +145,21 @@ def get_console_info(hostname, attrs):
     return console_info
 
 
-def show_data_output(header, data, json_output=False):
+def show_data_output(header, data, json_output=False, output_file=None):
     if json_output:
-        print(json.dumps(sorted(data, key=lambda x: x['Host']), indent=4))
+        output_content = json.dumps(sorted(data, key=lambda x: x['Host']), indent=4)
     else:
-        print(
-            tabulate(sorted(data, key=lambda x: x[0]), headers=header, tablefmt='grid'))
+        output_content = tabulate(sorted(data, key=lambda x: x[0]), headers=header, tablefmt='grid')
+
+    if output_file:
+        try:
+            with open(output_file, 'w') as f:
+                f.write(output_content)
+            print("Output saved to {}".format(output_file))
+        except Exception as e:
+            print("Failed to write to output file: {}".format(e))
+    else:
+        print(output_content)
 
 
 def action_list(parameters):
@@ -164,7 +173,7 @@ def action_list(parameters):
         for name, vars in hosts.items():
             data.append(
                 (name, vars['ansible_host'] if 'ansible_host' in vars else 'not_available'))
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_ping(parameters):
@@ -203,7 +212,7 @@ def action_ping(parameters):
                 data.append((name.split('|')[0], name.split('|')[
                             1], 'Success' if result['result'][0] == 0 else "Fail"))
 
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_ssh(parameters):
@@ -279,7 +288,7 @@ def action_pdu(parameters, action):
 
 def action_pdu_status(parameters):
     header, data = action_pdu(parameters, 'status')
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_pdu_failures(parameters):
@@ -292,17 +301,17 @@ def action_pdu_failures(parameters):
         else:
             if any(x['output_watts'] == '0' for x in entry[2]):
                 failures.append(entry)
-    show_data_output(header, failures, parameters['json'])
+    show_data_output(header, failures, parameters['json'], parameters['out'])
 
 
 def action_pdu_off(parameters):
     header, data = action_pdu(parameters, 'off')
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_pdu_on(parameters):
     header, data = action_pdu(parameters, 'on')
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_pdu_reboot(parameters):
@@ -312,7 +321,7 @@ def action_pdu_reboot(parameters):
     _, data_on = action_pdu(parameters, 'on')
 
     data = data + data_on
-    show_data_output(header, data, parameters['json'])
+    show_data_output(header, data, parameters['json'], parameters['out'])
 
 
 def action_dispatcher(parameters):
@@ -397,6 +406,8 @@ def main():
         type=int, required=False, default=1)
     parser.add_argument('-j', '--json', help='json output', action='store_true',
                         required=False, default=False)
+    parser.add_argument('-o', '--out', help='specify output file',
+                        required=False, default=None)
 
     args = parser.parse_args()
     if not validate_args(args):
@@ -435,6 +446,7 @@ def main():
                   'ipv6': args.ipv6,
                   'cmd': args.cmd,
                   'json': args.json,
+                  'out': args.out,
                   }
     action_dispatcher(parameters)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The devutils tool supports output content in json. To save the json format output content to a file, we can run the command and redirect the output content to a file. However, the libraries called by this tool may generate some error messages to stdout. Those error messages may be redirected to the json file too. Then the saved json file could be invalid and cause subsequent parsing issue.

#### How did you do it?
This change enhanced the devutils script to support specifying an output file. Only valid content will be saved to the output file. Error messages will only be sent to console.

When the new argument is not specified, behavior of the devutils tool remains the same.

#### How did you verify/test it?
Test run the script with and without `-o` argument.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
