### PR TITLE
[RDMA] Added ixia checker to prevent dualtor settings on ixia testbeds

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -65,6 +65,10 @@
       set_fact:
         ptf_image: "{{ testbed_facts['ptf_image_name'] }}"
 
+    - name: check if testbed is an ixia testbed
+      set_fact:
+        is_ixia_testbed: "{{ true if ptf_image == 'docker-keysight-api-server' else false }}"
+
     - name: set vm
       set_fact:
         vm_base: "{% if testbed_facts['vm_base'] != '' %}{{ testbed_facts['vm_base'] }}{% else %}''{% endif %}"
@@ -197,7 +201,7 @@
   - name: enable tunnel_qos_remap for T1 in dualtor deployment
     set_fact:
       enable_tunnel_qos_remap: true
-    when: "('leafrouter' == (vm_topo_config['dut_type'] | lower)) and (hwsku in hwsku_list_dualtor_t1)"
+    when: "('leafrouter' == (vm_topo_config['dut_type'] | lower)) and (hwsku in hwsku_list_dualtor_t1) and not (is_ixia_testbed)"
 
   - name: set default vm file path
     set_fact:


### PR DESCRIPTION
Add ixia checker to prevent dualtor config for T1s if ixia testbed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: With internal PR 2937, all 8102s' T1s were configured to become T1s connected to dualtor switches, hence they generated minigraphs that were configured with dualtor settings such as extra mappings etc that RDMA tests are not designed to encounter. This caused RDMA tests to fail because of incorrect fixture settings. I have added an ixia testbed checker to prevent dualtor setting on 8102.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
To stabilise 8102 RDMA pipeline

#### How did you do it?
Added ixia checker in the deploy-mg script

#### How did you verify/test it?
Ran `deploy-mg` on the affected switch, and it loaded the correct config. 

```
PLAY RECAP ***************************************************************************************************************************************************************************************************************************************************** STR-8102-C19-U24 : ok=79 changed=21 unreachable=0 failed=0 skipped=27 rescued=0 ignored=0
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
