### PR TITLE
Vxlan ecmp primary/secondary switchover tests.

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -67,4 +67,4 @@ def test_add_rack(configure_dut, tbinfo, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
 
     log_info("sys.version={}".format(sys.version))
-    do_test_add_rack(duthost, is_storage_backend='backend' in tbinfo['topo']['name'])
+    do_test_add_rack(duthost, is_storage_backend='backend' in tbinfo['topo']['name'], skip_clet_test=True)

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -1970,3 +1970,316 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_dport=False,
             random_src_ip=True,
             tolerance=0.03)
+
+class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
+    '''
+        Class for all the Vxlan tunnel cases where primary and secondary next hops are configured.
+    '''
+    def test_vxlan_priority_single_pri_sec_switchover(self, setUp, encap_type):
+        '''
+            tc4:create tunnel route 1 with two endpoints a = {a1, b1}. a1 is primary, b1 is secondary.
+            1) both a1,b1 are UP.
+            2) send packets to the route 1's prefix dst. packets are received at a1.
+            3) bring a1 down.
+            4) send packets to the route 1's prefix dst. packets are received at b1.
+        '''
+        if encap_type in ['v4_in_v6', 'v6_in_v6']:
+            pytest.skip("Skipping test. v6 underlay is not supported in priority tunnels.")
+        self.setup = setUp
+
+        Logger.info("Choose a vnet.")
+        vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
+
+        Logger.info("Create a new list of endpoint(s).")
+        tc1_end_point_list = []
+        for _ in range(2):
+            tc1_end_point_list.append(ecmp_utils.get_ip_address(
+                af=ecmp_utils.get_outer_layer_version(encap_type),
+                netid=NEXTHOP_PREFIX))
+
+        Logger.info("Create a new destination")
+        tc1_new_dest = ecmp_utils.get_ip_address(
+            af=ecmp_utils.get_payload_version(encap_type),
+            netid=DESTINATION_PREFIX)
+
+        Logger.info("Map the new destination and the new endpoint(s).")
+        self.setup[encap_type]['dest_to_nh_map'][vnet][tc1_new_dest] = \
+            tc1_end_point_list
+
+        Logger.info("Create a new priority endpoint config and Copy to the DUT.")
+
+        Logger.info("Create the json and apply the config in the DUT swss.")
+        # The config looks like:
+        # [
+        #   {
+        #     "VNET_ROUTE_TUNNEL_TABLE:vnet:tcx_new_dest/32": {
+        #       "endpoint": "{tcx_end_point_list}"
+        #       "endpoint_monitor": "{tcx_end_point_list}",
+        #       "primary" : "{}",
+        #       "adv_prefix" : "{}/{}",
+        #     },
+        #     "OP": "{}"
+        #   }
+        # ]
+        try:
+            ecmp_utils.create_and_apply_priority_config(
+                self.setup['duthost'],
+                vnet,
+                tc1_new_dest,
+                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
+                tc1_end_point_list,
+                [tc1_end_point_list[0]],
+                "SET")
+
+            #both pribary secondary are up.
+            #only primary should recieve traffic.
+            time.sleep(2)
+            down_list = tc1_end_point_list[1]
+            if isinstance(down_list, str):
+                down_list = [down_list]
+            self.setup['list_of_downed_endpoints'] =  set(down_list)
+            #setting both primary and secondary as up. only primary will recieve traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[0], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[1], "up")
+            time.sleep(10)
+
+            #verifying overlay_dmac
+            result = self.setup['duthost'].shell("sonic-db-cli APPL_DB HGET 'VNET_MONITOR_TABLE:{}:{}/{}' 'overlay_dmac'"
+                .format(tc1_end_point_list[0], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)]))['stdout']
+            assert result ==  u'25:35:45:55:65:75'
+
+
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
+
+            # Single primary-secondary switchover. Endpoint list = [A, A`], Primary[A] | Active NH=[A]  Action: A went Down | Result NH=[A`]
+            # NH has a single primary endpoint which upon failing is replaced by the single Backup endpoint
+            Logger.info("Single primary-secondary switchover.")
+            time.sleep(2)
+            down_list = tc1_end_point_list[0]
+            if isinstance(down_list, str):
+                down_list = [down_list]
+            self.setup['list_of_downed_endpoints'] =  set(down_list)
+            #setting primary down . only secondary  will recieve traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[0], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
+
+            # Single primary recovery. Endpoint list = [A, A`], Primary[A] | Active NH=[A`] |Action: A is back up | ResultNH=[A]
+            # NH has a single backup endpoint which upon recovery of primary is replaced.
+            Logger.info("Single primary recovery.")
+            time.sleep(2)
+            down_list = tc1_end_point_list[1]
+            if isinstance(down_list, str):
+                down_list = [down_list]
+            self.setup['list_of_downed_endpoints'] =  set(down_list)
+            #setting primary up . only primary  will recieve traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[0], "up")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
+
+            # Single primary backup Failure. Endpoint list = [A, A`]. Primary[A]| Active  NH=[A`]  A is DOWN  | Action: A` goes Down | result NH=[]
+            # No active Endpoint results in route being removed.
+            Logger.info("Single primary & backup Failure.")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[0], "down")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[1], "up")
+            time.sleep(10)
+            down_list = tc1_end_point_list
+            if isinstance(down_list, str):
+                down_list = [down_list]
+            self.setup['list_of_downed_endpoints'] =  set(down_list)
+            #setting both down . no traffic is recieved.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc1_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc1_end_point_list[1], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
+        except Exception:
+            ecmp_utils.create_and_apply_priority_config(
+                self.setup['duthost'],
+                vnet,
+                tc1_new_dest,
+                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
+                tc1_end_point_list,
+                [tc1_end_point_list[0]],
+                "DEL")
+
+    def test_vxlan_priority_multi_pri_sec_switchover(self, setUp, encap_type):
+        '''
+            tc2:create tunnel route 1 with 6 endpoints a = {A, B, C, A`, B`, C`}. A,B,C are primary, A`,B`,C` are secondary.
+            1) All eps are up.A,B,C,A`,B`,C`
+            2) send packets to the route 1's prefix dst. packets are received at A,B,C.
+            3) bring A down.
+            4) send packets to the route 1's prefix dst. packets are received at B,C.
+            5) bring B down.
+            6) send packets to the route 1's prefix dst. packets are received at C.
+            7) bring C down.
+            8) send packets to the route 1's prefix dst. packets are recieved at A`,B`,C`.
+            9) bring C` down.
+            10) send packets to the route 1's prefix dst. packets are recieved at A`,B``.
+            11) bring A up.
+            12) send packets to the route 1's prefix dst. packets are recieved at A.
+            13) bring B,C,C` up.
+            14) send packets to the route 1's prefix dst. packets are recieved at A,B,C.
+
+        '''
+        if encap_type in ['v4_in_v6', 'v6_in_v6']:
+            pytest.skip("Skipping test. v6 underlay is not supported in priority tunnels.")
+        self.setup = setUp
+
+        Logger.info("Choose a vnet.")
+        vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
+
+        Logger.info("Create a new list of endpoint(s).")
+        tc2_end_point_list = []
+        for _ in range(6):
+            tc2_end_point_list.append(ecmp_utils.get_ip_address(
+                af=ecmp_utils.get_outer_layer_version(encap_type),
+                netid=NEXTHOP_PREFIX))
+
+        Logger.info("Create a new destination")
+        tc2_new_dest = ecmp_utils.get_ip_address(
+            af=ecmp_utils.get_payload_version(encap_type),
+            netid=DESTINATION_PREFIX)
+
+        Logger.info("Map the new destination and the new endpoint(s).")
+        self.setup[encap_type]['dest_to_nh_map'][vnet][tc2_new_dest] = \
+            tc2_end_point_list
+
+        Logger.info("Create a new priority endpoint config and Copy to the DUT.")
+
+        Logger.info("Create the json and apply the config in the DUT swss.")
+        # The config looks like:
+        # [
+        #   {
+        #     "VNET_ROUTE_TUNNEL_TABLE:vnet:tcx_new_dest/32": {
+        #       "endpoint": "{tcx_end_point_list}"
+        #       "endpoint_monitor": "{tcx_end_point_list}",
+        #       "primary" : "{tcx_end_point_list[0:len/2]}",
+        #       "adv_prefix" : "{tcx_new_dest}/{32}",
+        #     },
+        #     "OP": "{}"
+        #   }
+        # ]
+        try:
+            primary_nhg = tc2_end_point_list[0:3]
+            secondary_nhg = tc2_end_point_list[3:6]
+
+            ecmp_utils.create_and_apply_priority_config(
+                self.setup['duthost'],
+                vnet,
+                tc2_new_dest,
+                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
+                tc2_end_point_list,
+                primary_nhg,
+                "SET")
+
+            time.sleep(5)
+            #Bringing all endpoints UP.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[0], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[1], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[2], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[3], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[4], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  tc2_end_point_list[5], "up")
+            #check all primary Eps are operational
+            inactive_list = list(secondary_nhg)
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            time.sleep(10)
+            #ensure that the traffic is distributed to all 3 primary Endpoints.
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups. Single primary failure.  Endpoint list = [A, B, C, A`, B`, C`], Primary = [A, B, C] | active NH = [A, B, C] | Action: A goes Down | Result NH=[B, C]
+            # One of the primaries goes down. The others stay active.
+            time.sleep(2)
+            inactive_list = list(secondary_nhg)
+            inactive_list.append(primary_nhg[0])
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting A down. B,C getting traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[0], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups. Multiple primary failure. Endpoint list = [A, B, C, A`, B`, C`], Primary = [A, B, C] | A already Down. active NH = [B, C] | Action: B goes Down. | Result:  NH=[C]
+            # 2 of the primaries goes down. The 3rd stay active. NH group is updated.
+            time.sleep(2)
+            inactive_list = list(secondary_nhg)
+            inactive_list += primary_nhg[0:2]
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting B down. C getting all traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[1], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups.  All primary failure. Endpoint list = [A, B, C, A`, B`, C`] Primary = [A, B, C] | A,B already Down active NH = [C] | Action: C goes Down.  | Result: NH=[A`, B`, C`]
+            # All the primaries are down. The backup endpoints are added to the NH group.
+            time.sleep(2)
+            inactive_list = list(primary_nhg)
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting C down, now all backups are up and recieving traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[2], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups. Backup Failure. Endpoint list = [A, B, C, A`, B`, C`] Primary = [A, B, C] | A, B, C already Down. Active NH = [A`, B`, C`] | Action: C` goes Down. | Result: NH=[A`, B`]
+            # All the primaries are down. Failure of a backup endpoint shall result in its removal from NH.
+            time.sleep(2)
+            inactive_list = list(primary_nhg)
+            inactive_list.append(secondary_nhg[2])
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting C`` down, now A` and B` are up and recieving traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  secondary_nhg[2], "down")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups. Single primary recovery. Endpoint list = [A, B, C, A`, B`, C`] Primary = [A, B, C] | Active NH = [A`, B`] | Action: A is Up. B, C still Down | Result: NH=[A]
+            # Primary takes precedence and is added to the NH. All the backups are removed.
+            time.sleep(2)
+            inactive_list = list(primary_nhg[1:3])
+            inactive_list += secondary_nhg
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting A up. only A will recieve traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[0], "up")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+
+            # Multiple primary backups. Multiple primary & backup recovery. Endpoint list = [A, B, C, A`, B`, C`] Primary = [A, B, C] | Active NH = [A] | Action: A is Up. B, C also come up | Result: NH=[A, B, C]
+            # Primary endpoints take precedence and are added to the NH.
+            time.sleep(2)
+            inactive_list = list(secondary_nhg)
+            if isinstance(inactive_list, str):
+                inactive_list = [inactive_list]
+            self.setup['list_of_downed_endpoints'] =  set(inactive_list)
+            #setting B, C and C` up. only A,B,C will recieve traffic.
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[1], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  primary_nhg[2], "up")
+            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'], tc2_new_dest, ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],  secondary_nhg[2], "up")
+
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
+
+        except Exception:
+            ecmp_utils.create_and_apply_priority_config(
+                self.setup['duthost'],
+                vnet,
+                tc2_new_dest,
+                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
+                tc2_end_point_list,
+                primary_nhg,
+                "DEL")
+

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -63,7 +63,7 @@ from tests.common.fixtures.ptfhost_utils \
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer 
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -2116,7 +2116,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "down")
- 
+
             time.sleep(10)
             self.dump_self_info_and_run_ptf("test1", encap_type, True)
 
@@ -2157,12 +2157,11 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             21) bring A,B up.
             22) send packets to the route 1's prefix dst. packets are recieved at A, B.
 
-            
         '''
         if encap_type in ['v4_in_v6', 'v6_in_v6']:
             pytest.skip("Skipping test. v6 underlay is not supported in priority tunnels.")
         self.setup = setUp
-        
+
         loganalyzer = LogAnalyzer(ansible_host=self.setup['duthost'],
                                   marker_prefix="ignore Logic error: basic_string::_M_construct null")
         loganalyzer.init()

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -870,13 +870,13 @@ numprocs=1
         time.sleep(3)
 
     def create_and_apply_priority_config(self,
-                                duthost,
-                                vnet,
-                                dest,
-                                mask,
-                                nhs,
-                                primary,
-                                op):
+                                         duthost,
+                                         vnet,
+                                         dest,
+                                         mask,
+                                         nhs,
+                                         primary,
+                                         op):
         '''
             Create a single destinatoin->endpoint list mapping, and configure
             it in the DUT.
@@ -913,5 +913,4 @@ numprocs=1
 
     def set_vnet_monitor_state(self, duthost, dest, mask, nh, state):
         duthost.shell("sonic-db-cli STATE_DB HSET 'VNET_MONITOR_TABLE|{}|{}/{}' 'state' '{}'"
-                              .format(nh, dest, mask, state))
-
+                      .format(nh, dest, mask, state))

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -50,6 +50,8 @@ class Ecmp_Utils(object):
     # in the vnet routes.
     HOST_MASK = {'v4': 32, 'v6': 128}
 
+    OVERLAY_DMAC = "25:35:45:55:65:75"
+
     def create_vxlan_tunnel(self,
                             duthost,
                             minigraph_data,
@@ -317,8 +319,8 @@ class Ecmp_Utils(object):
                 "vxlan_tunnel": "{}",
                 {}"vni": "{}",
                 "peer_list": "",
-                "overlay_dmac" : "25:35:45:55:65:75"
-            }}'''.format(name, tunnel_name, scope_entry, vni))
+                "overlay_dmac" : "{}"
+            }}'''.format(name, tunnel_name, scope_entry, vni, self.OVERLAY_DMAC))
 
             full_config = '{\n"VNET": {' + ",\n".join(config_list) + '\n}\n}'
 
@@ -914,3 +916,4 @@ numprocs=1
     def set_vnet_monitor_state(self, duthost, dest, mask, nh, state):
         duthost.shell("sonic-db-cli STATE_DB HSET 'VNET_MONITOR_TABLE|{}|{}/{}' 'state' '{}'"
                       .format(nh, dest, mask, state))
+

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -316,7 +316,8 @@ class Ecmp_Utils(object):
             config_list.append('''"{}": {{
                 "vxlan_tunnel": "{}",
                 {}"vni": "{}",
-                "peer_list": ""
+                "peer_list": "",
+                "overlay_dmac" : "25:35:45:55:65:75"
             }}'''.format(name, tunnel_name, scope_entry, vni))
 
             full_config = '{\n"VNET": {' + ",\n".join(config_list) + '\n}\n}'
@@ -867,3 +868,50 @@ numprocs=1
                 ",".join(map(str, intf_list)),
                 ",".join(ip_address_list)))
         time.sleep(3)
+
+    def create_and_apply_priority_config(self,
+                                duthost,
+                                vnet,
+                                dest,
+                                mask,
+                                nhs,
+                                primary,
+                                op):
+        '''
+            Create a single destinatoin->endpoint list mapping, and configure
+            it in the DUT.
+            duthost : AnsibleHost structure for the DUT.
+            vnet    : Name of the Vnet.
+            dest    : IP(v4/v6) address of the destination.
+            mask    : Dest netmask length.
+            nhs     : Nexthop list(v4/v6).
+            primary : list of primary endpoints.
+            op      : Operation to be done : SET or DEL.
+
+        '''
+        config = self.create_single_priority_route(vnet, dest, mask, nhs, primary, op)
+        str_config = '[\n' + config + '\n]'
+        self.apply_config_in_swss(duthost, str_config, op + "_vnet_route")
+
+    @classmethod
+    def create_single_priority_route(cls, vnet, dest, mask, nhs, primary, op):
+        '''
+            Create a single route entry for vnet, for the given dest, through
+            the endpoints:nhs, op:SET/DEL
+        '''
+        config = '''{{
+        "VNET_ROUTE_TUNNEL_TABLE:{}:{}/{}": {{
+            "endpoint": "{}",
+            "endpoint_monitor": "{}",
+            "primary" : "{}",
+            "monitoring" : "custom",
+            "adv_prefix" : "{}/{}"
+        }},
+        "OP": "{}"
+        }}'''.format(vnet, dest, mask, ",".join(nhs), ",".join(nhs), ",".join(primary), dest, mask, op)
+        return config
+
+    def set_vnet_monitor_state(self, duthost, dest, mask, nh, state):
+        duthost.shell("sonic-db-cli STATE_DB HSET 'VNET_MONITOR_TABLE|{}|{}/{}' 'state' '{}'"
+                              .format(nh, dest, mask, state))
+

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -916,4 +916,3 @@ numprocs=1
     def set_vnet_monitor_state(self, duthost, dest, mask, nh, state):
         duthost.shell("sonic-db-cli STATE_DB HSET 'VNET_MONITOR_TABLE|{}|{}/{}' 'state' '{}'"
                       .format(nh, dest, mask, state))
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR adds the tests for priority tunnels where switchover from primary-secondary endpoint sets is performed upon failure of endpoint.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform-specific information?
These tests only run on platforms that support Vxlan tunnels, such as Cisco 8102, Mlnx 4600, Mlnx 2700
#### Supported testbed topology if it's a new test case?
t1-64-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
