### PR TITLE
[Dual-Tor][Nvidia] Update the mocked tunnel configuration for Nvidia platforms

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -370,7 +370,6 @@ def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_pe
     dut = rand_selected_dut
 
     dut_loopback = (mock_peer_switch_loopback_ip - 1).ip
-
     tunnel_params = {
         'TUNNEL': {
             'MuxTunnel0': {
@@ -383,6 +382,9 @@ def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_pe
             }
         }
     }
+    if 'spc' in rand_selected_dut.get_asic_name():
+        tunnel_params['TUNNEL']['MuxTunnel0'].update(
+            {'src_ip': str(mock_peer_switch_loopback_ip.ip)})
 
     dut.copy(content=json.dumps(tunnel_params, indent=2), dest="/tmp/tunnel_params.json")
     dut.shell("sonic-cfggen -j /tmp/tunnel_params.json --write-to-db")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For Nvidia platforms, the tunnel source IP is needed for the IPinIP tunnel configuration. Currently, the dualtor t0 mocked tests doesn't configure the src_ip, need to add it when the dut is Nvidia device.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Support the dualtor t0 mocked tests on Nvidia platforms.
#### How did you do it?
Add the src_ip in the mocked tunnel configuration.
#### How did you verify/test it?
By automation, all related tests passed on 4600C.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
