### PR TITLE
[202012]Restore vlan running config after module test_host_vlan.py running.

### DIFF
--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -3,6 +3,7 @@ import pytest
 import random
 import time
 import tempfile
+import json
 
 from scapy.all import sniff
 from ptf import testutils
@@ -73,8 +74,20 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_VLAN_INTF_MAC)
 
     yield
-    
-    duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], dut_vlan_mac))
+
+    del_vlan_json = json.loads("""
+                [{
+                    "VLAN":{
+                        "%s":{
+                            "mac": "%s"
+                        }
+                    }
+                }]
+            """ % (vlan_intf["attachto"], dut_vlan_mac))
+    duthost.copy(content=json.dumps(del_vlan_json, indent=4), dest='/tmp/del_vlan_mac.json')
+    duthost.shell("configlet -d -j {}".format("/tmp/del_vlan_mac.json"))
+    duthost.shell("rm -rf /tmp/del_vlan_mac.json")
+
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == dut_vlan_mac)
 
 

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -86,7 +86,7 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
             """ % (vlan_intf["attachto"], dut_vlan_mac))
     duthost.copy(content=json.dumps(del_vlan_json, indent=4), dest='/tmp/del_vlan_mac.json')
     duthost.shell("configlet -d -j {}".format("/tmp/del_vlan_mac.json"))
-    duthost.shell("rm -rf /tmp/del_vlan_mac.json")
+    duthost.shell("rm -f /tmp/del_vlan_mac.json")
 
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == dut_vlan_mac)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
During module `vlan/test_host_vlan.py` running, it modify the vlan mac in running config. In teardown perid, it reset the vlan mac and add the vlan mac in running config, which is not exist in previous running config. We delete the vlan mac running config in the teardown period in this PR, which will avoid config reload and save running time. Due to cherry pick conflict of PR (https://github.com/sonic-net/sonic-mgmt/pull/8728), so raise this PR.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
During module `vlan/test_host_vlan.py` running, it modify the vlan mac in running config. In teardown perid, it reset the vlan mac and add the vlan mac in running config, which is not exist in previous running config. We delete the vlan mac running config in the teardown period in this PR, which will avoid config reload and save running time. 

#### How did you do it?
Delete the vlan mac running config in teardown period. 

#### How did you verify/test it?
```
02:03:12 conftest.core_dump_and_config_check      L2085 INFO   | Core dump and config check passed for vlan/test_host_vlan.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
