### PR TITLE
[GCU] Support SPC3 asic in GCU test

### DIFF
--- a/tests/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/tests/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -17,7 +17,8 @@
     "helper_data": {
         "rdma_config_update_validator": {
             "mellanox_asics": {
-                "spc1": [ "ACS-MSN2700", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2010", "Mellanox-SN2700", "Mellanox-SN2700-D48C8" ]
+                "spc1": [ "ACS-MSN2700", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2010", "Mellanox-SN2700", "Mellanox-SN2700-D48C8" ],
+                "spc3": [ "ACS-MSN4600C", "Mellanox-SN4600C-C64", "Mellanox-SN4600C-D48C40", "Mellanox-SN4600C-D100C12S2", "Mellanox-SN4600C-D112C8"]
             },
             "broadcom_asics": {
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],
@@ -42,6 +43,7 @@
                         "operations": ["remove", "add", "replace"],
                         "platforms": {
                             "spc1": "20181100",
+                            "spc3": "20181100",
                             "td2": "20181100",
                             "th": "20181100",
                             "th2": "20181100",

--- a/tests/generic_config_updater/gu_utils.py
+++ b/tests/generic_config_updater/gu_utils.py
@@ -308,10 +308,11 @@ def get_asic_name(duthost):
     elif asic_type == 'mellanox' or asic_type == 'vs' or asic_type == 'broadcom':
         hwsku = duthost.shell(GET_HWSKU_CMD)['stdout'].rstrip('\n')
         if asic_type == 'mellanox' or asic_type == 'vs':
-            spc1_hwskus = asic_mapping["mellanox_asics"]["spc1"]
-            if hwsku.lower() in [spc1_hwsku.lower() for spc1_hwsku in spc1_hwskus]:
-                asic = "spc1"
-                return asic
+            mlnx_asics = asic_mapping["mellanox_asics"]
+            for asic_shorthand, hwskus in mlnx_asics.items():
+                if hwsku.lower() in [hwsku_cur.lower() for hwsku_cur in hwskus]:
+                    asic = asic_shorthand
+                    break
         if asic_type == 'broadcom' or asic_type == 'vs':
             broadcom_asics = asic_mapping["broadcom_asics"]
             for asic_shorthand, hwskus in broadcom_asics.items():

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -167,8 +167,9 @@ def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, operation,
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-
-        if is_valid_config_update and is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable"):
+        if not is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable"):
+            pytest.skip("Skip PFCWD interval config update test on unsupported platform or version")
+        if is_valid_config_update:
             expect_op_success(duthost, output)
             ensure_application_of_updated_config(duthost, value)
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #8651
This test is to support SPC3 asic in GCU test.
Currently, the SPC3 asic is not included in file [sonic-mgmt/tests/generic_config_updater/gcu_field_operation_validators.conf.json](https://github.com/sonic-net/sonic-mgmt/blob/0d6fedb76aa3b95ce5b6cbd44c528b0dd7ffbfcd/tests/generic_config_updater/gcu_field_operation_validators.conf.json)
That results in test regression in `test_pfcwd_interval_config_updates` on SN4600c testbed.
```
            if is_valid_config_update and is_valid_platform_and_version(duthost, "PFC_WD", "PFCWD enable/disable"):
                expect_op_success(duthost, output)
                ensure_application_of_updated_config(duthost, value)
            else:
>               expect_op_failure(output)
E       Failed: The command should fail with non zero return code
```
This PR addressed the issue, and updated the logic of `test_pfcwd_interval_config_updates`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to add support of Mellanox spc3 platform in GCU test cases.

#### How did you do it?
1. Add SPC3 HWSKUs in file `gcu_field_operation_validators.conf.json`
2. Update the logic of `test_pfcwd_interval_config_updates`.

#### How did you verify/test it?
The change is verified on a SN4600 testbed
```
collected 8 items                                                                                                                                                                           

generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[True-existing-add] PASSED                                                                           [ 12%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[True-existing-replace] PASSED                                                                       [ 25%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[True-nonexistent-add] PASSED                                                                        [ 37%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[True-nonexistent-replace] PASSED                                                                    [ 50%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[False-existing-add] PASSED                                                                          [ 62%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[False-existing-replace] PASSED                                                                      [ 75%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[False-nonexistent-add] PASSED                                                                       [ 87%]
generic_config_updater/test_pfcwd_interval.py::test_pfcwd_interval_config_updates[False-nonexistent-replace] PASSED                                                                   [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
