### PR TITLE
[chassis][voq] change the voq inband interface to ip interface

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -81,24 +81,6 @@
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-{% if num_asics == 1 and (voq_inband_ip is defined or voq_inband_ipv6 is defined) %}
-      <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if voq_inband_ip is defined %}
-        <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[0] }}</Name>
-          <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ip[0] }}</a:PrefixStr>
-        </a:VoqInbandInterface>
-{% endif %}
-{% if voq_inband_ipv6 is defined %}
-        <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[0] }}</Name>
-          <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ipv6[0] }}</a:PrefixStr>
-        </a:VoqInbandInterface>
-{% endif %}
-      </VoqInbandInterfaces>
-{% endif %}
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
@@ -238,6 +220,22 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
+{% if num_asics == 1 and (voq_inband_ip is defined or voq_inband_ipv6 is defined) %}
+{% if voq_inband_ip is defined %}
+        <IPInterface>
+          <Name>VoqInband</Name>
+          <AttachTo>{{ voq_inband_intf[0] }}</AttachTo>
+          <PrefixStr>{{ voq_inband_ip[0] }}</PrefixStr>
+        </IPInterface>
+{% endif %}
+{% if voq_inband_ipv6 is defined %}
+        <IPInterface>
+          <Name>v6VoqInband</Name>
+          <AttachTo>{{ voq_inband_intf[0] }}</AttachTo>
+          <PrefixStr>{{ voq_inband_ipv6[0] }}</PrefixStr>
+        </IPInterface>
+{% endif %}
 {% endif %}
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -67,24 +67,6 @@
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-{% if voq_inband_ip is defined or voq_inband_ipv6 is defined %}
-      <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if voq_inband_ip is defined %}
-        <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[asic_index] }}</Name>
-          <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ip[asic_index] }}</a:PrefixStr>
-        </a:VoqInbandInterface>
-{% endif %}
-{% if voq_inband_ipv6 is defined %}
-        <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[asic_index] }}</Name>
-          <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ipv6[asic_index] }}</a:PrefixStr>
-        </a:VoqInbandInterface>
-{% endif %}
-      </VoqInbandInterfaces>
-{% endif %}
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
@@ -175,6 +157,22 @@
           <Prefix>{{ asic_config['neigh_asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_config['neigh_asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
         </IPInterface>
 {% endfor %}
+{% if num_asics == 1 and (voq_inband_ip is defined or voq_inband_ipv6 is defined) %}
+{% if voq_inband_ip is defined %}
+        <IPInterface>
+          <Name>VoqInband</Name>
+          <AttachTo>{{ voq_inband_intf[0] }}</AttachTo>
+          <PrefixStr>{{ voq_inband_ip[0] }}</PrefixStr>
+        </IPInterface>
+{% endif %}
+{% if voq_inband_ipv6 is defined %}
+        <IPInterface>
+          <Name>v6VoqInband</Name>
+          <AttachTo>{{ voq_inband_intf[0] }}</AttachTo>
+          <PrefixStr>{{ voq_inband_ipv6[0] }}</PrefixStr>
+        </IPInterface>
+{% endif %}
+{% endif %}
       </IPInterfaces>
       <SubInterfaces>
       </SubInterfaces>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In the PR https://github.com/sonic-net/sonic-buildimage/pull/15410 the parser is updated to make voqinband interfaces as ip interface
This PR is update the templates to generate the correct minigraph

#### How did you do it?
generate minigraph 
#### How did you verify/test it?
verify on voq chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
