### PR TITLE
Fix wrong parameter for function check_interfaces_and_services in test_reboot.py

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -81,7 +81,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     logging.info("Append the latest reboot type to the queue")
     REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
 
-    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
+    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
 
 
 def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,


### PR DESCRIPTION
…t_reboot.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
It carries wrong parameter into `check_interfaces_and_services`.
`check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)`

`reboot_type` is wrongly considered as `interfaces_wait_time` and causes the following issue.
```
>       while elapsed_time < timeout:
E       TypeError: '<' not supported between instances of 'int' and 'str'

delay      = 0
elapsed_time = 0
interval   = 20
kwargs     = {}
start_time = 1687524370.1760564
timeout    = 'cold'
```

```
def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
                                  interfaces_wait_time=MAX_WAIT_TIME_FOR_INTERFACES, reboot_type=None):
```
#### How did you do it?
Define reboot_type as reboot type, otherwise it is in the position of parameter of interfaces_wait_time.

#### How did you verify/test it?
Run `platform_tests/test_reboot.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
