### PR TITLE
Improve report_uploader to upload files by best effort

### DIFF
--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -78,50 +78,67 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         else:
             version = "UNKNOWN"
         for path_name in args.path_list:
-            reboot_data_regex = re.compile(
-                '.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
-            if reboot_data_regex.match(path_name):
-                kusto_db.upload_reboot_report(path_name, report_guid)
-            else:
-                if args.json:
-                    test_result_json = validate_junit_json_file(path_name)
+            try:
+                reboot_data_regex = re.compile(
+                    '.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
+                if reboot_data_regex.match(path_name):
+                    kusto_db.upload_reboot_report(path_name, report_guid)
                 else:
-                    roots = validate_junit_xml_path(path_name)
-                    test_result_json = parse_test_result(roots)
-                kusto_db.upload_report(
-                    test_result_json, tracking_id, report_guid, testbed, version)
+                    if args.json:
+                        test_result_json = validate_junit_json_file(path_name)
+                    else:
+                        roots = validate_junit_xml_path(path_name)
+                        test_result_json = parse_test_result(roots)
+                    kusto_db.upload_report(test_result_json, tracking_id, report_guid, testbed, version)
+            except Exception as e:
+                print("Failed to upload report '{}', exception: {}".format(path_name, repr(e)))
     elif args.category == "reachability":
         reachability_data = []
         for path_name in args.path_list:
-            with open(path_name) as f:
-                reachability_data.extend(json.load(f))
+            try:
+                with open(path_name) as f:
+                    reachability_data.extend(json.load(f))
+            except Exception as e:
+                print("Failed to parse reachability data '{}', exception: {}".format(path_name, repr(e)))
 
         kusto_db.upload_reachability_data(reachability_data)
     elif args.category == "pdu_status":
         pdu_data = []
         for path_name in args.path_list:
-            with open(path_name) as f:
-                pdu_data.extend(json.load(f))
+            try:
+                with open(path_name) as f:
+                    pdu_data.extend(json.load(f))
+            except Exception as e:
+                print("Failed to parse pdu status data '{}', exception: {}".format(path_name, repr(e)))
 
         kusto_db.upload_pdu_status_data(pdu_data)
     elif args.category == 'expected_runs':
         expected_runs = []
         for path_name in args.path_list:
-            with open(path_name) as f:
-                expected_runs.extend(json.load(f))
+            try:
+                with open(path_name) as f:
+                    expected_runs.extend(json.load(f))
+            except Exception as e:
+                print("Failed to parse expected runs data '{}', exception: {}".format(path_name, repr(e)))
         kusto_db.upload_expected_runs(expected_runs)
     elif args.category == "case_invoc":
         for path_name in args.path_list:
             fns = os.listdir(path_name)
             count = 0
             for fn in fns:
-                fn = os.path.join(path_name, fn)
-                kusto_db._upload_case_invoc_report_file(fn)
-                count += 1
-                print("Ingested file {}, {}/{}".format(fn, count, len(fns)))
+                try:
+                    fn = os.path.join(path_name, fn)
+                    kusto_db._upload_case_invoc_report_file(fn)
+                    count += 1
+                    print("Ingested file {}, {}/{}".format(fn, count, len(fns)))
+                except Exception as e:
+                    print("Failed to ingest file '{}', exception: {}".format(fn, repr(e)))
     elif args.category == "sai_header_def":
         for path_name in args.path_list:
-            kusto_db.upload_sai_header_def_report_file(path_name)
+            try:
+                kusto_db.upload_sai_header_def_report_file(path_name)
+            except Exception as e:
+                print("Failed to ingest file '{}', exception: {}".format(path_name, repr(e)))
 
     else:
         print('Unknown category "{}"'.format(args.category))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The report_uploader.py script supports uploading multiple report files in a batch to Kusto. However, if any of the report file is malformed, an exception would be raised and the entire uploading will fail.

#### How did you do it?
This change improved the report_uploader.py script to support uploading reports by best effort. This means that if any report file is malformed, that file will be skipped. The good report files still can be processed and uploaded.

#### How did you verify/test it?
Tested uploading multiple report files. One of the files is a malformed json file.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
