### PR TITLE
[Dual-Tor][Active-Active] Add semicolons back to the proto files

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
@@ -1,5 +1,5 @@
-import "nic_simulator_grpc_service.proto"
-syntax = "proto3"
+syntax = "proto3";
+import "nic_simulator_grpc_service.proto";
 
 
 service DualTorMgmtService {
@@ -15,42 +15,42 @@ service DualTorMgmtService {
 }
 
 message ListOfAdminRequest {
-    repeated string nic_addresses = 1
-    repeated AdminRequest admin_requests = 2
+    repeated string nic_addresses = 1;
+    repeated AdminRequest admin_requests = 2;
 }
 
 message ListOfAdminReply {
-    repeated string nic_addresses = 1
-    repeated AdminReply admin_replies = 2
+    repeated string nic_addresses = 1;
+    repeated AdminReply admin_replies = 2;
 }
 
 message ListOfOperationRequest {
-    repeated string nic_addresses = 1
-    repeated OperationRequest operation_requests = 2
+    repeated string nic_addresses = 1;
+    repeated OperationRequest operation_requests = 2;
 }
 
 message ListOfOperationReply {
-    repeated string nic_addresses = 1
-    repeated OperationReply operation_replies = 2
+    repeated string nic_addresses = 1;
+    repeated OperationReply operation_replies = 2;
 }
 
 message ListOfDropRequest {
-    repeated string nic_addresses = 1
-    repeated DropRequest drop_requests = 2
+    repeated string nic_addresses = 1;
+    repeated DropRequest drop_requests = 2;
 }
 
 message ListOfDropReply {
-    repeated string nic_addresses = 1
-    repeated DropReply drop_replies = 2
+    repeated string nic_addresses = 1;
+    repeated DropReply drop_replies = 2;
 }
 
 message ListOfNiCServerAdminStateRequest {
-    repeated string nic_addresses = 1
-    repeated bool admin_states = 2
+    repeated string nic_addresses = 1;
+    repeated bool admin_states = 2;
 }
 
 message ListOfNiCServerAdminStateReply {
-    repeated string nic_addresses = 1
-    repeated bool admin_states = 2
-    repeated bool successes = 3
+    repeated string nic_addresses = 1;
+    repeated bool admin_states = 2;
+    repeated bool successes = 3;
 }

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
@@ -1,4 +1,4 @@
-syntax = "proto3"
+syntax = "proto3";
 
 service DualToRActive {
     rpc QueryAdminForwardingPortState(AdminRequest) returns(AdminReply) {}
@@ -15,48 +15,48 @@ service DualToRActive {
 }
 
 message AdminRequest {
-    repeated int32 portid = 1
-    repeated bool state = 2
+    repeated int32 portid = 1;
+    repeated bool state = 2;
 }
 
 message AdminReply {
-    repeated int32 portid = 1
-    repeated bool state = 2
+    repeated int32 portid = 1;
+    repeated bool state = 2;
 }
 
 message OperationRequest {
-    repeated int32 portid = 1
+    repeated int32 portid = 1;
 }
 
 message OperationReply {
-    repeated int32 portid = 1
-    repeated bool state = 2
+    repeated int32 portid = 1;
+    repeated bool state = 2;
 }
 
 message LinkStateRequest {
-    repeated int32 portid = 1
+    repeated int32 portid = 1;
 }
 
 message LinkStateReply {
-    repeated int32 portid = 1
-    repeated bool state = 2
+    repeated int32 portid = 1;
+    repeated bool state = 2;
 }
 
 message ServerVersionRequest {
-    string version = 1
+    string version = 1;
 }
 
 message ServerVersionReply {
-    string version = 1
+    string version = 1;
 }
 
 message DropRequest {
-    repeated int32 portid = 1
-    repeated int32 direction = 2
-    bool recover = 3
+    repeated int32 portid = 1;
+    repeated int32 direction = 2;
+    bool recover = 3;
 }
 
 message DropReply {
-    repeated int32 portid = 1
-    repeated bool success = 2
+    repeated int32 portid = 1;
+    repeated bool success = 2;
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is to fix the issue https://github.com/sonic-net/sonic-mgmt/issues/8723.
The semicolons are mandatory syntax for the proto files but has been removed by PR https://github.com/sonic-net/sonic-mgmt/pull/8017, need to add them back.
And the `syntax = "proto3";` should be in the first line of the file.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix the gRPC proto files for nic simulator.
#### How did you do it?
Revert the change of the proto files made by PR#8017
#### How did you verify/test it?
Use testbed-cli.sh to deploy the dualtor-aa topology, all steps passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
