### PR TITLE
Move logs_before_reboot directory to /var/log after reboot

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -459,6 +459,23 @@ class AdvancedReboot:
         # Handle mellanox platform
         self.__handleMellanoxDut()
 
+    def move_logs_before_reboot(self):
+        source_dir = '/host/logs_before_reboot'
+        target_dir = '/var/log'
+
+        command = "test -d {}".format(source_dir)
+        result = self.duthost.shell(command, module_ignore_errors=True)
+
+        if result["rc"] == 0:
+            command = 'sudo mv ' + source_dir + ' ' + target_dir
+            result = self.duthost.shell(command, module_ignore_errors=True)
+            if result["rc"] == 0:
+                logger.info("Files under /host/logs_before_reboot copied successfully to {}.".format(target_dir))
+            else:
+                logger.info("Failed to copy files under /host/logs_before_reboot successfully to {}.".format(target_dir))
+        else:
+            logger.info("Directory {} does not exist.".format(source_dir))
+
     def runRebootTest(self):
         # Run advanced-reboot.ReloadTest for item in preboot/inboot list
         count = 0
@@ -498,6 +515,7 @@ class AdvancedReboot:
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
                 log_dir = self.__fetchTestLogs(rebootOper)
                 if self.advanceboot_loganalyzer:
+                    self.move_logs_before_reboot()
                     verification_errors = post_reboot_analysis(marker, event_counters=event_counters,
                                                                reboot_oper=rebootOper, log_dir=log_dir)
                     if verification_errors:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This is an enhancement to warm reboot test to help store logs under host/logs_before_reboot in techsupport capture during upgrade pipeline runs
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently logs under /host/logs_before_reboot is not collected during show techsupport. Moving /host/logs_before_reboot directory to /var/log temporarily under a more permanenetly solution exists in image

#### How did you do it?
Move directory /host/logs_before_reboot to /var/log

#### How did you verify/test it?
Manually ran test_warm_reboot. Directory /host/logs_before_reboot was moved to /var/log and test passed
https://elastictest.org/scheduler/testplan/64ac3c778524edcd5632d407

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
