### PR TITLE
Disable service warm_restart after test_service_warm_restart running

### DIFF
--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -102,4 +102,7 @@ def test_service_warm_restart(request, duthosts, rand_one_dut_hostname,
     advancedReboot = get_advanced_reboot(rebootType='service-warm-restart',
                                          service_list=candidate_service_list,
                                          advanceboot_loganalyzer=advanceboot_loganalyzer)
-    advancedReboot.runRebootTestcase()
+    try:
+        advancedReboot.runRebootTestcase()
+    finally:
+        advancedReboot.disable_service_warmrestart()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In test case `test_service_warm_restart`, the `warm_restart` of service is enabled but not disabled after test running.
After test running
```
admin@str2-msn4600c-acs-04:~$ show warm_restart config 
name       enable    timer_name    timer_duration    eoiu_enable
---------  --------  ------------  ----------------  -------------
snmp       true      NULL          NULL              NULL
swss       true      NULL          NULL              NULL
teamd      true      NULL          NULL              NULL
telemetry  true      NULL          NULL              NULL
lldp       true      NULL          NULL              NULL
radv       true      NULL          NULL              NULL
acms       true      NULL          NULL              NULL
pmon       true      NULL          NULL              NULL
bgp        true      NULL          NULL              NULL
```
If a `config reload` is issued with swss warm_restart enabled, syncd will not response to the `INIT_VIEW` notification. Then DUT gets stuck in bad state, which can't be recovered by config reload or config load_minigraph.
This PR addressed the issue by calling `disable_service_warmrestart` at the end of test running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to disable service warm_restart after test_service_warm_restart running.

#### How did you do it?
This PR addressed the issue by calling `disable_service_warmrestart` at the end of test running.

#### How did you verify/test it?
The change is verified by running `test_service_warm_restart`. After test running, check the warm_restart state of each service, confirm it's disabled.
```
admin@str2-msn4600c-acs-04:~$ show warm_restart config 
name       enable    timer_name    timer_duration    eoiu_enable
---------  --------  ------------  ----------------  -------------
snmp       false     NULL          NULL              NULL
swss       false     NULL          NULL              NULL
teamd      false     NULL          NULL              NULL
telemetry  false     NULL          NULL              NULL
lldp       false     NULL          NULL              NULL
radv       false     NULL          NULL              NULL
acms       false     NULL          NULL              NULL
pmon       false     NULL          NULL              NULL
bgp        false     NULL          NULL              NULL
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
