### PR TITLE
Fix the label for cherry-pick in workflow yaml

### DIFF
--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -67,7 +67,7 @@ jobs:
           while read label
           do
             echo label: $label
-            if [[ "$label" == "Approved for $branch branch" ]];then
+            if [[ "$label" == "Request for $branch branch" ]];then
               create_pr=1
             fi
             if [[ "$label" == "Created PR to $branch branch" ]];then
@@ -85,7 +85,7 @@ jobs:
           done <<< "$labels"
 
           if [[ "$create_pr" != "1" ]];then
-            echo "Didn't find 'Approved for $branch branch' tag."
+            echo "Didn't find 'Request for $branch branch' tag."
             return 0
           fi
           # Begin to cherry-pick PR
@@ -103,7 +103,7 @@ jobs:
             gh pr edit $pr_url --add-label "Cherry Pick Conflict_$branch"
             echo 'Add label "Cherry Pick Conflict_$branch" success'
             gh pr comment $pr_url --body "@${author} PR conflicts with $branch branch"
-            echo 'Add commnet "@${author} PR conflicts with $branch branch"'
+            echo 'Add comment "@${author} PR conflicts with $branch branch"'
           else
             # Create PR to release branch
             git push mssonicbld HEAD:cherry/$branch/${pr_id} -f
@@ -135,4 +135,3 @@ jobs:
           echo Begin to parse Branch: $branch
           cherry_pick
         done
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The workflow added for auto cherry-pick expects label like `Approved for $branch branch`.
For the sonic-mgmt repository, people are used to use label like `Request for $branch branch`.
Because of this difference, the cherry-pick actions are not really working.

#### How did you do it?
This fix updated the expected labels in workflow yaml to `Request for $branch branch`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
