### PR TITLE
[qos][doble commit] th2 qos parameter for 100000_300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -2082,6 +2082,86 @@ qos_params:
                     pkts_num_trig_ingr_drp: 5140
                     pkts_num_fill_egr_min: 16
                     cell_size: 208
+            100000_300m:
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7]
+                    dst_port_id: 0
+                    pgs_num: 14
+                    pkts_num_trig_pfc: 1826
+                    pkts_num_hdrm_full: 682
+                    pkts_num_hdrm_partial: 542
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4457
+                    pkts_num_trig_ingr_drp: 5140
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 5140
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 4457
+                    pkts_num_trig_ingr_drp: 5140
+                    pkts_num_fill_egr_min: 16
+                    cell_size: 208
             xon_1:
                 dscp: 3
                 ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

double commit PR https://github.com/sonic-net/sonic-mgmt/pull/8815

test_xoff_for_pcbb hit failure as below:
```
>       return qos_configs['qos_params'][dut_asic][dut_topo][profile_name]
E       KeyError: u'100000_300m'
```
RCA:
miss th2's qos parameter for "100000_300m".

#### How did you do it?

add th2 qos parameter for 100000_300m

#### How did you verify/test it?

pass local test:
```
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1] PASSED     [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2] PASSED     [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED     [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb
```

#### Any platform specific information?

just for broadcom th2 platform



#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
