### PR TITLE
Watchdog reboot skip

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -859,7 +859,6 @@ platform_tests/test_reboot.py::test_watchdog_reboot:
     conditions_logical_operator: or
     conditions:
       - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - "'t1' in topo_type and platform in ['x86_64-8102_64h_o-r0']"
 
 #######################################
 #####   test_reload_config.py     #####

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -299,7 +299,7 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list, tbinf):      # noqa F811
+                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list, tbinfo):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -316,7 +316,7 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     topo = tbinfo["topo"]["type"]
     platform = duthost.facts['platform']
     if bios_version < "218" and topo == "t1" and platform == "x86_64-8102_64h_o-r0":
-        pytest.skip("Skipping test due to BIOS version less than 218 and topo is t1 and platform is x86_64-8102_64h_o-r0")
+        pytest.skip("Skip test if BIOS ver <218 and topo is T1 and platform is M64")
     reboot_and_check(localhost, duthost,
                      conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -299,7 +299,7 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):      # noqa F811
+                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list, tbinf):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -310,7 +310,13 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
         pytest.skip(
             "Watchdog is not supported on this DUT, skip this test case")
-
+    output = duthost.shell("dmidecode -s bios-version")["stdout"]
+    bios = output.split('-')
+    bios_version = bios[1]
+    topo = tbinfo["topo"]["type"]
+    platform = duthost.facts['platform']
+    if bios_version < "218" and topo == "t1" and platform == "x86_64-8102_64h_o-r0":
+        pytest.skip("Skipping test due to BIOS version less than 218 and topo is t1 and platform is x86_64-8102_64h_o-r0")
     reboot_and_check(localhost, duthost,
                      conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga
msft cannot upgrade from the Ref. point to newer FPD
Upgrading to newer fpd will brick the box
they have old Proto boxes in their lab, Hence skipping this test. As there is no way to check bios from minigraph facts can't add skip in tests_mark_conditions_platform_tests.yaml. 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ X] 202205

### Approach
#### What is the motivation for this PR?
Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga
#### How did you do it?
Added skip in test_reboot.py for watchdog_reboot
#### How did you verify/test it?
============================================================================================= short test summary info =============================================================================================
SKIPPED [1] /data/tests/platform_tests/test_reboot.py:281: Skip test if BIOS ver <218 and topo is T1 and platform is M64
=========================================================================================== 1 skipped in 189.89 seconds ===========================================================================================

#### Any platform specific information?
T1 topology, Cisco platform x86_64-8102_64h_o-r0
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
