### PR TITLE
cisco-8000: qos-sai: topo-t2 pg-shared wm parameters for lossless test

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3506,6 +3506,16 @@ qos_params:
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
                     pkts_num_margin: 20
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 14804
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    packet_size: 1350
+                    cell_size: 384
+                    pkts_num_egr_mem: 6885
             400000_300m:
                 pkts_num_leak_out: 10
                 xoff_1:
@@ -3524,6 +3534,17 @@ qos_params:
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
                     pkts_num_margin: 20
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 14804
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    packet_size: 1350
+                    cell_size: 384
+                    pkts_num_egr_mem: 6885
+
     jr2:
         topo-any:
             100000_300m:


### PR DESCRIPTION
Adding qos.yaml parameters for pg-shared WM test, for topo-t2 for cisco-8000. Only lossless is being added. Lossy is skipped as part of PR:8480.