### PR TITLE
Update test report uploading scripts to support test case numbers data

### DIFF
--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -144,6 +144,17 @@
                                                                              '{"column":"TestbedName","Properties":{"path":"$.testbed"}}]'
 
 ###############################################################################
+# TEST CASE NUMBERS TABLE SETUP                                               #
+# 1. Create a TestCaseNumbers table to store expected test case numbers       #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+
+.create-merge table TestCaseNumbers (Timestamp:datetime, Branch:string, TotalCount:int)
+.create table TestCaseNumbers ingestion json mapping 'TestCaseNumbersV1' @'[{"column":"Timestamp","Properties":{"path":"$.timestamp"}},'
+                                                                           '{"column":"Branch","Properties":{"path":"$.branch"}},'
+                                                                           '{"column":"TotalCount","Properties":{"path":"$.count"}}]'
+
+###############################################################################
 # RAW REBOOT REPORT TABLE SETUP                                               #
 # 1. Create a RawRebootTimingData table to store reboot test timings          #
 # 2. Add a JSON mapping for the table                                         #

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -99,6 +99,7 @@ class KustoConnector(ReportDBConnector):
     REBOOT_TIMING_TABLE = "RebootTimingData"
     TEST_CASE_TABLE = "TestCases"
     EXPECTED_TEST_RUNS_TABLE = "ExpectedTestRuns"
+    TEST_CASE_NUMBERS_TABLE = "TestCaseNumbers"
     PIPELINE_TABLE = "TestReportPipeline"
     CASE_INVOC_TABLE = "CaseInvocationCoverage"
     SAI_HEADER_INVOC_TABLE = "SAIHeaderDefinition"
@@ -115,6 +116,7 @@ class KustoConnector(ReportDBConnector):
         REBOOT_TIMING_TABLE: DataFormat.MULTIJSON,
         TEST_CASE_TABLE: DataFormat.JSON,
         EXPECTED_TEST_RUNS_TABLE: DataFormat.JSON,
+        TEST_CASE_NUMBERS_TABLE: DataFormat.JSON,
         PIPELINE_TABLE: DataFormat.JSON,
         CASE_INVOC_TABLE: DataFormat.MULTIJSON,
         SAI_HEADER_INVOC_TABLE: DataFormat.MULTIJSON,
@@ -132,6 +134,7 @@ class KustoConnector(ReportDBConnector):
         REBOOT_TIMING_TABLE: "RebootTimingDataMapping",
         TEST_CASE_TABLE: "TestCasesMappingV1",
         EXPECTED_TEST_RUNS_TABLE: "ExpectedTestRunsV1",
+        TEST_CASE_NUMBERS_TABLE: "TestCaseNumbersV1",
         PIPELINE_TABLE: "FlatPipelineMappingV1",
         CASE_INVOC_TABLE: "CaseInvocationCoverageMapping",
         SAI_HEADER_INVOC_TABLE: "SAIHeaderDefinitionMapping",
@@ -267,6 +270,9 @@ class KustoConnector(ReportDBConnector):
 
     def upload_expected_runs(self, expected_runs: List) -> None:
         self._ingest_data(self.EXPECTED_TEST_RUNS_TABLE, expected_runs)
+
+    def upload_case_numbers(self, case_numbers: List) -> None:
+        self._ingest_data(self.TEST_CASE_NUMBERS_TABLE, case_numbers)
 
     def _upload_swss_log_file(self, swss_file: str) -> None:
         self._ingest_data_file(self.SWSSDATA_TABLE, swss_file)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -121,6 +121,12 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
             except Exception as e:
                 print("Failed to parse expected runs data '{}', exception: {}".format(path_name, repr(e)))
         kusto_db.upload_expected_runs(expected_runs)
+    elif args.category == 'case_numbers':
+        case_numbers = []
+        for path_name in args.path_list:
+            with open(path_name) as f:
+                case_numbers.extend(json.load(f))
+        kusto_db.upload_case_numbers(case_numbers)
     elif args.category == "case_invoc":
         for path_name in args.path_list:
             fns = os.listdir(path_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This change updated the test report uploading scripts to support test case numbers data. With this change, we can regular run scripts to collect test case numbers in this repository.

#### How did you do it?
* Added new table TestCaseNumbers.
* Added a new category case_numbers.

#### How did you verify/test it?
Test run uploading collected data to Kusto.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
