### PR TITLE
Remove duplicate wm_buf_pool_lossy and wm_buf_pool_lossless entries

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2526,6 +2526,15 @@ qos_params:
                 pkts_num_margin: 4
                 packet_size: 1350
                 cell_size: 384
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_trig_egr_drp: 4000
+                pkts_num_fill_egr_min: 0
+                cell_size: 384
+                packet_size: 1350
             shared_res_size_1:
                 ecn: 1
                 packet_size: 1350
@@ -2664,15 +2673,6 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
-            wm_buf_pool_lossy:
-                dscp: 8
-                ecn: 1
-                pg: 0
-                queue: 0
-                pkts_num_trig_egr_drp: 4000
-                pkts_num_fill_egr_min: 0
-                cell_size: 384
-                packet_size: 1350
             100000_40m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -3701,15 +3701,6 @@ qos_params:
                     pkts_num_trig_pfc: 3415
                     pkts_num_margin: 4
                     packet_size: 1350
-                wm_buf_pool_lossless:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    queue: 3
-                    pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 3415
-                    cell_size: 384
-                    packet_size: 1350
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1
@@ -3744,15 +3735,6 @@ qos_params:
                     pkts_num_trig_pfc: 3415
                     cell_size: 384
                     packet_size: 1350
-            wm_buf_pool_lossy:
-                dscp: 8
-                ecn: 1
-                pg: 0
-                queue: 0
-                pkts_num_trig_egr_drp: 4000
-                pkts_num_fill_egr_min: 0
-                cell_size: 384
-                packet_size: 1350
             400000_300m:
                 pkts_num_leak_out: 0
                 pkts_num_egr_mem: 6884
@@ -3873,9 +3855,6 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 3415
-                    cell_size: 384
-                    packet_size: 1350
                     pkts_num_trig_pfc: 3038
                     cell_size: 384
                     packet_size: 1350


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. Put wm_buf_pool_lossy before portspeed_cablelength section, all portspeed_cablelength use the same value.
2. Remove duplicate wm_buf_pool_lossy and wm_buf_pool_lossless entries.
3. Remove/correct duplicate pkts_num_trig_pfc/cell_size/packet_size in wm_buf_pool_lossless entry in topo-t2 400000_300m section.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
