### PR TITLE
Move /host/logs_before_reboot to /var/log/

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -467,7 +467,7 @@ class AdvancedReboot:
         result = self.duthost.shell(command)
 
         if result["rc"] == 0:
-            command = f"find {source_dir} -type f -exec cp {{}} {target_dir}/{{}}.preboot \\;"
+            command = 'sudo find ' + source_dir + ' -type f -exec sh -c \'mv "$0" "' + target_dir + '/$(basename "$0").preboot"\' {} \\;'
             result = self.duthost.shell(command)
             if result["rc"] == 0:
                 logger.info("Files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -463,7 +463,7 @@ class AdvancedReboot:
         source_dir = '/host/logs_before_reboot'
         target_dir = '/var/log'
 
-        command = f"test -d {source_dir}"
+        command = "test -d {}".format(source_dir)
         result = self.duthost.shell(command)
 
         if result["rc"] == 0:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -468,7 +468,7 @@ class AdvancedReboot:
 
         if result["rc"] == 0:
             command = 'sudo find ' + source_dir + ' -type f -exec sh -c \'mv "$0" "' + target_dir + '/$(basename "$0").preboot"\' {} \\;'
-            result = self.duthost.shell(command)
+            result = self.duthost.shell(command, module_ignore_errors=True)
             if result["rc"] == 0:
                 logger.info("Files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
             else:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -459,6 +459,24 @@ class AdvancedReboot:
         # Handle mellanox platform
         self.__handleMellanoxDut()
 
+    def move_logs_before_reboot(self):
+        source_dir = '/host/logs_before_reboot'
+        target_dir = '/var/log'
+
+        command = f"test -d {source_dir}"
+        result = self.duthost.shell(command)
+
+        if result["rc"] == 0:
+            command = f"find {source_dir} -type f -exec cp {{}} {target_dir}/{{}}.preboot \\;"
+            result = self.duthost.shell(command)
+            if result["rc"] == 0:
+                logger.info("Files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
+            else:
+                logger.info("Failed to copy files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
+
+        else:
+            logger.info("Directory {} does not exist.".format(source_dir))
+
     def runRebootTest(self):
         # Run advanced-reboot.ReloadTest for item in preboot/inboot list
         count = 0
@@ -498,6 +516,7 @@ class AdvancedReboot:
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
                 log_dir = self.__fetchTestLogs(rebootOper)
                 if self.advanceboot_loganalyzer:
+                    self.move_logs_before_reboot()
                     verification_errors = post_reboot_analysis(marker, event_counters=event_counters,
                                                                reboot_oper=rebootOper, log_dir=log_dir)
                     if verification_errors:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -464,7 +464,7 @@ class AdvancedReboot:
         target_dir = '/var/log'
 
         command = "test -d {}".format(source_dir)
-        result = self.duthost.shell(command)
+        result = self.duthost.shell(command, module_ignore_errors=True)
 
         if result["rc"] == 0:
             command = 'sudo find ' + source_dir + ' -type f -exec sh -c \'mv "$0" "' + target_dir + '/$(basename "$0").preboot"\' {} \\;'
@@ -472,8 +472,7 @@ class AdvancedReboot:
             if result["rc"] == 0:
                 logger.info("Files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
             else:
-                logger.info("Failed to copy files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
-
+                logger.info("Failed to copy files under /host/logs_before_reboot successfully to {}.".format(target_dir))
         else:
             logger.info("Directory {} does not exist.".format(source_dir))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently logs under /host/logs_before_reboot is not collected during show techsupport. Moving logs to /var/log temporarily under a more permanenetly solution exists in image

#### How did you do it?
Move logs under /host/logs_before_reboot to /var/log/<filename>.preboot

#### How did you verify/test it?
Manually tested test_warm_reboot. Created files under /host/logs_before_reboot and verified files were successfully moved to /var/log with .preboot suffix after reboot

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
