### PR TITLE
iface_namingmode: Modify show ip route test case using a dummy static route

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -96,6 +96,7 @@ t1-lag:
   - container_checker/test_container_checker.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - http/test_http_copy.py
+  - iface_namingmode/test_iface_namingmode.py
   - ipfwd/test_mtu.py
   - lldp/test_lldp.py
   - monit/test_monit_status.py

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -961,7 +961,7 @@ class TestShowIP():
         if not setup['physical_interfaces']:
             pytest.skip('No non-portchannel member interface present')
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def static_route_intf(self,  duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, tbinfo):
         """
         Returns the alias and names of the spine ports

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -981,7 +981,7 @@ class TestShowIP():
         if not setup['physical_interfaces']:
             pytest.skip('No non-portchannel member interface present')
 
-        for mg_intf in  setup['minigraph_facts'][u'minigraph_interfaces']:
+        for mg_intf in setup['minigraph_facts'][u'minigraph_interfaces']:
             if mg_intf[u'attachto'] == setup['physical_interfaces'][0]:
                 dev = mg_intf[u'attachto']
                 namespace = setup['minigraph_facts']['minigraph_neighbors'][dev]['namespace']
@@ -990,17 +990,18 @@ class TestShowIP():
                     ip_version = ''
                     dst_ip = '192.168.1.1'
                 else:
-                    ip_version =  '-6'
+                    ip_version = '-6'
                     dst_ip = '::/0'
                 if namespace:
-                    duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".format(namespace, ip_version, dst_ip, gw_ip, dev))
+                    duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".\
+                                  format(namespace, ip_version, dst_ip, gw_ip, dev))
                 else:
                     duthost.shell("ip {} route add {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))
                 static_route_intf['interface'].append(dev)
                 static_route_intf['alias'].append(setup['port_name_map'][dev])
 
         yield static_route_intf
-        for mg_intf in  setup['minigraph_facts'][u'minigraph_interfaces']:
+        for mg_intf in setup['minigraph_facts'][u'minigraph_interfaces']:
             if mg_intf[u'attachto'] == setup['physical_interfaces'][0]:
                 dev = mg_intf[u'attachto']
                 namespace = setup['minigraph_facts']['minigraph_neighbors'][dev]['namespace']
@@ -1010,10 +1011,11 @@ class TestShowIP():
                     ip_version = ''
                     dst_ip = '192.168.1.1'
                 else:
-                    ip_version =  '-6'
+                    ip_version = '-6'
                     dst_ip = '::/0'
                 if namespace:
-                    duthost.shell("ip netns exec {} ip {} route del {}  via {} dev {}".format(namespace, ip_version, dst_ip, gw_ip, dev))
+                    duthost.shell("ip netns exec {} ip {} route del {}  via {} dev {}".\
+                                  format(namespace, ip_version, dst_ip, gw_ip, dev))
                 else:
                     duthost.shell("ip {} route del {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import re
+import ipaddress
 
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.utilities import wait, wait_until
@@ -960,33 +961,61 @@ class TestShowIP():
         if not setup['physical_interfaces']:
             pytest.skip('No non-portchannel member interface present')
 
-    @pytest.fixture(scope='class')
-    def spine_ports(self, setup, tbinfo):
+    @pytest.fixture
+    def static_route_intf(self,  duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, tbinfo):
         """
         Returns the alias and names of the spine ports
 
         Args:
             setup: Fixture defined in this module
         Returns:
-            spine_ports: dictionary containing lists of aliases and names
+            static_route_intf: dictionary containing lists of aliases and names
             of the spine ports
         """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
-        spine_ports = dict()
-        spine_ports['interface'] = list()
-        spine_ports['alias'] = list()
+        static_route_intf = dict()
+        static_route_intf['interface'] = list()
+        static_route_intf['alias'] = list()
 
-        for key, value in list(minigraph_neighbors.items()):
-            if (key in setup['physical_interfaces']
-                    and ('T2' in value['name'] or (tbinfo['topo']['type'] == 't2' and 'T3' in value['name']))):
-                spine_ports['interface'].append(key)
-                spine_ports['alias'].append(setup['port_name_map'][key])
-
-        if not spine_ports['interface']:
+        if not setup['physical_interfaces']:
             pytest.skip('No non-portchannel member interface present')
 
-        logger.info('spine_ports:\n{}'.format(spine_ports))
-        return spine_ports
+        for mg_intf in  setup['minigraph_facts'][u'minigraph_interfaces']:
+            if mg_intf[u'attachto'] == setup['physical_interfaces'][0]:
+                dev = mg_intf[u'attachto']
+                namespace = setup['minigraph_facts']['minigraph_neighbors'][dev]['namespace']
+                gw_ip = mg_intf['peer_addr']
+                if ipaddress.ip_address(gw_ip).version == 4:
+                    ip_version = ''
+                    dst_ip = '192.168.1.1'
+                else:
+                    ip_version =  '-6'
+                    dst_ip = '::/0'
+                if namespace:
+                    duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".format(namespace, ip_version, dst_ip, gw_ip, dev))
+                else:
+                    duthost.shell("ip {} route add {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))
+                static_route_intf['interface'].append(dev)
+                static_route_intf['alias'].append(setup['port_name_map'][dev])
+
+        yield static_route_intf
+        for mg_intf in  setup['minigraph_facts'][u'minigraph_interfaces']:
+            if mg_intf[u'attachto'] == setup['physical_interfaces'][0]:
+                dev = mg_intf[u'attachto']
+                namespace = setup['minigraph_facts']['minigraph_neighbors'][dev]['namespace']
+                gw_ip = mg_intf['peer_addr']
+                dst_ip = '192.168.1.1'
+                if ipaddress.ip_address(gw_ip).version == 4:
+                    ip_version = ''
+                    dst_ip = '192.168.1.1'
+                else:
+                    ip_version =  '-6'
+                    dst_ip = '::/0'
+                if namespace:
+                    duthost.shell("ip netns exec {} ip {} route del {}  via {} dev {}".format(namespace, ip_version, dst_ip, gw_ip, dev))
+                else:
+                    duthost.shell("ip {} route del {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))
 
     def test_show_ip_interface(self, setup, setup_config_mode):
         """
@@ -1029,29 +1058,24 @@ class TestShowIP():
                     assert re.search(r'{}\s+{}'.format(item['attachto'], item['addr']),
                                      show_ipv6_interface) is not None
 
-    def test_show_ip_route_v4(self, setup_config_mode, spine_ports, tbinfo):
+    def test_show_ip_route_v4(self, setup_config_mode, static_route_intf, tbinfo):
         """
         Checks whether 'show ip route <ip>' lists the interface name as
         per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
         dip = '192.168.1.1'
-        # In T2 topo, 192.168.1.1 is forwarded via a route learnt over ibgp from other LC, which will fail the test
-        # because the vias in 'show ip route' output are Inband ports. Explicitly use '0.0.0.0' here to check the
-        # output of default route, whose vias should be local ports.
-        if tbinfo['topo']['type'].startswith('t2'):
-            dip = '0.0.0.0'
         route = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ip route {}'.format(ifmode, dip))['stdout']
         logger.info('route:\n{}'.format(route))
 
         if mode == 'alias':
-            for alias in spine_ports['alias']:
+            for alias in static_route_intf['alias']:
                 assert re.search(r'via {}'.format(alias), route) is not None
         elif mode == 'default':
-            for intf in spine_ports['interface']:
+            for intf in static_route_intf['interface']:
                 assert re.search(r'via {}'.format(intf), route) is not None
 
-    def test_show_ip_route_v6(self, setup_config_mode, spine_ports):
+    def test_show_ip_route_v6(self, setup_config_mode, static_route_intf):
         """
         Checks whether 'show ipv6 route <ipv6>' lists the interface name
         as per the configured naming mode
@@ -1061,8 +1085,8 @@ class TestShowIP():
         logger.info('route:\n{}'.format(route))
 
         if mode == 'alias':
-            for alias in spine_ports['alias']:
+            for alias in static_route_intf['alias']:
                 assert re.search(r'via {}'.format(alias), route) is not None
         elif mode == 'default':
-            for intf in spine_ports['interface']:
+            for intf in static_route_intf['interface']:
                 assert re.search(r'via {}'.format(intf), route) is not None

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -991,7 +991,7 @@ class TestShowIP():
                     dst_ip = '192.168.1.1'
                 else:
                     ip_version = '-6'
-                    dst_ip = '::/0'
+                    dst_ip = 'fd0a::1'
                 if namespace:
                     duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".
                                   format(namespace, ip_version, dst_ip, gw_ip, dev))
@@ -1010,7 +1010,7 @@ class TestShowIP():
                 dst_ip = '192.168.1.1'
             else:
                 ip_version = '-6'
-                dst_ip = '::/0'
+                dst_ip = 'fd0a::1'
 
             if namespace:
                 duthost.shell("ip netns exec {} ip {} route del {} via {}".
@@ -1083,7 +1083,8 @@ class TestShowIP():
         as per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
-        route = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ipv6 route ::/0'.format(ifmode))['stdout']
+        dip = 'fd0a::1'
+        route = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ipv6 route {}'.format(ifmode, dip))['stdout']
         logger.info('route:\n{}'.format(route))
 
         if mode == 'alias':

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -973,7 +973,6 @@ class TestShowIP():
             of the spine ports
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
         static_route_intf = dict()
         static_route_intf['interface'] = list()
         static_route_intf['alias'] = list()
@@ -993,7 +992,7 @@ class TestShowIP():
                     ip_version = '-6'
                     dst_ip = '::/0'
                 if namespace:
-                    duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".\
+                    duthost.shell("ip netns exec {} ip {} route add {}  via {} dev {}".
                                   format(namespace, ip_version, dst_ip, gw_ip, dev))
                 else:
                     duthost.shell("ip {} route add {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))
@@ -1014,7 +1013,7 @@ class TestShowIP():
                     ip_version = '-6'
                     dst_ip = '::/0'
                 if namespace:
-                    duthost.shell("ip netns exec {} ip {} route del {}  via {} dev {}".\
+                    duthost.shell("ip netns exec {} ip {} route del {}  via {} dev {}".
                                   format(namespace, ip_version, dst_ip, gw_ip, dev))
                 else:
                     duthost.shell("ip {} route del {}  via {} dev {}".format(ip_version, dst_ip, gw_ip, dev))

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -241,6 +241,7 @@ test_t1_lag() {
     configlet/test_add_rack.py \
     container_checker/test_container_checker.py \
     http/test_http_copy.py \
+    iface_namingmode/test_iface_namingmode.py \
     ipfwd/test_mtu.py \
     lldp/test_lldp.py \
     monit/test_monit_status.py \
@@ -280,6 +281,7 @@ test_multi_asic_t1_lag_pr() {
     tgname=multi_asic_t1_lag
     tests="\
     bgp/test_bgp_fact.py \
+    iface_namingmode/test_iface_namingmode.py \
     snmp/test_snmp_default_route.py \
     snmp/test_snmp_loopback.py \
     snmp/test_snmp_pfc_counters.py \

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -241,7 +241,6 @@ test_t1_lag() {
     configlet/test_add_rack.py \
     container_checker/test_container_checker.py \
     http/test_http_copy.py \
-    iface_namingmode/test_iface_namingmode.py \
     ipfwd/test_mtu.py \
     lldp/test_lldp.py \
     monit/test_monit_status.py \
@@ -281,7 +280,6 @@ test_multi_asic_t1_lag_pr() {
     tgname=multi_asic_t1_lag
     tests="\
     bgp/test_bgp_fact.py \
-    iface_namingmode/test_iface_namingmode.py \
     snmp/test_snmp_default_route.py \
     snmp/test_snmp_loopback.py \
     snmp/test_snmp_pfc_counters.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
1. For T2 topology, show ip route checks if  there is a default route via non portchannel interface towards a T3 neighbor and test checks if that interface name is displayed as per the correct mode (default/alias). 
2. Test will be skipped for T2 topology if there is no T3 neighbor, this will skip the test on a LC if there is a no T3 neighbor.

#### How did you do it?
1. Add a dummy route to 192.168.1.1/::0/0 via one of the non portchannel interface and update test to check if that particular interface name is displayed correctly as per the selected mode.
2. Currently iface_namingmode test case is being run only for t0 testbed in PR checker,  show_ip_route test is skipped on t0 as there is no non-portchannel IP interface. So add this test to be run on t1-lag and multi-asic testbeds.

#### How did you verify/test it?
Verified that the test passes on packet-chassis, voq chassis, single asic device with t1-lag topology.

PR checker test passed on t1-lag VS testbed:
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v4[alias-vlab-03] PASSED [ 48%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[alias-vlab-03] PASSED [ 50%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
