### PR TITLE
Call duthost_console fixture for test_escape_character test case

### DIFF
--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -8,6 +8,7 @@ import six
 from tests.common.helpers.assertions import pytest_assert
 
 TOTAL_PACKETS = 100
+packet_number = 10
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -16,9 +17,7 @@ pytestmark = [
 
 
 def test_console_escape(duthost_console):
-    child = pexpect.spawn("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS))
-    time.sleep(5)
-    child.sendcontrol('C')
-    child.expect(r"\^C")
-    match = re.search(r'(\d) packets transmitted', six.ensure_text(child.read()))
-    pytest_assert(int(match.group(1)) < TOTAL_PACKETS, "Escape Character does not work.")
+    duthost_console.send_command("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS),
+                                               expect_string=r"icmp_seq={}".format(packet_number))
+    duthost_console.send_command("\x03",
+                                 expect_string=r"{} packets transmitted".format(packet_number), max_loops=300)

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -1,11 +1,7 @@
-import pexpect
 import logging
-import time
-import re
 import pytest
 import six
 
-from tests.common.helpers.assertions import pytest_assert
 
 TOTAL_PACKETS = 100
 packet_number = 10

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import six
 
 
 TOTAL_PACKETS = 100

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -13,6 +13,6 @@ pytestmark = [
 
 def test_console_escape(duthost_console):
     duthost_console.send_command("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS),
-                                               expect_string=r"icmp_seq={}".format(packet_number))
+                                 expect_string=r"icmp_seq={}".format(packet_number))
     duthost_console.send_command("\x03",
                                  expect_string=r"{} packets transmitted".format(packet_number), max_loops=300)

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -15,7 +15,7 @@ pytestmark = [
 ]
 
 
-def test_console_escape():
+def test_console_escape(duthost_console):
     child = pexpect.spawn("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS))
     time.sleep(5)
     child.sendcontrol('C')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- This PR fixes '_test_escape_character_' test under _dut_console_ test suite.
- Currently test runs the respective '_ping_' command on the test bed server instead of running it on the **console** of the respective DUT.
- And also pexpect.spawn creates child process for ping under sonic-mgmt docker where the test is running instead of the DUT console.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- Fix '_test_escape_character_' test under _dut_console_ test suite, by calling '_duthost_console_' fixture. 
- Currently test runs on test bed server and executes '_ping_' command which is not the expected behavior.

#### How did you do it?
- Call '_duthost_console_' fixture of conftest.py from the test case.
- Send 'ping' command and escape character directly on the DUT console instead of creating child process.

#### How did you verify/test it?
- Ran the dut_console test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![dut_console](https://github.com/sonic-net/sonic-mgmt/assets/114024719/99f64b9c-218c-40ee-a9e2-9f7965efbeab)
