### PR TITLE
sonic-mgmt: Fix test_memory_checker.py test for low memory skus

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -34,7 +34,7 @@ CONTAINER_RESTART_THRESHOLD_SECS = 180
 CONTAINER_CHECK_INTERVAL_SECS = 1
 MONIT_RESTART_THRESHOLD_SECS = 320
 MONIT_CHECK_INTERVAL_SECS = 5
-WAITING_SYSLOG_MSG_SECS = 130
+WAITING_SYSLOG_MSG_SECS = 360
 
 
 def remove_container(duthost, container_name):
@@ -521,7 +521,7 @@ def test_memory_checker(duthosts, enum_dut_feature_container, test_setup_and_cle
     # and number of vm_workers is hard coded. We will extend this testing on all containers after
     # the feature 'memory_checker' is fully implemented.
     container_name = "telemetry"
-    vm_workers = 6
+    vm_workers = 2
 
     pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
                    and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
@@ -569,7 +569,7 @@ def test_monit_reset_counter_failure(duthosts, enum_dut_feature_container, test_
     # and number of vm_workers is hard coded. We will extend this testing on all containers after
     # the feature 'memory_checker' is fully implemented.
     container_name = "telemetry"
-    vm_workers = 6
+    vm_workers = 2
 
     pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
                    and ("20201231" in duthost.os_version or parse_version(duthost.kernel_version) > parse_version("4.9.0")),

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -620,7 +620,7 @@ def test_monit_new_syntax(duthosts, enum_dut_feature_container, test_setup_and_c
     # and number of vm_workers is hard coded. We will extend this testing on all containers after
     # the feature 'memory_checker' is fully implemented.
     container_name = "telemetry"
-    vm_workers = 6
+    vm_workers = 2
 
     pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
                    and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The test_memory_checker.py test tries to consume >400MB of RAM in the telemetry container using 'stress -m 6' which by default mallocs 6*256MB.

With docker in ram on a system with 4GB of RAM there is limited available memory and we can no longer malloc 6*256MB.

Instead, modify the test to use 2 vm_workers which results in 'stress -m 2' which gets us over the 400MB limit that is being checked by monit and the config is in /etc/monit/conf.d/monit_telemetry. The test also does not wait long enough before checking that the expected log messages are available in syslog. Increase the time before checking syslog from 130sec to 360sec. In testing it can take ~3min30sec for the logs to appear.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #8642

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_memory_checker.py that is failing on 7050QX platform with docker in ram.

#### How did you do it?
As per description, modify the test to consume memory within the bounds of the available memory on a 4GB RAM system using docker in ram.

#### How did you verify/test it?
Verify that the test test_memory_checker.py is passing on 202205 sonic mgmt + 202205 swi.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
