### PR TITLE
Removed skip for password hardening test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -656,17 +656,6 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
-#####       passw_hardening       #####
-#######################################
-passw_hardening/test_passw_hardening.py:
-  skip:
-    reason: "Password-hardening supported just in master version"
-    conditions_logical_operator: or
-    conditions:
-        - "release not in ['master']"
-        - https://github.com/sonic-net/sonic-mgmt/issues/6428
-
-#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR removes the skip of password hardening test, as the issue #6428 is already fixed, and the test can run on 202205 and 202211 branches.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Remove the skip for password hardening test as the test can run on any branch (not only master)
#### How did you do it?
Removed the skip from test_mark_conditions.py
#### How did you verify/test it?
ran the test without the skip.
#### Any platform specific information?
no
