### PR TITLE
[cherry-pick] [PR:7781] Fix for PID assertion issue - PSUD and CHASSID platform cases (#7781)

### DIFF
--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -67,7 +67,7 @@ def check_daemon_status(duthosts, enum_rand_one_per_hwsku_hostname):
         time.sleep(10)
 
 def check_expected_daemon_status(duthost, expected_daemon_status):
-    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status
 
 def check_if_daemon_restarted(duthost, daemon_name, pre_daemon_pid):
@@ -146,6 +146,7 @@ def test_pmon_chassisd_stop_and_start_status(check_daemon_status, duthosts, enum
 
     duthost.start_pmon_daemon(daemon_name)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(50, 25, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
@@ -196,6 +197,7 @@ def test_pmon_chassisd_kill_and_start_status(check_daemon_status, duthosts, enum
 
     duthost.stop_pmon_daemon(daemon_name, SIG_KILL, pre_daemon_pid)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)

--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -70,8 +70,14 @@ def check_daemon_status(duthosts, enum_supervisor_dut_hostname):
         duthost.start_pmon_daemon(daemon_name)
         time.sleep(10)
 
+
+def check_if_daemon_restarted(duthost, daemon_name, pre_daemon_pid):
+    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+    return (daemon_pid > pre_daemon_pid)
+
+
 def check_expected_daemon_status(duthost, expected_daemon_status):
-    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     return daemon_status == expected_daemon_status
 
 def collect_data(duthost):
@@ -165,6 +171,7 @@ def test_pmon_psud_stop_and_start_status(check_daemon_status, duthosts, enum_sup
 
     duthost.start_pmon_daemon(daemon_name)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(50, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
@@ -192,6 +199,7 @@ def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, enum_sup
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(50, 10, 5, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
@@ -219,6 +227,7 @@ def test_pmon_psud_kill_and_start_status(check_daemon_status, duthosts, enum_sup
 
     duthost.stop_pmon_daemon(daemon_name, SIG_KILL, pre_daemon_pid)
 
+    wait_until(120, 10, 0, check_if_daemon_restarted, duthost, daemon_name, pre_daemon_pid)
     wait_until(120, 10, 0, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)


### PR DESCRIPTION
**Cherry-Pick PR #7781 :** For resolving conflicts.
Fix for PID assertion issue - PSUD and CHASSID platform cases.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixing up other chassisd and psud platform tests to poll for deamon to restart with bigger pid than before.
This is an extension of PR https://github.com/sonic-net/sonic-mgmt/pull/7150.

Summary:
Fixes # (issue)

Fixes PSUD '_stop & start_', '_term & start_' and '_kill & start_' test cases by making sure the daemon restarted has bigger PID than before.
Fixes CHASSID '_stop & start'_ and '_kill & start_' test cases by making sure the daemon restarted has bigger PID than before.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- Currently PSUD and CHASSID platform test cases like 'term & start', '_kill & start_' and '_stop & start'_ don't check if the restarted daemon has bigger pid than the previous one or not.
- Currently "_check_expected_daemon_status_" doesn't verify about pre-daemon-pid, just returns TRUE even if the status is RUNNING with old PID.

#### How did you do it?

- By invoking '_check_if_daemon_restarted_' method on the above-mentioned cases and making sure the new pid is bigger than the old pid.

#### How did you verify/test it?

- Ran the respective platform tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
