### PR TITLE
Resolve testQosSaiSharedReservationSize's bad fix introduced from PR#8557 and PR#8377

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -757,7 +757,7 @@ class TestQosSai(QosSaiBase):
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
         src_testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
         dst_testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
-        (src_port_ids, dst_portids) = check_skip_shared_res_test
+        (_, src_port_ids, dst_port_ids) = check_skip_shared_res_test
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?


encounter qos test, caused by below 2 bad fix:


bad fix from PR #8557
```
  File "/home/xuchen3/env-d/sonic-mgmt-int/tests/qos/test_qos_sai.py", line 765, in testQosSaiSharedReservationSize
    (src_port_ids, dst_portids) = check_skip_shared_res_test
ValueError: too many values to unpack
```

bad fix from PR#8377

```
>           "dst_port_ids": dst_port_ids,
            "dst_port_ips": [dst_testPortIps[port]['peer_addr'] for port in dst_port_ids],
            "pkt_counts":  qosConfig[sharedResSizeKey]["pkt_counts"],
            "shared_limit_bytes": qosConfig[sharedResSizeKey]["shared_limit_bytes"],
            "hwsku":dutTestParams['hwsku']
        })
E       NameError: global name 'dst_port_ids' is not defined
```


#### How did you do it?

resolve bax fix

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
