### PR TITLE
Align generic rsyslog updater according to the new server type

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -180,23 +180,23 @@ def syslog_server_tc1_add_duplicate(duthost):
 def syslog_server_tc1_xfail(duthost):
     """ Test expect fail testcase
 
-    ("add", "10.0.0.587", "cc98:2008::1"), ADD Invalid IPv4 address
-    ("add", "10.0.0.5", "cc98:2008::xyz"), ADD Invalid IPv6 address
-    ("remove", "10.0.0.6", "cc98:2008:1"), REMOVE Unexist IPv4 address
-    ("remove", "10.0.0.5", "cc98:2008::2") REMOVE Unexist IPv6 address
+    ("add", "-badhostname", "cc98:2008::1"),   ADD Invalid hostname
+    ("add", "goodhostname", "cc98:2008::xyz"), ADD Invalid IPv6 address
+    ("remove", "10.0.0.6", "cc98:2008:1"),     REMOVE Unexist IPv4 address
+    ("remove", "goodhostname", "cc98:2008::2") REMOVE Unexist IPv6 address
     """
     xfail_input = [
-        ("add", "10.0.0.587", "cc98:2008::1"),
-        ("add", "10.0.0.5", "cc98:2008::xyz"),
+        ("add", "-badhostname", "cc98:2008::1"),
+        ("add", "goodhostname", "cc98:2008::xyz"),
         ("remove", "10.0.0.6", "cc98:2008:1"),
         ("remove", "10.0.0.5", "cc98:2008::2")
     ]
 
-    for op, dummy_syslog_server_v4, dummy_syslog_server_v6 in xfail_input:
+    for op, dummy_syslog_server_hostname, dummy_syslog_server_v6 in xfail_input:
         json_patch = [
             {
                 "op": "{}".format(op),
-                "path": "/SYSLOG_SERVER/{}".format(dummy_syslog_server_v4),
+                "path": "/SYSLOG_SERVER/{}".format(dummy_syslog_server_hostname),
                 "value": {}
             },
             {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test fail in https://github.com/sonic-net/sonic-buildimage/pull/14513

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Align the test according to the new rsyslog server type. Originally only IPv4 and IPv6 addresses were supported. Now hostames are supported as well 

#### How did you do it?
Update the generic updater test to follow new schema

#### How did you verify/test it?
Run it on t1 setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Update for available test case

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
