### PR TITLE
Add scripts for generating SecureCRT session files for testbeds.

### DIFF
--- a/ansible/devutil/inv_helpers.py
+++ b/ansible/devutil/inv_helpers.py
@@ -1,4 +1,5 @@
 import yaml
+import jinja2
 
 try:
     from ansible.parsing.dataloader import DataLoader
@@ -120,19 +121,25 @@ class HostManager():
                         'username': 'ansible_user',
                         'password': ['ansible_password']}
         }
-        if 'sonic' in groups:
-            res['username'] = vars['secret_group_vars']['str']['sonicadmin_user']
-            res['password'] = [vars['secret_group_vars']
-                               ['str']['sonicadmin_password']]
-            res['password'].append(vars['ansible_altpassword'])
+
+        if 'secret_group_vars' in vars:
+            if 'sonic' in groups:
+                res['username'] = vars['secret_group_vars']['str']['sonicadmin_user']
+                res['password'] = [vars['secret_group_vars']
+                                   ['str']['sonicadmin_password']]
+                res['password'].append(vars['ansible_altpassword'])
+            else:
+                for group, cred in k_v.items():
+                    if group in groups:
+                        res['username'] = vars['secret_group_vars'][cred['alias']
+                                                                    ][cred['username']]
+                        res['password'] = [vars['secret_group_vars']
+                                           [cred['alias']][p] for p in cred['password']]
+                        break
         else:
-            for group, cred in k_v.items():
-                if group in groups:
-                    res['username'] = vars['secret_group_vars'][cred['alias']
-                                                                ][cred['username']]
-                    res['password'] = [vars['secret_group_vars']
-                                       [cred['alias']][p] for p in cred['password']]
-                    break
+            res['username'] = jinja2.Template(vars['ansible_ssh_user']).render(**vars)
+            res['password'] = jinja2.Template(vars['ansible_ssh_pass']).render(**vars)
+
         # console username and password
         console_login_creds = vars.get("console_login", {})
         res["console_user"] = {}

--- a/ansible/devutil/inv_helpers.py
+++ b/ansible/devutil/inv_helpers.py
@@ -138,7 +138,7 @@ class HostManager():
         res["console_user"] = {}
         res["console_password"] = {}
 
-        for k, v in console_login_creds.iteritems():
+        for k, v in console_login_creds.items():
             res["console_user"][k] = v["user"]
             res["console_password"][k] = v["passwd"]
 

--- a/ansible/devutil/ssh_session_repo.py
+++ b/ansible/devutil/ssh_session_repo.py
@@ -252,7 +252,7 @@ class SecureCRTCryptoV2:
     '''
     SecureCRT password encryption V2 implementation.
 
-    Credit: https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/python3/SecureCRTCipher.py
+    Credit: https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/b9b39d26e54fba4c70fe23909e0e8e19b3ddddbb/python3/SecureCRTCipher.py
     '''
     def __init__(self, ConfigPassphrase: str = ''):
         '''

--- a/ansible/devutil/ssh_session_repo.py
+++ b/ansible/devutil/ssh_session_repo.py
@@ -266,7 +266,8 @@ class SecureCRTCryptoV2:
     """
     SecureCRT password encryption V2 implementation.
 
-    Credit: https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/b9b39d26e54fba4c70fe23909e0e8e19b3ddddbb/python3/SecureCRTCipher.py
+    Credit: https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/
+            b9b39d26e54fba4c70fe23909e0e8e19b3ddddbb/python3/SecureCRTCipher.py
     """
 
     def __init__(self, ConfigPassphrase: str = ""):

--- a/ansible/devutil/ssh_session_repo.py
+++ b/ansible/devutil/ssh_session_repo.py
@@ -1,0 +1,289 @@
+"""
+This file contains the utility classes to generate SSH session repository.
+
+Currently, we support generating the SSH session repository for SecureCRT.
+"""
+
+import os
+from Crypto.Hash import SHA256
+from Crypto.Cipher import AES
+
+class SshSessionRepoGenerator(object):
+    """Base class for ssh session repo generator."""
+
+    def __init__(self, target, template_file):
+        """Store all parameters as attributes.
+
+        Args:
+            target (str): Output target.
+            template_file (str): SSH session template file.
+        """
+        self.target = target
+        self.template = self._load_template(template_file)
+
+    def _load_template(self, template_file):
+        """Load SSH session template file.
+
+        Args:
+            template_file (str): SSH session template file.
+
+        Returns:
+            str: SSH session template file content.
+        """
+        raise NotImplementedError
+
+    def generate(self, session_path, ssh_ip, ssh_user, ssh_pass):
+        """Generate SSH session for a node.
+
+        This is a virtual method that should be implemented by child class.
+
+        Args:
+            testbed (object): Represents a testbed setup.
+            testbed_node (object): Represents a connectable node in the testbed.
+        """
+        raise NotImplementedError
+
+
+class SecureCRTSshSessionRepoGenerator(SshSessionRepoGenerator):
+    """SSH session repo generator for SecureCRT.
+
+    It derives from SshSessionRepoGenerator and implements the generate method.
+    """
+
+    def __init__(self, target, template_file):
+        super().__init__(target, template_file)
+        self.crypto = SecureCRTCryptoV2()
+
+    def _load_template(self, template_file):
+        """Load SSH session template file.
+
+        Args:
+            template_file (str): SSH session template file.
+
+        Returns:
+            str: SSH session template file content.
+        """
+        if template_file is None:
+            raise ValueError("SSH session template file is not specified.")
+        
+        if not os.path.isfile(template_file):
+            raise ValueError("SSH session template file {} does not exist.".format(template_file))
+        
+        template = ""
+        with open(template_file, "r", encoding='utf-8-sig') as f:
+            for line in f:
+                if line.startswith('S:"Username"='):
+                    template += 'S:"Username"=%USERNAME%\n'
+                    continue
+                elif line.startswith('S:"Hostname"='):
+                    template += 'S:"Hostname"=%HOST%\n'
+                    continue
+                elif line.startswith('S:"Password V2"='):
+                    template += 'S:"Password V2"=%PASSWORD%\n'
+                    continue
+                elif line.startswith('S:"SSH2 Authentications V2"='):
+                    template += 'S:"SSH2 Authentications V2"=password,publickey,keyboard-interactive,gssapi\n'
+                    continue
+                else:
+                    template += line
+
+            return template
+
+    def generate(self, session_path, ssh_ip, ssh_user, ssh_pass):
+        """Generate SSH session for a testbed node."""
+        # In SecureCRT, every SSH session is stored in a ini file separately,
+        # hence we add .ini extension to the session path in order to generate individual SSH session file.
+        ssh_session_file_path = os.path.join(self.target, session_path + ".ini")
+
+        # Recursively create SSH session file directory
+        ssh_session_folder = os.path.dirname(ssh_session_file_path)
+        self._create_ssh_session_folder(ssh_session_folder)
+
+        # Generate SSH session file
+        ssh_session_name = os.path.basename(session_path)
+        ssh_session_file_content = self._generate_ssh_session_file_content(
+            ssh_session_name, ssh_ip, ssh_user, ssh_pass
+        )
+        with open(ssh_session_file_path, 'w') as ssh_session_file:
+            ssh_session_file.write(ssh_session_file_content)
+
+        # Add newly created session file into current folder data
+        ssh_session_folder_data = SecureCRTRepoFolderData.from_folder(
+            ssh_session_folder, create_if_not_exist=True
+        )
+        ssh_session_folder_data.add_session(ssh_session_name)
+        ssh_session_folder_data.save()
+
+    def _create_ssh_session_folder(self, ssh_session_file_dir):
+        """Recursively create SSH session file directory level by level if it does not exist,
+        and init the folder with a folder data ini file.
+
+        Args:
+            ssh_session_file_dir (str): SSH session file folder.
+        """
+        if os.path.exists(ssh_session_file_dir):
+            return
+
+        # Recursively create parent folder
+        parent_ssh_session_file_dir = os.path.dirname(ssh_session_file_dir)
+        if not os.path.exists(parent_ssh_session_file_dir):
+            self._create_ssh_session_folder(parent_ssh_session_file_dir)
+
+        # Create current folder
+        os.mkdir(ssh_session_file_dir)
+
+        # Add current folder to parent folder data, since it is newly created
+        parent_folder_data = SecureCRTRepoFolderData.from_folder(
+            parent_ssh_session_file_dir, create_if_not_exist=True
+        )
+        parent_folder_data.add_folder(os.path.basename(ssh_session_file_dir))
+        parent_folder_data.save()
+
+    def _generate_ssh_session_file_content(
+        self, session_name, ssh_ip, ssh_user, ssh_pass
+    ):
+        """Generate SSH session file content:
+
+        Args:
+            session_path (str): SSH session file path.
+            ssh_ip (str): SSH IP address.
+            ssh_user (str): SSH username.
+            ssh_pass (str): SSH password.
+
+        Returns:
+            str: SSH session file content.
+        """
+        encrypted_pass = "02:" + self.crypto.encrypt(ssh_pass)
+        return (
+            self.template.replace("%USERNAME%", ssh_user)
+            .replace("%HOST%", ssh_ip)
+            .replace("%PASSWORD%", encrypted_pass)
+        )
+
+
+class SecureCRTRepoFolderData(object):
+    """This class represents the __FolderData__.ini file in SecureCRT SSH session repository."""
+
+    @classmethod
+    def from_folder(cls, folder, create_if_not_exist=False):
+        """Create a SecureCRTRepoFolderData object from a folder.
+
+        Args:
+            folder (str): Folder name.
+            create_if_not_exist (bool, optional): Create the folder if it does not exist. Defaults to False.
+
+        Returns:
+            SecureCRTRepoFolderData: SecureCRTRepoFolderData object.
+        """
+        ini_path = os.path.join(folder, "__FolderData__.ini")
+        if not os.path.exists(ini_path):
+            if create_if_not_exist:
+                with open(ini_path, "w") as ini_file:
+                    ini_file.write('S:"Folder List"=\r\n')
+                    ini_file.write('S:"Session List"=\r\n')
+                    ini_file.write('S:"Is Expanded"=00000000\r\n')
+            else:
+                return None
+
+        return cls(folder, ini_path)
+
+    def __init__(self, folder, ini_path):
+        """Init SecureCRTRepoFolderData object.
+
+        Args:
+            ini_path (str): __FolderData__.ini file path.
+        """
+        self.folder = folder
+        self.ini_path = ini_path
+
+        self.folder_list = []
+        self.session_list = []
+        self.is_expanded = False
+
+        self._parse_ini_file()
+
+    def _parse_ini_file(self):
+        if not os.path.exists(self.ini_path):
+            return
+
+        with open(self.ini_path, "r") as ini_file:
+            for line in ini_file:
+                if line.startswith('S:"Folder List"='):
+                    self.folder_list = set([e for e in line.split("=")[1].strip().split(":") if e])
+                elif line.startswith('S:"Session List"='):
+                    self.session_list = set([e for e in line.split("=")[1].strip().split(":") if e])
+                elif line.startswith('S:"Is Expanded"='):
+                    self.is_expanded = bool(int(line.split("=")[1].strip()))
+
+    def add_folder(self, folder):
+        """Add a folder to the folder list.
+
+        Args:
+            folder (str): Folder name.
+        """
+        self.folder_list.add(folder)
+
+    def add_session(self, session):
+        """Add a session to the session list.
+
+        Args:
+            session (str): Session name.
+        """
+        self.session_list.add(session)
+
+    def set_is_expanded(self, is_expanded):
+        """Set is_expanded.
+
+        Args:
+            is_expanded (bool): is_expanded.
+        """
+        self.is_expanded = is_expanded
+
+    def save(self):
+        """Write to __FolderData__.ini file."""
+        with open(self.ini_path, "w") as ini_file:
+            ini_file.write('S:"Folder List"=' + ":".join(sorted(self.folder_list)) + ":\r\n")
+            ini_file.write('S:"Session List"=' + ":".join(sorted(self.session_list)) + ":\r\n")
+            ini_file.write(
+                'S:"Is Expanded"=' + "00000001" if self.is_expanded else "00000000" + "\r\n"
+            )
+
+class SecureCRTCryptoV2:
+    '''
+    SecureCRT password encryption V2 implementation.
+
+    Credit: https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/python3/SecureCRTCipher.py
+    '''
+    def __init__(self, ConfigPassphrase: str = ''):
+        '''
+        Initialize SecureCRTCryptoV2 object.
+
+        Args:
+            ConfigPassphrase: The config passphrase that SecureCRT uses. Leave it empty if config passphrase is not set.
+        '''
+        self.IV = b'\x00' * AES.block_size
+        self.Key = SHA256.new(ConfigPassphrase.encode('utf-8')).digest()
+
+    def encrypt(self, Plaintext: str):
+        '''
+        Encrypt plaintext and return corresponding ciphertext.
+
+        Args:
+            Plaintext: A string that will be encrypted.
+
+        Returns:
+            Hexlified ciphertext string.
+        '''
+        plain_bytes = Plaintext.encode('utf-8')
+        if len(plain_bytes) > 0xffffffff:
+            raise OverflowError('Plaintext is too long.')
+        
+        plain_bytes = \
+            len(plain_bytes).to_bytes(4, 'little') + \
+            plain_bytes + \
+            SHA256.new(plain_bytes).digest()
+        padded_plain_bytes = \
+            plain_bytes + \
+            os.urandom(AES.block_size - len(plain_bytes) % AES.block_size)
+        cipher = AES.new(self.Key, AES.MODE_CBC, iv = self.IV)
+        return cipher.encrypt(padded_plain_bytes).hex()

--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -89,7 +89,7 @@ class TestBedNode(object):
                 self.ssh_user = host_vars["creds"]["username"]
                 self.ssh_pass = host_vars["creds"]["password"][0]
             except Exception as e:
-                print("Error: Failed to get host vars for {}: {}".format(self.name, repr(e)))
+                print("Error: Failed to get host vars for {}: {}".format(self.name, str(e)))
                 self.ssh_ip = None
                 self.ssh_user = None
                 self.ssh_pass = None

--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -6,6 +6,7 @@ import os
 import re
 import yaml
 
+
 class TestBed(object):
     """Data model that represents a testbed object."""
 
@@ -89,7 +90,11 @@ class TestBedNode(object):
                 self.ssh_user = host_vars["creds"]["username"]
                 self.ssh_pass = host_vars["creds"]["password"][0]
             except Exception as e:
-                print("Error: Failed to get host vars for {}: {}".format(self.name, str(e)))
+                print(
+                    "Error: Failed to get host vars for {}: {}".format(
+                        self.name, str(e)
+                    )
+                )
                 self.ssh_ip = None
                 self.ssh_user = None
                 self.ssh_pass = None

--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -1,0 +1,95 @@
+"""
+Utility classes for loading and managing testbed data.
+"""
+
+import os
+import re
+import yaml
+
+class TestBed(object):
+    """Data model that represents a testbed object."""
+
+    @classmethod
+    def from_file(cls, testbed_file="testbed.yaml", testbed_pattern=None, hosts=None):
+        """Load all testbed objects from YAML file.
+
+        Args:
+            testbed_file (str): Path to testbed file.
+            testbed_pattern (str): Regex pattern to filter testbeds.
+            hosts (AnsibleHosts): AnsibleHosts object that contains all hosts in the testbed.
+
+        Returns:
+            dict: Testbed name to testbed object mapping.
+        """
+        # Check existence of testbed file
+        if not os.path.isfile(testbed_file):
+            raise ValueError("Testbed file {} does not exist.".format(testbed_file))
+
+        # Parse testbed_pattern as regex
+        if testbed_pattern:
+            testbed_pattern = re.compile(testbed_pattern)
+
+        # Load testbed file
+        with open(testbed_file, "r") as f:
+            raw_testbeds = yaml.safe_load(f)
+
+        # Loop through each raw testbed object and create TestBed object that matches with testbed_pattern regex
+        testbeds = {}
+        for raw_testbed in raw_testbeds:
+            if testbed_pattern and not testbed_pattern.match(raw_testbed["conf-name"]):
+                continue
+            testbeds[raw_testbed["conf-name"]] = cls(raw_testbed, hosts=hosts)
+
+        return testbeds
+
+    def __init__(self, raw_dict, hosts=None):
+        """Initialize a testbed object.
+
+        Args:
+            raw_dict (dict): Raw testbed data object.
+            hosts (AnsibleHosts): AnsibleHosts object that contains all hosts in the testbed.
+        """
+        # Assign all fields in raw_dict to this object
+        for key, value in raw_dict.items():
+            setattr(self, key.replace("-", "_"), value)
+
+        # Create a PTF node object
+        self.ptf_node = TestBedNode(self.ptf, hosts)
+
+        # Loop through each DUT in the testbed and create TestBedNode object
+        self.dut_nodes = {}
+        for dut in raw_dict["dut"]:
+            self.dut_nodes[dut] = TestBedNode(dut, hosts)
+
+        # Some testbeds are dummy ones and doesn't have inv_name specified,
+        # so we need to use "unknown" as inv_name instead.
+        if not hasattr(self, "inv_name"):
+            self.inv_name = "unknown"
+
+
+class TestBedNode(object):
+    """Data model that represents a testbed node object."""
+
+    def __init__(self, name, hosts=None):
+        """Initialize a testbed node object.
+
+        Args:
+            name (str): Node name.
+            ansible_vars (dict): Ansible variables of the node.
+        """
+        self.name = name
+        self.ssh_ip = None
+        self.ssh_user = None
+        self.ssh_pass = None
+
+        if hosts:
+            try:
+                host_vars = hosts.get_host_vars(self.name)
+                self.ssh_ip = host_vars["ansible_host"]
+                self.ssh_user = host_vars["creds"]["username"]
+                self.ssh_pass = host_vars["creds"]["password"][0]
+            except Exception as e:
+                print("Error: Failed to get host vars for {}: {}".format(self.name, repr(e)))
+                self.ssh_ip = None
+                self.ssh_user = None
+                self.ssh_pass = None

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -1,0 +1,180 @@
+"""
+Script used to generate SSH session files for console access to devices.
+"""
+
+import argparse
+import os
+from devutil.testbed import TestBed
+from devutil.inv_helpers import HostManager
+from devutil.ssh_session_repo import SecureCRTSshSessionRepoGenerator
+
+
+class TestBedSshSessionRepoGenerator(object):
+    """SSH session repo generator for testbeds."""
+
+    def __init__(self, testbeds, repo_generator):
+        """Store all parameters as attributes.
+
+        Args:
+            testbeds (dict): Testbed name to testbed object mapping.
+            repo_generator (SshSessionRepoGenerator): SSH session repo generator.
+        """
+        self.testbeds = testbeds
+        self.repo_generator = repo_generator
+
+    def generate(self):
+        """Generate SSH session repo."""
+        for testbed in self.testbeds.values():
+            self._generate_ssh_sessions_for_testbed(testbed)
+
+    def _generate_ssh_sessions_for_testbed(self, testbed):
+        """Generate SSH sessions for a testbed.
+
+        Args:
+            testbed (object): Represents a testbed setup.
+        """
+        print("Start generating SSH sessions for testbed: {}".format(testbed.conf_name))
+
+        testbed_nodes = [["ptf", testbed.ptf_node]] + [
+            ["dut", item] for item in testbed.dut_nodes.values()
+        ]
+        for testbed_node in testbed_nodes:
+            self._generate_ssh_session_for_testbed_node(
+                testbed, testbed_node[0], testbed_node[1]
+            )
+
+        print(
+            "Finish generating SSH session files for testbed: {}\n".format(
+                testbed.conf_name
+            )
+        )
+
+    def _generate_ssh_session_for_testbed_node(
+        self, testbed, testbed_node_type, testbed_node
+    ):
+        """Generate SSH session for a testbed node.
+
+        We use the following naming convention for SSH session path:
+            <InvName>/<TestbedName>/<NodeType>-<NodeName>
+
+        Args:
+            testbed (object): Represents a testbed setup.
+            testbed_node_type (str): Type of the testbed node. It can be "ptf" or "dut".
+            testbed_node (object): Represents a connectable node in the testbed.
+        """
+        if testbed_node.ssh_ip is None:
+            print(
+                "Skip generating SSH session for testbed node: Testbed = {}, Type = {}, Node = {} (SSH IP is not specified)".format(
+                    testbed.conf_name, testbed_node_type, testbed_node.name
+                )
+            )
+            return
+
+        print(
+            "Start generating SSH session for testbed node: Testbed = {}, Type = {}, Node = {}".format(
+                testbed.conf_name, testbed_node_type, testbed_node.name
+            )
+        )
+
+        session_path = os.path.join(
+            testbed.inv_name,
+            testbed.conf_name,
+            testbed_node_type + "-" + testbed_node.name,
+        )
+        self.repo_generator.generate(
+            session_path,
+            testbed_node.ssh_ip,
+            testbed_node.ssh_user,
+            testbed_node.ssh_pass,
+        )
+
+
+def main(args):
+    print("Loading ansible host inventory: {}\n".format(args.inventory_file_paths))
+    ansible_hosts = HostManager(args.inventory_file_paths)
+
+    print(
+        "Loading testbed config: TestBedFile = {}, Pattern = {}".format(
+            args.testbed_file_path, args.testbed_pattern
+        )
+    )
+    testbeds = TestBed.from_file(
+        args.testbed_file_path, args.testbed_pattern, ansible_hosts
+    )
+    if len(testbeds) == 0:
+        print("No testbeds loaded. Exit.")
+        return
+    else:
+        print("{} testbeds loaded.\n".format(len(testbeds)))
+
+    print(
+        "Starting SSH session repo generation with config: OutputDir = {}, Template = {}".format(
+            args.target, args.template_file_path
+        )
+    )
+    repo_generator = SecureCRTSshSessionRepoGenerator(
+        args.target, args.template_file_path
+    )
+    testbed_repo_generator = TestBedSshSessionRepoGenerator(testbeds, repo_generator)
+    testbed_repo_generator.generate()
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    example_text = """Examples:
+
+- python3 ssh_session_gen.py -i inventory -o /data/sessions/testbeds -p some_securecrt_session.ini
+- python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds -p some_securecrt_session.ini
+- python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds -p some_securecrt_session.ini
+"""
+    parser = argparse.ArgumentParser(
+        description="Generate SSH session files for console access to devices.",
+        epilog=example_text,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        "-t",
+        "--testbed",
+        type=str,
+        dest="testbed_file_path",
+        default="testbed.yaml",
+        help="Testbed file path.",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--testbed-name",
+        type=str,
+        dest="testbed_pattern",
+        default=".*",
+        help="Testbed name regex.",
+    )
+
+    parser.add_argument(
+        "-i",
+        "--inventory",
+        dest="inventory_file_paths",
+        nargs="+",
+        help="Ansible host inventory file paths.",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        dest="target",
+        required=True,
+        help="Output target.",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--template",
+        type=str,
+        dest="template_file_path",
+        help="Session file template path. Used for clone your current session settings.",
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 - python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds -p some_securecrt_session.ini
 - python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds -p some_securecrt_session.ini
 
-To generate the SSH session files for SecureCRT, we need to provide a few information:
+To generate the SSH session files for SecureCRT, we need to do a few things first:
 1. Install pycryptodome package. We can do it via pip3: pip3 install pycryptodome.
 2. Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access to your testbed machines, this
    allows us to inherit the session settings from the template file, such as SSH proxies, fonts and etc. This is te some_securecrt_session.ini file

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -64,7 +64,8 @@ class TestBedSshSessionRepoGenerator(object):
         """
         if testbed_node.ssh_ip is None:
             print(
-                "Skip generating SSH session for testbed node: Testbed = {}, Type = {}, Node = {} (SSH IP is not specified)".format(
+                """Skip generating SSH session for testbed node: Testbed = {}, Type = {}, Node = {}
+                (SSH IP is not specified)""".format(
                     testbed.conf_name, testbed_node_type, testbed_node.name
                 )
             )
@@ -124,17 +125,20 @@ if __name__ == "__main__":
     example_text = """Examples:
 - python3 ssh_session_gen.py -i inventory -o /data/sessions/testbeds -p some_securecrt_session.ini
 - python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds -p some_securecrt_session.ini
-- python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds -p some_securecrt_session.ini
+- python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds \
+    -p some_securecrt_session.ini
 
 To generate the SSH session files for SecureCRT, we need to do a few things first:
 1. Install pycryptodome package. We can do it via pip3: pip3 install pycryptodome.
-2. Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access to your testbed machines, this
-   allows us to inherit the session settings from the template file, such as SSH proxies, fonts and etc. This is te some_securecrt_session.ini file
-   in the examples above.
-3. Setup the `secrets.json` file under `ansible/group_vars/all`. This allows us to get the SSH credentials for the testbed nodes.
+2. Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access
+   to your testbed machines, this allows us to inherit the session settings from the template file, such as SSH 
+   proxies, fonts and etc. This is te some_securecrt_session.ini file in the examples above.
+3. Setup the `secrets.json` file under `ansible/group_vars/all`. This allows us to get the SSH credentials for the
+   testbed nodes.
 
-Please also note that, sonic-mgmt ansible playbook support multiple credentials for the same host. However, SecureCRT only supports one credential,
-so we will use the first one in the list. If you see SSH login failures, please check the `secrets.json` file and use the alternative credentials.
+Please also note that, sonic-mgmt ansible playbook support multiple credentials for the same host. However, SecureCRT
+only supports one credential, so we will use the first one in the list. If you see SSH login failures, please check
+the `secrets.json` file and use the alternative credentials.
 """
     parser = argparse.ArgumentParser(
         description="Generate SSH session files for console access to devices.",

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -122,10 +122,19 @@ def main(args):
 if __name__ == "__main__":
     # Parse arguments
     example_text = """Examples:
-
 - python3 ssh_session_gen.py -i inventory -o /data/sessions/testbeds -p some_securecrt_session.ini
 - python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds -p some_securecrt_session.ini
 - python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds -p some_securecrt_session.ini
+
+To generate the SSH session files for SecureCRT, we need to provide a few information:
+1. Install pycryptodome package. We can do it via pip3: pip3 install pycryptodome.
+2. Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access to your testbed machines, this
+   allows us to inherit the session settings from the template file, such as SSH proxies, fonts and etc. This is te some_securecrt_session.ini file
+   in the examples above.
+3. Setup the `secrets.json` file under `ansible/group_vars/all`. This allows us to get the SSH credentials for the testbed nodes.
+
+Please also note that, sonic-mgmt ansible playbook support multiple credentials for the same host. However, SecureCRT only supports one credential,
+so we will use the first one in the list. If you see SSH login failures, please check the `secrets.json` file and use the alternative credentials.
 """
     parser = argparse.ArgumentParser(
         description="Generate SSH session files for console access to devices.",

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 To generate the SSH session files for SecureCRT, we need to do a few things first:
 1. Install pycryptodome package. We can do it via pip3: pip3 install pycryptodome.
 2. Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access
-   to your testbed machines, this allows us to inherit the session settings from the template file, such as SSH 
+   to your testbed machines, this allows us to inherit the session settings from the template file, such as SSH
    proxies, fonts and etc. This is te some_securecrt_session.ini file in the examples above.
 3. Setup the `secrets.json` file under `ansible/group_vars/all`. This allows us to get the SSH credentials for the
    testbed nodes.


### PR DESCRIPTION
### Description of PR

Summary:
This changes adds scripts for generating SecureCRT session files for testbeds.

To use it, we can run commands like `python3 ssh_session_gen.py -i inventory -o /data/sessions/testbeds -p some_securecrt_session.ini` to generate all session files in our testbed.

We can also use `-n <testbed-name-regex>` to scope to only the testbed we like to keep or use `-t <testbed-file> to use another testbed YAML config, if needed.

And to generate the SSH session files for SecureCRT, we need to do a few pre-steps:
- Install pycryptodome package via pip3.
- Prepare an existing session file as template (passed by -p). Since our dev machine might not have direct access to your testbed machines, this allows us to inherit the session settings from the template file, such as SSH proxies, fonts and etc.
- Setup credential files that you are using for your ansible. This allows us to get the SSH credentials for the testbed nodes.

Please also note that, sonic-mgmt ansible playbook support multiple credentials for the same host. However, SecureCRT only supports one credential, so we will use the first one in the list. If you see SSH login failures, please check the your credential file and use the alternative credentials.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

This change is supposed to help developers accessing the testbed in daily work.

#### How did you do it?

This change added a script to generate the session files for all or selected testbeds.

And the test will be generated in the path of: <InvName>/<TestbedName>/<NodeType>-<NodeName>. E.g. lab/ixanvl-vs-conf/dut-vlan-01

#### How did you verify/test it?

Generated all sessions
![image](https://github.com/sonic-net/sonic-mgmt/assets/1533278/d3a4c384-ce31-458b-aeb8-ffaeb21bfcf7)

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A. Not a test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
