### PR TITLE
Fix the timeout issue in test_cacl_function

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -105,7 +105,7 @@ logger -t cacltest "added cacl test rules"
 iptables -nL | logger -t cacltest
 
 # Sleep to allow Ansible playbook ample time to attempt to connect and timeout
-sleep 180
+sleep 150
 
 # Delete the test ACL config file
 rm -rf /tmp/testacl.json

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -64,7 +64,7 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                              state='stopped',
                              search_regex=SONIC_SSH_REGEX,
                              delay=30,
-                             timeout=60,
+                             timeout=40,
                              module_ignore_errors=True)
 
     pytest_assert(not res.is_failed, "SSH port did not stop. {}".format(res.get('msg', '')))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/8707 changed the timeout, but on physical testbed, cacl rules was effected immediately. test_cacl_function case failed because deleted time is too long, ssh connection is still timeout when running to the step of checking the good ssh connection.

The timestamp of running script: 07:10:52.94
cacl rules effected timestamp: 07:10:55.10, 2s later.

**Verify timeout when cacl rules exist:**
wait_for ssh stop: delay 30, timeout 40:
On physical testbed, this step costs 34s, because when it found can't connect to dut via ssh by delaying 30s, the return result is True. 
On virtual testbed, this step costs 70s. Not sure whether cacl rules are effected much slowly.

wait_for ssh start: delay 0, timeout 10:
On pysical testbed, this step costs 11s
On virtual testbed, this step costs 23s.

get_snmp_facts:
On pysical testbed, this step costs 31s
On virtual testbed, this step costs 35s.

So the shortest cacl effected time is 34+11+31=76s
the longest cacl effected time is 70+23+35 = 128s.


**Verify cacl rules are deleted**
wait_for ssh start: delay 0, timeout 90

So I set cacl deleted timeout to 150s, which is bigger than the longest cacl effected time 128s.
Even the shorted time + next timeout 90 = 86+90 = 166s > 150s, next wait_ssh start check will pass, because cacl is deleted by then.

```
Jul  3 07:10:52.943632 str2-7050cx3-acs-03 INFO python[111265]: ansible-command Invoked with _uses_shell=True _raw_params=nohup /tmp/config_service_acls.sh < /dev/null > /dev/null 2>&1 & warn=True stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
Jul  3 07:10:53.526068 str2-7050cx3-acs-03 INFO caclmgrd[103946]: ACL change detected for namespace ''
Jul  3 07:10:53.526300 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Spawning ACL update thread for namepsace '' ...
Jul  3 07:10:53.609850 str2-7050cx3-acs-03 NOTICE cacltest: added cacl test rules
Jul  3 07:10:53.616107 str2-7050cx3-acs-03 NOTICE cacltest: Chain INPUT (policy ACCEPT)
Jul  3 07:10:53.616275 str2-7050cx3-acs-03 NOTICE cacltest: target     prot opt source               destination         
Jul  3 07:10:53.616388 str2-7050cx3-acs-03 NOTICE cacltest: ACCEPT     all  --  127.0.0.1            0.0.0.0/0           
Jul  3 07:10:53.616481 str2-7050cx3-acs-03 NOTICE cacltest: ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
...   
Jul  3 07:10:53.619634 str2-7050cx3-acs-03 NOTICE cacltest: ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            TTL match TTL < 2
Jul  3 07:10:53.619732 str2-7050cx3-acs-03 NOTICE cacltest: 
Jul  3 07:10:53.619815 str2-7050cx3-acs-03 NOTICE cacltest: Chain FORWARD (policy ACCEPT)
Jul  3 07:10:53.619906 str2-7050cx3-acs-03 NOTICE cacltest: target     prot opt source               destination         
Jul  3 07:10:53.619993 str2-7050cx3-acs-03 NOTICE cacltest: 
Jul  3 07:10:53.620076 str2-7050cx3-acs-03 NOTICE cacltest: Chain OUTPUT (policy ACCEPT)
Jul  3 07:10:53.620169 str2-7050cx3-acs-03 NOTICE cacltest: target     prot opt source               destination         
Jul  3 07:10:54.027758 str2-7050cx3-acs-03 INFO caclmgrd[103946]: ACL config not stable for namespace '': 1 changes detected in the past 0.5 seconds. Skipping update ...
Jul  3 07:10:54.529432 str2-7050cx3-acs-03 INFO caclmgrd[103946]: ACL config for namespace '' has not changed for 0.5 seconds. Applying updates ...
Jul  3 07:10:54.564190 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Translating ACL rules for control plane ACL 'NTP_ACL' (service: 'NTP')
Jul  3 07:10:54.564480 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Translating ACL rules for control plane ACL 'SNMP_ACL' (service: 'SNMP')
Jul  3 07:10:54.564785 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Translating ACL rules for control plane ACL 'SSH_ONLY' (service: 'SSH')
Jul  3 07:10:54.588652 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Issuing the following iptables commands:
Jul  3 07:10:54.588939 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -P INPUT ACCEPT
...
Jul  3 07:10:54.595053 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT
Jul  3 07:10:54.595331 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT
Jul  3 07:10:54.595533 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -A INPUT -p udp --dport 67:68 -j ACCEPT
Jul  3 07:10:54.595829 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -p udp --dport 67:68 -j ACCEPT
...

Jul  3 07:10:54.609062 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -A INPUT -d 10.0.0.46/32 -j DROP
Jul  3 07:10:54.609292 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -d fc00::5c/128 -j DROP
Jul  3 07:10:54.609525 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -A INPUT -d 10.0.0.48/32 -j DROP
Jul  3 07:10:54.609758 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -d fc00::60/128 -j DROP
Jul  3 07:10:54.609989 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -A INPUT -m ttl --ttl-lt 2 -j ACCEPT
Jul  3 07:10:54.610305 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -p tcp -m hl --hl-lt 2 -j ACCEPT
Jul  3 07:10:54.610538 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   iptables -A INPUT -j DROP
Jul  3 07:10:54.610733 str2-7050cx3-acs-03 INFO caclmgrd[103946]:   ip6tables -A INPUT -j DROP
Jul  3 07:10:55.108235 str2-7050cx3-acs-03 INFO caclmgrd[103946]: Issuing the following iptables commands:
```
#### How did you do it?
Recalculate the timetout time for cacl_function based on the time data from physical and virtual testbed.

#### How did you verify/test it?
`cacl/test_cacl_function.py  PASSED                                                                   [100%]`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
