### PR TITLE
Skip test_replace_fec on M0/Mx topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -459,9 +459,12 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
 
 generic_config_updater/test_eth_interface.py::test_replace_fec:
   skip:
-    reason: 'replace_fec ethernet test is not supported on virtual switch'
+    reason: '1. replace_fec ethernet test is not supported on virtual switch
+             2. Skip on M0 and Mx topo due to DUT interfaces do not support config fec'
+    conditions_logical_operator: OR
     conditions:
       - "platform in ['x86_64-kvm_x86_64-r0']"
+      - "topo_type in ['m0', 'mx'] and https://github.com/sonic-net/sonic-mgmt/issues/8600"
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip test_replace_fec on M0/Mx topo due to DUT interfaces don't support config `FEC`.
Issue: #8600 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip test_replace_fec on M0/Mx topo due to DUT interfaces don't support config `FEC`.

#### How did you do it?
Use the conditional mark to skip this test.

#### How did you verify/test it?
Verified on a M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
