### PR TITLE
Remove xfail condition mark for test_system_health

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -176,7 +176,7 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
     reason: "Copp test_trap_config_save_after_reboot is not yet supported on multi-asic platform or not supported after docker_inram enabled"
     conditions:
       - "is_multi_asic==True"
-      - "build_version > '20220531.27' and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
+      - "int(build_version.split('.')[1]) > 27 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
 
 #######################################
 #####            crm              #####
@@ -970,7 +970,7 @@ show_techsupport/test_techsupport.py::test_techsupport:
     strict: True
     conditions:
       - "branch in ['internal-202012']"
-      - "build_version <= '20201231.33'"
+      - "int(build_version.split('.')[1]) <= 33"
 
 #######################################
 #####            snmp             #####
@@ -1050,7 +1050,7 @@ syslog/test_syslog.py:
     reason: "Generic internal image issue"
     conditions:
       - "branch in ['internal-202012']"
-      - "build_version <= '20201231.33'"
+      - "int(build_version.split('.')[1]) <= 33"
 
 syslog/test_syslog_source_ip.py:
   skip:
@@ -1058,6 +1058,15 @@ syslog/test_syslog_source_ip.py:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/6479
 
+#######################################
+#####         system_health       #####
+#######################################
+system_health/test_system_health.py::test_service_checker_with_process_exit:
+  xfail:
+    strict: True
+    conditions:
+      - "branch in ['internal-202012']"
+      - "int(build_version.split('.')[1]) <= 44"
 
 #######################################
 #####           telemetry         #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1058,15 +1058,6 @@ syslog/test_syslog_source_ip.py:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/6479
 
-#######################################
-#####         system_health       #####
-#######################################
-system_health/test_system_health.py::test_service_checker_with_process_exit:
-  xfail:
-    strict: True
-    conditions:
-      - "branch in ['internal-202012']"
-      - "build_version <= '20201231.44'"
 
 #######################################
 #####           telemetry         #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
`system_health/test_system_health.py::test_service_checker_with_process_exit` is running to pass with latest 202012 image whatever platform is.
But from test result, it's still xfail, because the build_version is 20201231.105, string comparing with 20201231.44, it's smaller than 20201231.44.


#### How did you do it?
Split the version number and do compare then.

#### How did you verify/test it?
`system_health/test_system_health.py::test_service_checker_with_process_exit PASSED [100%]`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
