### PR TITLE
MUX linkmgr table database states do NOT match expected state in dualtor_io test

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -33,7 +33,7 @@ ICMP_RESPONDER_CONF_TEMPL = "icmp_responder.conf.j2"
 GARP_SERVICE_PY = 'garp_service.py'
 GARP_SERVICE_CONF_TEMPL = 'garp_service.conf.j2'
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
-PROBER_INTERVAL_MS = 1000
+PROBER_INTERVAL_MS = 2000
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes randomly test failure in dualtor_io folder. High possibility with 7260 dual tor testbed.
Failure summary:
Failed: Database states don't match expected state active, incorrect STATE_DB values { "MUX_LINKMGR_TABLE|Ethernet192": { "state": "unhealthy" } }
Interface name and number varies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
7260 dualtor testbed dualtor_io test case failed:
MUX linkmgr table database states do NOT match expected state in dualtor_io test

#### How did you do it?
7260 has more port number than 7050. The mux probe icmp packet will be sent by each port. Due to icmp responder performance, the probe packet may be dropped.
So the fix will be: in the icmp responder, increase the prober interval from 1s to 2s.

#### How did you verify/test it?
Run nightly on 7260 dualtor testbed and didn't see the test failure again.

#### Any platform specific information?
7260 dualtor testbed.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
