### PR TITLE
[Snappi] Config reload to stabilize DUT after container restart

### DIFF
--- a/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -7,6 +7,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
 from tests.common.snappi.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
     snappi_api, snappi_testbed_config       # noqa F401
 from tests.common.snappi.qos_fixtures import prio_dscp_map, lossless_prio_list      # noqa F401
+from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
 from .files.pfcwd_basic_helper import run_pfcwd_basic_test
@@ -304,6 +305,8 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
                          prio_dscp_map=prio_dscp_map,
                          trigger_pfcwd=trigger_pfcwd)
 
+    config_reload(duthost=duthost, config_source='minigraph', safe_reload=True)
+
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('restart_service', ['swss'])
@@ -363,3 +366,5 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
                          prio_list=lossless_prio_list,
                          prio_dscp_map=prio_dscp_map,
                          trigger_pfcwd=trigger_pfcwd)
+
+    config_reload(duthost=duthost, config_source='minigraph', safe_reload=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: After pfcwd tests that restarted the swss container, corresponding containers such as bgp, teamd, radv would also go down without recovering in RDMA nightly pipelines. The effect of these down containers would successively spread to future tests causing them to fail. Normally, the sanity checker in the pipeline will handle down containers and restart them as necessary, but due to the limitations of the sanity checker, they cannot be enabled on RDMA pipelines, hence the power to restart down containers after a test is not there, so this change acts to reload the containers after swss service restart tests for pfcwd.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Prevent successive test failure for RDMA pipelines when containers fail to be brought up again

#### How did you do it?
config reload the DUT safely after swss service restart tests

#### How did you verify/test it?
Tested on RDMA testbed in lab. Containers come back up after the test when container autorestart is disabled as in a pipeline.

```
admin@STR-8102:~$ docker ps 
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS               NAMES
b877f06c8159        docker-snmp:latest                "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            snmp
97ae0dccd69e        docker-sonic-telemetry:latest     "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            telemetry
fced3f4e7dc6        docker-vnet-monitor:latest        "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            vnet-monitor
899aef30bdc5        docker-dhcp-relay:latest          "/usr/bin/docker_ini…"   7 hours ago         Up 9 minutes                            dhcp_relay
f370b459ff84        docker-router-advertiser:latest   "/usr/bin/docker-ini…"   7 hours ago         Up 9 minutes                            radv
c36ee39b6e8c        docker-lldp:latest                "/usr/bin/docker-lld…"   7 hours ago         Up 9 minutes                            lldp
0d862592dfa4        docker-syncd-cisco:latest         "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            syncd
7fa1a0e98583        docker-teamd:latest               "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            teamd
244f048cc609        docker-fpm-frr:latest             "/usr/bin/docker_ini…"   7 hours ago         Up 9 minutes                            bgp
6d744139e52b        docker-orchagent:latest           "/usr/bin/docker-ini…"   7 hours ago         Up 9 minutes                            swss
a0b03bf36a67        docker-sonic-restapi:latest       "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            restapi
297de51466ac        docker-acms:latest                "/usr/local/bin/supe…"   7 hours ago         Up 9 minutes                            acms
a7019eae52aa        docker-platform-monitor:latest    "/usr/bin/docker_ini…"   7 hours ago         Up 9 minutes                            pmon
a12ec40307fa        docker-database:latest            "/usr/local/bin/dock…"   7 hours ago         Up 29 minutes                           database
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
