### PR TITLE
Vxlan ECMP test failure in python3 env.

### DIFF
--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -266,8 +266,14 @@ class Ecmp_Utils(object):
             # If the given address is "net.1", the return address is "net.101"
             # THE ASSUMPTION HERE IS THAT THE DUT ADDRESSES ARE ENDING IN ".1".
             # addr.decode is only in python2.7
-            ptf_ip = str(ip_address(addr.decode())+100)
-
+            ptf_ip = ""
+            if  hasattr(addr, 'decode'):
+                #python 2.7
+                ptf_ip = str(ip_address(addr.decode())+100)
+            else:
+                #python 3
+                ptf_ip = str(ip_address(addr)+100)
+            
             if "Ethernet" in intf:
                 return_dict[intf] = ptf_ip
             elif "PortChannel" in intf:

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -273,7 +273,7 @@ class Ecmp_Utils(object):
             else:
                 # python 3
                 ptf_ip = str(ip_address(addr)+100)
-            
+
             if "Ethernet" in intf:
                 return_dict[intf] = ptf_ip
             elif "PortChannel" in intf:

--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -267,11 +267,11 @@ class Ecmp_Utils(object):
             # THE ASSUMPTION HERE IS THAT THE DUT ADDRESSES ARE ENDING IN ".1".
             # addr.decode is only in python2.7
             ptf_ip = ""
-            if  hasattr(addr, 'decode'):
-                #python 2.7
+            if hasattr(addr, 'decode'):
+                # python 2.7
                 ptf_ip = str(ip_address(addr.decode())+100)
             else:
-                #python 3
+                # python 3
                 ptf_ip = str(ip_address(addr)+100)
             
             if "Ethernet" in intf:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR fixes the issue which is caused when the decode function is called on a string in python3. There is no decode function implemented in python3 as strings in python3 are by default unicode. This results in an exception.
This change checks if the decode function is present. i.e python2.7 then calls it otherwise skips it.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
