### PR TITLE
Set key "asic0" in single-asic scenerio to keep consistent with multi-asic in function `core_dump_and_config_check`.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1862,7 +1862,7 @@ def __dut_reload(duts_data, node=None, results=None):
         logger.error('Missing kwarg "node" or "results"')
         return
     logger.info("dut reload called on {}".format(node.hostname))
-    node.copy(content=json.dumps(duts_data[node.hostname]["pre_running_config"][None], indent=4),
+    node.copy(content=json.dumps(duts_data[node.hostname]["pre_running_config"]["asic0"], indent=4),
               dest='/etc/sonic/config_db.json', verbose=False)
 
     if node.is_multi_asic:
@@ -1943,7 +1943,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             if not duthost.stat(path="/etc/sonic/running_golden_config.json")['stat']['exists']:
                 logger.info("Collecting running golden config before test on {}".format(duthost.hostname))
                 duthost.shell("sonic-cfggen -d --print-data > /etc/sonic/running_golden_config.json")
-            duts_data[duthost.hostname]["pre_running_config"][None] = \
+            duts_data[duthost.hostname]["pre_running_config"]["asic0"] = \
                 json.loads(duthost.shell("cat /etc/sonic/running_golden_config.json", verbose=False)['stdout'])
 
             if duthost.is_multi_asic:
@@ -1982,7 +1982,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             logger.info("Collecting running config after test on {}".format(duthost.hostname))
             # get running config after running
             duts_data[duthost.hostname]["cur_running_config"] = {}
-            duts_data[duthost.hostname]["cur_running_config"][None] = \
+            duts_data[duthost.hostname]["cur_running_config"]["asic0"] = \
                 json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
             if duthost.is_multi_asic:
                 for asic_index in range(0, duthost.facts.get('num_asic')):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR (https://github.com/sonic-net/sonic-mgmt/pull/6527), it enhanced function `core_dump_and_config_check` to be multi-asic aware. But in single-asic scenerio, it simply set the key None, which does not make scene. In this PR, I reset the key "asic0" in single-asic scenerio to keep consistent with the key value of multi-asic scenerio. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR (https://github.com/sonic-net/sonic-mgmt/pull/6527), it enhanced function `core_dump_and_config_check` to be multi-asic aware. But in single-asic scenerio, it simply set the key None, which does not make scene. In this PR, I reset the key "asic0" in single-asic scenerio to keep consistent with the key value of multi-asic scenerio. 

#### How did you do it?
Change the key in single-asic scenerio from `None` to `asic0`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
