### PR TITLE
[acl][m0] Add support for m0-2vlan in test_null_route_helper

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -11,6 +11,7 @@ import ptf.packet as scapy
 
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa F401
 import ptf.testutils as testutils
+from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 
 logger = logging.getLogger(__name__)
@@ -29,11 +30,6 @@ ACL_TABLE_NAME_V4 = "NULL_ROUTE_ACL_TABLE_V4"
 ACL_TABLE_NAME_V6 = "NULL_ROUTE_ACL_TABLE_V6"
 
 NULL_ROUTE_HELPER = "null_route_helper"
-
-DST_IP = {
-    4: "192.168.0.2",
-    6: "fc02:1000::2"
-}
 
 FORWARD = "FORWARD"
 DROP = "DROP"
@@ -183,11 +179,21 @@ def setup_ptf(rand_selected_dut, ptfhost, tbinfo):
     dst_ports = {}
     vlan_name = ""
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    vlans = {}
     for vlan_info in mg_facts["minigraph_vlan_interfaces"]:
         ip_ver = ipaddress.ip_network(vlan_info['addr'], False).version
-        dst_ports[ip_ver] = str(ipaddress.ip_address(vlan_info['addr']) + 1) + '/' + str(vlan_info['prefixlen'])
-        vlan_name = vlan_info['attachto']
+        if vlan_info["attachto"] not in vlans:
+            vlans[vlan_info["attachto"]] = {}
+        vlans[vlan_info["attachto"]][ip_ver] = vlan_info
 
+    for key, value in vlans.items():
+        if len(value.keys()) == 2:
+            vlan_name = key
+            for ip_ver, value in value.items():
+                dst_ports[ip_ver] = str(ipaddress.ip_address(value['addr']) + 1) + '/' + str(value['prefixlen'])
+            break
+
+    pytest_require(vlan_name != "", "Cannot get correct vlan")
     vlan_port = mg_facts['minigraph_vlans'][vlan_name]['members'][0]
     dst_ports['port'] = mg_facts['minigraph_ptf_indices'][vlan_port]
 
@@ -263,7 +269,7 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter, apply_pre_defi
         ip_ver = ipaddress.ip_network(src_ip.encode().decode(), False).version
         logger.info("Testing with src_ip = {} action = {} expected_result = {}"
                     .format(src_ip, action, expected_result))
-        pkt, exp_pkt = generate_packet(src_ip, DST_IP[ip_ver], router_mac)
+        pkt, exp_pkt = generate_packet(src_ip, ptf_port_info[ip_ver].split("/")[0], router_mac)
         if action != "":
             rand_selected_dut.shell(NULL_ROUTE_HELPER + " " + action)
             time.sleep(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently, test_null_route_helper uses fixed destination IPs (`DST_IP`) to test, which not support m0-2vlan topo.

#### How did you do it?
Get vlan interface and member dynamically, skip test if cannot get vlan meets requirement.

#### How did you verify/test it?
Run test on t0, mx, m0, m0-2vlan testbeds, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
