### PR TITLE
Skip PBH test and interface loopback action test on dualtor topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -335,42 +335,46 @@ dut_console:
 ecmp/inner_hashing/test_inner_hashing.py:
   skip:
     conditions_logical_operator: or
-    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform"
+    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
       - "platform in ['x86_64-mlnx_msn2700-r0']"
       - "topo_type not in ['t0']"
       - "asic_type not in ['mellanox']"
+      - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_inner_hashing_lag.py:
   skip:
     conditions_logical_operator: or
-    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform"
+    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
       - "platform in ['x86_64-mlnx_msn2700-r0']"
       - "topo_type not in ['t0']"
       - "asic_type not in ['mellanox']"
+      - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing.py:
   skip:
     conditions_logical_operator: or
-    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform"
+    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
       - "platform in ['x86_64-mlnx_msn2700-r0']"
       - "topo_type not in ['t0']"
       - "asic_type not in ['mellanox']"
+      - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
   skip:
     conditions_logical_operator: or
-    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform"
+    reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
       - "platform in ['x86_64-mlnx_msn2700-r0']"
       - "topo_type not in ['t0']"
       - "asic_type not in ['mellanox']"
+      - "'dualtor' in topo_name"
 
 ecmp/test_fgnhg.py:
   skip:
@@ -515,11 +519,12 @@ http/test_http_copy.py:
 #######################################
 iface_loopback_action/test_iface_loopback_action.py:
   skip:
-    reason: "Not working on non-mellanox platform or T1 topo"
+    reason: "Not working on non-mellanox platform or T1 topo. Test does not support dualtor topology."
     conditions_logical_operator: "OR"
     conditions:
       - "asic_type not in ['mellanox'] and https://github.com/sonic-net/sonic-mgmt/issues/7704"
       - "'t1' in topo_name"
+      - "'dualtor' in topo_name"
 
 #######################################
 #####      iface_namingmode       #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PBH test and interface loopback action test doesn't support dualtor topology and there is no plan to enhance them in short time. Skip the tests on dualtor topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The PBH test and interface loopback action test doesn't support dualtor topology and there is no plan to enhance them in short time. 

#### How did you do it?
Skip the tests on dualtor topologies.
#### How did you verify/test it?
By automation, tests are skipped on dualtor.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
