### PR TITLE
Fix missing namespace option in interface restart code

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -90,7 +90,9 @@ def bring_up_dut_interfaces(request, duthosts, enum_rand_one_per_hwsku_frontend_
 
         # Enable outer interfaces
         for port in ports:
-            duthost.no_shutdown(ifname=port)
+            namespace = mg_facts["minigraph_neighbors"][port]['namespace']
+            namespace_arg = '-n {}'.format(namespace) if namespace else ''
+            duthost.command("sudo config interface {} startup {}".format(namespace_arg, port))
 
 
 def get_state_times(timestamp, state, state_times, first_after_offset=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

After certain tests, we try to bring up all the interfaces as a post-test action. However, the code as written doesn't work on multi-ASIC systems, since it doesn't provide the correct ASIC namespace to the command. We replace the call to an explicit CLI command to bring up the interface, and provide the namespace argument if needed.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
