### PR TITLE
[span]Fix span test issue: IndexError: list index out of range in the test_port_mirroring

### DIFF
--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -36,11 +36,14 @@ def ports_for_test(cfg_facts):
     '''
     # Select vlan for test
     vlans = cfg_facts['VLAN']
-    vlan = [vlans[vlan]['vlanid'] for vlan in list(vlans.keys())][0]
+    vlan_ids = [vlans[vlan]['vlanid'] for vlan in list(vlans.keys())]
 
     # Select 3 ports for test
-    ports = cfg_facts['VLAN_MEMBER']['Vlan{}'.format(vlan)]
-    port_names = [port_name for port_name in list(ports.keys()) if 'PortChannel' not in port_name]
+    for vlan in vlan_ids:
+        ports = cfg_facts['VLAN_MEMBER']['Vlan{}'.format(vlan)]
+        port_names = [port_name for port_name in list(ports.keys()) if 'PortChannel' not in port_name]
+        if len(port_names) >= 3:
+            break
     selected_ports = [port_names[0], port_names[1], port_names[-1]]
 
     # Generate port info for selected ports


### PR DESCRIPTION
In the span test, it will choose some physical port from the vlan, when there are more than one vlan, in original logic, it will always choose port from the first vlan member, but we can not guarantee there are more than 3 physical port in the first vlan member. change the logic to choose the physical port from the vlan which has more than 3 physical ports.

Change-Id: I587d716b7381b3cf9d44b09acc0120f078b260ee

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix https://github.com/sonic-net/sonic-mgmt/issues/8795
Fixes # (issue) IndexError: list index out of range in the test_port_mirroring

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
When run the test_port_mirroring, sometimes we will get the following issue.
The root cause for the issue is that there maybe more than one vlan Vlan101 and Vlan102, in the current logic it will choose 3 physical ports from the vlan member, and will always choose the from the first vlan(the first key of cfg_facts['VLAN']) member. but the order of the vlan is not fixed. so sometimes there maybe no physical ports in the vlan member, so the issue it triggered.
```
IndexError: list index out of range
cfg_facts = {'ACL_TABLE': {'DATAACL': {'policy_desc': 'DATAACL', 'ports': ['PortChannel101', 'PortChannel102', 'PortChannel103', '...'rate_limit_interval': '600', 'state': 'enabled'}, ...}, 'BGP_DEVICE_GLOBAL': {'STATE': {'tsa_enabled': 'false'}}, ...}

    @pytest.fixture(scope="module")
    def ports_for_test(cfg_facts):
        '''
        Used to select 3 ports for test and generate info on them
    
        Args:
            duthosts: All DUTs belonging to the testbed.
            rand_one_dut_hostname: hostname of a random chosen dut to run test.
            cfg_facts: pytest fixture
    
        Return:
            dict: port info for 3 selected ports
        '''
        # Select vlan for test
        vlans = cfg_facts['VLAN']
        vlan = [vlans[vlan]['vlanid'] for vlan in list(vlans.keys())][0]
    
        # Select 3 ports for test
        ports = cfg_facts['VLAN_MEMBER']['Vlan{}'.format(vlan)]
        port_names = [port_name for port_name in list(ports.keys()) if 'PortChannel' not in port_name]
>       selected_ports = [port_names[0], port_names[1], port_names[-1]]
E       IndexError: list index out of range

cfg_facts  = {'ACL_TABLE': {'DATAACL': {'policy_desc': 'DATAACL', 'ports': ['PortChannel101', 'PortChannel102', 'PortChannel103', '...'rate_limit_interval': '600', 'state': 'enabled'}, ...}, 'BGP_DEVICE_GLOBAL': {'STATE': {'tsa_enabled': 'false'}}, ...}
port_names = []
ports      = {'PortChannel201': {'tagging_mode': 'tagged'}}
vlan       = '101'
vlans      = {'Vlan101': {'dhcp_servers': ['192.0.0.1', '192.0.0.2', '192.0.0.3', '192.0.0.4'], 'dhcpv6_servers': ['fc02:2000::1', ...3', '192.0.0.4'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3', 'fc02:2000::4'], 'vlanid': '102'}}

span/conftest.py:44: IndexError
```
#### How did you do it?
When choose 3 physical ports from the vlan member,  if the first vlan don't have enough physical ports, then go to the next one, till the 3 physical ports can be found in on vlan.
#### How did you verify/test it?
Run the test case, and it could always pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
