### PR TITLE
skip COPP/test_copp.py/test_trap_config_save_after_reboot case for the devices which docker_inram enabled

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -182,9 +182,11 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
-    reason: "Copp test_trap_config_save_after_reboot is not yet supported on multi-asic platform"
+    conditions_logical_operator: or
+    reason: "Copp test_trap_config_save_after_reboot is not yet supported on multi-asic platform or not supported after docker_inram enabled"
     conditions:
       - "is_multi_asic==True"
+      - "build_version > '20220531.27' and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
 
 #######################################
 #####            crm              #####

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -9,7 +9,9 @@ from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
-pytest.mark.topology('any')
+pytestmark = [
+    pytest.mark.topology('any'),
+]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After enabling docker_inram feature, test_trap_config_save_after_reboot is experiencing a hang in the nightly pipeline build.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
After enabling docker_inram feature, test_trap_config_save_after_reboot is experiencing a hang in the nightly pipeline build.
Docker_inram feature would install docker into memory instead of disk. so it would not keep the change after reboot.

#### How did you do it?
Skip the case

#### How did you verify/test it?
copp/test_copp.py::TestCOPP::test_policer[str2-7050qx-32s-acs-01-ARP] PASSED [  7%]
copp/test_copp.py::TestCOPP::test_policer[str2-7050qx-32s-acs-01-IP2ME] PASSED [ 14%]
copp/test_copp.py::TestCOPP::test_policer[str2-7050qx-32s-acs-01-SNMP] PASSED [ 21%]
copp/test_copp.py::TestCOPP::test_policer[str2-7050qx-32s-acs-01-SSH] PASSED [ 28%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-BGP] PASSED [ 35%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-DHCP] PASSED [ 42%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-DHCP6] PASSED [ 50%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-LACP] PASSED [ 57%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-LLDP] PASSED [ 64%]
copp/test_copp.py::TestCOPP::test_no_policer[str2-7050qx-32s-acs-01-UDLD] PASSED [ 71%]
copp/test_copp.py::TestCOPP::test_add_new_trap[str2-7050qx-32s-acs-01] PASSED [ 78%]
copp/test_copp.py::TestCOPP::test_remove_trap[str2-7050qx-32s-acs-01-delete_feature_entry] PASSED [ 85%]
copp/test_copp.py::TestCOPP::test_remove_trap[str2-7050qx-32s-acs-01-disable_feature_status] PASSED [ 92%]
copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[str2-7050qx-32s-acs-01] SKIPPED [100%]

------ generated xml file: /azp/_work/72/s/tests/logs/copp/test_copp.xml -------
#### Any platform specific information?
7050qx/7060, which has a small disk (< 4G) and enabled docker_inram 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
