### PR TITLE
[Python3 migration]Fix ferret.py Python2&3 compatibility issue in test_decap

### DIFF
--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -2,11 +2,12 @@
 
 # python t.py -f /tmp/vxlan_decap.json -s 192.168.8.1
 
-import http.server
-import socketserver
+import SimpleHTTPServer
+import SocketServer
 import select
 import shutil
 import json
+import BaseHTTPServer
 import time
 import socket
 import ctypes
@@ -16,7 +17,7 @@ import binascii
 import argparse
 import os
 
-from io import StringIO
+from cStringIO import StringIO
 from collections import namedtuple
 
 
@@ -26,7 +27,7 @@ Record = namedtuple(
 ASIC_TYPE = None
 
 
-class Ferret(http.server.BaseHTTPRequestHandler):
+class Ferret(BaseHTTPServer.BaseHTTPRequestHandler):
     server_version = "FerretHTTP/0.1"
 
     def do_POST(self):
@@ -95,7 +96,7 @@ class RestAPI(object):
     PORT = 448
 
     def __init__(self, obj, db, src_ip):
-        self.httpd = socketserver.TCPServer(("", self.PORT), obj)
+        self.httpd = SocketServer.TCPServer(("", self.PORT), obj)
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         self.context.verify_mode = ssl.CERT_NONE
         self.context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
@@ -155,7 +156,7 @@ class Poller(object):
         self.httpd = httpd
 
     def poll(self):
-        handlers = list(self.mapping.keys()) + [self.httpd.handler()]
+        handlers = self.mapping.keys() + [self.httpd.handler()]
         while True:
             (rdlist, _, _) = select.select(handlers, [], [])
             for handler in rdlist:
@@ -327,7 +328,7 @@ def extract_iface_names(config_file):
         graph = json.load(fp)
 
     net_ports = []
-    for name, val in list(graph['minigraph_portchannels'].items()):
+    for name, val in graph['minigraph_portchannels'].items():
         members = ['eth%d' % graph['minigraph_port_indices'][member]
                    for member in val['members']]
         net_ports.extend(members)

--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -2,7 +2,6 @@
 
 # python t.py -f /tmp/vxlan_decap.json -s 192.168.8.1
 
-import SimpleHTTPServer
 import SocketServer
 import select
 import shutil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes ferret.py Python2&3 compatibility issue in test_decap

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_decap test failed due to Python3 migration. The ferret.py is running in ptf with Python2 env.

#### How did you do it?
Make it Python2 compatible.

#### How did you verify/test it?
Manually run decap/test_decap.py with physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
