### PR TITLE
Update testcase test_nhop_group_member_count

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -189,7 +189,9 @@ def get_crm_info(duthost, asic):
     """
     get_group_stats = ("{} COUNTERS_DB HMGET CRM:STATS"
                        " crm_stats_nexthop_group_used"
-                       " crm_stats_nexthop_group_available").format(asic.sonic_db_cli)
+                       " crm_stats_nexthop_group_available"
+                       " crm_stats_nexthop_group_member_used"
+                       " crm_stats_nexthop_group_member_available").format(asic.sonic_db_cli)
     pytest_assert(wait_until(25, 5, 0, lambda: (len(duthost.command(get_group_stats)["stdout_lines"]) >= 2)),
                   get_group_stats)
 
@@ -197,8 +199,10 @@ def get_crm_info(duthost, asic):
     pytest_assert(result["rc"] == 0 or len(result["stdout_lines"]) < 2, get_group_stats)
 
     crm_info = {
-        "used": int(result["stdout_lines"][0]),
-        "available": int(result["stdout_lines"][1])
+        "used_nhop_grp": int(result["stdout_lines"][0]),
+        "available_nhop_grp": int(result["stdout_lines"][1]),
+        "used_nhop_grp_mem": int(result["stdout_lines"][2]),
+        "available_nhop_grp_mem": int(result["stdout_lines"][3])
     }
 
     get_polling = '{} CONFIG_DB HMGET "CRM|Config" "polling_interval"'.format(
@@ -326,6 +330,7 @@ def test_nhop_group_member_count(duthost, tbinfo):
         default_max_nhop_paths = 2
         polling_interval = 1
         sleep_time = 380
+        sleep_time_sync_before = 120
     elif is_innovium_device(duthost):
         default_max_nhop_paths = 3
         polling_interval = 10
@@ -350,12 +355,6 @@ def test_nhop_group_member_count(duthost, tbinfo):
     switch_capability = dict(list(zip(it, it)))
     max_nhop = switch_capability.get("MAX_NEXTHOP_GROUP_COUNT")
     max_nhop = nhop_group_limit if max_nhop is None else int(max_nhop)
-    if is_cisco_device(duthost) or is_innovium_device(duthost):
-        crm_stat = get_crm_info(duthost, asic)
-        nhop_group_count = crm_stat["available"]
-        nhop_group_count = int(nhop_group_count * CISCO_NHOP_GROUP_FILL_PERCENTAGE)
-    else:
-        nhop_group_count = min(max_nhop, nhop_group_limit) + extra_nhops
 
     # find out an active IP port
     ip_ifaces = list(asic.get_active_ip_interfaces(tbinfo).keys())
@@ -373,7 +372,25 @@ def test_nhop_group_member_count(duthost, tbinfo):
     # indices
     indices = list(range(arp_count))
     ip_indices = combinations(indices, default_max_nhop_paths)
+    ip_prefix = ipaddr.IPAddress("192.168.0.0")
 
+    crm_before = get_crm_info(duthost, asic)
+
+    # increase CRM polling time
+    asic.command("crm config polling interval {}".format(polling_interval))
+
+    if is_cisco_device(duthost) or is_innovium_device(duthost):
+        # Waiting for ARP routes to be synced and programmed
+        time.sleep(sleep_time_sync_before)
+        crm_stat = get_crm_info(duthost, asic)
+        nhop_group_count = crm_stat["available_nhop_grp"]
+        nhop_group_mem_count = crm_stat["available_nhop_grp_mem"]
+        nhop_group_count = int(nhop_group_count * CISCO_NHOP_GROUP_FILL_PERCENTAGE)
+        # Consider both available nhop_grp and nhop_grp_mem before creating nhop_groups
+        nhop_group_mem_count = int((nhop_group_mem_count) / default_max_nhop_paths * CISCO_NHOP_GROUP_FILL_PERCENTAGE)
+        nhop_group_count = min(nhop_group_mem_count, nhop_group_count)
+    else:
+        nhop_group_count = min(max_nhop, nhop_group_limit) + extra_nhops
     # initialize log analyzer
     marker = "NHOP TEST PATH COUNT {} {}".format(nhop_group_count, eth_if)
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker)
@@ -382,15 +399,7 @@ def test_nhop_group_member_count(duthost, tbinfo):
     loganalyzer.expect_regex = []
     loganalyzer.ignore_regex.extend(loganalyzer_ignore_regex_list())
 
-    ip_prefix = ipaddr.IPAddress("192.168.0.0")
-
-    crm_before = get_crm_info(duthost, asic)
-
-    # increase CRM polling time
-    asic.command("crm config polling interval {}".format(polling_interval))
-
     logger.info("Adding {} next hops on {}".format(nhop_group_count, eth_if))
-
     # create nexthop group
     nhop = IPRoutes(duthost, asic)
     try:
@@ -422,18 +431,18 @@ def test_nhop_group_member_count(duthost, tbinfo):
     # skip this check on Mellanox as ASIC resources are shared
     if is_cisco_device(duthost):
         pytest_assert(
-            crm_after["available"] + nhop_group_count == crm_before["available"],
+            crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
             "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(
-                crm_after["available"], crm_after["used"], nhop_group_count, crm_before["available"]
+                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"], nhop_group_count, crm_before["available_nhop_grp"]
             )
         )
     elif is_mellanox_device(duthost):
         logger.info("skip this check on Mellanox as ASIC resources are shared")
     else:
         pytest_assert(
-            crm_after["available"] == 0,
-            "Unused NHOP group resource:{}, used:{}".format(
-                crm_after["available"], crm_after["used"]
+            crm_after["available_nhop_grp"] == 0,
+            "Unused NHOP group resource:{}, used_nhop_grp:{}".format(
+                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"]
             )
         )
 


### PR DESCRIPTION
The intention of the testcase is to fill the ecmp member table, but the testcase considers available ecmp groups and then adds members to it without considering the availability in the member table. The change is to fill the members based on availability of both the member table and group table to avoid either of them going out of resource.

Changes:
1. For nhop_group_count, take the min of (availble ecmp groups) and (available ecmp members / default_max_nhop_paths).
2. Creating ARP entries is consuming some ecmp members. So, query the crm available resources after arp entries are programmed and synced.
