### PR TITLE
Fix sub_port_interfaces python3 migration issue

### DIFF
--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -147,8 +147,8 @@ def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port,
     router_mac = duthost.facts['router_mac']
     src_port_number = int(get_port_number(src_port))
     dst_port_number = int(get_port_number(dst_port))
-    src_mac = ptfadapter.dataplane.get_mac(0, src_port_number)
-    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port_number)
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port_number).decode()
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port_number).decode()
     # Get VLAN ID from name of sub-port
     if '.' in src_port:
         src_vlan_vid = int(src_port.split('.')[1])

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -292,7 +292,7 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
 
     # Define encapsulated packet
     pkt = create_packet(eth_dst=router_mac,
-                        eth_src=ptfadapter.dataplane.get_mac(0, src_port_number),
+                        eth_src=ptfadapter.dataplane.get_mac(0, src_port_number).decode(),
                         ip_src=ip_src,
                         ip_dst=ip_dst,
                         ip_tunnel=ip_tunnel,
@@ -303,7 +303,7 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
 
     # Build expected packet
     inner_packet = pkt[packet.IP].payload[packet.IP].copy()
-    exp_pkt = Ether(src=router_mac, dst=ptfadapter.dataplane.get_mac(0, dst_port_number)) \
+    exp_pkt = Ether(src=router_mac, dst=ptfadapter.dataplane.get_mac(0, dst_port_number).decode()) \
         / Dot1Q(vlan=int(dst_port.split('.')[1])) / inner_packet
     exp_pkt['IP'].ttl -= 1
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After the python3 migration, the routing between sub ports and tunneling cases started to fail in verifying the packets:
```
duthost = <MultiAsicSonicHost r-tigon-20>
ptfadapter = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>, src_port = 'eth6.20'
dst_port = 'eth6.50', ip_src = '172.16.0.2', ip_dst = '172.16.0.14', tr_type = 'TCP', pktlen = 100, ttl = 63

    def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, tr_type, pktlen, ttl):
       ...
       ...
    
        pkt_filter = FilterPktBuffer(ptfadapter=ptfadapter,
                                     exp_pkt=exp_pkt,
                                     dst_port_numbers=dst_port_number,
                                     match_fields=[("802.1Q", "vlan"), ("Ethernet", "src"), ("Ethernet", "dst"),
                                                   ("IP", "src"), ("IP", "dst"), (tr_type, "dport")],
                                     ignore_fields=[])
    
        pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
    
>       pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
E       Failed: Expected packet not available:
E       False
```
The packets can not be successfully filtered by the pkt_filter.
In python3, the mac address got from ptdadapter is in byte type, but it is str type in the captured packet from buffer.
Test can pass if we decode the src/dst mac to str.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the sub_port_interfaces python3 migration issue
#### How did you do it?
decode the src/dst mac to str
#### How did you verify/test it?
Run the test cases, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
