### PR TITLE
Enable and optimize teamd retry count test cases

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -38,7 +38,7 @@ t0:
   - override_config_table/test_override_config_table.py
   - pc/test_po_cleanup.py
   - pc/test_po_update.py
-  - platform_tests/test_advanced_reboot.py::test_warm_reboot
+#  - platform_tests/test_advanced_reboot.py::test_warm_reboot
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py
   - radv/test_radv_ipv6_ra.py
@@ -80,7 +80,7 @@ t0-sonic:
   - macsec/test_fault_handling.py
   - macsec/test_interop_protocol.py
   - pc/test_retry_count.py
-  - platform_tests/test_advanced_reboot.py::test_warm_reboot
+#  - platform_tests/test_advanced_reboot.py::test_warm_reboot
 
 dualtor:
   - arp/test_arp_extended.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -38,7 +38,7 @@ t0:
   - override_config_table/test_override_config_table.py
   - pc/test_po_cleanup.py
   - pc/test_po_update.py
-#  - platform_tests/test_advanced_reboot.py::test_warm_reboot
+  - platform_tests/test_advanced_reboot.py::test_warm_reboot
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py
   - radv/test_radv_ipv6_ra.py
@@ -79,6 +79,8 @@ t0-sonic:
   - macsec/test_deployment.py
   - macsec/test_fault_handling.py
   - macsec/test_interop_protocol.py
+  - pc/test_retry_count.py
+  - platform_tests/test_advanced_reboot.py::test_warm_reboot
 
 dualtor:
   - arp/test_arp_extended.py

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -200,11 +200,11 @@ test_t0() {
 }
 
 test_t0_sonic() {
-    # Run tests_1vlan on vlab-01 virtual switch
     # TODO: Use a marker to select these tests rather than providing a hard-coded list here.
     tgname=t0-sonic
     tests="\
       bgp/test_bgp_fact.py \
+      pc/test_retry_count.py \
       macsec"
 
     pushd $SONIC_MGMT_DIR/tests

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -6,6 +6,7 @@ import tempfile
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
 from scapy.all import Packet, ByteField, ShortField, MACField, XStrFixedLenField, ConditionalField
 from scapy.all import split_layers, bind_layers, rdpcap
 import scapy.contrib.lacp
@@ -58,9 +59,20 @@ class LACPRetryCount(Packet):
         ConditionalField(XStrFixedLenField("reserved", "", 50), lambda pkt:pkt.version != 0xf1),
     ]
 
+def verify_retry_count(hosts, expected_retry_count):
+    for host in hosts:
+        cfg_facts = host.config_facts(host=host.hostname, source="running")["ansible_facts"]
+        port_channels = cfg_facts["PORTCHANNEL"].keys()
+        for port_channel in port_channels:
+            port_channel_status = host.get_port_channel_status(port_channel)
+            for _, status in list(port_channel_status["ports"].items()):
+                if status["runner"]["partner_retry_count"] != expected_retry_count:
+                    return False
+
+    return True
 
 @pytest.fixture(scope="class")
-def higher_retry_count_on_peers(request, nbrhosts):
+def higher_retry_count_on_peers(request, duthost, nbrhosts):
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Only supported with SONiC neighbor")
 
@@ -73,7 +85,7 @@ def higher_retry_count_on_peers(request, nbrhosts):
         nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 5")
 
     # Wait for retry count info to be updated
-    time.sleep(5)
+    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [duthost], 5), "Retry count info on DUT has not been changed to 5.")
 
     yield
 
@@ -81,11 +93,11 @@ def higher_retry_count_on_peers(request, nbrhosts):
         nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 3")
 
     # Wait for retry count info to be updated
-    time.sleep(90)
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3), "Retry count info on DUT has not been changed to 3.")
 
 
 @pytest.fixture(scope="class")
-def higher_retry_count_on_dut(request, duthost):
+def higher_retry_count_on_dut(request, duthost, nbrhosts):
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Only supported with SONiC neighbor")
 
@@ -100,7 +112,7 @@ def higher_retry_count_on_dut(request, duthost):
         duthost.shell("sudo config portchannel retry-count set {} 5".format(port_channel))
 
     # Wait for retry count info to be updated
-    time.sleep(5)
+    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 5), "Retry count info on neighbors has not been changed to 5.")
 
     yield
 
@@ -108,7 +120,7 @@ def higher_retry_count_on_dut(request, duthost):
         duthost.shell("sudo config portchannel retry-count set {} 3".format(port_channel))
 
     # Wait for retry count info to be updated
-    time.sleep(90)
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3), "Retry count info on neighbors has not been changed to 3.")
 
 
 @pytest.fixture(scope="function")
@@ -182,12 +194,12 @@ def check_lacpdu_packet_version(duthost):
 
 
 @pytest.fixture(scope="function")
-def disable_retry_count_on_peer(request, nbrhosts, higher_retry_count_on_peers):
+def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers):
     for nbr in list(nbrhosts.keys()):
         nbrhosts[nbr]['host'].shell("teamdctl PortChannel1 state item set runner.enable_retry_count_feature false")
 
     # Wait 90 seconds for retry count to get updated on the DUT
-    time.sleep(90)
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3), "Retry count info on neighbors has not been reset to 3.")
 
     yield
 
@@ -196,13 +208,13 @@ def disable_retry_count_on_peer(request, nbrhosts, higher_retry_count_on_peers):
 
 
 @pytest.fixture(scope="function")
-def disable_retry_count_on_dut(request, duthost, higher_retry_count_on_dut):
+def disable_retry_count_on_dut(duthost, nbrhosts, higher_retry_count_on_dut):
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
         duthost.shell("teamdctl {} state item set runner.enable_retry_count_feature false".format(port_channel))
 
     # Wait 90 seconds for retry count to get updated on the peers
-    time.sleep(90)
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3), "Retry count info on neighbors has not been reset to 3.")
 
     yield
 

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -55,8 +55,7 @@ class LACPRetryCount(Packet):
         ConditionalField(XStrFixedLenField("partner_retry_count_reserved", "", 1), lambda pkt:pkt.version == 0xf1),
         ByteField("terminator_type", 0),
         ByteField("terminator_length", 0),
-        ConditionalField(XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1),
-        ConditionalField(XStrFixedLenField("reserved", "", 50), lambda pkt:pkt.version != 0xf1),
+        MultipleTypeField([(XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1),], XStrFixedLenField("reserved", "", 50)),
     ]
 
 def verify_retry_count(hosts, expected_retry_count):

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -228,9 +228,8 @@ class TestNeighborRetryCount:
         """
         for nbr in list(nbrhosts.keys()):
             port_channel_status = nbrhosts[nbr]['host'].get_port_channel_status("PortChannel1")
-            pytest_assert(port_channel_status["runner"]["retry_count"] == 5, "retry count on neighbor is incorrect")
             pytest_assert(port_channel_status["runner"]["retry_count"] == 5,
-                          "retry count on DUT is incorrect; expected 5, but is {}"
+                          "retry count on neighbor is incorrect; expected 5, but is {}"
                           .format(port_channel_status["runner"]["retry_count"]))
 
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -7,7 +7,7 @@ import tempfile
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
-from scapy.all import Packet, ByteField, ShortField, MACField, XStrFixedLenField, ConditionalField
+from scapy.all import Packet, ByteField, ShortField, MACField, XStrFixedLenField, ConditionalField, MultipleTypeField
 from scapy.all import split_layers, bind_layers, rdpcap
 import scapy.contrib.lacp
 import scapy.layers.l2
@@ -55,8 +55,10 @@ class LACPRetryCount(Packet):
         ConditionalField(XStrFixedLenField("partner_retry_count_reserved", "", 1), lambda pkt:pkt.version == 0xf1),
         ByteField("terminator_type", 0),
         ByteField("terminator_length", 0),
-        MultipleTypeField([(XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1),], XStrFixedLenField("reserved", "", 50)),
+        MultipleTypeField([(XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1)],
+                          XStrFixedLenField("reserved", "", 50)),
     ]
+
 
 def verify_retry_count(hosts, expected_retry_count):
     for host in hosts:
@@ -69,6 +71,7 @@ def verify_retry_count(hosts, expected_retry_count):
                     return False
 
     return True
+
 
 @pytest.fixture(scope="class")
 def higher_retry_count_on_peers(request, duthost, nbrhosts):
@@ -84,7 +87,8 @@ def higher_retry_count_on_peers(request, duthost, nbrhosts):
         nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 5")
 
     # Wait for retry count info to be updated
-    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [duthost], 5), "Retry count info on DUT has not been changed to 5.")
+    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [duthost], 5),
+                  "Retry count on DUT has not been changed to 5.")
 
     yield
 
@@ -92,7 +96,8 @@ def higher_retry_count_on_peers(request, duthost, nbrhosts):
         nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 3")
 
     # Wait for retry count info to be updated
-    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3), "Retry count info on DUT has not been changed to 3.")
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3),
+                  "Retry count on DUT has not been changed to 3.")
 
 
 @pytest.fixture(scope="class")
@@ -111,7 +116,8 @@ def higher_retry_count_on_dut(request, duthost, nbrhosts):
         duthost.shell("sudo config portchannel retry-count set {} 5".format(port_channel))
 
     # Wait for retry count info to be updated
-    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 5), "Retry count info on neighbors has not been changed to 5.")
+    pytest_assert(wait_until(5, 1, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 5),
+                  "Retry count on neighbors has not been changed to 5.")
 
     yield
 
@@ -119,7 +125,8 @@ def higher_retry_count_on_dut(request, duthost, nbrhosts):
         duthost.shell("sudo config portchannel retry-count set {} 3".format(port_channel))
 
     # Wait for retry count info to be updated
-    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3), "Retry count info on neighbors has not been changed to 3.")
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3),
+                  "Retry count on neighbors has not been changed to 3.")
 
 
 @pytest.fixture(scope="function")
@@ -198,7 +205,8 @@ def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers):
         nbrhosts[nbr]['host'].shell("teamdctl PortChannel1 state item set runner.enable_retry_count_feature false")
 
     # Wait 90 seconds for retry count to get updated on the DUT
-    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3), "Retry count info on neighbors has not been reset to 3.")
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3),
+                  "Retry count on neighbors has not been reset to 3.")
 
     yield
 
@@ -213,7 +221,8 @@ def disable_retry_count_on_dut(duthost, nbrhosts, higher_retry_count_on_dut):
         duthost.shell("teamdctl {} state item set runner.enable_retry_count_feature false".format(port_channel))
 
     # Wait 90 seconds for retry count to get updated on the peers
-    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3), "Retry count info on neighbors has not been reset to 3.")
+    pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3),
+                  "Retry count on neighbors has not been reset to 3.")
 
     yield
 

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -113,6 +113,9 @@ def higher_retry_count_on_dut(request, duthost):
 
 @pytest.fixture(scope="function")
 def config_reload_on_cleanup(request, nbrhosts, duthost):
+    if request.config.getoption("enable_macsec"):
+        pytest.skip("Skip for now, since config reload will disable macsec for future test cases")
+
     yield
 
     for nbr in list(nbrhosts.keys()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Enable the teamd retry count test cases in the t0-sonic PR test pipeline. Two test cases will be skipped due to limitations when running with a macsec profile applied.

Additionally, optimize those test cases to take less time, by using `wait_until` instead of fixed-length sleeps.

Note that the teamd retry count test cases will add about 20 minutes to the t0-sonic runtime.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Tested by running the `pc/test_retry_count.py` test file with both `--neighbor_type=sonic` and `--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI` test parameters, with an image that supports the teamd retry count feature on both sides (DUT and neighbors).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
