### PR TITLE
Fix for drop_packets tests failure

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -47,6 +47,9 @@ def get_pkt_drops(duthost, cli_cmd, asic_index):
     match = re.search("Last cached time was.*\n", stdout)
     if match:
         stdout = re.sub("Last cached time was.*\n", "", stdout)
+    match = re.search("Reminder:.*", stdout)
+    if match:
+        stdout = re.sub("Reminder:.*", "", stdout)
 
     try:
         return json.loads(stdout)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- After 'cherry-pick' of PR#[2703](https://github.com/sonic-net/sonic-utilities/pull/2703/files) to 202205 branch, some of the '_drop_packets_' test cases are failing with the following issue.
- `drop_packets error: > raise Exception("Failed to parse output of '{}', err={}".format(cli_cmd, str(err)))
E Exception: Failed to parse output of 'portstat -j -n {} ', err=Extra data: line 274 column 1 - line 274 column 84 (char 6244 - 6327)`
- This PR fixes the above issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- To fix 'drop_packets' test case failure shown below,
- `
drop_packets error: > raise Exception("Failed to parse output of '{}', err={}".format(cli_cmd, str(err)))
E Exception: Failed to parse output of 'portstat -j -n {} ', err=Extra data: line 274 column 1 - line 274 column 84 (char 6244 - 6327)
`

#### How did you do it?
- '_portstat -j -n asicX_' command output (JSON) at the end has a statement "`Reminder: Please execute 'show interface counters -d all' to include internal links`".
- JSON parsing fails due to this statement at the end of the output.
- Test case is adjusted to ignore this statement and consider only the json output of the portstat command.

#### How did you verify/test it?
- Ran the drop_packets test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![drop_packets](https://github.com/sonic-net/sonic-mgmt/assets/114024719/4f1988b5-66cd-4c91-8eef-5b31e6c8dd82)
