### PR TITLE
fix test_tunnel_decap_dscp_to_pg_mapping failure caused by unknonw asic name

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1655,7 +1655,7 @@ Totals               6450                 6449
         if ("Broadcom Limited Device b960" in output or
                 "Broadcom Limited Broadcom BCM56960" in output):
             asic = "th"
-        elif "Broadcom Limited Device b971" in output:
+        elif "Device b971" in output:
             asic = "th2"
         elif ("Broadcom Limited Device b850" in output or
                 "Broadcom Limited Broadcom BCM56850" in output):

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -500,6 +500,7 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
     """
     toggle_mux_to_host(rand_selected_dut)
     asic = rand_selected_dut.get_asic_name()
+    pytest_assert(asic != 'unknown', 'Get unknown asic name')
     # TODO: Get the cell size for other ASIC
     if asic == 'th2':
         cell_size = 208


### PR DESCRIPTION
…ic name

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

hit test_tunnel_decap_dscp_to_pg_mapping failure on testbed "vms21-dual-t0-7260", as below:

```
"/root/env-python3/bin/ptf",
"--test-dir",
"saitests/py3",
"sai_qos_tests.TunnelDscpToPgMapping",
"--platform-dir",
"ptftests",
"--platform",
"remote",
"-t",
"platform_asic=u'broadcom';cell_size=256;inner_dscp_to_pg_map={0: 0, 1: 0, 2: 0, 3: 2, 4: 6, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0, 11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0, 21: 0, 22: 0, 23: 0, 24: 0, 25: 0, 26: 0, 27: 0, 28: 0, 29: 0, 30: 0, 31: 0, 32: 0, 33: 0, 34: 0, 35: 0, 36: 0, 37: 0, 38: 0, 39: 0, 40: 0, 41: 0, 42: 0, 43: 0, 44: 0, 45: 0, 46: 0, 47: 0, 48: 0, 49: 0, 50: 0, 51: 0, 52: 0, 53: 0, 54: 0, 55: 0, 56: 0, 57: 0, 58: 0, 59: 0, 60: 0, 61: 0, 62: 0, 63: 0};src_port_id=132;dst_port_ip=u'192.168.0.39';active_tor_ip=u'10.1.0.32';standby_tor_mac=u'98:5d:82:23:b2:f8';src_server=u'10.3.146.129:9092';standby_tor_ip=u'10.1.0.33';active_tor_mac=u'd4:af:f7:7b:d5:a8';sonic_asic_type=u'broadcom';dst_port_id=82;port_map_file_ini='/root/default_interface_to_front_map.ini'",
"--disable-ipv6",
"--disable-vxlan",
"--disable-geneve",
"--disable-erspan",
"--disable-mpls",
"--disable-nvgre",
"--log-file",
"/tmp/sai_qos_tests.TunnelDscpToPgMapping.log",
"--test-case-timeout",
"600"], "delta": "0:00:32.040626",
"end": "2023-07-03 21:15:09.238297",
"failed": true, "msg": "non-zero return code",
"rc": 1, "start": "2023-07-03 21:14:37.197671",
"stderr": "/root/env-python3/bin/ptf:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
sai_qos_tests.TunnelDscpToPgMapping ... FAIL

======================================================================
FAIL: sai_qos_tests.TunnelDscpToPgMapping
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1057, in runTest
    assert(pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg] >= (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size)
AssertionError
```


RCA:

incorrect cell_size value cause watermark checking failue.
for testbed vms21-dual-t0-7260, asic is "th2", cell_size should be 208 instead of 256.

The reason of using 256 as cell size for TunnelDscpToPgMapping test is unknow asic name, and selected a default cell size. As below:

command output don't meet detecting rule "Broadcom Limited Device b971":

```
admin@str2-7260cx3-acs-10:~$ lspci | grep -i broadcom
01:00.0 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM57762 Gigabit Ethernet PCIe (rev 20)
02:00.0 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM57762 Gigabit Ethernet PCIe (rev 20)
07:00.0 Ethernet controller: Broadcom Inc. and subsidiaries Device b971 (rev 11)
07:00.1 Ethernet controller: Broadcom Inc. and subsidiaries Device b971 (rev 11)
```



#### How did you do it?

- assert unknown asic name
- update asic th2's detecting condition, to get correct asic name

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
