### PR TITLE
skip dhcpmon counter test in 202111 branch

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -304,7 +304,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     if testing_mode == DUAL_TOR_MODE:
         skip_release(duthost, ["201811", "201911"])
 
-    skip_dhcpmon = testing_mode == DUAL_TOR_MODE or "201811" in duthost.os_version or "201911" in duthost.os_version
+    skip_dhcpmon = testing_mode == DUAL_TOR_MODE or duthost.os_version in ["201811", "201911", "202111"]
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:


### PR DESCRIPTION
### Description of PR
Skip dhcpmon counter test introduced by https://github.com/sonic-net/sonic-mgmt/pull/7656

Summary:
Fixes 202111 PR test failure

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Recently 202111 PR testing failure because of PR7656.
202111 base code is old, which does not support dhcpmon counter test case, we need skip it.

#### How did you do it?
Skip 202111.

#### How did you verify/test it?
re-run test_dhcp_relay.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
