### PR TITLE
Fix python3 issue in everflow test

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -846,14 +846,14 @@ class BaseEverflowTest(object):
             if six.PY2:
                 payload = binascii.unhexlify("0" * 44) + str(payload)
             else:
-                payload = binascii.unhexlify("0" * 44) + str(payload).encode('utf-8')
+                payload = binascii.unhexlify("0" * 44) + bytes(payload)
 
         if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get(
                 "platform_asic") in ["broadcom-dnx"]:
             if six.PY2:
                 payload = binascii.unhexlify("0" * 24) + str(payload)
             else:
-                payload = binascii.unhexlify("0" * 24) + str(payload).encode('utf-8')
+                payload = binascii.unhexlify("0" * 24) + bytes(payload)
 
         expected_packet = testutils.simple_gre_packet(
             eth_src=setup[direction]["egress_router_mac"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The everflow ipv6 test is failing on internal branch. The error is as below
```
2023-06-28T06:04:01.8322847Z ========== EXPECTED ==========
2023-06-28T06:04:01.8323845Z Mask:
2023-06-28T06:04:01.8324185Z 
2023-06-28T06:04:01.8325148Z packet status: OK
2023-06-28T06:04:01.8326195Z packet:
2023-06-28T06:04:01.8327465Z 0000  00 01 02 03 04 05 1C 34 DA 2D E8 00 08 00 45 20  .......4.-....E 
2023-06-28T06:04:01.8328735Z 0010  01 2C 00 00 00 00 04 2F AF 7E 01 01 01 01 02 02  .,...../.~......
2023-06-28T06:04:01.8330000Z 0020  02 02 00 00 89 49 00 00 00 00 00 00 00 00 00 00  .....I..........
2023-06-28T06:04:01.8331426Z 0030  00 00 00 00 00 00 00 00 00 00 00 00 62 27 5C 78  ............b'\x
2023-06-28T06:04:01.8332841Z 0040  31 63 34 5C 78 64 61 2D 5C 78 65 38 5C 78 30 30  1c4\xda-\xe8\x00
2023-06-28T06:04:01.8334056Z 0050  52 5C 78 63 64 5C 78 61 35 26 5C 78 31 37 5C 78  R\xcd\xa5&\x17\x
2023-06-28T06:04:01.8335328Z 0060  30 30 5C 78 38 36 5C 78 64 64 60 5C 78 30 30 5C  00\x86\xdd`\x00\
2023-06-28T06:04:01.8336605Z 0070  78 30 30 5C 78 30 30 5C 78 30 30 2E 5C 78 30 36  x00\x00\x00.\x06
2023-06-28T06:04:01.8337870Z 0080  40 20 5C 78 30 32 5C 78 30 32 25 7C 6B 5C 78 61  @ \x02\x02%|k\xa
2023-06-28T06:04:01.8339123Z 0090  39 5C 78 38 32 5C 78 64 34 5C 78 38 62 23 5C 78  9\x82\xd4\x8b#\x
2023-06-28T06:04:01.8340382Z 00a0  30 65 5C 78 66 32 71 5C 78 30 30 5C 78 30 38 20  0e\xf2q\x00\x08 
2023-06-28T06:04:01.8341666Z 00b0  5C 78 30 32 5C 78 30 32 25 7C 6B 5C 78 61 39 5C  \x02\x02%|k\xa9\
2023-06-28T06:04:01.8342932Z 00c0  78 38 32 5C 78 64 34 5C 78 38 62 23 5C 78 30 65  x82\xd4\x8b#\x0e
2023-06-28T06:04:01.8344167Z 00d0  5C 78 66 32 71 5C 78 30 30 5C 74 2E 5C 78 65 30  \xf2q\x00\t.\xe0
2023-06-28T06:04:01.8345554Z 00e0  5C 78 30 31 5C 78 62 62 5C 78 30 30 5C 78 30 30  \x01\xbb\x00\x00
2023-06-28T06:04:01.8346821Z 00f0  5C 78 30 30 5C 78 30 30 5C 78 30 30 5C 78 30 30  \x00\x00\x00\x00
2023-06-28T06:04:01.8348094Z 0100  5C 78 30 30 5C 78 30 30 50 5C 78 30 32 20 5C 78  \x00\x00P\x02 \x
2023-06-28T06:04:01.8349370Z 0110  30 30 5C 78 38 33 63 5C 78 30 30 5C 78 30 30 44  00\x83c\x00\x00D
2023-06-28T06:04:01.8350822Z 0120  44 44 44 44 44 44 44 44 44 44 44 44 44 44 44 44  DDDDDDDDDDDDDDDD
2023-06-28T06:04:01.8352272Z 0130  44 44 44 44 44 44 44 44 44 27                    DDDDDDDDD'
2023-06-28T06:04:01.8352771Z 
2023-06-28T06:04:01.8353894Z packet's mask:
2023-06-28T06:04:01.8355021Z 0000  00 00 00 00 00 00 FF FF FF FF FF FF FF FF F0 00  ................
2023-06-28T06:04:01.8356276Z 0010  00 00 FF FF 1F FF FF FF 00 00 FF FF FF FF FF FF  ................
2023-06-28T06:04:01.8357519Z 0020  FF FF FF FF FF FF 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8358718Z 0030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8359962Z 0040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8361298Z 0050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8362580Z 0060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8363826Z 0070  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8365012Z 0080  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8366278Z 0090  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8367567Z 00a0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8368759Z 00b0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8370010Z 00c0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8371281Z 00d0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8372683Z 00e0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8373941Z 00f0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8375220Z 0100  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8382838Z 0110  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8384124Z 0120  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
2023-06-28T06:04:01.8385321Z 0130  00 00 00 00 00 00 00 00 00 00                    ..........
2023-06-28T06:04:01.8385807Z 
2023-06-28T06:04:01.8386823Z ========== RECEIVED ==========
2023-06-28T06:04:01.8388393Z 1 total packets. Displaying most recent 1 packets:
2023-06-28T06:04:01.8390506Z ------------------------------
2023-06-28T06:04:01.8391831Z 0000  3E 80 B6 7C 4A 44 1C 34 DA 2D E8 00 08 00 45 20  >..|JD.4.-....E 
2023-06-28T06:04:01.8393071Z 0010  00 92 00 00 40 00 04 2F 70 18 01 01 01 01 02 02  ....@../p.......
2023-06-28T06:04:01.8394325Z 0020  02 02 00 00 89 49 00 16 01 00 AD 40 00 00 00 00  .....I.....@....
2023-06-28T06:04:01.8395712Z 0030  07 1B 0A 16 4E E0 00 68 00 00 00 0B 1C 34 DA 2D  ....N..h.....4.-
2023-06-28T06:04:01.8396934Z 0040  E8 00 52 CD A5 26 17 00 86 DD 60 00 00 00 00 2E  ..R..&....`.....
2023-06-28T06:04:01.8398161Z 0050  06 40 20 02 02 25 7C 6B A9 82 D4 8B 23 0E F2 71  .@ ..%|k....#..q
2023-06-28T06:04:01.8399404Z 0060  00 08 20 02 02 25 7C 6B A9 82 D4 8B 23 0E F2 71  .. ..%|k....#..q
2023-06-28T06:04:01.8400610Z 0070  00 09 2E E0 01 BB 00 00 00 00 00 00 00 00 50 02  ..............P.
2023-06-28T06:04:01.8401922Z 0080  20 00 C5 69 00 00 74 65 73 74 73 2E 65 76 65 72   ..i..tests.ever
2023-06-28T06:04:01.8403131Z 0090  66 6C 6F 77 2E 74 65 73 74 5F 65 76 65 72 66 6C  flow.test_everfl
2023-06-28T06:04:01.8404268Z ==============================
```
From the test log, we can see that the mirroring packet is actually received, but the expected packet is much longer than the actual mirroring packet.
It's because of a code issue in python3
```
payload = binascii.unhexlify("0" * 44) + str(payload).encode('utf-8')
```  
This PR address the issue by removing the `encode` operation, and use `bytes` to convert the packet into byte array.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix a python3 issue in everflow test.

#### How did you do it?
This PR address the issue by removing the `encode` operation, and use `bytes` to convert the packet into byte array.

#### How did you verify/test it?
The change is verified on python3 environment
```
collected 20 items                                                                                                                                                                          

everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[cli-default] PASSED                                                                                  [  5%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[cli-default] PASSED                                                                                  [ 10%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[cli-default] PASSED                                                                               [ 15%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[cli-default] PASSED                                                                               [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[cli-default] PASSED                                                                               [ 25%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[cli-default] PASSED                                                                         [ 30%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[cli-default] PASSED                                                                         [ 35%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[cli-default] PASSED                                                                                 [ 40%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[cli-default] PASSED                                                                                      [ 45%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[cli-default] PASSED                                                                                  [ 50%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[cli-default] PASSED                                                                              [ 55%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[cli-default] PASSED                                                                           [ 60%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[cli-default] PASSED                                                                           [ 65%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[cli-default] PASSED                                                                                        [ 70%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[cli-default] PASSED                                                                              [ 75%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[cli-default] PASSED                                                                                    [ 80%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[cli-default] PASSED                                                                                       [ 85%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[cli-default] PASSED                                                                                         [ 90%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[cli-default] PASSED                                                                                        [ 95%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[cli-default] PASSED                                                                                       [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
