### PR TITLE
Fix issue 8497: PTF test collected a huge number of unexpected pkt when test failed

### DIFF
--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -4,7 +4,7 @@ import logging
 import re
 import struct
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
 from multiprocessing import Process
 
 import cryptography.exceptions
@@ -386,7 +386,7 @@ def load_macsec_info(duthost, port, force_reload=None):
 
 
 def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pkt=None):
-    recent_packets = []
+    recent_packets = deque(maxlen=test.dataplane.POLL_MAX_RECENT_PACKETS)
     packet_count = 0
     if timeout is None:
         timeout = ptf.ptfutils.default_timeout


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/8497

#### How did you do it?
Change the type of recent_packets to ring buffer for reducing the recent failure packets

#### How did you verify/test it?
Check Azp.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
