### PR TITLE
Add back an important import in ansible arp_responder.py

### DIFF
--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -10,6 +10,7 @@ from fcntl import ioctl
 import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 scapy2.conf.use_pcap = True
+import scapy.arch.pcapdnet # noqa F401
 
 
 def hexdump(data):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This import is necessary in the arp_responder but was accidentally removed by PR https://github.com/sonic-net/sonic-mgmt/pull/8064.
```
import scapy.arch.pcapdnet
```
Need to add it back or some tests will fail.(we have observed failures in acl test which is related to this issue)
For details of this import, please reference this PR https://github.com/sonic-net/sonic-mgmt/pull/8481
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix the ansible arp_responder
#### How did you do it?
Add the import 
```
import scapy.arch.pcapdnet
```
#### How did you verify/test it?
Run the affected acl test, all passed after the fix.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
