### PR TITLE
improve dhcpv6 test packets to cover option parse cases

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -28,6 +28,8 @@ DHCP6OptOptReq = scapy.layers.dhcp6.DHCP6OptOptReq
 DHCP6OptElapsedTime = scapy.layers.dhcp6.DHCP6OptElapsedTime
 DHCP6OptIA_NA = scapy.layers.dhcp6.DHCP6OptIA_NA
 DUID_LLT = scapy.layers.dhcp6.DUID_LLT
+DHCP6OptIfaceId = scapy.layers.dhcp6.DHCP6OptIfaceId
+DHCP6OptServerId = scapy.layers.dhcp6.DHCP6OptServerId
 
 
 class DataplaneBaseTest(BaseTest):
@@ -262,6 +264,7 @@ class DHCPTest(DataplaneBaseTest):
                                                      peeraddr=self.client_link_local)
         reply_relay_reply_packet /= DHCP6OptRelayMsg(
             message=[DHCP6_Reply(trid=12345)])
+        reply_relay_reply_packet /= DHCP6OptIfaceId(ifaceid=self.vlan_ip)
 
         return reply_relay_reply_packet
 
@@ -276,6 +279,7 @@ class DHCPTest(DataplaneBaseTest):
             msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         relay_forward_packet /= DHCP6OptRelayMsg(
             message=[DHCP6_Solicit(trid=12345)])
+        relay_forward_packet /= DHCP6OptElapsedTime(elapsedtime=0)
 
         return relay_forward_packet
 
@@ -287,6 +291,7 @@ class DHCPTest(DataplaneBaseTest):
         packet_inside = DHCP6_RelayForward(
             msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)])
+        packet_inside /= DHCP6OptElapsedTime(elapsedtime=0)
         relayed_relay_packet /= DHCP6_RelayForward(msgtype=12, hopcount=1, linkaddr=self.relay_linkaddr,
                                                    peeraddr=self.client_link_local)
         relayed_relay_packet /= DHCP6OptRelayMsg(message=[packet_inside])
@@ -304,6 +309,7 @@ class DHCPTest(DataplaneBaseTest):
         packet_inside = DHCP6_RelayReply(
             msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
+        relay_relay_reply_packet /= DHCP6OptServerId(duid=DUID_LLT(lladdr="00:11:22:33:44:55"))
         relay_relay_reply_packet /= DHCP6OptRelayMsg(message=[packet_inside])
 
         return relay_relay_reply_packet


### PR DESCRIPTION
### Description of PR
Improve dhcpv6_relay_test.py test packets, insert different options in different packets to cover more cases.
1. Add DHCP6OptServerId in Relay-Reply packets
2. Add DHCP6OptIfaceId in Relay-Reply packets
3. Add DHCP6OptElapsedTime relay-forward packets

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Improve dhcpv6 test cases to cover option parser logic and packet sanity tests.

Improve dhcpv6_relay_test.py test packets, insert different options in different packets to cover more cases.
1. Add DHCP6OptServerId in Relay-Reply packets
2. Add DHCP6OptIfaceId in Relay-Reply packets
3. Add DHCP6OptElapsedTime relay-forward packets

#### How did you do it?
Add DHCP6OptServerId, DHCP6OptIfaceId, DHCP6OptElapsedTime in relay-forward/relay-reply packets.

#### How did you verify/test it?
<img width="1074" alt="image" src="https://github.com/sonic-net/sonic-mgmt/assets/111116206/3a6f2d7d-fc8b-43a5-bddc-d7fe65a76c62">


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
