### PR TITLE
Restore crm polling interval after module `crm/test_crm.py` running.

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import time
 import json
 import logging
+import re
 
 from test_crm import RESTORE_CMDS
 from tests.common.helpers.crm import CRM_POLLING_INTERVAL
@@ -135,10 +136,24 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
 
 @pytest.fixture(scope="module", autouse=True)
 def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """ Set CRM polling interval to 1 second """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     wait_time = 2
+
+    # Get polling interval
+    output = duthost.command('crm show summary')['stdout']
+    parsed = re.findall(r'Polling Interval: +(\d+) +second', output)
+    if parsed:
+        original_polling_interval = int(parsed[0])
+
+    # Set CRM polling interval to 1 second
     duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))["stdout"]
+    logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
+    time.sleep(wait_time)
+
+    yield
+
+    # Set CRM polling interval to original value
+    duthost.command("crm config polling interval {}".format(original_polling_interval))["stdout"]
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
 

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -142,7 +142,7 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     # Get polling interval
     output = duthost.command('crm show summary')['stdout']
     parsed = re.findall(r'Polling Interval: +(\d+) +second', output)
-    original_polling_interval = int(parsed[0])
+    original_crm_polling_interval = int(parsed[0])
 
     # Set CRM polling interval to 1 second
     duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))["stdout"]
@@ -152,7 +152,7 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     yield
 
     # Set CRM polling interval to original value
-    duthost.command("crm config polling interval {}".format(original_polling_interval))["stdout"]
+    duthost.command("crm config polling interval {}".format(original_crm_polling_interval))["stdout"]
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
 

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -142,8 +142,7 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     # Get polling interval
     output = duthost.command('crm show summary')['stdout']
     parsed = re.findall(r'Polling Interval: +(\d+) +second', output)
-    if parsed:
-        original_polling_interval = int(parsed[0])
+    original_polling_interval = int(parsed[0])
 
     # Set CRM polling interval to 1 second
     duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))["stdout"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
During module `crm/test_crm.py` running, it reset the crm polling interval which will mofidy running config and cause config reload after the module running. We restore the crm polling interval in this PR, which will avoid config reload and save running time. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During module `crm/test_crm.py` running, it reset the crm polling interval which will mofidy running config and cause config reload after the module running. We restore the crm polling interval in this PR, which will avoid config reload and save running time. 

#### How did you do it?
Get the original crm polling interval and resotre it in the tear down period.

#### How did you verify/test it?
```
04:08:45 conftest.core_dump_and_config_check      L2101 INFO   | Core dump and config check passed for crm/test_crm.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
