### PR TITLE
 [GCU E2E Testing] Update RDMA GCU E2E Tests- MMU Config 

### DIFF
--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -5,9 +5,10 @@ import re
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
-from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
+from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.generic_config_updater.gu_utils import is_valid_platform_and_version
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -129,8 +130,11 @@ def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation):
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        expect_op_success(duthost, output)
-        ensure_application_of_updated_config(duthost, new_dynamic_th, pg_lossless_profiles)
+        if is_valid_platform_and_version(duthost, "BUFFER_PROFILE", "PG headroom modification"):
+            expect_op_success(duthost, output)
+            ensure_application_of_updated_config(duthost, new_dynamic_th, pg_lossless_profiles)
+        else:
+            expect_op_failure(output)
         logger.info("Config successfully updated and verified.")
     finally:
         delete_tmpfile(duthost, tmpfile)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Update GCU RDMA E2E MMU config test to consider the RDMA platform validator check PR https://github.com/sonic-net/sonic-utilities/pull/2791 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Due to https://github.com/sonic-net/sonic-utilities/pull/2791, expected behavior of GCU E2E RDMA tests changed. This PR accounts for the expected changes in GCU for MMU Config. 
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
