### PR TITLE
Enabling bfd anmd vxlan ecmp tests for Mlnx 2700

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -52,7 +52,7 @@ bfd/test_bfd.py:
   skip:
     reason: "Test not supported for platforms other than Nvidia 4600c/4700/5600 and cisco-8102. Skipping the test"
     conditions:
-      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0']"
+      -  "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0'])"
 
 bfd/test_bfd.py::test_bfd_basic:
   skip:
@@ -1138,9 +1138,9 @@ vxlan/test_vnet_vxlan.py:
 
 vxlan/test_vxlan_ecmp.py:
   skip:
-    reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on 4600c and 8102."
+    reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on 4600c, 2700 and 8102."
     conditions:
-      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0'])"
+      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0'])"
 
 #######################################
 #####           wan_lacp          #####

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -151,8 +151,8 @@ def fixture_setUp(duthosts,
     else:
         raise RuntimeError("Pls update this script for your platform.")
 
-    platform =  duthosts[rand_one_dut_hostname].facts['platform']
-    if platform == 'x86_64-mlnx_msn2700-r0' and encap_type in ['v4_in_v6','v6_in_v6']:
+    platform = duthosts[rand_one_dut_hostname].facts['platform']
+    if platform == 'x86_64-mlnx_msn2700-r0' and encap_type in ['v4_in_v6', 'v6_in_v6']:
         pytest.skip("Skipping test. v6 underlay is not supported on Mlnx 2700")
 
     # Should I keep the temporary files copied to DUT?

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -151,6 +151,10 @@ def fixture_setUp(duthosts,
     else:
         raise RuntimeError("Pls update this script for your platform.")
 
+    platform =  duthosts[rand_one_dut_hostname].facts['platform']
+    if platform == 'x86_64-mlnx_msn2700-r0' and encap_type in ['v4_in_v6','v6_in_v6']:
+        pytest.skip("Skipping test. v6 underlay is not supported on Mlnx 2700")
+
     # Should I keep the temporary files copied to DUT?
     ecmp_utils.Constants['KEEP_TEMP_FILES'] = \
         request.config.option.keep_temp_files


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This change enables the vxlan ecmp and BFD tests for Mlnx 2700.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
The existing tests were not enabled for Mlnx 2700.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
