### PR TITLE
[route flap] [multi-asic] [chassis] change filter method to filter out external nexthops

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -208,6 +208,43 @@ def is_dualtor(tbinfo):
     return "dualtor" in tbinfo["topo"]["name"]
 
 
+def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
+    # Get internal bgp ips for later filtering
+    internal_bgp_ips = duthost.get_internal_bgp_peers().keys()
+    dev_port = None
+    route_to_ping = None
+    for dst_prefix in dst_prefix_set:
+        if dev_port:
+            break
+        route_to_ping = dst_prefix.route
+        cmd = ' -c "show ip route {} json"'.format(route_to_ping)
+        if duthost.is_multi_asic:
+            for asic in duthost.frontend_asics:
+                if dev_port:
+                    break
+                dev = json.loads(asic.run_vtysh(cmd)['stdout'])
+                for per_hop in dev[route_to_ping][0]['nexthops']:
+                    if 'interfaceName' not in per_hop.keys():
+                        continue
+                    if 'ip' not in per_hop.keys():
+                        continue
+                    if per_hop['ip'] in internal_bgp_ips:
+                        continue
+                    dev_port = per_hop['interfaceName']
+        else:
+            dev = json.loads(asichost.run_vtysh(cmd)['stdout'])
+            for per_hop in dev[route_to_ping][0]['nexthops']:
+                if 'interfaceName' not in per_hop.keys():
+                    continue
+                if 'ip' not in per_hop.keys():
+                    continue
+                if per_hop['ip'] in internal_bgp_ips:
+                    continue
+                dev_port = per_hop['interfaceName']
+    pytest_assert(dev_port, "dev_port not exist")
+    return dev_port, route_to_ping
+
+
 def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
                     get_function_conpleteness_level, announce_default_routes,
                     enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
@@ -256,35 +293,7 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
             dst_prefix_set.add(entry)
     pytest_assert(dst_prefix_set, "dst_prefix_set is empty")
 
-    # Get internal bgp ips for later filtering
-    internal_bgp_ips = duthost.get_internal_bgp_peers().keys()
-    dev_port = None
-    for dst_prefix in dst_prefix_set:
-        if dev_port:
-            break
-        route_to_ping = dst_prefix.route
-        cmd = ' -c "show ip route {} json"'.format(route_to_ping)
-        if duthost.is_multi_asic:
-            for asic in duthost.frontend_asics:
-                if dev_port:
-                    break
-                dev = json.loads(asic.run_vtysh(cmd)['stdout'])
-                for per_hop in dev[route_to_ping][0]['nexthops']:
-                    if 'interfaceName' not in per_hop.keys():
-                        continue
-                    if 'ip' in per_hop.keys() and per_hop['ip'] in internal_bgp_ips:
-                        continue
-                    dev_port = per_hop['interfaceName']
-        else:
-            dev = json.loads(asichost.run_vtysh(cmd)['stdout'])
-            for per_hop in dev[route_to_ping][0]['nexthops']:
-                if 'interfaceName' not in per_hop.keys():
-                    continue
-                if 'ip' in per_hop.keys() and per_hop['ip'] in internal_bgp_ips:
-                    continue
-                dev_port = per_hop['interfaceName']
-
-    pytest_assert(dev_port, "dev_port not exist")
+    dev_port, route_to_ping = get_dev_port_and_route(duthost, asichost, dst_prefix_set)
     route_nums = len(dst_prefix_set)
     logger.info("route_nums = %d" % route_nums)
 

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -236,10 +236,6 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
             for per_hop in dev[route_to_ping][0]['nexthops']:
                 if 'interfaceName' not in per_hop.keys():
                     continue
-                if 'ip' not in per_hop.keys():
-                    continue
-                if per_hop['ip'] in internal_bgp_ips:
-                    continue
                 dev_port = per_hop['interfaceName']
     pytest_assert(dev_port, "dev_port not exist")
     return dev_port, route_to_ping


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/8612

### Type of change
call `get_internal_bgp_peers` to get internal bgp ips from config db, exclude internal bgps, instead of basing on naming format.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
ran this testcase on Arista and Cisco chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
