### PR TITLE
Revert "Update ansible tmp path at cfg file (#8348)"

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,7 @@
 inventory      = /etc/ansible/hosts
 library        = library:library/ixia
 module_utils   = module_utils
-remote_tmp     = /tmp/.ansible-$USER
+remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
 forks          = 5
 poll_interval  = 15


### PR DESCRIPTION
This reverts commit 738f96d54a0ca50aa922d0f8b93b9f8531365416.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
202205 ‘s pr test constantly fails on tacacs/test_ro_disk.py, sample: [Test plan 649df312747396c5b3a09483: GitHub_PullRequest_PR_15655_BUILD_304247_JOB_kvmtest-t0_by_Elastictest - Elastictest (elastictest.org)](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Felastictest.org%2Fscheduler%2Ftestplan%2F649df312747396c5b3a09483&data=05%7C01%7Cjianquanye%40microsoft.com%7Cf19381a8f38648590efb08db7933a6bc%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638237034979124708%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=KuWHqvONDEDJs7D%2BVEYLpqIqbhoaNRUY5rboZS06Z0k%3D&reserved=0)

The direct reason is after the change [Update ansible tmp path at cfg file by slutati1536 · Pull Request #8348 · sonic-net/sonic-mgmt (github.com)](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsonic-net%2Fsonic-mgmt%2Fpull%2F8348%2Ffiles&data=05%7C01%7Cjianquanye%40microsoft.com%7Cf19381a8f38648590efb08db7933a6bc%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638237034979280942%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=IJaxNmEsMgLcpmsy7hCD%2F%2FIy2oBFlJ7eHM3adfZHwVk%3D&reserved=0) is cherry-picked into 202205, ansible need to create tmp file on the /tmp directory of DUT.
But the test_ro_disk.py makes /tmp to be read-only, then ansible considers it as unreachable.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
