### PR TITLE
Xoff longlink

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3524,25 +3524,6 @@ qos_params:
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
                     pkts_num_margin: 20
-            100000_120000m:
-                pkts_num_leak_out: 0
-                pkts_num_egr_mem: 1276
-                xoff_1:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
-                    packet_size: 8140
-                    pkts_num_margin: 20
-                xoff_2:
-                    dscp: 4
-                    ecn: 1
-                    pg: 4
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
-                    packet_size: 8140
-                    pkts_num_margin: 20
     jr2:
         topo-any:
             100000_300m:

--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3524,6 +3524,25 @@ qos_params:
                     pkts_num_trig_ingr_drp: 10589
                     packet_size: 1350
                     pkts_num_margin: 20
+            100000_120000m:
+                pkts_num_leak_out: 0
+                pkts_num_egr_mem: 1276
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4481
+                    pkts_num_trig_ingr_drp: 7689
+                    packet_size: 8140
+                    pkts_num_margin: 20
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 4481
+                    pkts_num_trig_ingr_drp: 7689
+                    packet_size: 8140
+                    pkts_num_margin: 20
     jr2:
         topo-any:
             100000_300m:


### PR DESCRIPTION
Adding qos.yaml parameters for Xoff test, for cisco-8000, for topo-t2 longlink(120Kms). This triggers packets eviction to HBM.