### PR TITLE
[CoPP] Remove specific version for libssl1.1 to fix setup error

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -215,7 +215,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
         cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                 rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
-                && apt-get install -y python-pip build-essential libssl1.1=1.1.1n-0+deb10u4 libssl-dev libffi-dev python-dev python-setuptools wget cmake \
+                && apt-get install -y python-pip build-essential libssl1.1 libssl-dev libffi-dev python-dev python-setuptools wget cmake \
                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                 && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                 && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
CoPP failed at setup while installing packages.


```
{
  "changed": true,
  "cmd": [
    "docker",
    "exec",
    "-e",
    "http_proxy=http://10.201.148.40:8080",
    "-e",
    "https_proxy=http://10.201.148.40:8080",
    "syncd",
    "bash",
    "-c",
    "                 rm -rf /var/lib/apt/lists/*                 && apt-get update                 && apt-get install -y python-pip build-essential libssl1.1=1.1.1n-0+deb10u4 libssl-dev libffi-dev python-dev python-setuptools wget cmake                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz                 && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0                 && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0                 && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy                 && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py                 && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py                 "
  ],
  "delta": "0:00:06.332621",
  "end": "2023-06-13 15:56:53.848252",
  "failed": true,
  "msg": "non-zero return code",
  "rc": 100,
  "start": "2023-06-13 15:56:47.515631",
  "stderr": "E: Unable to correct problems, you have held broken packages.",
  "stderr_lines": [
    "E: Unable to correct problems, you have held broken packages."
  ],
  "stdout": "Get:1 http://deb.debian.org/debian buster InRelease [122 kB]\nGet:2 http://deb.debian.org/debian buster-updates InRelease [56.6 kB]\nGet:3 http://deb.debian.org/debian buster-backports InRelease [51.4 kB]\nGet:4 http://deb.debian.org/debian-security buster/updates InRelease [34.8 kB]\nGet:5 http://deb.debian.org/debian buster/contrib Sources [42.5 kB]\nGet:6 http://deb.debian.org/debian buster/main Sources [7852 kB]\nGet:7 http://deb.debian.org/debian buster/non-free Sources [85.9 kB]\nGet:8 http://deb.debian.org/debian buster/contrib amd64 Packages [50.1 kB]\nGet:9 http://deb.debian.org/debian buster/non-free amd64 Packages [87.8 kB]\nGet:10 http://deb.debian.org/debian buster/main amd64 Packages [7909 kB]\nGet:11 http://deb.debian.org/debian buster-updates/main Sources [4616 B]\nGet:12 http://deb.debian.org/debian buster-updates/main amd64 Packages [8788 B]\nGet:13 http://deb.debian.org/debian buster-backports/main amd64 Packages [487 kB]\nGet:14 http://deb.debian.org/debian buster-backports/non-free amd64 Packages [37.2 kB]\nGet:15 http://deb.debian.org/debian buster-backports/contrib amd64 Packages [9196 B]\nGet:16 http://deb.debian.org/debian-security buster/updates/non-free Sources [2680 B]\nGet:17 http://deb.debian.org/debian-security buster/updates/main Sources [358 kB]\nGet:18 http://deb.debian.org/debian-security buster/updates/main amd64 Packages [511 kB]\nGet:19 http://deb.debian.org/debian-security buster/updates/non-free amd64 Packages [9148 B]\nFetched 17.7 MB in 4s (4444 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nlibssl1.1 is already the newest version (1.1.1n-0+deb10u4).\nlibssl1.1 set to manually installed.\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n libssl-dev : Depends: libssl1.1 (= 1.1.1n-0+deb10u5) but 1.1.1n-0+deb10u4 is to be installed",
  "stdout_lines": [
    "Get:1 http://deb.debian.org/debian buster InRelease [122 kB]",
    "Get:2 http://deb.debian.org/debian buster-updates InRelease [56.6 kB]",
    "Get:3 http://deb.debian.org/debian buster-backports InRelease [51.4 kB]",
    "Get:4 http://deb.debian.org/debian-security buster/updates InRelease [34.8 kB]",
    "Get:5 http://deb.debian.org/debian buster/contrib Sources [42.5 kB]",
    "Get:6 http://deb.debian.org/debian buster/main Sources [7852 kB]",
    "Get:7 http://deb.debian.org/debian buster/non-free Sources [85.9 kB]",
    "Get:8 http://deb.debian.org/debian buster/contrib amd64 Packages [50.1 kB]",
    "Get:9 http://deb.debian.org/debian buster/non-free amd64 Packages [87.8 kB]",
    "Get:10 http://deb.debian.org/debian buster/main amd64 Packages [7909 kB]",
    "Get:11 http://deb.debian.org/debian buster-updates/main Sources [4616 B]",
    "Get:12 http://deb.debian.org/debian buster-updates/main amd64 Packages [8788 B]",
    "Get:13 http://deb.debian.org/debian buster-backports/main amd64 Packages [487 kB]",
    "Get:14 http://deb.debian.org/debian buster-backports/non-free amd64 Packages [37.2 kB]",
    "Get:15 http://deb.debian.org/debian buster-backports/contrib amd64 Packages [9196 B]",
    "Get:16 http://deb.debian.org/debian-security buster/updates/non-free Sources [2680 B]",
    "Get:17 http://deb.debian.org/debian-security buster/updates/main Sources [358 kB]",
    "Get:18 http://deb.debian.org/debian-security buster/updates/main amd64 Packages [511 kB]",
    "Get:19 http://deb.debian.org/debian-security buster/updates/non-free amd64 Packages [9148 B]",
    "Fetched 17.7 MB in 4s (4444 kB/s)",
    "Reading package lists...",
    "Reading package lists...",
    "Building dependency tree...",
    "Reading state information...",
    "libssl1.1 is already the newest version (1.1.1n-0+deb10u4).",
    "libssl1.1 set to manually installed.",
    "Some packages could not be installed. This may mean that you have",
    "requested an impossible situation or if you are using the unstable",
    "distribution that some required packages have not yet been created",
    "or been moved out of Incoming.",
    "The following information may help to resolve the situation:",
    "",
    "The following packages have unmet dependencies:",
    " libssl-dev : Depends: libssl1.1 (= 1.1.1n-0+deb10u5) but 1.1.1n-0+deb10u4 is to be installed"
  ]
}
```
#### How did you do it?
Latest 20201231.102 image may upgrade packages, 1.1.1n-0+deb10u5 became the target version, not 1.1.1n-0+deb10u4.
Remove specific version to make sure it could install latest version.

` " libssl-dev : Depends: libssl1.1 (= 1.1.1n-0+deb10u5) but 1.1.1n-0+deb10u4 is to be installed"`



#### How did you verify/test it?

Run `rm -rf /var/lib/apt/lists/* && apt-get update                 && apt-get install -y python-pip build-essential libssl1.1 libssl-dev libffi-dev python-dev= python-setuptools wget cmake                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz                 && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0                 && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0                 && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy                 && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py                 && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py` in syncd docker container.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
