### PR TITLE
Skip ECN config test on unsupported platform

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -5,7 +5,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
-from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
+from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.generic_config_updater.gu_utils import is_valid_platform_and_version
@@ -100,6 +100,6 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
             expect_op_success(duthost, output)
             ensure_application_of_updated_config(duthost, configdb_field, ",".join(values))
         else:
-            expect_op_failure(output)
+            pytest.skip("ECN tuning is not supported on this platform or version")
     finally:
         delete_tmpfile(duthost, tmpfile)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 8648
If is_valid_platform_and_version returns False, we will see below exception
```
**Description**

        try:
            if is_valid_platform_and_version(duthost, "WRED_PROFILE", "ECN tuning"):
                output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
                expect_op_success(duthost, output)
                ensure_application_of_updated_config(duthost, configdb_field, ",".join(values))
            else:
>               expect_op_failure(output)
E               UnboundLocalError: local variable 'output' referenced before assignment
```
It's because the `output` variable is not defined.
Actually, the test case should be skipped if the platform is unsupported.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip ECN config test on unsupported platform.

#### How did you do it?
If `is_valid_platform_and_version` returns `False`, skip the test.

#### How did you verify/test it?
Verified on a SN4600 testbed
```
collected 4 items                                                                                                                                                                           

generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold] SKIPPED                                                                        [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_max_threshold] SKIPPED                                                                        [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_drop_probability] SKIPPED                                                                     [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold,green_max_threshold,green_drop_probability] SKIPPED                             [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
