### PR TITLE
Stabilize `test_po_update`

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -514,6 +514,17 @@ class SonicAsic(object):
                                             pc=pc_name,
                                             intf=interface_name))
 
+    def get_portchannel_members(self, pc_name):
+        """
+        Get the running PortChannel members of the given PortChannel
+        """
+        cmd = "show interfaces portchannel"
+        ret = self.sonichost.show_and_parse(cmd)
+        for pc in ret:
+            if pc["team dev"] == pc_name:
+                return None if pc["ports"] == "" else pc["ports"].split(",")
+        return None
+
     def switch_arptable(self, *module_args, **complex_args):
         complex_args['namespace'] = self.namespace
         return self.sonichost.switch_arptable(*module_args, **complex_args)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize test cases in `test_po_update`.
The test cases are flaky on some platforms because the 2 seconds delay is not enough to remove members from LAG.
The test failed with below error logs
```
Jun  5 14:26:30.267255 str-msn2700-06 ERR swss#orchagent: :- removeLag: Failed to remove non-empty LAG PortChannel999
Jun  5 14:26:30.363586 str-msn2700-06 ERR swss#orchagent: :- removeLag: Failed to remove non-empty LAG PortChannel999
```
This PR addressed the issue by checking the members in LAG instead of sleep.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to stabilize test cases in `test_po_update`.

#### How did you do it?
This PR addressed the issue by checking the members in LAG instead of sleep.

#### How did you verify/test it?
The change is verified on a Mellanox testbed
```
collected 2 items                                                                                                                                                                           

pc/test_po_update.py::test_po_update[str2-msn4600c-acs-01-None] PASSED                                                                                                                [ 50%]
pc/test_po_update.py::test_po_update_io_no_loss[str2-msn4600c-acs-01-None]  PASSED                                                                                                     [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
