### PR TITLE
[GCU E2E Test] skip test_eth_interface.py::test_replace_fec and test_update_speed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -463,9 +463,9 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
 
 generic_config_updater/test_eth_interface.py::test_replace_fec:
   skip:
-    reason: 'replace_fec ethernet test is not supported on virtual switch'
+    reason: 'replace_fec ethernet test depends on StateDB values. GCU needs to be updated to consider StateDB'
     conditions:
-      - "platform in ['x86_64-kvm_x86_64-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8600
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
   skip:
@@ -474,8 +474,8 @@ generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
       - "asic_type in ['cisco-8000']"
 
 generic_config_updater/test_eth_interface.py::test_update_speed:
-  xfail:
-    reason: 'Xfail this script due to this not being a production scenario and misleading StateDB output for valid speed'
+  skip:
+    reason: 'Skip this script due to this not being a production scenario and misleading StateDB output for valid speed'
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/8143
 

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -205,7 +205,7 @@ def test_toggle_pfc_asym(duthost, ensure_dut_readiness, pfc_asym):
 def test_replace_fec(duthost, ensure_dut_readiness, fec):
     json_patch = [
         {
-            "op": "replace",
+            "op": "add",
             "path": "/PORT/Ethernet0/fec",
             "value": "{}".format(fec)
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 
Two Issues: [Testcase test_replace_fec fail on the interfaces not supporting config FEC](https://github.com/sonic-net/sonic-mgmt/issues/8600#top), 
[generic_config_updater/test_eth_interface.py failed](https://github.com/sonic-net/sonic-mgmt/issues/8143)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_replace_fec was failing on some platforms for two reasons:
1. GCU does not consider StateDB values and validates only against ConfigDB YANG models. GCU needs to be updated to validate against StateDB in addition to ConfigDB YANG models. Only after being validated against StateDB should GCU permit the config change to fec. 
2. In cases where the fec field does not already exist, the patch fails to apply.

test_update_speed, test_update_description, and test_admin_change were failing or resulting in error logs for the same reason:
1. GCU needs to validate against StateDB before allowing the config change. test_update_speed resulted in failure/error logs because GCU change ConfigDB speed to an invalid value. Orchagent crashed as a result of the invalid speed config, which showed up in error logs of test_update_description and test_admin_change. 


#### How did you do it?
Long term fix: Fix GCU to validate against StateDB (instead of just ConfigDB YANG models). 
Short term fix: This PR skips test_replace_fec and test_update_speed because `fec` and `speed` are the fields that need to be validated against StateDB. 
I changed `replace` to `add` to account for cases where the `fec` field may not already exist in ConfigDB
#### How did you verify/test it?

#### Any platform specific information?
All platforms for which FEC does not support both values `rs` and `fc`, all platforms with port speed config requirements not in YANG models
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
