### PR TITLE
qos-sai - Fix shared-res-size skip function.

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -757,7 +757,7 @@ class TestQosSai(QosSaiBase):
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
         src_testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
         dst_testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
-        (src_port_ids, dst_portids) = check_port_count
+        (src_port_ids, dst_portids) = check_skip_shared_res_test
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -58,7 +58,10 @@ def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer
 
 
 @pytest.fixture(autouse=False)
-def check_skip_shared_res_test(self, dutQosConfig, get_src_dst_asic_and_duts, dutConfig):
+@pytest.fixture(autouse=False)
+def check_skip_shared_res_test(
+        sharedResSizeKey, dutQosConfig,
+        get_src_dst_asic_and_duts, dutConfig):
     qosConfig = dutQosConfig["param"]
     src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
     src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
@@ -68,7 +71,7 @@ def check_skip_shared_res_test(self, dutQosConfig, get_src_dst_asic_and_duts, du
     dst_testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
 
     if not sharedResSizeKey in qosConfig.keys():
-        pytest.skip( 
+        pytest.skip(
             "Shared reservation size parametrization '%s' "
             "is not enabled" % sharedResSizeKey)
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -58,7 +58,6 @@ def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer
 
 
 @pytest.fixture(autouse=False)
-@pytest.fixture(autouse=False)
 def check_skip_shared_res_test(
         sharedResSizeKey, dutQosConfig,
         get_src_dst_asic_and_duts, dutConfig):


### PR DESCRIPTION
Hi @abdosi , @XuChen-MSFT : Pls reveiw this. I had put wrong code for skipping SharedResSize in qos-sai. This PR fixes the skip function's arguments. Pls treat this an urgent request.

Thanks,
rraghav