### PR TITLE
[Mellanox] Mock PSU fan direction if current image support it

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -650,7 +650,7 @@ class FanData:
             return 'red'
 
         return 'green'
-    
+
     def mock_psu_fan_dir(self, direction):
         try:
             dir_file = 'psu{}_fan_dir'.format(self.index)
@@ -658,7 +658,7 @@ class FanData:
             return 'intake' if direction == 1 else 'exhaust'
         except SysfsNotExistError:
             return NOT_AVAILABLE
-            
+
 
 class TemperatureData:
     """

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -903,7 +903,8 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
             naming_rule['name'] = 'psu_{}_fan_1'
         else:
             led_color = 'green'
-        support_psu_fan_dir = self.mock_helper.dut.shell('sonic-db-cli STATE_DB HGET "FAN_INFO|psu1_fan1" direction')['stdout'].strip() != 'N/A'
+        check_psu_fan_dir_cmd = 'sonic-db-cli STATE_DB HGET "FAN_INFO|psu1_fan1" direction'
+        support_psu_fan_dir = self.mock_helper.dut.shell(check_psu_fan_dir_cmd)['stdout'].strip() != 'N/A'
         for index in range(1, psu_count + 1):
             try:
                 fan_data = FanData(self.mock_helper, naming_rule, index)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Mock PSU fan direction if the image support it.

There was a commit to support PSU fan direction. However, the test case test_show_platform_fanstatus_mocked does not mock PSU fan direction and expect the direction is always "N/A". This could cause test case failure if the image supports PSU fan direction.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Mock PSU fan direction if the image support it

#### How did you do it?

Mock PSU fan direction if the image support it

#### How did you verify/test it?

Run the test on two images, one supports PSU fan direction, the other does not support it. Both passed.

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
