### PR TITLE
Change reload source in module `autorestart/test_container_autorestart.py`.

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -40,7 +40,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True)
 
 
 def enable_autorestart(duthost):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is a config reload in module `autorestart/test_container_autorestart.py` and previously it reload from `running_golden_config`. This source will add BREAKOUT_CFG in running config and cause another reload in the teardown period of this module. In this PR, we change the reload source from `running_golden_config` to `config_db`, which will avoid unnecessary reload and save running time. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
There is a config reload in module `autorestart/test_container_autorestart.py` and previously it reload from `running_golden_config`. This source will add BREAKOUT_CFG in running config and cause another reload in the teardown period of this module. In this PR, we change the reload source from `running_golden_config` to `config_db`, which will avoid unnecessary reload and save running time. 

#### How did you do it?
Change reload source from `running_golden_config` to `config_db`.

#### How did you verify/test it?
```
03:59:08 conftest.core_dump_and_config_check      L2131 INFO   | Core dump and config check passed for autorestart/test_container_autorestart.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
