### PR TITLE
[Fix] fix test_cacl_function failure

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -105,7 +105,7 @@ logger -t cacltest "added cacl test rules"
 iptables -nL | logger -t cacltest
 
 # Sleep to allow Ansible playbook ample time to attempt to connect and timeout
-sleep 120
+sleep 180
 
 # Delete the test ACL config file
 rm -rf /tmp/testacl.json

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -64,7 +64,7 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                              state='stopped',
                              search_regex=SONIC_SSH_REGEX,
                              delay=30,
-                             timeout=40,
+                             timeout=60,
                              module_ignore_errors=True)
 
     pytest_assert(not res.is_failed, "SSH port did not stop. {}".format(res.get('msg', '')))
@@ -117,5 +117,5 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                    version="v2c",
                    community=creds['snmp_rocommunity'],
                    wait=True,
-                   timeout=20,
+                   timeout=120,
                    interval=20)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_cacl_function failure,
It takes 70s to wait for the ssh port down, which was 45s.
Then during the verification of SNMP, the acl rule has been deleted.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
