### PR TITLE
[sonic-mgmt/route/test_route_flap.py] Skip over routes for the IB interface when selecting the route to ping.

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -27,7 +27,7 @@ LOOP_TIMES_LEVEL_MAP = {
     'diagnose': 50
 }
 
-WAIT_EXPECTED_PACKET_TIMEOUT = 5
+WAIT_EXPECTED_PACKET_TIMEOUT = 15
 EXABGP_BASE_PORT = 5000
 NHIPV4 = '10.10.246.254'
 WITHDRAW = 'withdraw'
@@ -230,11 +230,15 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                         continue
                     if per_hop['ip'] in internal_bgp_ips:
                         continue
+                    if 'IB' in per_hop['interfaceName']:
+                        continue
                     dev_port = per_hop['interfaceName']
         else:
             dev = json.loads(asichost.run_vtysh(cmd)['stdout'])
             for per_hop in dev[route_to_ping][0]['nexthops']:
                 if 'interfaceName' not in per_hop.keys():
+                    continue
+                if 'IB' in per_hop['interfaceName']:
                     continue
                 dev_port = per_hop['interfaceName']
     pytest_assert(dev_port, "dev_port not exist")


### PR DESCRIPTION
### Description of PR

Fix issue #8821 by re-introducing the filtering of IB interface.  This was the previous route selection behavior before the recent addition of filtering for external nexthops.

Also increased the timeout on waiting for packets as this makes the test pass consistently in our t2 set-up.

Summary:
Fixes #8821

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Fix failing test for our multi-asic linecard by re-introducing the filtering out of routes with IB port.

#### How did you do it?

#### How did you verify/test it?
Ran the test with the fix in our t2 multi-asic set-up and verified it passed.

#### Any platform specific information?
Issue only occurs on multi-asic

#### Supported testbed topology if it's a new test case?

### Documentation

