### PR TITLE
Correction in condition check for t2 in  dutTestParams - qos_sai_base

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1462,7 +1462,7 @@ class QosSaiBase(QosBase):
         duthost = get_src_dst_asic_and_duts['src_dut']
 
         # This is not needed in T2.
-        if dutTestParams["topo"] in ['t2']:
+        if "t2" in dutTestParams["topo"]:
             yield
             return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: One of the change in qos_sai_base for  populateArpEntries in PR -https://github.com/sonic-net/sonic-mgmt/pull/8377 ; the check for t2 is failing

The dutTestParams["topo"] return a string which is combination of topo_type and chassis name.
For ex., **t2_ixre_chassisxxx**
Hence, the correct check would be - -> if "t2" in dutTestParams["topo"]
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Qos  test suite failed as the if condition was not fulfilled and the arp table were cleared for t2 topology
#### How did you do it?
Changed the if condition to check if "t2" string is present in the dutTestParams["topo"]
#### How did you verify/test it?
Ran the Qos test suite for t2 topology
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
