### PR TITLE
Fix trigger condition for the cherry-pick workflow

### DIFF
--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre_cherry_pick:
-    if: github.repository_owner == 'sonic-net' && github.event.pull_request.merged == true && ( (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ','), 'Approved for 20')) || (github.event.action == 'labeled' && startsWith(github.event.label.name, 'Approved for 20')) )
+    if: github.repository_owner == 'sonic-net' && github.event.pull_request.merged == true && ( (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ','), 'Request for 20')) || (github.event.action == 'labeled' && startsWith(github.event.label.name, 'Request for 20')) )
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #8511 updated the cherry-pick workflow to use lable "Request for 20xx branch". However, the workflow condition was not updated accordingly. The workflow actions are still skipped when labels like "Request for 20xx branch" is set.

#### How did you do it?
This change updated the trigger condition in the workflow yaml to match labels start with "Request for 20".

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
