### PR TITLE
[202205][dualtor][active-active] Enable decap tests

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -40,6 +40,10 @@ import sys
 import random
 import logging
 import json
+import six
+import ipaddress
+import itertools
+import fib
 
 import ipaddress
 import ptf
@@ -113,6 +117,12 @@ class DecapPacketTest(BaseTest):
         ptf_test_port_map = self.test_params.get('ptf_test_port_map')
         with open(ptf_test_port_map) as f:
             self.ptf_test_port_map = json.load(f)
+
+        # preprocess ptf_test_port_map to support multiple DUTs as target DUT
+        for port_map in self.ptf_test_port_map.values():
+            if not isinstance(port_map["target_dut"], list):
+                port_map["target_dut"] = [port_map["target_dut"]]
+                port_map["target_src_mac"] = [port_map["target_src_mac"]]
 
         self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
 
@@ -206,9 +216,20 @@ class DecapPacketTest(BaseTest):
         dst_mac = '00:11:22:33:44:55'
         router_mac = target_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']  # Outer dest mac
 
-        active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
-        lo_ip = self.lo_ips[active_dut_index]
-        lo_ipv6 = self.lo_ipv6s[active_dut_index]
+        target_dut = self.ptf_test_port_map[str(src_port)]['target_dut']
+        if len(target_dut) == 1:
+            active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'][0])
+            lo_ip = self.lo_ips[active_dut_index]
+            lo_ipv6 = self.lo_ipv6s[active_dut_index]
+        elif len(target_dut) == 2:
+            # for active-active dualtor, Loopback2 is used for test, and
+            # it is same on both ToRs.
+            assert self.lo_ips[0] == self.lo_ips[1]
+            assert self.lo_ipv6s[0] == self.lo_ipv6s[1]
+            lo_ip = self.lo_ips[0]
+            lo_ipv6 = self.lo_ipv6s[0]
+        else:
+            raise ValueError("Unsupported target DUT count %s" % (target_dut))
 
         # Set DSCP value for the inner layer
         dscp_in = self.DSCP_RANGE[self.dscp_in_idx]
@@ -300,12 +321,12 @@ class DecapPacketTest(BaseTest):
 
         return pkt, exp_pkt
 
-    def send_and_verify(self, dst_ip, expected_ports, src_port, dut_index, outer_pkt_type='ipv4', triple_encap=False,
+    def send_and_verify(self, dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type='ipv4', triple_encap=False,
                         outer_ttl=None, inner_ttl=None):
         '''
         @summary: This function builds encap packet, send and verify their arrival.
         @dst_ip: the destination ip for the inner IP header
-        @expected_ports: list of ports that a packet can arrived from
+        @exp_port_lists: list of ports that a packet can arrived from
         @src_port: the physical port that the packet will be sent from
         @dut_index: Index of the DUT that the test packet is targeted for
         @outer_pkt_type: Outer layter packet type, either 'ipv4' or 'ipv6'
@@ -369,70 +390,85 @@ class DecapPacketTest(BaseTest):
         #send and verify the return packets
         send_packet(self, src_port, pkt)
 
-        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, (tos|tc)={}, ttl={})/IP(src={}, dst={}, (tos|tc)={}, ttl={}) from interface {}'\
-            .format(pkt.src,
-                    pkt.dst,
-                    outer_src_ip,
-                    outer_dst_ip,
-                    outer_tos,
-                    outer_ttl_info,
-                    inner_src_ip,
-                    dst_ip,
-                    inner_tos,
-                    inner_ttl_info,
-                    src_port))
-        logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={}, (tos|tc)={}, ttl={}) on interfaces {}'\
-            .format('any',
-                    'any',
-                    inner_src_ip,
-                    dst_ip,
-                    exp_tos,
-                    exp_ttl,
-                    str(expected_ports)))
+        expected_ports = list(itertools.chain(*exp_port_lists))
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, (tos|tc)={}, ttl={})/'
+                     'IP(src={}, dst={}, (tos|tc)={}, ttl={}) from interface {}'
+                     .format(pkt.src,
+                             pkt.dst,
+                             outer_src_ip,
+                             outer_dst_ip,
+                             outer_tos,
+                             outer_ttl_info,
+                             inner_src_ip,
+                             dst_ip,
+                             inner_tos,
+                             inner_ttl_info,
+                             src_port))
+        logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={}, (tos|tc)={}, ttl={}) on interfaces {}'
+                     .format('any',
+                             'any',
+                             inner_src_ip,
+                             dst_ip,
+                             exp_tos,
+                             exp_ttl,
+                             str(expected_ports)))
 
-        matched, received = verify_packet_any_port(self, masked_exp_pkt, expected_ports)
-        logging.info('Received expected packet on interface {}'.format(str(expected_ports[matched])))
+        matched, received = verify_packet_any_port(
+            self, masked_exp_pkt, expected_ports)
+        logging.info('Received expected packet on interface {}'.format(
+            str(expected_ports[matched])))
         return matched, received
 
-    def send_and_verify_all(self, dst_ip, expected_ports, src_port, dut_index, outer_pkt_type):
+    def send_and_verify_all(self, dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type):
         """
         @summary: This method builds different encap packets, send and verify their arrival
         @dest_ip: The destination ip for the inner IP header
-        @expected_ports: List of ports that a packet can arrive from
+        @exp_port_lists: List of ports that a packet can arrive from
         @src_port: The physical port that the packet will be sent from
         @dut_index: Index of the DUT that the test packet is targeted for
         @outer_pkt_type: Indicates whether the outer packet is ipv4 or ipv6
         """
 
-        self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type)
-        self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, outer_ttl=64, inner_ttl=self.max_internal_hops +2)
+        self.send_and_verify(dst_ip, exp_port_lists,
+                             src_port, dut_index, outer_pkt_type)
+        self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index,
+                             outer_pkt_type, outer_ttl=64, inner_ttl=self.max_internal_hops + 2)
         if self.ttl_mode == "pipe":
-            self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, outer_ttl=self.max_internal_hops +1, inner_ttl=64)
+            self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index,
+                                 outer_pkt_type, outer_ttl=self.max_internal_hops + 1, inner_ttl=64)
         elif self.ttl_mode == "uniform":
-            self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, outer_ttl=self.max_internal_hops +2, inner_ttl=64)
+            self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index,
+                                 outer_pkt_type, outer_ttl=self.max_internal_hops + 2, inner_ttl=64)
 
         # Triple encapsulation
-        self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, triple_encap=True)
-        self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, triple_encap=True, outer_ttl=64, inner_ttl=self.max_internal_hops +2)
+        self.send_and_verify(dst_ip, exp_port_lists, src_port,
+                             dut_index, outer_pkt_type, triple_encap=True)
+        self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type,
+                             triple_encap=True, outer_ttl=64, inner_ttl=self.max_internal_hops + 2)
         if self.ttl_mode == "pipe":
-            self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, triple_encap=True, outer_ttl=self.max_internal_hops +1, inner_ttl=64)
+            self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type,
+                                 triple_encap=True, outer_ttl=self.max_internal_hops + 1, inner_ttl=64)
         elif self.ttl_mode == "uniform":
-            self.send_and_verify(dst_ip, expected_ports, src_port, dut_index, outer_pkt_type, triple_encap=True, outer_ttl=self.max_internal_hops +2, inner_ttl=64)
+            self.send_and_verify(dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type,
+                                 triple_encap=True, outer_ttl=self.max_internal_hops + 2, inner_ttl=64)
 
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
+            active_dut_indexes = [0]
             if self.single_fib == 'multiple-fib':
-                active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
+                active_dut_indexes = self.ptf_test_port_map[str(src_port)]['target_dut']
+
+            next_hops = [self.fibs[active_dut_index][dst_ip] for active_dut_index in active_dut_indexes]
+            exp_port_lists = [next_hop.get_next_hop_list() for next_hop in next_hops]
+            for exp_port_list in exp_port_lists:
+                if src_port in exp_port_list:
+                    break
             else:
-                active_dut_index = 0
-            next_hop = self.fibs[active_dut_index][dst_ip]
-            exp_port_list = next_hop.get_next_hop_list()
-            if src_port in exp_port_list:
-                continue
-            logging.info('src_port={}, exp_port_list={}, active_dut_index={}'.format(src_port, exp_port_list, active_dut_index))
-            break
-        return src_port, exp_port_list, next_hop
+                logging.info('src_port={}, exp_port_lists={}, active_dut_index={}'.format(
+                    src_port, exp_port_lists, active_dut_indexes))
+                break
+        return src_port, exp_port_lists, next_hops
 
     def run_encap_combination_test(self, outer_pkt_type, inner_pkt_type):
         """
@@ -474,16 +510,25 @@ class DecapPacketTest(BaseTest):
 
         logging.info('Checking dst_ips={}'.format(dst_ips))
         for dst_ip in dst_ips:
-            src_port, exp_port_list, _ = self.get_src_and_exp_ports(dst_ip)
+            src_port, exp_port_lists, _ = self.get_src_and_exp_ports(dst_ip)
 
-            if not exp_port_list:
-                logging.info('Skip checking ip_range {} with exp_ports {}, outer_pkt_type={}, inner_pkt_type={}'\
-                    .format(ip_range, exp_port_list, outer_pkt_type, inner_pkt_type))
-                return
+            # if dst_ip is local to DUT, the nexthops will be empty.
+            # for active-active dualtor testbed, if the dst_ip is local to the upper ToR and src_port is an
+            # active-active port, the expect egress ports of upper ToR will be empty, exp_port_lists will be
+            # like [[], [30, 31, 32, 33]].
+            # for single DUT testbed, if the dst_ip is local to the ToR, the exp_port_lists will be like [[]].
+            # so let's skip checking this IP range if any sub-list is empty.
+            for exp_port_list in exp_port_lists:
+                if not exp_port_list:
+                    logging.info('Skip checking ip range {} with exp_ports {}'.format(
+                        ip_range, exp_port_lists))
+                    return
 
-            logging.info('Checking ip range {}, outer_pkt_type={}, inner_pkt_type={}, src_port={}, exp_port_list={}, dst_ip={}, dut_index={}'\
-                .format(ip_range, outer_pkt_type, inner_pkt_type, src_port, exp_port_list, dst_ip, dut_index))
-            self.send_and_verify_all(dst_ip, exp_port_list, src_port, dut_index, outer_pkt_type)
+            logging.info('Checking ip range {}, outer_pkt_type={}, inner_pkt_type={}, '
+                         'src_port={}, exp_port_lists={}, dst_ip={}, dut_index={}'
+                         .format(ip_range, outer_pkt_type, inner_pkt_type, src_port, exp_port_lists, dst_ip, dut_index))
+            self.send_and_verify_all(
+                dst_ip, exp_port_lists, src_port, dut_index, outer_pkt_type)
 
     def runTest(self):
         """

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -10,7 +10,6 @@ from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                             # noqa F401
 from tests.common.dualtor.dual_tor_common import mux_config                             # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
-from tests.common.dualtor.dual_tor_common import active_standby_ports                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER, RESET
 
@@ -539,7 +538,7 @@ def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):    # noqa F811
+def toggle_all_simulator_ports_to_random_side(active_standby_ports, duthosts, mux_server_url, tbinfo, mux_config):    # noqa F811
     """
     A function level fixture to toggle all ports to a random side.
     """
@@ -603,7 +602,7 @@ def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, 
             return False
         return True
 
-    if 'dualtor' not in tbinfo['topo']['name']:
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
         return
 
     _toggle_all_simulator_ports(mux_server_url, RANDOM, tbinfo)

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -13,22 +13,26 @@ from datetime import datetime
 import time
 
 import pytest
-import requests
 from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
-from tests.common.fixtures.fib_utils import fib_info_files
-from tests.common.fixtures.fib_utils import single_fib_for_duts
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
+from tests.common.fixtures.fib_utils import fib_info_files                  # noqa F401
+from tests.common.fixtures.fib_utils import single_fib_for_duts             # noqa F401
 from tests.ptf_runner import ptf_runner
-from tests.common.helpers.assertions import pytest_assert as pt_assert
-from tests.common.dualtor.mux_simulator_control import mux_server_url
+from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa F401
 from tests.common.utilities import wait, setup_ferret
+from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports                               # noqa F401
+from tests.common.dualtor.dual_tor_common import mux_config                                         # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side    # noqa F401
+from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                # noqa F401
+
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +76,13 @@ def ip_ver(request):
 
 
 @pytest.fixture(scope='module')
-def loopback_ips(duthosts, duts_running_config_facts):
+def loopback_ips(active_active_ports, duthosts, duts_running_config_facts, tbinfo):             # noqa F811
+    if "dualtor" in tbinfo["topo"]["name"] and active_active_ports:
+        # for dualtor testbeds with active-active mux ports, use Loopback2
+        lo_dev = "Loopback2"
+    else:
+        lo_dev = "Loopback0"
+
     lo_ips = []
     lo_ipv6s = []
     for duthost in duthosts:
@@ -82,7 +92,7 @@ def loopback_ips(duthosts, duts_running_config_facts):
         lo_ip = None
         lo_ipv6 = None
         # Loopback0 ip is same on all ASICs
-        for addr in cfg_facts[0][1]["LOOPBACK_INTERFACE"]["Loopback0"]:
+        for addr in cfg_facts[0][1]["LOOPBACK_INTERFACE"][lo_dev]:
             ip = IPNetwork(addr).ip
             if ip.version == 4 and not lo_ip:
                 lo_ip = str(ip)
@@ -154,14 +164,6 @@ def apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mod
         duthost.shell('rm /tmp/decap_conf_{}.json'.format(op))
 
 
-def set_mux_side(tbinfo, mux_server_url, side):
-    if 'dualtor' in tbinfo['topo']['name']:
-        res = requests.post(mux_server_url, json={"active_side": side})
-        pt_assert(res.status_code==200, 'Failed to set active side: {}'.format(res.text))
-        return res.json()   # Response is new mux_status of all mux Y-cables.
-    return {}
-
-
 def simulate_vxlan_teardown(duthosts, ptfhost, tbinfo):
     for duthost in duthosts:
         setup_ferret(duthost, ptfhost, tbinfo)
@@ -173,13 +175,9 @@ def simulate_vxlan_teardown(duthosts, ptfhost, tbinfo):
         ptfhost.shell('supervisorctl stop ferret')
 
 
-@pytest.fixture
-def set_mux_random(tbinfo, mux_server_url):
-    return set_mux_side(tbinfo, mux_server_url, 'random')
-
-
-def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mux_random, supported_ttl_dscp_params, ip_ver, loopback_ips,
-               duts_running_config_facts, duts_minigraph_facts):
+def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,                                   # noqa F811
+               toggle_all_simulator_ports_to_random_side, supported_ttl_dscp_params, ip_ver, loopback_ips,  # noqa F811
+               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator):             # noqa F811
     setup_info = setup_teardown
     asic_type = duthosts[0].facts["asic_type"]
     ecn_mode = "copy_from_outer"
@@ -206,26 +204,27 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mu
         ptf_runner(ptfhost,
                    "ptftests",
                    "IP_decap_test.DecapPacketTest",
-                    platform_dir="ptftests",
-                    params={"outer_ipv4": setup_info["outer_ipv4"],
-                            "outer_ipv6": setup_info["outer_ipv6"],
-                            "inner_ipv4": setup_info["inner_ipv4"],
-                            "inner_ipv6": setup_info["inner_ipv6"],
-                            "lo_ips": setup_info["lo_ips"],
-                            "lo_ipv6s": setup_info["lo_ipv6s"],
-                            "ttl_mode": ttl_mode,
-                            "dscp_mode": dscp_mode,
-                            "asic_type": asic_type,
-                            "ignore_ttl": setup_info["ignore_ttl"],
-                            "max_internal_hops": setup_info["max_internal_hops"],
-                            "fib_info_files": setup_info["fib_info_files"],
-                            "single_fib_for_duts": setup_info["single_fib_for_duts"],
-                            "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts)
-                            },
-                    qlen=PTFRUNNER_QLEN,
-                    log_file=log_file)
-    except Exception as detail:
-        raise Exception(detail)
+                   platform_dir="ptftests",
+                   params={"outer_ipv4": setup_info["outer_ipv4"],
+                           "outer_ipv6": setup_info["outer_ipv6"],
+                           "inner_ipv4": setup_info["inner_ipv4"],
+                           "inner_ipv6": setup_info["inner_ipv6"],
+                           "lo_ips": setup_info["lo_ips"],
+                           "lo_ipv6s": setup_info["lo_ipv6s"],
+                           "ttl_mode": ttl_mode,
+                           "dscp_mode": dscp_mode,
+                           "asic_type": asic_type,
+                           "ignore_ttl": setup_info["ignore_ttl"],
+                           "max_internal_hops": setup_info["max_internal_hops"],
+                           "fib_info_files": setup_info["fib_info_files"],
+                           "single_fib_for_duts": setup_info["single_fib_for_duts"],
+                           "ptf_test_port_map": ptf_test_port_map_active_active(
+                               ptfhost, tbinfo, duthosts, mux_server_url,
+                               duts_running_config_facts, duts_minigraph_facts,
+                               mux_status_from_nic_simulator())
+                           },
+                   qlen=PTFRUNNER_QLEN,
+                   log_file=log_file)
     finally:
         # Remove test decap configuration
         if vxlan != "set_unset":


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add decap test support on dualtor-aa topology.

Signed-off-by: Longxiang Lyu lolv@microsoft.com

#### How did you do it?
As for active-active dualtor, the upstream packet from ptf is ECMPed to both ToRs, so we cannot tell which ToR could receive the IPinIP packet. So let's use Loopback2 to bind decap rules for dualtor-aa topology, so IPinIP packets from ptf with dest IP as Loopback2 address will be duplicated to both ToRs, and could be decapsulated by both ToRs.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
