### PR TITLE
update traffic disruption validating logic for dualtor_io tests

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -100,12 +100,14 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay, allow_disruption
                             "Maximum allowed disruption: {}s"
                             .format(server_ip, longest_disruption, delay))
 
-        if total_duplications > allowed_disruption and _validate_long_disruption(result['disruptions'], allowed_disruption, delay):
+        if total_duplications > allowed_disruption and _validate_long_disruption(result['disruptions'],
+                                                                                 allowed_disruption, delay):
             failures.append("Traffic to server {} was duplicated {} times. "
                             "Allowed number of duplications: {}"
                             .format(server_ip, total_duplications, allowed_disruption))
 
-        if longest_duplication > delay and _validate_long_disruption(result['duplications'], allowed_disruption, delay):
+        if longest_duplication > delay and _validate_long_disruption(result['duplications'],
+                                                                     allowed_disruption, delay):
             failures.append("Traffic on server {} was duplicated for {}s. "
                             "Maximum allowed duplication: {}s"
                             .format(server_ip, longest_duplication, delay))
@@ -131,7 +133,7 @@ def _validate_long_disruption(disruptions, allowed_disruption, delay):
 
         disruption_length = disruption['end_time'] - disruption['start_time']
         allowed_disruption -= math.ceil(disruption_length/delay)
-        
+
         if allowed_disruption < 0:
             return True
     return False

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -95,13 +95,13 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay, allow_disruption
                             "disrupted {} times. Allowed number of disruptions: {}"
                             .format(server_ip, total_disruptions, allowed_disruption))
 
-        if longest_disruption > delay:
+        if longest_disruption > delay and _validate_long_disruption(result['disruptions'],
+                                                                    allowed_disruption, delay):
             failures.append("Traffic on server {} was disrupted for {}s. "
                             "Maximum allowed disruption: {}s"
                             .format(server_ip, longest_disruption, delay))
 
-        if total_duplications > allowed_disruption and _validate_long_disruption(result['disruptions'],
-                                                                                 allowed_disruption, delay):
+        if total_duplications > allowed_disruption:
             failures.append("Traffic to server {} was duplicated {} times. "
                             "Allowed number of duplications: {}"
                             .format(server_ip, total_duplications, allowed_disruption))
@@ -134,6 +134,7 @@ def _validate_long_disruption(disruptions, allowed_disruption, delay):
         disruption_length = disruption['end_time'] - disruption['start_time']
         allowed_disruption -= math.ceil(disruption_length/delay)
 
+        logger.debug("disruption_length: {}, allowed_disruption: {}".format(disruption_length, allowed_disruption))
         if allowed_disruption < 0:
             return True
     return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For some `test_link_drop` cases we saw test failures due to two continuous disruptions combined as one. 

This PR updates verification logic for long disruptions. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run test_link_drop cases.  `disruption_length=11.6447122097` (which is greated than 10s), didn't cause test failure. 

```
21:24:49 data_plane_utils.validate_traffic_result L0087 INFO   | Server 192.168.0.19 summary:
{
    "disruption_after_traffic": false, 
    "disruption_before_traffic": false, 
    "longest_disruption": 11.644712209701538, 
    "longest_duplication": 0, 
    "received_packet_diff": -74, 
    "received_packets": 551, 
    "total_disruptions": 2, 
    "total_duplications": 0
}
21:24:49 data_plane_utils._validate_long_disrupti L0139 INFO   | disruption_length: 7.58572387695, allowed_disruption: 2.0
21:24:49 data_plane_utils._validate_long_disrupti L0139 INFO   | disruption_length: 11.6447122097, allowed_disruption: 0.0
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
