### PR TITLE
[dualtor][active-active] Fix `validate_active_active_dualtor_setup`

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -27,6 +27,7 @@ from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
+from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                            # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_common import cable_type                                             # noqa F401
 from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa F401
@@ -1480,7 +1481,8 @@ def config_dualtor_arp_responder(tbinfo, duthost, mux_config, ptfhost):     # no
 
 
 @pytest.fixture
-def validate_active_active_dualtor_setup(duthosts, active_active_ports, ptfhost, tbinfo):                 # noqa F811
+def validate_active_active_dualtor_setup(
+    duthosts, active_active_ports, ptfhost, tbinfo, restart_nic_simulator):  # noqa F811
     """Validate that both ToRs are active for active-active mux ports."""
 
     def check_active_active_port_status(duthost, ports, status):
@@ -1497,11 +1499,11 @@ def validate_active_active_dualtor_setup(duthosts, active_active_ports, ptfhost,
     if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
         return
 
-    # verify icmp_responder is running
-    icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
-    if "RUNNING" not in icmp_responder_status:
-        ptfhost.shell("supervisorctl start icmp_responder")
+    if not all(check_active_active_port_status(duthost, active_active_ports, "active") for duthost in duthosts):
+        restart_nic_simulator()
+        ptfhost.shell("supervisorctl restart icmp_responder")
 
+    # verify icmp_responder is running
     icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
     pt_assert("RUNNING" in icmp_responder_status, "icmp_responder not running in ptf")
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -151,6 +151,12 @@ def remove_ip_addresses(ptfhost):
     ptfhost.remove_ip_addresses()
     # Interfaces restart is required, otherwise the ipv6 link-addresses won't back.
     ptfhost.restart_interfaces()
+    # NOTE: up/down ptf interfaces will interrupt icmp_responder socket
+    # read/write operations, so let's restart icmp_responder if it is running
+    icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)
+    if icmp_responder_status["rc"] == 0 and "RUNNING" in icmp_responder_status["stdout"]:
+        logger.debug("restart icmp_responder after restart ptf ports")
+        ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In the `dualtor-aa` nightly run, some testcase failed at `validate_active_active_dualtor_setup` as the mux ports are not all active. The root cause is fixture `remove_ip_addresses` restarts the ptf ports, which will make the sockets open in `icmp_responder` in an error state.
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>



#### How did you do it?
So let's do the folllowing two things:
1. in `remove_ip_addresses` fixture, let's restart `icmp_responder` after restarting ptf ports if `icmp_responder` is running.

2. in `validate_active_active_dualtor_setup`, let's add recover to restart both `icmp_responder` and `nic_simulator` if mux status check fails.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
