### PR TITLE
Adapting tests to run on T2 chassis by changing rand_one_dut_hostname

### DIFF
--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -13,8 +13,8 @@ TEST_FILE_2_NAME = "test_file_2.bin"
 BLOCK_SIZE = 500000000
 
 @pytest.fixture
-def setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup_teardown(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     # Copies script to DUT
     duthost.copy(src="scp/perform_scp.py", dest="/home/admin/perform_scp.py")
 
@@ -28,8 +28,10 @@ def setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
     for file in files_to_remove_2:
         ptfhost.file(path=file, state="absent")
 
-def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, creds):
-    duthost = duthosts[rand_one_dut_hostname]
+
+def test_scp_copy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_teardown, creds):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
     ptf_ip = ptfhost.mgmt_ip
 
     # Generate the file from /dev/urandom


### PR DESCRIPTION
### Description of PR
Enhance test_scp_copy.py to run on rand_one_dut_hostname(randomly selected dut). We need the test cases to run on both supervisor and the line card (per hwsku).

This PR is the same as PR #6880.  I created this PR due to Cherry Pick Conflict_202205. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Modified testcases to run on multi-dut.

#### How did you do it?
Replaced 'rand_one_dut_hostname' with 'enum_rand_one_per_hwsku_hostname'.

#### How did you verify/test it?
Ran test cases on a multi duts multi asics chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
