### PR TITLE
[Snappi] Validate that switch ignores PFC frame received with no bit set in the class enable vector

### DIFF
--- a/tests/common/snappi/common_helpers.py
+++ b/tests/common/snappi/common_helpers.py
@@ -705,3 +705,20 @@ def get_pfc_frame_count(duthost, port, priority, is_tx=False):
     pause_frame_count = raw_out.split()[priority + 1]
 
     return int(pause_frame_count.replace(',', ''))
+
+
+def get_queue_count(duthost, port, priority):
+    """
+    Get the egress queue count in packets and bytes for a given port and priority from SONiC CLI.
+    This is the equivalent of the "show queue counters" command.
+    Args:
+        duthost (Ansible host instance): device under test
+        port (str): port name
+        priority (int): priority of flow
+    Returns:
+        tuple (int, int): total count of packets and bytes in the queue
+    """
+    raw_out = duthost.shell("show queue counters {} | sed -n '/\(UC{}\)/p'".format(port, priority))['stdout']
+    total_pkts = raw_out.split()[2]
+    total_bytes = raw_out.split()[3]
+    return int(total_pkts.replace(',', '')), int(total_bytes.replace(',', ''))

--- a/tests/common/snappi/common_helpers.py
+++ b/tests/common/snappi/common_helpers.py
@@ -707,7 +707,7 @@ def get_pfc_frame_count(duthost, port, priority, is_tx=False):
     return int(pause_frame_count.replace(',', ''))
 
 
-def get_queue_count(duthost, port, priority):
+def get_egress_queue_count(duthost, port, priority):
     """
     Get the egress queue count in packets and bytes for a given port and priority from SONiC CLI.
     This is the equivalent of the "show queue counters" command.

--- a/tests/common/snappi/common_helpers.py
+++ b/tests/common/snappi/common_helpers.py
@@ -718,7 +718,7 @@ def get_queue_count(duthost, port, priority):
     Returns:
         tuple (int, int): total count of packets and bytes in the queue
     """
-    raw_out = duthost.shell("show queue counters {} | sed -n '/\(UC{}\)/p'".format(port, priority))['stdout']
+    raw_out = duthost.shell("show queue counters {} | sed -n '/UC{}/p'".format(port, priority))['stdout']
     total_pkts = raw_out.split()[2]
     total_bytes = raw_out.split()[3]
     return int(total_pkts.replace(',', '')), int(total_bytes.replace(',', ''))

--- a/tests/common/snappi/snappi_helpers.py
+++ b/tests/common/snappi/snappi_helpers.py
@@ -309,8 +309,3 @@ def wait_for_arp(snappi_api, max_attempts=10, poll_interval_sec=1):
                   "ARP is not resolved in {} seconds".format(max_attempts * poll_interval_sec))
 
     return attempts
-
-
-class class_enable_vector(Enum):
-    NO_BIT_SET = 0
-    BIT_SET = 1

--- a/tests/common/snappi/snappi_helpers.py
+++ b/tests/common/snappi/snappi_helpers.py
@@ -8,6 +8,7 @@ chassis instead of reading it from fanout_graph_facts fixture.
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi.common_helpers import ansible_stdout_to_str, get_peer_snappi_chassis
 import time
+from enum import Enum
 
 
 class SnappiFanoutManager():
@@ -308,3 +309,8 @@ def wait_for_arp(snappi_api, max_attempts=10, poll_interval_sec=1):
                   "ARP is not resolved in {} seconds".format(max_attempts * poll_interval_sec))
 
     return attempts
+
+
+class class_enable_vector(Enum):
+    NO_BIT_SET = 0
+    BIT_SET = 1

--- a/tests/snappi/pfc/files/helper.py
+++ b/tests/snappi/pfc/files/helper.py
@@ -3,11 +3,11 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts                  # noqa F401
-from tests.common.snappi.snappi_helpers import get_dut_port_id
+from tests.common.snappi.snappi_helpers import get_dut_port_id, class_enable_vector
 from tests.common.snappi.common_helpers import pfc_class_enable_vector,\
     get_lossless_buffer_size, get_pg_dropped_packets,\
     stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count
+    get_pfc_frame_count, get_queue_count
 from tests.common.snappi.port import select_ports, select_tx_port
 from tests.common.snappi.snappi_helpers import wait_for_arp
 
@@ -40,7 +40,8 @@ def run_pfc_test(api,
                  prio_dscp_map,
                  test_traffic_pause,
                  headroom_test_params=None,
-                 pfc_pause_src_mac=None):
+                 pfc_pause_src_mac=None,
+                 class_enable_vec=class_enable_vector.BIT_SET):
     """
     Run a PFC test
     Args:
@@ -60,6 +61,7 @@ def run_pfc_test(api,
         headroom_test_params (array): 2 element array if the associated pfc pause quanta
                                     results in no packet drop [pfc_delay, headroom_result]
         pfc_pause_src_mac (string): source MAC address of PFC Pause frames
+        class_enable_vec (ENUM): ENUM of class enable vector settings
     Returns:
         N/A
     """
@@ -111,15 +113,17 @@ def run_pfc_test(api,
                   data_flow_delay_sec=DATA_FLOW_DELAY_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_dscp_map=prio_dscp_map,
-                  pfc_pause_src_mac=pfc_pause_src_mac)
+                  pfc_pause_src_mac=pfc_pause_src_mac,
+                  class_enable_vec=class_enable_vec)
 
     flows = testbed_config.flows
 
     all_flow_names = [flow.name for flow in flows]
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
-    # Clear PFC counters before traffic run
+    # Clear PFC and queue counters before traffic run
     duthost.command("pfcstat -c")
+    duthost.command("sonic-clear queuecounters")
 
     """ Run traffic """
     flow_stats = __run_traffic(api=api,
@@ -148,7 +152,8 @@ def run_pfc_test(api,
                      speed_gbps=speed_gbps,
                      test_flow_pause=test_traffic_pause,
                      tolerance=TOLERANCE_THRESHOLD,
-                     headroom_test_params=headroom_test_params)
+                     headroom_test_params=headroom_test_params,
+                     class_enable_vec=class_enable_vec)
 
 
 def __gen_traffic(testbed_config,
@@ -167,7 +172,8 @@ def __gen_traffic(testbed_config,
                   data_flow_delay_sec,
                   data_pkt_size,
                   prio_dscp_map,
-                  pfc_pause_src_mac):
+                  pfc_pause_src_mac,
+                  class_enable_vec):
     """
     Generate configurations of flows, including test flows, background flows and
     pause storm. Test flows and background flows are also known as data flows.
@@ -189,6 +195,7 @@ def __gen_traffic(testbed_config,
         data_pkt_size (int): packet size of data flows in byte
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
         pfc_pause_src_mac (string): source MAC address of PFC Pause frames
+        class_enable_vec (int): ENUM of class enable vector settings
     Returns:
         flows configurations (list): the list should have configurations of
         len(test_flow_prio_list) test flow, len(bg_flow_prio_list) background
@@ -231,7 +238,7 @@ def __gen_traffic(testbed_config,
     rx_port_name = testbed_config.ports[rx_port_id].name
     data_flow_delay_nanosec = sec_to_nanosec(data_flow_delay_sec)
 
-    """ Test flows """
+    """ Test flows - lossless traffic """
     for prio in test_flow_prio_list:
         test_flow = testbed_config.flows.flow(name='{} Prio {}'.format(test_flow_name, prio))[-1]
         test_flow.tx_rx.port.tx_name = tx_port_name
@@ -261,7 +268,7 @@ def __gen_traffic(testbed_config,
         flow_port_config[0][str(tx_port_config.peer_port)].append(int(prio))
         flow_port_config[1][str(rx_port_config.peer_port)].append(int(prio))
 
-    """ Background flows """
+    """ Background flows - lossy traffic """
     for prio in bg_flow_prio_list:
         bg_flow = testbed_config.flows.flow(name='{} Prio {}'.format(bg_flow_name, prio))[-1]
         bg_flow.tx_rx.port.tx_name = tx_port_name
@@ -308,7 +315,8 @@ def __gen_traffic(testbed_config,
         pause_pkt = pause_flow.packet.pfcpause()[-1]
         pause_pkt.src.value = pfc_pause_src_mac if pfc_pause_src_mac else '00:00:fa:ce:fa:ce'
         pause_pkt.dst.value = '01:80:C2:00:00:01'
-        pause_pkt.class_enable_vector.value = vector
+        pause_pkt.class_enable_vector.value = class_enable_vector.NO_BIT_SET.value if class_enable_vec == \
+            class_enable_vector.NO_BIT_SET else vector
         pause_pkt.pause_class_0.value = pause_time[0]
         pause_pkt.pause_class_1.value = pause_time[1]
         pause_pkt.pause_class_2.value = pause_time[2]
@@ -408,7 +416,8 @@ def __verify_results(rows,
                      speed_gbps,
                      test_flow_pause,
                      tolerance,
-                     headroom_test_params=None):
+                     headroom_test_params=None,
+                     class_enable_vec=class_enable_vector.BIT_SET):
     """
     Verify if we get expected experiment results
     Args:
@@ -425,6 +434,7 @@ def __verify_results(rows,
         tolerance (float): maximum allowable deviation
         headroom_test_params (array): 2 element array if the associated pfc pause quanta
             results in no packet drop [pfc_delay, headroom_result]
+        class_enable_vec (ENUM): ENUM of class enable vector settings
     Returns:
         N/A
     """
@@ -435,6 +445,7 @@ def __verify_results(rows,
     pause_flow_rx_frames = pause_flow_row.frames_rx
     pytest_assert(pause_flow_tx_frames > 0 and pause_flow_rx_frames == 0,
                   'All the pause frames should be dropped')
+    test_tx_frames = []
 
     """ Check background flows """
     for row in rows:
@@ -466,6 +477,7 @@ def __verify_results(rows,
 
         tx_frames = row.frames_tx
         rx_frames = row.frames_rx
+        test_tx_frames.append(tx_frames)
 
         if test_flow_pause:
             pytest_assert(tx_frames > 0 and rx_frames == 0,
@@ -519,9 +531,16 @@ def __verify_results(rows,
                                   'Total TX dropped packets {} should be 0'.
                                   format(dropped_packets))
 
-        # Check if pause frames are counted in the PFC counters
-        for peer_port, prios in flow_port_config[1].items():
-            for prio in prios:
-                pfc_pause_rx_frames = get_pfc_frame_count(duthost, peer_port, prio)
+    # Check if pause frames are correctly counted in the PFC counters
+    for peer_port, prios in flow_port_config[1].items():
+        for prio in range(len(prios)):
+            pfc_pause_rx_frames = get_pfc_frame_count(duthost, peer_port, prios[prio])
+            total_egress_packets, _ = get_queue_count(duthost, peer_port, prios[prio])
+            if test_flow_pause and class_enable_vec == class_enable_vector.BIT_SET:
                 pytest_assert(pfc_pause_rx_frames > 0,
                               "PFC pause frames with zero source MAC are not counted in the PFC counters")
+            elif class_enable_vec == class_enable_vector.NO_BIT_SET:
+                pytest_assert(pfc_pause_rx_frames == 0,
+                              "PFC pause frames with no bit set in the class enable vector should be dropped")
+                pytest_assert(total_egress_packets == test_tx_frames[prio], "Queue counters should increment for \
+                              invalid PFC pause frames")

--- a/tests/snappi/pfc/files/helper.py
+++ b/tests/snappi/pfc/files/helper.py
@@ -41,7 +41,7 @@ def run_pfc_test(api,
                  test_traffic_pause,
                  headroom_test_params=None,
                  pfc_pause_src_mac=None,
-                 class_enable_vec=True):
+                 set_class_enable_vec=True):
     """
     Run a PFC test
     Args:
@@ -61,7 +61,7 @@ def run_pfc_test(api,
         headroom_test_params (array): 2 element array if the associated pfc pause quanta
                                     results in no packet drop [pfc_delay, headroom_result]
         pfc_pause_src_mac (string): source MAC address of PFC Pause frames
-        class_enable_vec (bool): whether the PFC class enable vector has been set or not
+        set_class_enable_vec (bool): whether the PFC class enable vector has been set or not
     Returns:
         N/A
     """
@@ -114,7 +114,7 @@ def run_pfc_test(api,
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_dscp_map=prio_dscp_map,
                   pfc_pause_src_mac=pfc_pause_src_mac,
-                  class_enable_vec=class_enable_vec)
+                  set_class_enable_vec=set_class_enable_vec)
 
     flows = testbed_config.flows
 
@@ -153,7 +153,7 @@ def run_pfc_test(api,
                      test_flow_pause=test_traffic_pause,
                      tolerance=TOLERANCE_THRESHOLD,
                      headroom_test_params=headroom_test_params,
-                     class_enable_vec=class_enable_vec)
+                     set_class_enable_vec=set_class_enable_vec)
 
 
 def __gen_traffic(testbed_config,
@@ -173,7 +173,7 @@ def __gen_traffic(testbed_config,
                   data_pkt_size,
                   prio_dscp_map,
                   pfc_pause_src_mac,
-                  class_enable_vec):
+                  set_class_enable_vec):
     """
     Generate configurations of flows, including test flows, background flows and
     pause storm. Test flows and background flows are also known as data flows.
@@ -195,7 +195,7 @@ def __gen_traffic(testbed_config,
         data_pkt_size (int): packet size of data flows in byte
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
         pfc_pause_src_mac (string): source MAC address of PFC Pause frames
-        class_enable_vec (bool): whether the PFC class enable vector has been set or not
+        set_class_enable_vec (bool): whether the PFC class enable vector has been set or not
     Returns:
         flows configurations (list): the list should have configurations of
         len(test_flow_prio_list) test flow, len(bg_flow_prio_list) background
@@ -315,7 +315,7 @@ def __gen_traffic(testbed_config,
         pause_pkt = pause_flow.packet.pfcpause()[-1]
         pause_pkt.src.value = pfc_pause_src_mac if pfc_pause_src_mac else '00:00:fa:ce:fa:ce'
         pause_pkt.dst.value = '01:80:C2:00:00:01'
-        pause_pkt.class_enable_vector.value = vector if class_enable_vec else 0
+        pause_pkt.class_enable_vector.value = vector if set_class_enable_vec else 0
         pause_pkt.pause_class_0.value = pause_time[0]
         pause_pkt.pause_class_1.value = pause_time[1]
         pause_pkt.pause_class_2.value = pause_time[2]
@@ -415,7 +415,7 @@ def __verify_results(rows,
                      speed_gbps,
                      test_flow_pause,
                      tolerance,
-                     class_enable_vec,
+                     set_class_enable_vec,
                      headroom_test_params=None):
     """
     Verify if we get expected experiment results
@@ -431,7 +431,7 @@ def __verify_results(rows,
         speed_gbps (int): link speed in Gbps
         test_flow_pause (bool): if test flows are expected to be paused
         tolerance (float): maximum allowable deviation
-        class_enable_vec (bool): whether the PFC class enable vector has been set or not
+        set_class_enable_vec (bool): whether the PFC class enable vector has been set or not
         headroom_test_params (array): 2 element array if the associated pfc pause quanta
             results in no packet drop [pfc_delay, headroom_result]
     Returns:
@@ -538,7 +538,7 @@ def __verify_results(rows,
         for prio in range(len(prios)):
             pfc_pause_rx_frames = get_pfc_frame_count(duthost, peer_port, prios[prio], is_tx=False)
             total_egress_packets, _ = get_egress_queue_count(duthost, peer_port, prios[prio])
-            if class_enable_vec:
+            if set_class_enable_vec:
                 pytest_assert(pfc_pause_rx_frames > 0,
                               "PFC pause frames with zero source MAC are not counted in the PFC counters")
             else:

--- a/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -16,16 +16,16 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('tgen')]
 
 
-def test_pfc_unset_bit_enable_vector_single_lossless_prio(snappi_api, # noqa F811
-                                                          snappi_testbed_config, # noqa F811
-                                                          conn_graph_facts, # noqa F811
-                                                          fanout_graph_facts, # noqa F811
-                                                          duthosts,
-                                                          rand_one_dut_hostname,
-                                                          rand_one_dut_portname_oper_up,
-                                                          enum_dut_lossless_prio,
-                                                          all_prio_list, # noqa F811
-                                                          prio_dscp_map): # noqa F811
+def test_pfc_unset_cev_single_prio(snappi_api, # noqa F811
+                                   snappi_testbed_config, # noqa F811
+                                   conn_graph_facts, # noqa F811
+                                   fanout_graph_facts, # noqa F811
+                                   duthosts,
+                                   rand_one_dut_hostname,
+                                   rand_one_dut_portname_oper_up,
+                                   enum_dut_lossless_prio,
+                                   all_prio_list, # noqa F811
+                                   prio_dscp_map): # noqa F811
     """
     Test if PFC frames with no bit set in the class enable vector are ignored by the DUT
     for a single lossless priority
@@ -73,16 +73,16 @@ def test_pfc_unset_bit_enable_vector_single_lossless_prio(snappi_api, # noqa F81
                  class_enable_vec=class_enable_vector.NO_BIT_SET)
 
 
-def test_pfc_unset_bit_enable_vector_multi_lossless_prio(snappi_api, # noqa F811
-                                                         snappi_testbed_config, # noqa F811
-                                                         conn_graph_facts, # noqa F811
-                                                         fanout_graph_facts, # noqa F811
-                                                         duthosts,
-                                                         rand_one_dut_hostname,
-                                                         rand_one_dut_portname_oper_up,
-                                                         lossless_prio_list, # noqa F811
-                                                         lossy_prio_list, # noqa F811
-                                                         prio_dscp_map): # noqa F811
+def test_pfc_unset_cev_multi_prio(snappi_api, # noqa F811
+                                  snappi_testbed_config, # noqa F811
+                                  conn_graph_facts, # noqa F811
+                                  fanout_graph_facts, # noqa F811
+                                  duthosts,
+                                  rand_one_dut_hostname,
+                                  rand_one_dut_portname_oper_up,
+                                  lossless_prio_list, # noqa F811
+                                  lossy_prio_list, # noqa F811
+                                  prio_dscp_map): # noqa F811
     """
     Test if PFC frames with no bit set in the class enable vector are ignored by the DUT
     for multiple lossless priorities

--- a/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -1,0 +1,127 @@
+import logging
+import pytest
+
+from files.helper import run_pfc_test
+from tests.common.helpers.assertions import pytest_require
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts # noqa F401
+from tests.common.snappi.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
+    snappi_api, snappi_testbed_config # noqa F401
+from tests.common.snappi.snappi_helpers import class_enable_vector
+from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+    lossy_prio_list # noqa F401
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology('tgen')]
+
+
+def test_pfc_unset_bit_enable_vector_single_lossless_prio(snappi_api, # noqa F811
+                                                          snappi_testbed_config, # noqa F811
+                                                          conn_graph_facts, # noqa F811
+                                                          fanout_graph_facts, # noqa F811
+                                                          duthosts,
+                                                          rand_one_dut_hostname,
+                                                          rand_one_dut_portname_oper_up,
+                                                          enum_dut_lossless_prio,
+                                                          all_prio_list, # noqa F811
+                                                          prio_dscp_map): # noqa F811
+    """
+    Test if PFC frames with no bit set in the class enable vector are ignored by the DUT
+    for a single lossless priority
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        snappi_testbed_config (pytest fixture): testbed configuration information
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_dut_portname_oper_up (str): port to test, e.g., 's6100-1|Ethernet0'
+        enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
+        all_prio_list (pytest fixture): list of all the priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+    Returns:
+        N/A
+    """
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    dut_hostname2, lossless_prio = enum_dut_lossless_prio.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname == dut_hostname2,
+                   "Priority and port are not mapped to the expected DUT")
+
+    testbed_config, port_config_list = snappi_testbed_config
+    duthost = duthosts[rand_one_dut_hostname]
+    lossless_prio = int(lossless_prio)
+
+    pause_prio_list = [lossless_prio]
+    test_prio_list = [lossless_prio]
+    bg_prio_list = [p for p in all_prio_list]
+    bg_prio_list.remove(lossless_prio)
+
+    run_pfc_test(api=snappi_api,
+                 testbed_config=testbed_config,
+                 port_config_list=port_config_list,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=False,
+                 class_enable_vec=class_enable_vector.NO_BIT_SET)
+
+
+def test_pfc_unset_bit_enable_vector_multi_lossless_prio(snappi_api, # noqa F811
+                                                         snappi_testbed_config, # noqa F811
+                                                         conn_graph_facts, # noqa F811
+                                                         fanout_graph_facts, # noqa F811
+                                                         duthosts,
+                                                         rand_one_dut_hostname,
+                                                         rand_one_dut_portname_oper_up,
+                                                         lossless_prio_list, # noqa F811
+                                                         lossy_prio_list, # noqa F811
+                                                         prio_dscp_map): # noqa F811
+    """
+    Test if PFC frames with no bit set in the class enable vector are ignored by the DUT
+    for multiple lossless priorities
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        snappi_testbed_config (pytest fixture): testbed configuration information
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_dut_portname_oper_up (str): port to test, e.g., 's6100-1|Ethernet0'
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        lossy_prio_list (pytest fixture): list of all the lossy priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+    Returns:
+        N/A
+    """
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname,
+                   "Port is not mapped to the expected DUT")
+
+    testbed_config, port_config_list = snappi_testbed_config
+    duthost = duthosts[rand_one_dut_hostname]
+
+    pause_prio_list = lossless_prio_list
+    test_prio_list = lossless_prio_list
+    bg_prio_list = lossy_prio_list
+
+    run_pfc_test(api=snappi_api,
+                 testbed_config=testbed_config,
+                 port_config_list=port_config_list,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=False,
+                 class_enable_vec=class_enable_vector.NO_BIT_SET)

--- a/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -69,7 +69,7 @@ def test_pfc_unset_cev_single_prio(snappi_api, # noqa F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
-                 class_enable_vec=False)
+                 set_class_enable_vec=False)
 
 
 def test_pfc_unset_cev_multi_prio(snappi_api, # noqa F811
@@ -123,4 +123,4 @@ def test_pfc_unset_cev_multi_prio(snappi_api, # noqa F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
-                 class_enable_vec=False)
+                 set_class_enable_vec=False)

--- a/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -7,7 +7,6 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401
 from tests.common.snappi.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
     snappi_api, snappi_testbed_config # noqa F401
-from tests.common.snappi.snappi_helpers import class_enable_vector
 from tests.common.snappi.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list # noqa F401
 
@@ -70,7 +69,7 @@ def test_pfc_unset_cev_single_prio(snappi_api, # noqa F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
-                 class_enable_vec=class_enable_vector.NO_BIT_SET)
+                 class_enable_vec=False)
 
 
 def test_pfc_unset_cev_multi_prio(snappi_api, # noqa F811
@@ -124,4 +123,4 @@ def test_pfc_unset_cev_multi_prio(snappi_api, # noqa F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
-                 class_enable_vec=class_enable_vector.NO_BIT_SET)
+                 class_enable_vec=False)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Device should ignore PFC frame received with no bit set in the class enable vector field. It should not account for those and not react to pfc frames. 

We need to cover 2 cases here:

1) PFC frame accounting on the DUT
2) DUT reaction to the pfc frames

With the following topology,

ixia port 1 --> dut --> ixia port2

Send lossless and lossy traffic from ixia port 1 to ixia port 2
Send pfc frames with class enable vector field set to 0 and max pause quanta specified in all time class fields from ixia port2 at a duration needed to fully block the egress queue

Fixes # (issue) #6733

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Close RDMA related test gap 

#### How did you do it?
Set the class enable vector to 0, and performed traffic flow validation on both the ixia side as well as the switch

#### How did you verify/test it?
Tested on RDMA testbed in the lab

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
