### PR TITLE
Enable `icmp_responder` on session level for `dualtor` topology

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -235,9 +235,9 @@ icmp_responder_session_started = False
 def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
     """Run icmp_responder on ptfhost session-wise on dualtor testbeds with active-active ports."""
     # No vlan is available on non-t0 testbed, so skip this fixture
-    if "dualtor-mixed" not in tbinfo["topo"]["name"] and "dualtor-aa" not in tbinfo["topo"]["name"]:
+    if "dualtor" not in tbinfo["topo"]["name"]:
         logger.info("Skip running icmp_responder at session level, "
-                    "it is only for dualtor testbed with active-active mux ports.")
+                    "it is only for dualtor testbed.")
         yield
         return
 
@@ -269,8 +269,17 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    # NOTE: Leave icmp_responder running for dualtor-mixed topology
-    return
+    if "dualtor-mixed" in tbinfo["topo"]["name"] or "dualtor-aa" in tbinfo["topo"]["name"]:
+        logger.info("Leave icmp_responder running for dualtor-mixed/dualtor-aa topology")
+        return
+
+    logger.info("Stop running icmp_responder")
+    ptfhost.shell("supervisorctl stop icmp_responder")
+    icmp_responder_session_started = False
+
+    logger.info("Recover linkmgrd probe interval")
+    recover_linkmgrd_probe_interval(duthosts, tbinfo)
+    duthosts.shell("config save -y")
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is a part of fixes for `dualtor_io` flaky tests. Observed mux flaps before tests start. It is because for acitve-standby dualtors, icmp_responder is started by `run_icmp_reponder` fixture which runs on module level. 

To make sure icmp_responder consistently functions, I'm enabling it from session level now. 

Notice: 
For active-active and mixed topo, icmp_responder starts at session level, and remains running at end of test.  
For active-standby topo, icmp_responder starts at session level, and stops at end of test, 
For other cases, icmp_responder is handled by `run_icmp_responder` which runs on module level. 

sign-off: Jing Zhang zhangjing@microsoft.com 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run test_normal_op tests on dualtor-aa topo and dualtor topo. 
```
[dualtor-aa]
22:50:55 ptfhost_utils.run_icmp_responder_session L0252 INFO   | Start running icmp_responder
22:52:03 ptfhost_utils.run_icmp_responder         L0298 INFO   | icmp_responder is already running.
23:00:18 ptfhost_utils.run_icmp_responder_session L0272 INFO   | Leave icmp_responder running for dualtor-mixed/dualtor-aa topology

[dualtor]
23:03:42 ptfhost_utils.run_icmp_responder_session L0246 INFO   | Start running icmp_responder
23:05:56 ptfhost_utils.run_icmp_responder         L0292 INFO   | icmp_responder is already running.
23:12:15 ptfhost_utils.run_icmp_responder_session L0269 INFO   | Stop running icmp_responder
23:12:17 ptfhost_utils.run_icmp_responder_session L0273 INFO   | Recover linkmgrd probe interval
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
