### PR TITLE
cisco:  Qos yaml params for lossy-queue test for topo-t2

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3506,6 +3506,15 @@ qos_params:
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
                     pkts_num_margin: 20
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 20
+                    packet_size: 1350
+                    cell_size: 384
+
             400000_300m:
                 pkts_num_leak_out: 10
                 xoff_1:


### PR DESCRIPTION
Adding qos.yaml parameters for lossy Queue test for cisco-8000 for topo-t2.