### PR TITLE
[platform_tests] Fix test_reboot reboot_type passed as interfaces_wait_time

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -81,7 +81,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     logging.info("Append the latest reboot type to the queue")
     REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
 
-    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
+    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
 
 
 def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/8646 introduces regression in which a new arg is added to `check_interfaces_and_services` but the call made from `reboot_and_check` is not updated to handle the new arg.

This regression causes all of test_reboot.py to fail.

#### How did you do it?
Fix call in `reboot_and_check`.

#### How did you verify/test it?
Tested on arista device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
