### PR TITLE
Add a function to compare running config. 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1883,7 +1883,7 @@ def compare_running_config(pre_running_config, cur_running_config):
     if type(pre_running_config) != type(cur_running_config):
         return False
 
-    if type(pre_running_config) is not "dict":
+    if type(pre_running_config) is not dict:
         if set(pre_running_config) != set(cur_running_config):
             return False
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1878,23 +1878,26 @@ def __dut_reload(duts_data, node=None, results=None):
 
 
 def compare_running_config(pre_running_config, cur_running_config):
-    if pre_running_config == cur_running_config:
-        return True
     if type(pre_running_config) != type(cur_running_config):
         return False
-
-    if type(pre_running_config) is not dict:
-        if set(pre_running_config) != set(cur_running_config):
-            return False
-        else:
-            return True
-
-    if set(pre_running_config.keys()) != set(cur_running_config.keys()):
-        return False
-    for key in pre_running_config.keys():
-        if not compare_running_config(pre_running_config[key], cur_running_config[key]):
-            return False
+    if pre_running_config == cur_running_config:
         return True
+    else:
+        if type(pre_running_config) is dict:
+            if set(pre_running_config.keys()) != set(cur_running_config.keys()):
+                return False
+            for key in pre_running_config.keys():
+                if not compare_running_config(pre_running_config[key], cur_running_config[key]):
+                    return False
+                return True
+        # We only have string in list in running config now, so we can ignore the order of the list.
+        elif type(pre_running_config) is list:
+            if set(pre_running_config) != set(cur_running_config):
+                return False
+            else:
+                return True
+        else:
+            return False
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1876,6 +1876,17 @@ def __dut_reload(duts_data, node=None, results=None):
 
     config_reload(node, wait_before_force_reload=300)
 
+def compare_running_config(pre_running_config, cur_running_config):
+    if pre_running_config == cur_running_config:
+        return True
+    if type(pre_running_config) != type(cur_running_config):
+        return False
+    if sorted(pre_running_config.keys()) != sorted(cur_running_config.keys()):
+        return False
+    for key in pre_running_config.keys():
+        if not compare_running_config(pre_running_config[key], cur_running_config[key]):
+            return False
+        return True
 
 @pytest.fixture(scope="module", autouse=True)
 def core_dump_and_config_check(duthosts, tbinfo, request):
@@ -2050,7 +2061,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
                                         }
                                     }
                                 )
-                    elif pre_running_config[key] != cur_running_config[key]:
+                    elif not compare_running_config(pre_running_config[key], cur_running_config[key]):
                         inconsistent_config[duthost.hostname][cfg_context].update(
                             {
                                 key: {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1876,6 +1876,7 @@ def __dut_reload(duts_data, node=None, results=None):
 
     config_reload(node, wait_before_force_reload=300)
 
+
 def compare_running_config(pre_running_config, cur_running_config):
     if pre_running_config == cur_running_config:
         return True
@@ -1887,6 +1888,7 @@ def compare_running_config(pre_running_config, cur_running_config):
         if not compare_running_config(pre_running_config[key], cur_running_config[key]):
             return False
         return True
+
 
 @pytest.fixture(scope="module", autouse=True)
 def core_dump_and_config_check(duthosts, tbinfo, request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1882,7 +1882,14 @@ def compare_running_config(pre_running_config, cur_running_config):
         return True
     if type(pre_running_config) != type(cur_running_config):
         return False
-    if sorted(pre_running_config.keys()) != sorted(cur_running_config.keys()):
+
+    if type(pre_running_config) is not "dict":
+        if set(pre_running_config) != set(cur_running_config):
+            return False
+        else:
+            return True
+
+    if set(pre_running_config.keys()) != set(cur_running_config.keys()):
         return False
     for key in pre_running_config.keys():
         if not compare_running_config(pre_running_config[key], cur_running_config[key]):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We only use `==` to compare running config before, but our running config is a nested dict, and if the value is disordered, it will wrongly return false. Just in module `acl/test_acl_outer_vlan.py`, it somehow change the order of part of the running dict from `{"DATAACL": {"ports": ["PortChannel101", "PortChannel102", "PortChannel104", "PortChannel103"]}}` to `{"DATAACL": {"ports": ["PortChannel101", "PortChannel102", "PortChannel103", "PortChannel104"]}}`. And this disorder will cause config reload after running all cases in this module. In this PR, I add a function to compare running config, which will avoid such wrong judgement caused by order. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
We only use `==` to compare running config before, but our running config is a nested dict, and if the value is disordered, it will wrongly return false. Just in module `acl/test_acl_outer_vlan.py`, it somehow change the order of part of the running dict from `{"DATAACL": {"ports": ["PortChannel101", "PortChannel102", "PortChannel104", "PortChannel103"]}}` to `{"DATAACL": {"ports": ["PortChannel101", "PortChannel102", "PortChannel103", "PortChannel104"]}}`. And this disorder will cause config reload after running all cases in this module. In this PR, I add a function to compare running config, which will avoid such wrong judgement caused by order. 

#### How did you do it?
Add a function to compare two running config dict. 

#### How did you verify/test it?
```
06:35:15 conftest.core_dump_and_config_check      L2115 INFO   | Core dump and config check passed for acl/test_acl_outer_vlan.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
