### PR TITLE
EOS-T2-Config-Template: Fix Portchannel min-links config

### DIFF
--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -57,6 +57,13 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% set ns = namespace(po_mbr_cnt=0) %}
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Ethernet') %}
+{% set ns.po_mbr_cnt = ns.po_mbr_cnt + 1 %}
+{% endif %}
+{% endfor %}
+
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -66,7 +73,8 @@ interface {{ name }}
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}
- port-channel min-links 2
+{% set min_links = (ns.po_mbr_cnt * 0.75) | round(0, 'ceil') | int %}
+ port-channel min-links {{ min_links }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -57,6 +57,13 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% set ns = namespace(po_mbr_cnt=0) %}
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Ethernet') %}
+{% set ns.po_mbr_cnt = ns.po_mbr_cnt + 1 %}
+{% endif %}
+{% endfor %}
+
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -66,7 +73,8 @@ interface {{ name }}
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}
- port-channel min-links 1
+{% set min_links = (ns.po_mbr_cnt * 0.75) | round(0, 'ceil') | int %}
+ port-channel min-links {{ min_links }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -57,6 +57,13 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% set ns = namespace(po_mbr_cnt=0) %}
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Ethernet') %}
+{% set ns.po_mbr_cnt = ns.po_mbr_cnt + 1 %}
+{% endif %}
+{% endfor %}
+
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -66,7 +73,8 @@ interface {{ name }}
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}
- port-channel min-links 2
+{% set min_links = (ns.po_mbr_cnt * 0.75) | round(0, 'ceil') | int %}
+ port-channel min-links {{ min_links }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -57,6 +57,13 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
+{% set ns = namespace(po_mbr_cnt=0) %}
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Ethernet') %}
+{% set ns.po_mbr_cnt = ns.po_mbr_cnt + 1 %}
+{% endif %}
+{% endfor %}
+
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
 {% if name.startswith('Loopback') %}
@@ -66,7 +73,8 @@ interface {{ name }}
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}
- port-channel min-links 1
+{% set min_links = (ns.po_mbr_cnt * 0.75) | round(0, 'ceil') | int %}
+ port-channel min-links {{ min_links }}
 {% endif %}
 {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active


### PR DESCRIPTION
Summary:
Fix eos config template to generate min-links for po based on SONiC logic.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
CEOS config template currently hardcodes po min-link. This causes problem(po doesnt come up/ wrong min-link config on neighbor) when we define new topologies with different po members.

#### How did you do it?
Modified jinja t2 template files by counting number of Ethernet members and by multiplying them with 0.75 and taking a ceil with round off to integer. 

#### How did you verify/test it?
Verified by checking min-link config on ceos neighbors after add-topo execution.
Verified that Port channels with different member counts come up.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
NA

