### PR TITLE
update BufferPoolWatermarkTest for cisco-8000 hbm

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4280,6 +4280,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 # No additional packet margin needed while sending,
                 # but small margin still needed during boundary checks below
                 pkts_num=1
+                expected_wm = pkts_num_fill_min * cell_occupancy
             else:
                 pkts_num=(1 + upper_bound_margin) // cell_occupancy
             while (expected_wm < total_shared):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After enable hbm for long-link, the bufferpool for lossless is hbm.
Before packets are evicted to hbm, the bufferpool watermark will always be 0.
Once hit the eviction threshold, the whole voq is evicted to hbm, and the bufferpool watermark will be increased once by a large value.

Send pkts_num_fill_ingr_min packets as initial, which is one packet less than eviction threshold, bufferpool watermark is 0.
Before the while loop, set expected_wm = pkts_num_fill_min * cell_occupancy.
Then in while loop, the expected_wm will be added up to the correct value.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
