### PR TITLE
Add wm_q_wm_all_ports entries for gb long-link

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -3536,8 +3536,31 @@ qos_params:
                     pkts_num_trig_pfc: 6404
                     cell_size: 8192
                     packet_size: 6144
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 2048
+                    cell_size: 6144
+                    packet_size: 6144
             400000_120000m:
                 pkts_num_leak_out: 0
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 6404
+                    pkts_num_margin: 2048
+                    cell_size: 6144
+                    packet_size: 6144
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 3072
+                    cell_size: 384
                 wm_buf_pool_lossless:
                     dscp: 3
                     ecn: 1
@@ -3546,6 +3569,12 @@ qos_params:
                     pkts_num_fill_ingr_min: 181
                     pkts_num_trig_pfc: 23044
                     cell_size: 8192
+                    packet_size: 6144
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 2048
+                    cell_size: 6144
                     packet_size: 6144
             wrr:
                 ecn: 1
@@ -3847,7 +3876,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 12152
+                    pkts_num_trig_ingr_drp: 13660
                     pkts_num_margin: 3072
                     cell_size: 384
                 wm_q_shared_lossy:
@@ -3943,8 +3972,8 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 3202
-                    pkts_num_margin: 2048
+                    pkts_num_trig_ingr_drp: 855
+                    pkts_num_margin: 1024
                     cell_size: 6144
                     packet_size: 6144
                 wm_q_shared_lossy:
@@ -3972,6 +4001,12 @@ qos_params:
                     pkts_num_fill_ingr_min: 181
                     pkts_num_trig_pfc: 642
                     cell_size: 8192
+                    packet_size: 6144
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 855
+                    pkts_num_margin: 1024
+                    cell_size: 6144
                     packet_size: 6144
             400000_120000m:
                 pkts_num_leak_out: 0
@@ -4005,8 +4040,8 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 11522
-                    pkts_num_margin: 4096
+                    pkts_num_trig_ingr_drp: 855
+                    pkts_num_margin: 1024
                     cell_size: 6144
                     packet_size: 6144
                 wm_q_shared_lossy:
@@ -4025,6 +4060,12 @@ qos_params:
                     pkts_num_fill_ingr_min: 181
                     pkts_num_trig_pfc: 642
                     cell_size: 8192
+                    packet_size: 6144
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 855
+                    pkts_num_margin: 1024
+                    cell_size: 6144
                     packet_size: 6144
     jr2:
         topo-any:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, Add wm_q_wm_all_ports entries for gb long-link.
   Packet size 6144 is used for long-link test, 1 packet occupies 1 hbm block.
   pkt_count 855 is for multi-asic scenario, it is the packet number to trigger pfc in 200G backplane port. This case tests queue watermark in egress asic. 

2, Update wm_q_shared_lossless pkts_num in topo-t2 section. 
    In multi-asic, this case tests queue watermark in egress asic. 
    The maximum packets in voq is related with 200G backplane port which is ingress port in egress asic, not related with ingress port in ingress asic. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
