### PR TITLE
[202205] Enable QoS sai test on T1-Lag topology

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -690,8 +690,7 @@ class QosSaiBase(QosBase):
         topo = tbinfo["topo"]["name"]
 
 
-        # LAG ports in T1 TOPO need to be removed in Mellanox devices
-        if topo in self.SUPPORTED_T0_TOPOS or isMellanoxDevice(src_dut):
+        if topo in self.SUPPORTED_T0_TOPOS:
             # Only single asic is supported for this scenario, so use src_dut and src_asic - which will be the same
             # as dst_dut and dst_asic
             pytest_assert(
@@ -706,9 +705,6 @@ class QosSaiBase(QosBase):
             testPortIds[src_dut_index][src_asic_index] = set(src_mgFacts["minigraph_ptf_indices"][port]
                                 for port in src_mgFacts["minigraph_ports"].keys())
             testPortIds[src_dut_index][src_asic_index] -= set(dutLagInterfaces)
-            if isMellanoxDevice(src_dut):
-                # The last port is used for up link from DUT switch
-                testPortIds[src_dut_index][src_asic_index] -= {len(src_mgFacts["minigraph_ptf_indices"]) - 1}
             testPortIds[src_dut_index][src_asic_index] = sorted(testPortIds[src_dut_index][src_asic_index])
             pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0, "Skip test since no ports are available for testing")
 
@@ -941,7 +937,7 @@ class QosSaiBase(QosBase):
             "dutTopo": dutTopo,
             "srcDutInstance" : src_dut,
             "dstDutInstance": get_src_dst_asic_and_duts['dst_dut'],
-            "dualTor": request.config.getoption("--qos_dual_tor"),
+            "dualTor": dualTor,
             "dualTorScenario": len(dualtor_ports_for_duts) != 0
         }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test gap https://github.com/sonic-net/sonic-mgmt/issues/8701 .



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
The change was verified on a Mellanox-SN4600 testbed, with T1-LAG-64 topology.
Only 1 test case is failing `testQosSaiHeadroomPoolSize`.
```
collected 126 items                                                                                                                                                                         

qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]  ^HPASSED                                                                                                                    [  0%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED                                                                                                    [  1%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED                                                                                                    [  2%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_3] SKIPPED                                                                                                   [  3%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_4] SKIPPED                                                                                                   [  3%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_1] PASSED                                                                                    [  4%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_2]  ^HPASSED                                                                                    [  5%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_3] SKIPPED                                                                                   [  6%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_4] SKIPPED                                                                                   [  7%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED                                                                                                      [  7%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED                                                                                                      [  8%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_3] SKIPPED                                                                                                     [  9%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_4] SKIPPED                                                                                                     [ 10%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_1] SKIPPED                                                                                            [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_2] SKIPPED                                                                                            [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_3] SKIPPED                                                                                            [ 12%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_4] SKIPPED                                                                                            [ 13%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic]  ^H
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_1] SKIPPED                                                                               [ 15%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_2] SKIPPED                                                                               [ 15%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[single_asic] SKIPPED                                                                                                 [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossless] SKIPPED                                                                              [ 17%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossy]  ^HSKIPPED                                                                                 [ 18%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED                                                                                                             [ 19%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] SKIPPED                                                                                       [ 19%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] SKIPPED                                                                                                      [ 20%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-downstream] PASSED                                                                                   [ 21%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-upstream] PASSED                                                                                     [ 22%]
......
qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[multi_dut-wm_q_wm_all_ports] SKIPPED                                                                              [100%]             
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
