### PR TITLE
[ansible/library]: (conn_graph_facts.py) Parse LAG info

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -5,7 +5,7 @@ import yaml
 import os
 import logging
 import traceback
-import ipaddr as ipaddress
+import ipaddr
 from operator import itemgetter
 from itertools import groupby
 from collections import defaultdict
@@ -203,7 +203,7 @@ class Parse_Lab_Graph():
                     management_ip = l3info.find(
                         'ManagementIPInterface').attrib['Prefix']
                     deviceinfo[hostname]['ManagementIp'] = management_ip
-                    mgmtip = ipaddress.IPNetwork(management_ip)
+                    mgmtip = ipaddr.IPNetwork(management_ip)
                     deviceinfo[hostname]['mgmtip'] = str(mgmtip.ip)
                     management_gw = str(mgmtip.network+1)
                     deviceinfo[hostname]['ManagementGw'] = management_gw
@@ -239,7 +239,7 @@ class Parse_Lab_Graph():
                         deviceinfo[hostname]['Os'] = attributes.get('Os')
                         mgmt_ip = attributes.get('ManagementIp')
                         management_gw = str(
-                            ipaddress.IPNetwork(mgmt_ip).network+1)
+                            ipaddr.IPNetwork(mgmt_ip).network+1)
                         deviceinfo[hostname]['ManagementIp'] = mgmt_ip
                         deviceinfo[hostname]['ManagementGw'] = management_gw
                         self.consolelinks[hostname] = {}
@@ -295,7 +295,7 @@ class Parse_Lab_Graph():
                         deviceinfo[hostname]['Os'] = attributes.get('Os')
                         mgmt_ip = attributes.get('ManagementIp')
                         management_gw = str(
-                            ipaddress.IPNetwork(mgmt_ip).network+1)
+                            ipaddr.IPNetwork(mgmt_ip).network+1)
                         deviceinfo[hostname]['ManagementIp'] = mgmt_ip
                         deviceinfo[hostname]['ManagementGw'] = management_gw
                         self.bmclinks[hostname] = {}

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -195,7 +195,10 @@ class Parse_Lab_Graph():
         if devicel3s is not None:
             for l3info in devicel3s:
                 hostname = l3info.attrib['Hostname']
-                if hostname is not None:
+                if (
+                    hostname is not None
+                    and l3info.find('ManagementIPInterface') is not None
+                ):
                     deviceinfo[hostname]["Hostname"] = hostname
                     management_ip = l3info.find(
                         'ManagementIPInterface').attrib['Prefix']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary: 
- Parse LAG info
- Remove ipaddr renaming
- Only parse MGMT ip info if available

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
WAN has port channel info under DevicesL3Info entries in graph data. This data can be parsed if available.

#### How did you do it?
conn_graph_facts.py was updated to parse IPInterface and PortChannelInterface entries under DevicesL3Info.

#### How did you verify/test it?
Parsed internal wan graph data and validated output. Example:
```
{
    ...
    "device_conn": {
        "router-1": {
            "et-0/0/1": {
                "peerdevice": "router-2",
                "peerport": "HundredGigE0/1/0/1",
                "speed": "100000",
                "lag": "PortChannel1",
                "peer_lag": "PortChannel1"
            },
            ...
        }
        ...
    },
    "device_lag_conn": {
        "router-1": {
            "PortChannel1": {
                "ipv4": "172.20.16.0/31",
                "ipv6": "2a01:111:e210:0:172:20:16:1/126",
                "members": [
                    "et-0/0/1"
                ],
                "peer_ipv4": "172.20.16.1/31",
                "peer_ipv6": "2a01:111:e210:0:172:20:16:2/126",
                "peer_members": [
                    "HundredGigE0/1/0/1"
                ],
                "peer_lag": "PortChannel1",
                "peer_device": "router-2"
            },
            ...
        }
        ...
    },
    ...
}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
