### PR TITLE
Ignore MAC learning event before disabling MAC learning

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -308,6 +308,10 @@ def analyze_sairedis_rec(messages, result, offset_from_kexec):
                             .get("timestamp", {}).get("Start")
                         if not fdb_aging_disable_start:
                             break
+                        # Ignore MAC learning events before FDB aging disable, as MAC learning is still allowed
+                        log_time = timestamp.strftime(FMT)
+                        if _parse_timestamp(log_time) < _parse_timestamp(fdb_aging_disable_start):
+                            break
                         first_after_offset = fdb_aging_disable_start
                     else:
                         first_after_offset = result.get("reboot_time", {}).get(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case `platform_tests.test_advanced_reboot.test_fast_reboot` is flaky with below error
```
platform_tests/test_advanced_reboot.py:46: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/fixtures/advanced_reboot.py:574: in runRebootTestcase
    return self.runRebootTest()
common/fixtures/advanced_reboot.py:548: in runRebootTest
    reboot_oper=rebootOper, log_dir=log_dir)
platform_tests/conftest.py:536: in post_reboot_analysis
    verify_mac_jumping(test_name, analyze_result, verification_errors)
platform_tests/conftest.py:353: in verify_mac_jumping
    if _parse_timestamp(mac_expiry_start) > _parse_timestamp(fdb_aging_disable_start) and\
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    def _parse_timestamp(timestamp):
        try:
>           time = datetime.strptime(timestamp, FMT)
E           TypeError: strptime() argument 1 must be string, not None

platform_tests/conftest.py:32: TypeError
```
It's because the MAC learning event before disabling MAC learning in `sairedis.log` is parsed by `analyze_sairedis_rec`. That results in `Start count == 1`, but the timestamp is not recorded. The code is
```
def get_state_times(timestamp, state, state_times, first_after_offset=None):
    ......
    if state_status in timestamps:
       ......
    elif first_after_offset:
        state_dict[state_status+" count"] = 1
        # capture the first occurence as the one after offset timestamp and ignore the ones before
        # this is useful to find time after a specific instance, for eg. - kexec time or FDB disable time.
        if _parse_timestamp(first_after_offset) < _parse_timestamp(time):
            timestamps[state_status] = time
    else:
       ......
    return {state_name: state_dict}
```
This PR addressed the issue by ignoring the MAC_LEARNING_EVENT before disabling MAC learning. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to stabilize fast_reboot test.

#### How did you do it?
This PR addressed the issue by ignoring the MAC_LEARNING_EVENT before disabling MAC learning. 

#### How did you verify/test it?
The change is verified by running `test_fast_reboot`, `test_warm_reboot` and `test_warm_reboot_mac_jump`.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
