### PR TITLE
[acl] Skip acl egress ipv6 for 7215

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
@@ -1,0 +1,338 @@
+#############################
+#####     test_acl.py   #####
+#############################
+acl/test_acl.py::TestAclWithPortToggle::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
@@ -1,49 +1,11 @@
-#############################
-#####     test_acl.py   #####
-#############################
+acl/test_acl.py::TestAclWithPortToggle::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
 acl/test_acl.py::TestAclWithPortToggle::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
@@ -57,21 +19,35 @@ acl/test_acl.py::TestAclWithPortToggle::test_icmp_source_ip_match_dropped[ipv6-e
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithPortToggle::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithPortToggle::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithPortToggle::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
@@ -85,70 +61,21 @@ acl/test_acl.py::TestAclWithPortToggle::test_rules_priority_dropped[ipv6-egress-
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithPortToggle::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
@@ -162,6 +89,55 @@ acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplin
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
+acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
 acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
@@ -169,154 +145,21 @@ acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-upli
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestIncrementalAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestIncrementalAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
-acl/test_acl.py::TestIncrementalAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestIncrementalAcl::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
-  xfail:
-    reason: "Egress issue in Nokia"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
-acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
@@ -330,7 +173,161 @@ acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->do
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
+acl/test_acl.py::TestBasicAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
 acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
+  xfail:
+    reason: "Egress issue in Nokia"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_acl.py::TestIncrementalAcl::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There is issue in 7215 for test_acl in ipv6 egress scenario.

#### How did you do it?
Add skip condition.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
