### PR TITLE
Adding additonal new portSpeedCableLength to qos yaml

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3947,7 +3947,113 @@ qos_params:
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
-            400000_2000m:
+            100000_120000m:
+                pkts_num_leak_out: 5
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_margin: 100
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_margin: 100
+                hdrm_pool_size:
+                    dscps: [ 3, 4 ]
+                    ecn: 1
+                    pgs: [ 3, 4 ]
+                    src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
+                    dst_port_id: 18
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 37549
+                    pkts_num_hdrm_full: 362
+                    pkts_num_hdrm_partial: 182
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_ingr_drp: 55808
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 37449
+                    pkts_num_dismiss_pfc: 200
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 37449
+                    pkts_num_dismiss_pfc: 200
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 7
+                    ecn: 1
+                    pg: 1
+                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_margin: 200
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 51
+                    pkts_num_trig_pfc: 37449
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 51
+                    pkts_num_trig_egr_drp: 2396745
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 55808
+                    cell_size: 4096
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_pfc: 37549
+                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2396745
+                    cell_size: 4096
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 4096
+            400000_120000m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48
                 xoff_1:
@@ -3955,14 +4061,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 50358
+                    pkts_num_trig_ingr_drp: 750848
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 50358
+                    pkts_num_trig_ingr_drp: 750848
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -3980,7 +4086,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 50358
+                    pkts_num_trig_ingr_drp: 750848
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
@@ -4026,7 +4132,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 50358
+                    pkts_num_trig_ingr_drp: 750848
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -4034,8 +4140,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 50358
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 750848
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR is an extension to PR https://github.com/sonic-net/sonic-mgmt/pull/8478 adding profile-**100000_120000m and 400000_120000m**
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The below PR introduced new cable length for uplink/downlink ports for chassis.
https://github.com/sonic-net/sonic-buildimage/pull/14908

1.Accordingly, qos.yml has been added with new qos cable length profile-**100000_120000m and 400000_120000m**
2. Removing the profile -400000_2000m, as this is not required.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
The below PR introduced new cable length for uplink/downlink ports for chassis
https://github.com/sonic-net/sonic-buildimage/pull/14908

Accordingly qos.yml has been added with new qos cable length profile-**100000_120000m and 400000_120000m**
#### What is the motivation for this PR?

#### How did you do it?
Added with new qos cable length profile-100000_120000m and 400000_120000m in qos.yml

#### How did you verify/test it?
Executed qos testcases T2 topology on for single_asic ,single_dut_multi_asic & multi_dut

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
