### PR TITLE
[qos 202012] add retry to tolerate performance issue of send pfc

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import sys
 import time
 from ptf.mask import Mask
 import ptf.packet as scapy
@@ -35,6 +36,8 @@ DUMMY_MAC = "aa:aa:aa:aa:aa:aa"
 VLAN_MAC = "00:aa:bb:cc:dd:ee"
 
 PFC_PKT_COUNT = 10000000 # Cost 32 seconds
+PFC_PAUSE_TEST_RETRY_MAX = 5
+
 
 @pytest.fixture(scope='module', autouse=True)
 def check_running_condition(tbinfo, duthost):
@@ -285,6 +288,31 @@ def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_du
         counter_poll_config(rand_selected_dut, 'queue', 10000)
 
 
+def pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, dut, port, queue, pkt, src_port, exp_pkt, dst_ports):
+    try:
+        # Start PFC storm from leaf fanout switch
+        start_pfc_storm(storm_handler, peer_info, prio)
+        ptfadapter.dataplane.flush()
+        # Record the queue counter before sending test packet
+        base_queue_count = get_queue_counter(dut, port, queue, True)
+        # Send testing packet again
+        testutils.send_packet(ptfadapter, src_port, pkt, 1)
+        # The packet should be paused
+        testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
+        # Check the queue counter didn't increase
+        queue_count = get_queue_counter(dut, port, queue, False)
+        assert base_queue_count == queue_count
+        return True
+    except AssertionError:
+        logger.info('assert {}'.format(sys.exc_info()))
+        return False
+    except Exception:
+        logger.info('exception {}'.format(sys.exc_info()))
+        return False
+    finally:
+        stop_pfc_storm(storm_handler)
+
+
 def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_unselected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
@@ -336,21 +364,24 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
                                     pfc_queue_idx=prio,
                                     pfc_frames_number=PFC_PKT_COUNT,
                                     peer_info=peer_info)
-        try:
-            # Start PFC storm from leaf fanout switch
-            start_pfc_storm(storm_handler, peer_info, prio)
-            # Record the queue counter before sending test packet
-            base_queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, True)
-            # Send testing packet again
-            testutils.send_packet(ptfadapter, src_port, pkt, 1)
-            # The packet should be paused
-            testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
-            # Check the queue counter didn't increase
-            queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, False)
-            pytest_assert(base_queue_count == queue_count, "The queue {} for port {} counter increased unexpectedly".format(queue, actual_port_name))
 
-        finally:
-            stop_pfc_storm(storm_handler)
+        retry = 0
+        while retry < PFC_PAUSE_TEST_RETRY_MAX:
+            try:
+                if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut, actual_port_name,
+                                  queue, pkt, src_port, exp_pkt, dst_ports):
+                    break
+            except AssertionError:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, actual_port_name))
+            except Exception:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, actual_port_name))
+            time.sleep(5)
 
 
 def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
@@ -398,20 +429,25 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
                                     pfc_queue_idx=prio,
                                     pfc_frames_number=PFC_PKT_COUNT,
                                     peer_info=peer_info)
-        try:
-            # Start PFC storm from leaf fanout switch
-            start_pfc_storm(storm_handler, peer_info, prio)
-            # Read queue counter before sending packet
-            base_queue_count = get_queue_counter(rand_selected_dut, dualtor_meta['selected_port'], queue, True)
-            # Send testing packet again
-            testutils.send_packet(ptfadapter, src_port, tunnel_pkt.exp_pkt, 1)
-            # The packet should be paused
-            testutils.verify_no_packet(ptfadapter, exp_pkt, dualtor_meta['target_server_port'])
-            # Check the queue counter didn't increase
-            queue_count = get_queue_counter(rand_selected_dut, dualtor_meta['selected_port'], queue, False)
-            pytest_assert(base_queue_count == queue_count, "The queue {} for port {} counter increased unexpectedly".format(queue, dualtor_meta['selected_port']))
-        finally:
-            stop_pfc_storm(storm_handler)
+
+        retry = 0
+        while retry < PFC_PAUSE_TEST_RETRY_MAX:
+            try:
+                if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut,
+                                  dualtor_meta['selected_port'], queue, tunnel_pkt.exp_pkt, src_port, exp_pkt,
+                                  dualtor_meta['target_server_port']):
+                    break
+            except AssertionError:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, dualtor_meta['selected_port']))
+            except Exception:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, dualtor_meta['selected_port']))
+            time.sleep(5)
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

double commit https://github.com/sonic-net/sonic-mgmt/pull/8424 to 202012 branch


case "test_pfc_pause_extra_lossless_standby" and "test_pfc_pause_extra_lossless_active" failed, as below:
```
            try:
                # Start PFC storm from leaf fanout switch
                start_pfc_storm(storm_handler, peer_info, prio)
                # Record the queue counter before sending test packet
                base_queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, True)
                # Send testing packet again
                testutils.send_packet(ptfadapter, src_port, pkt, 1)
                # The packet should be paused
                testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
                # Check the queue counter didn't increase
                queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, False)
>               pytest_assert(base_queue_count == queue_count, "The queue {} for port {} counter increased unexpectedly".format(queue, actual_port_name))
E               Failed: The queue 6 for port Ethernet124 counter increased unexpectedly
```
RCA:
performance issue of sending pfc, it cause failed to pause dut's transmition.

solution:
Long term solution is move these cases to ixia folder, and send pfc pause frame from ixia.
Short term solution is adding retry

#### How did you do it?
add retry to tolerate this performance issue
#### How did you verify/test it?
pass local test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
