### PR TITLE
[mvrf]: Fastboot and Warm reboot is not supported for T2 profile(Cisco)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -634,6 +634,18 @@ mvrf:
     conditions:
       - "topo_type in ['m0', 'mx']"
 
+mvrf/test_mgmtvrf.py::TestReboot::test_warmboot:
+  skip:
+    reason: 'Warmboot is not supported on Cisco distributed chasiss for T2 profile'
+    conditions:
+      - "'t2' in topo_name and asic_type in ['cisco-8000']"
+
+mvrf/test_mgmtvrf.py::TestReboot::test_fastboot:
+  skip:
+    reason: 'Fastboot is not supported on Cisco distributed chasiss for T2 profile'
+    conditions:
+      - "'t2' in topo_name and asic_type in ['cisco-8000']"
+
 #######################################
 #####           nat               #####
 #######################################


### PR DESCRIPTION
Summary:
[mvrf]: Fastboot and Warm reboot is not supported for T2 profile on Cisco's distributed chassis

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
[mvrf]: Fastboot and Warm reboot is not supported for T2 profile on Cisco's distributed chassis

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
