### PR TITLE
[202205] Fix tunnel qos remap test

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -434,10 +434,9 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     duthost.shell_cmds(cmds=cmds)
 
 
-@pytest.fixture(scope='class')
-def dut_qos_maps(get_src_dst_asic_and_duts):
+def _dut_qos_map(dut):
     """
-    A module level fixture to get QoS map from DUT host.
+    A helper function to get QoS map from DUT host.
     Return a dict
     {
         "dscp_to_tc_map": {
@@ -452,7 +451,6 @@ def dut_qos_maps(get_src_dst_asic_and_duts):
     or an empty dict if failed to parse the output
     """
     maps = {}
-    dut = get_src_dst_asic_and_duts['src_dut']
     try:
         if dut.is_multi_asic:
             sonic_cfggen_cmd = "sonic-cfggen -n asic0 -d --var-json"
@@ -483,13 +481,33 @@ def dut_qos_maps(get_src_dst_asic_and_duts):
     return maps
 
 
-def separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+@pytest.fixture(scope='class')
+def dut_qos_maps(get_src_dst_asic_and_duts):
+    """
+    A class level fixture to get QoS map from DUT host.
+    Return a dict
+    """
+    dut = get_src_dst_asic_and_duts['src_dut']
+    return _dut_qos_map(dut)
+
+
+@pytest.fixture(scope='module')
+def dut_qos_maps_module(rand_selected_front_end_dut):
+    """
+    A module level fixture to get QoS map from DUT host.
+    return a dict
+    """
+    dut = rand_selected_front_end_dut
+    return _dut_qos_map(dut)
+
+
+def separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module):
     """
     A helper function to check if separated DSCP_TO_TC_MAP is applied to
     downlink/unlink ports.
     """
     dscp_to_tc_map_names = set()
-    for port_name, qos_map in dut_qos_maps['port_qos_map'].iteritems():
+    for port_name, qos_map in dut_qos_maps_module['port_qos_map'].iteritems():
         if port_name == "global":
             continue
         dscp_to_tc_map_names.add(qos_map.get("dscp_to_tc_map", ""))
@@ -498,20 +516,20 @@ def separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
     return False
 
 
-def load_dscp_to_pg_map(duthost, port, dut_qos_maps):
+def load_dscp_to_pg_map(duthost, port, dut_qos_maps_module):
     """
     Helper function to calculate DSCP to PG map for a port.
     The map is derived from DSCP_TO_TC_MAP + TC_TO_PG_MAP
     return a dict like {0:0, 1:1...}
     """
     try:
-        port_qos_map = dut_qos_maps['port_qos_map']
+        port_qos_map = dut_qos_maps_module['port_qos_map']
         dscp_to_tc_map_name = port_qos_map[port]['dscp_to_tc_map'].split('|')[-1].strip(']')
         tc_to_pg_map_name = port_qos_map[port]['tc_to_pg_map'].split('|')[-1].strip(']')
         # Load dscp_to_tc_map
-        dscp_to_tc_map = dut_qos_maps['dscp_to_tc_map'][dscp_to_tc_map_name]
+        dscp_to_tc_map = dut_qos_maps_module['dscp_to_tc_map'][dscp_to_tc_map_name]
         # Load tc_to_pg_map
-        tc_to_pg_map = dut_qos_maps['tc_to_priority_group_map'][tc_to_pg_map_name]
+        tc_to_pg_map = dut_qos_maps_module['tc_to_priority_group_map'][tc_to_pg_map_name]
         # Calculate dscp to pg map
         dscp_to_pg_map = {}
         for dscp, tc in dscp_to_tc_map.items():
@@ -522,20 +540,20 @@ def load_dscp_to_pg_map(duthost, port, dut_qos_maps):
         return {}
 
 
-def load_dscp_to_queue_map(duthost, port, dut_qos_maps):
+def load_dscp_to_queue_map(duthost, port, dut_qos_maps_module):
     """
     Helper function to calculate DSCP to Queue map for a port.
     The map is derived from DSCP_TO_TC_MAP + TC_TO_QUEUE_MAP
     return a dict like {0:0, 1:1...}
     """
     try:
-        port_qos_map = dut_qos_maps['port_qos_map']
+        port_qos_map = dut_qos_maps_module['port_qos_map']
         dscp_to_tc_map_name = port_qos_map[port]['dscp_to_tc_map'].split('|')[-1].strip(']')
         tc_to_queue_map_name = port_qos_map[port]['tc_to_queue_map'].split('|')[-1].strip(']')
         # Load dscp_to_tc_map
-        dscp_to_tc_map = dut_qos_maps['dscp_to_tc_map'][dscp_to_tc_map_name][dscp_to_tc_map_name]
+        dscp_to_tc_map = dut_qos_maps_module['dscp_to_tc_map'][dscp_to_tc_map_name][dscp_to_tc_map_name]
         # Load tc_to_queue_map
-        tc_to_queue_map = dut_qos_maps['tc_to_queue_map'][tc_to_queue_map_name]
+        tc_to_queue_map = dut_qos_maps_module['tc_to_queue_map'][tc_to_queue_map_name]
         # Calculate dscp to queue map
         dscp_to_queue_map = {}
         for dscp, tc in dscp_to_tc_map.items():

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
@@ -140,22 +140,6 @@ qos/test_pfc_pause.py::test_no_pfc:
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6716
 
-qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue[active-standby]:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6667
-
-qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite[active-standby]:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6667
-
 route/test_route_flap.py::test_route_flap:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import sys
 import time
 from ptf.mask import Mask
 import ptf.packet as scapy
@@ -10,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # lgtm
 from tests.common.fixtures.ptfhost_utils import run_garp_service          # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # lgtm[py/unused-import]
-from tests.common.fixtures.duthost_utils import dut_qos_maps              # lgtm[py/unused-import]
+from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import separated_dscp_to_tc_map_on_uplink
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_lower_tor, toggle_all_simulator_ports_to_rand_selected_tor, toggle_all_simulator_ports_to_rand_unselected_tor # lgtm[py/unused-import]
@@ -33,8 +34,11 @@ SERVER_IP = "192.168.0.2"
 DUMMY_IP = "1.1.1.1"
 DUMMY_MAC = "aa:aa:aa:aa:aa:aa"
 VLAN_MAC = "00:aa:bb:cc:dd:ee"
+DEFAULT_RPC_PORT = "9092"
 
 PFC_PKT_COUNT = 10000000 # Cost 32 seconds
+PFC_PAUSE_TEST_RETRY_MAX = 5
+
 
 @pytest.fixture(scope='module', autouse=True)
 def check_running_condition(tbinfo, duthost):
@@ -202,7 +206,7 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
         counter_poll_config(rand_selected_dut, 'queue', 10000)
 
 
-def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, dut_qos_maps):
+def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, dut_qos_maps_module):
     """
     The test case is to verify separated DSCP_TO_TC_MAP/TC_TO_QUEUE_MAP on uplink and downlink ports of dualtor
     Test steps
@@ -211,7 +215,7 @@ def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_du
     3. Build regular packet with dst_ip = dummy IP (routed by default route)
     4. Ingress the packet from downlink port, verify the packets egressed from expected queue 
     """
-    pytest_require(separated_dscp_to_tc_map_on_uplink(rand_selected_dut, dut_qos_maps), 
+    pytest_require(separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module), 
                     "Skip test because separated QoS map is not applied")
     dualtor_meta = dualtor_info(ptfhost, rand_unselected_dut, rand_selected_dut, tbinfo)
     t1_ports = get_t1_active_ptf_ports(rand_selected_dut, tbinfo)
@@ -285,6 +289,31 @@ def test_separated_qos_map_on_tor(ptfhost, rand_selected_dut, rand_unselected_du
         counter_poll_config(rand_selected_dut, 'queue', 10000)
 
 
+def pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, dut, port, queue, pkt, src_port, exp_pkt, dst_ports):
+    try:
+        # Start PFC storm from leaf fanout switch
+        start_pfc_storm(storm_handler, peer_info, prio)
+        ptfadapter.dataplane.flush()
+        # Record the queue counter before sending test packet
+        base_queue_count = get_queue_counter(dut, port, queue, True)
+        # Send testing packet again
+        testutils.send_packet(ptfadapter, src_port, pkt, 1)
+        # The packet should be paused
+        testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
+        # Check the queue counter didn't increase
+        queue_count = get_queue_counter(dut, port, queue, False)
+        assert base_queue_count == queue_count
+        return True
+    except AssertionError:
+        logger.info('assert {}'.format(sys.exc_info()))
+        return False
+    except Exception:
+        logger.info('exception {}'.format(sys.exc_info()))
+        return False
+    finally:
+        stop_pfc_storm(storm_handler)
+
+
 def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_unselected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
     """
     The test case is to verify PFC pause frame can pause extra lossless queues in dualtor deployment.
@@ -336,21 +365,24 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
                                     pfc_queue_idx=prio,
                                     pfc_frames_number=PFC_PKT_COUNT,
                                     peer_info=peer_info)
-        try:
-            # Start PFC storm from leaf fanout switch
-            start_pfc_storm(storm_handler, peer_info, prio)
-            # Record the queue counter before sending test packet
-            base_queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, True)
-            # Send testing packet again
-            testutils.send_packet(ptfadapter, src_port, pkt, 1)
-            # The packet should be paused
-            testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
-            # Check the queue counter didn't increase
-            queue_count = get_queue_counter(rand_selected_dut, actual_port_name, queue, False)
-            pytest_assert(base_queue_count == queue_count, "The queue {} for port {} counter increased unexpectedly".format(queue, actual_port_name))
-
-        finally:
-            stop_pfc_storm(storm_handler)
+        
+        retry = 0
+        while retry < PFC_PAUSE_TEST_RETRY_MAX:
+            try:
+                if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut, actual_port_name,
+                                  queue, pkt, src_port, exp_pkt, dst_ports):
+                    break
+            except AssertionError:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, actual_port_name))
+            except Exception:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, actual_port_name))
+            time.sleep(5)
 
 
 def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor, tbinfo, ptfadapter, conn_graph_facts, fanout_graph_facts):
@@ -398,20 +430,25 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
                                     pfc_queue_idx=prio,
                                     pfc_frames_number=PFC_PKT_COUNT,
                                     peer_info=peer_info)
-        try:
-            # Start PFC storm from leaf fanout switch
-            start_pfc_storm(storm_handler, peer_info, prio)
-            # Read queue counter before sending packet
-            base_queue_count = get_queue_counter(rand_selected_dut, dualtor_meta['selected_port'], queue, True)
-            # Send testing packet again
-            testutils.send_packet(ptfadapter, src_port, tunnel_pkt.exp_pkt, 1)
-            # The packet should be paused
-            testutils.verify_no_packet(ptfadapter, exp_pkt, dualtor_meta['target_server_port'])
-            # Check the queue counter didn't increase
-            queue_count = get_queue_counter(rand_selected_dut, dualtor_meta['selected_port'], queue, False)
-            pytest_assert(base_queue_count == queue_count, "The queue {} for port {} counter increased unexpectedly".format(queue, dualtor_meta['selected_port']))
-        finally:
-            stop_pfc_storm(storm_handler)
+
+        retry = 0
+        while retry < PFC_PAUSE_TEST_RETRY_MAX:
+            try:
+                if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut,
+                                  dualtor_meta['selected_port'], queue, tunnel_pkt.exp_pkt, src_port, exp_pkt,
+                                  [dualtor_meta['target_server_port']]):
+                    break
+            except AssertionError:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, dualtor_meta['selected_port']))
+            except Exception:
+                retry += 1
+                if retry == PFC_PAUSE_TEST_RETRY_MAX:
+                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                        queue, dualtor_meta['selected_port']))
+            time.sleep(5)
 
 
 @pytest.mark.disable_loganalyzer
@@ -442,9 +479,9 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
             "active_tor_ip": dut_config["selected_tor_loopback"],
             "standby_tor_mac": dut_config["unselected_tor_mac"],
             "standby_tor_ip": dut_config["unselected_tor_loopback"],
-            "server": dut_config["selected_tor_mgmt"],
+            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
             "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
-            "port_map_file": dut_config["port_map_file"],
+            "port_map_file_ini": dut_config["port_map_file_ini"],
             "sonic_asic_type": dut_config["asic_type"],
             "platform_asic": dut_config["platform_asic"],
             "cell_size": cell_size
@@ -481,8 +518,8 @@ def test_xoff_for_pcbb(rand_selected_dut, ptfhost, dut_config, qos_config, xoff_
             "active_tor_ip": dut_config["selected_tor_loopback"],
             "standby_tor_mac": dut_config["unselected_tor_mac"],
             "standby_tor_ip": dut_config["unselected_tor_loopback"],
-            "server": dut_config["selected_tor_mgmt"],
-            "port_map_file": dut_config["port_map_file"],
+            "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
+            "port_map_file_ini": dut_config["port_map_file_ini"],
             "platform_asic": dut_config["platform_asic"],
             "sonic_asic_type": dut_config["asic_type"],
         })

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -138,7 +138,10 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     asic_type = duthost.facts["asic_type"]
-    platform_asic = duthost.facts['platform_asic']
+    if 'platform_asic' in duthost.facts:
+        platform_asic = duthost.facts['platform_asic']
+    else:
+        platform_asic = None
     # Always use the first portchannel member
     lag_port_name = list(mg_facts['minigraph_portchannels'].values())[0]['members'][0]
     lag_port_ptf_id = mg_facts['minigraph_ptf_indices'][lag_port_name]
@@ -173,7 +176,7 @@ def dut_config(rand_selected_dut, rand_unselected_dut, tbinfo, ptf_portmap_file_
         "unselected_tor_mgmt": unselected_tor_mgmt,
         "unselected_tor_mac": unselected_tor_mac,
         "unselected_tor_loopback": unselected_tor_loopback,
-        "port_map_file": ptf_portmap_file_module
+        "port_map_file_ini": ptf_portmap_file_module
     }
 
 

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -52,7 +52,6 @@ class ThriftInterface(BaseTest):
         else:
             self.src_server_ip = 'localhost'
             src_server_port = 9092
-
         if "dst_server" in self.test_params:
             # server has format <server_ip>:<server_port>
             dst_server = self.test_params['dst_server'].strip().split(":")
@@ -84,6 +83,16 @@ class ThriftInterface(BaseTest):
                             interface_to_front_mapping['dst'][a_ptf_port] = a_ptf_port_info['dut_port']
                 else:
                     interface_to_front_mapping['dst'] = interface_to_front_mapping['src']
+        elif "port_map_file_ini" in self.test_params:
+            user_input = self.test_params['port_map_file_ini']
+            interface_to_front_mapping['src'] = {}
+            f = open(user_input, 'r')
+            for line in f:
+                if (len(line) > 0 and (line[0] == '#' or line[0] == ';' or line[0]=='/')):
+                    continue
+                interface_front_pair = line.split("@")
+                interface_to_front_mapping['src'][interface_front_pair[0]] = interface_front_pair[1].strip()
+            f.close()
         else:
             exit("No ptf interface<-> switch front port mapping, please specify as parameter or in external file")
         # dictionary with key 'src' or 'dst'
@@ -160,8 +169,8 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
-                                                                                            self.src_server_ip))
+            assert 'Success rv = 0' in stdOut[1], "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+                                                                                            self.src_server_ip)
 
         sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
 
@@ -173,7 +182,7 @@ class ThriftInterface(BaseTest):
                                                             self.test_params['dut_username'],
                                                             self.test_params['dut_password'],
                                                             cmd)
-            assert ('Success rv = 0' in stdOut[1]), "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
+            assert 'Success rv = 0' in stdOut[1], "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index,
                                                                                         self.src_server_ip)
         sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4503,7 +4503,7 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             # Enable tx on dest port
             self.sai_thrift_port_tx_enable(
-                self.client, asic_type, [dst_port_id])
+                self.dst_client, asic_type, [dst_port_id])
 
 
 class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -92,7 +92,7 @@ def switch_init(clients):
         return _port_list, _sai_port_list, _front_port_list
 
     port_list['src'], sai_port_list['src'], front_port_list['src'] = _get_data_for_client(clients['src'], 'src')
-    if 'dst' not in clients:
+    if 'dst' not in clients or clients['src'] == clients['dst']:
         port_list['dst'] = port_list['src']
         sai_port_list['dst'] = sai_port_list['src']
         front_port_list['dst'] = front_port_list['src']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix #6667
This PR is to fix regression in `tunnel_qos_remap.py`.

Below test cases are fixed
- test_encap_dscp_rewrite
- test_bounced_back_traffic_in_expected_queue
- test_tunnel_decap_dscp_to_queue_mapping
- test_separated_qos_map_on_tor
- test_pfc_pause_extra_lossless_standby
- test_pfc_pause_extra_lossless_active
- test_tunnel_decap_dscp_to_pg_mapping

Test case `test_xoff_for_pcbb` is not fixed yet. Will fix it in another PR.
The change of PR #8424 is also included in this PR.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix test regression in `tunnel_qos_remap.py`.

#### How did you do it?
Improve test logic and code to make it compatible with the multi-ASIC change.

#### How did you verify/test it?
The change is verified on a dualtor testbed.
```
collected 13 items                                                                                                                                                                                                     

qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite[active-standby] PASSED                                                                                                                                     [  7%]
qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite[active-active] SKIPPED                                                                                                                                     [ 15%]
qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue[active-standby]  ^HPASSED                                                                                                                 [ 23%]
qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue[active-active] SKIPPED                                                                                                                 [ 30%]
qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_queue_mapping  ^H ^HPASSED                                                                                                                                     [ 38%]
qos/test_tunnel_qos_remap.py::test_separated_qos_map_on_tor PASSED                                                                                                                                               [ 46%]
qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_standby  ^HPASSED                                                                                                                                       [ 53%]
qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_active PASSED                                                                                                                                        [ 61%]
qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_pg_mapping  ^H ^H ^HPASSED                                                                                                                                        [ 69%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
