### PR TITLE
fix get psu status issue 

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -178,7 +178,7 @@ def get_healthy_psu_num(duthost):
     psus_status = psuutil_status_output["stdout_lines"][2:]
     for iter in psus_status:
         fields = iter.split()
-        if fields[2] == 'OK':
+        if 'OK' in fields:
             healthy_psus += 1
 
     return healthy_psus


### PR DESCRIPTION
### Description of PR
Following is psu status output info.
Script failed to parse field "Status"
show platform psustatus 
PSU    Model        Serial         HW Rev    Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -----------  -----------  --------  -------------  -------------  -----------  --------  -----
PSU 1  PSU2KW-ACPI  POG2627K0QR      0.00         412.50          13.70       165.50  OK        N/A
PSU 2  PSU2KW-ACPI  POG2627K0T4      0.00         412.50          17.50       210.75  OK        N/A

sudo psuutil status
PSU    Model        Serial         Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -----------  -----------  -------------  -------------  -----------  --------  -----
PSU0   PSU2KW-ACPI  POG2627K0QR         412.50          13.80       166.50  OK        N/A
PSU1   PSU2KW-ACPI  POG2627K0T4         412.50          17.50       210.75  OK        N/A

Summary:
Fixes get psuutil status issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix get psuutil status issue, the offset of cli output field of "status" is not right handled in script.
In order to avoid cli format change in future, use 'OK' in cli output info to check status.


#### How did you do it?

#### How did you verify/test it?
Re-run platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
