### PR TITLE
Get peer fanout from the first interface on the dut connected to the …

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -165,7 +165,8 @@ def is_mellanox_fanout(duthost, localhost):
         logger.info("Get dut_facts failed, reason:{}".format(e.results['msg']))
         return False
 
-    fanout_host = dut_facts["device_conn"][duthost.hostname]["Ethernet0"]["peerdevice"]
+    intf = list(dut_facts["device_conn"][duthost.hostname].keys())[0]
+    fanout_host = dut_facts["device_conn"][duthost.hostname][intf]["peerdevice"]
 
     try:
         fanout_facts = \


### PR DESCRIPTION
### Description of PR
Get peer fanout from the first interface on the dut which is connected to the fanout instead of Ethernet0

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In is_mellanox_fanout definition interface Ethernet0 is hard coded as the interface that is connected to the fanout. 
This is fine for a T2 max topology since all interfaces are connected to a fanout.
For a T2 min topology if Ethernet0 is not used (not connected to a fanout), it will produce an error:

        fanout_host = dut_facts["device_conn"][duthost.hostname]["Ethernet0"]["peerdevice"]
        E       KeyError: 'Ethernet0'
 
Therefore, we should get the peer fanout from the first interface that is connected to a fanout.

#### How did you do it?
We get the peer fanout using the first interface that is connected to the fanout.

#### How did you verify/test it?
It was tested on multi ASICs T2 chassis with min topology and made sure the connected interface is not Ethernet0.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
