### PR TITLE
skip active forwarding check on cisco platforms

### DIFF
--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -139,8 +139,8 @@ def test_mac_move(
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
 
     # active forwarding check after fdb ageout/flush
-    # skip Mellanox platforms for the traffic will be flooded in the vlan when there is no fdb entries
-    if not tor.facts['asic_type'] == 'mellanox':
+    # skip Mellanox and cisco platforms for the traffic will be flooded in the vlan when there is no fdb entries
+    if not (tor.facts['asic_type'] == 'mellanox' or tor.facts['asic_type'] == 'cisco-8000'):
         tor.shell("fdbclear")
         server_traffic_monitor = ServerTrafficMonitor(
             tor, ptfhost, vmhost, tbinfo, test_port,


### PR DESCRIPTION
Description: 
In Dualtor/test_orchagent_mac_move.py, when doing active forwarding check after fdb ageout/flush, traffic gets flooded in vlan for cisco and Mellanox platforms. Because of this, the testcase fails. To avoid this, skip condition is added for Mellanox platforms. This PR is including the same skip condition for Cisco platforms as well.

Changes: 
Put 'cisco-8000' in the skip condition along with Mellanox
if not (tor.facts['asic_type'] == 'mellanox' or tor.facts['asic_type'] == 'cisco-8000'):
        tor.shell("fdbclear")
        server_traffic_monitor = ServerTrafficMonitor(
            tor, ptfhost, vmhost, tbinfo, test_port,
            conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
        )

Verification: 
The test was run on a T0 testbed after making above changes and it passed.