### PR TITLE
[202205][m0][route] Add support for m0-2vlan in test_route_perf

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -223,7 +223,7 @@ def test_perf_add_remove_routes(tbinfo, duthosts, enum_rand_one_per_hwsku_fronte
     # Number of routes for test
     set_num_routes = request.config.getoption("--num_routes")
     if set_num_routes is None:
-        topo_name = tbinfo["topo"]["name"]
+        topo_name = tbinfo["topo"]["type"]
         if topo_name in ["m0", "mx"]:
             set_num_routes = DEAFULT_M0_MX_NUM_ROUTES
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_route_perf failed at m0-2vlan topo

#### How did you do it?
Add support for m0-2vlan

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
