### PR TITLE
Temporarily disable checking IPv6 BGP routing on neighbors for warm-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -148,7 +148,7 @@ class Arista(host_device.HostDevice):
             'interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
         samples[cur_time] = sample
 
-        while not (quit_enabled and v4_routing_ok and v6_routing_ok):
+        while not (quit_enabled and v4_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands
             # but wait for v4_routing_ok and v6_routing_ok

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -148,6 +148,9 @@ class Arista(host_device.HostDevice):
             'interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
         samples[cur_time] = sample
 
+        # TODO: Disabling v6_routing_ok check due to IPv6 FRR issue. Re-add v6_routing_ok once either:
+        # * https://github.com/FRRouting/frr/issues/13587 is fixed and the fix gets merged into SONiC, or
+        # * https://github.com/sonic-net/sonic-buildimage/pull/12853 is reverted
         while not (quit_enabled and v4_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -103,6 +103,9 @@ class Sonic(host_device.HostDevice):
             lacp_thread.setDaemon(True)
             lacp_thread.start()
 
+        # TODO: Disabling v6_routing_ok check due to IPv6 FRR issue. Re-add v6_routing_ok once either:
+        # * https://github.com/FRRouting/frr/issues/13587 is fixed and the fix gets merged into SONiC, or
+        # * https://github.com/sonic-net/sonic-buildimage/pull/12853 is reverted
         while not (quit_enabled and v4_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -103,7 +103,7 @@ class Sonic(host_device.HostDevice):
             lacp_thread.setDaemon(True)
             lacp_thread.start()
 
-        while not (quit_enabled and v4_routing_ok and v6_routing_ok):
+        while not (quit_enabled and v4_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands
             # but wait for v4_routing_ok and v6_routing_ok


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Due to sonic-net/sonic-buildimage#12853, IPv6 BGP is partially broken, where some IPv6 BGP prefixes aren't advertised up to T1 neighbors. In an effort to get the warm reboot PR checker re-enabled, disable checking the IPv6 BGP routing for now.

Once that PR is either fixed or reverted, revert this PR.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
