### PR TITLE
Use systemctl to restart radv

### DIFF
--- a/tests/radv/test_radv_run.py
+++ b/tests/radv/test_radv_run.py
@@ -23,7 +23,7 @@ def test_radv_deployment_id(duthost):
     # Need to generate supervisord.conf
     docker_cmd = 'docker exec radv sonic-cfggen -d -t \
 /usr/share/sonic/templates/docker-router-advertiser.supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf'
-    restart_cmd = 'docker restart radv'
+    restart_cmd = 'systemctl reset-failed radv; systemctl restart radv'
     origin_id = duthost.shell(get_cmd)['stdout']
     duthost.shell(set_cmd.format(PO2VLAN_DEPLOYMENT_ID))
     duthost.shell(docker_cmd)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Using “docker restart radv” will cause service to fail and not restarted.

#### How did you do it?
Use "systemctl restart" instead.

#### How did you verify/test it?
Run this test case and check radv container status.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
