### PR TITLE
Fix false alert for pmon services check in sanity check

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -701,7 +701,7 @@ class SonicHost(AnsibleHostBase):
             # In this situation, service container status should be false
             # We can check status is valid or not
             # You can just add valid status str in this tuple if meet later
-            if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL', 'BACKOFF'):
+            if status not in ('RUNNING', 'EXITED', 'STOPPED', 'FATAL', 'BACKOFF', 'STARTING'):
                 service_critical_process['status'] = False
             # 2. Check status is not running
             elif status != 'RUNNING':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Dualtor pipeline always failed because pmon santicy check failed.
Because status of ycabled is STARTING.
It's not included in status set of process in function `parse_service_status_and_critical_process` and then failed status set to be False wrongly.
Also because there is no critical process in pmon, we should skip sanity check even ycable is starting, the pmon container is running, that should pass sanity check for pmon process.

```
{
  "failed": true,
  "msg": "At least running one of the commands failed",
  "cmds": [
    "docker exec pmon supervisorctl status",
...
  ],
  "results": [
    {
      "cmd": "docker exec pmon supervisorctl status",
      "rc": 3,
      "stdout": "chassis_db_init                  EXITED    Jun 30 03:10 AM\ncontainercfgd                    RUNNING   pid 39, uptime 0:05:18\ndependent-startup                EXITED    Jun 30 03:10 AM\nledd                             RUNNING   pid 30, uptime 0:05:22\nlm-sensors                       EXITED    Jun 30 03:10 AM\npcied                            RUNNING   pid 38, uptime 0:05:19\npsud                             RUNNING   pid 34, uptime 0:05:21\nrsyslogd                         RUNNING   pid 24, uptime 0:05:24\nsupervisor-proc-exit-listener    RUNNING   pid 21, uptime 0:05:26\nsyseepromd                       RUNNING   pid 36, uptime 0:05:21\nthermalctld                      RUNNING   pid 37, uptime 0:05:20\nxcvrd                            RUNNING   pid 32, uptime 0:05:22\nycabled                          STARTING  \n",
      "stderr": "",
      "stdout_lines": [
        "chassis_db_init                  EXITED    Jun 30 03:10 AM",
        "containercfgd                    RUNNING   pid 39, uptime 0:05:18",
        "dependent-startup                EXITED    Jun 30 03:10 AM",
        "ledd                             RUNNING   pid 30, uptime 0:05:22",
        "lm-sensors                       EXITED    Jun 30 03:10 AM",
        "pcied                            RUNNING   pid 38, uptime 0:05:19",
        "psud                             RUNNING   pid 34, uptime 0:05:21",
        "rsyslogd                         RUNNING   pid 24, uptime 0:05:24",
        "supervisor-proc-exit-listener    RUNNING   pid 21, uptime 0:05:26",
        "syseepromd                       RUNNING   pid 36, uptime 0:05:21",
        "thermalctld                      RUNNING   pid 37, uptime 0:05:20",
        "xcvrd                            RUNNING   pid 32, uptime 0:05:22",
        "ycabled                          STARTING  "
      ],
      "stderr_lines": [
        
      ]
    },
```
#### How did you do it?
Add STARTING into status set, we missed this status before.

#### How did you verify/test it?
Run any case with sanity check enable.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
