### PR TITLE
 VLAN to VNI not implemented loganalyzer error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -177,3 +177,4 @@ r, ".* ERR .*CounterCheck: Invalid port oid.*"
 # https://msazure.visualstudio.com/One/_workitems/edit/17617756
 # https://msazure.visualstudio.com/One/_workitems/edit/17863895
 r, ".* ERR syncd\d*#syncd.*SAI_API_ACL:_brcm_sai_acl_entry_bind.*"
+r, ".* ERR syncd#syncd:.*SAI_LOG|SAI_API_TUNNEL: VLAN to VNI not implemented yet.*"


### PR DESCRIPTION
Description:  
Seeing a loganalyzer error 'ERR syncd#syncd: SAI_LOG|SAI_API_TUNNEL:VLAN to VNI not implemented yet' when running decap/test_decap.py script. the SDK code that dumps that message is the old code, has been there since 2021.
It's dumped when create tunnel with type of VLAN to VNI.
In the test sonic-mgmt code, decap/test_decap.py doesn't have new change to add that, probably some common code, since it's harmless and cases can pass, proposing to add this message to ignore list.

Changes: 
Adding a line 'r, ".* ERR syncd#syncd:.*SAI_LOG|SAI_API_TUNNEL: VLAN to VNI not implemented yet.*"' to loganalyzer_common_ignore.txt file.


Verification: 
The test was run on a T0 testbed after making above changes and it passed.

This PR needs to be backported to 202205 branch
