### PR TITLE
Enhance cleanup.sh process in 202205

### DIFF
--- a/ansible/roles/vm_set/templates/cleanup.sh.j2
+++ b/ansible/roles/vm_set/templates/cleanup.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # stop rynning VMs
 test -z "$(virsh list --state-running --name)" || virsh list --state-running --name | xargs -I % virsh destroy %
@@ -18,13 +18,17 @@ rm -f {{ root_path }}/disks/*
 test -z "$(ovs-vsctl list-br)" || ovs-vsctl list-br | xargs -I % ovs-vsctl del-br %
 
 # stop exabgp process before stopping ptf container
-test -z "$(docker ps | grep ptf | awk '{print $NF}')"
-ptf_container_name=$(docker ps | grep ptf | awk '{print $NF}')
-for ptf in  $ptf_container_name;
+ptf_container_names=$(docker ps | grep ptf | awk '{print $NF}')
+for ptf in $ptf_container_names;
 do
-  test -z "$(docker exec $ptf supervisorctl status | grep exabgp | awk '{print $1}')"
-  exabgp_process_name="$(docker exec $ptf supervisorctl status | grep exabgp | awk '{print $1}')"
-  docker exec $ptf supervisorctl stop $exabgp_process_name
+  process_name="$(docker exec $ptf supervisorctl status | awk '{print $1}')"
+  for process in $process_name;
+  do
+    process_status="$(docker exec $ptf supervisorctl status | grep $process | awk '{print $2}')"
+    if [[ $process_status == "RUNNING" ]]; then
+      docker exec $ptf supervisorctl stop $process
+    fi
+  done
 done
 
 # stop all running docker containers


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
cleanup.sh will stop all exabgp process before stop ptf container, but test servers are still possible to get stuck
#### How did you do it?
Stop all running supervisorctl process instead of all exabgp process
Cherry-pick from PR https://github.com/sonic-net/sonic-mgmt/pull/8485
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
