### PR TITLE
Enable TACACS accounting UT on 202012 branch

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -7,8 +7,9 @@ import pytest
 
 
 from .test_authorization import ssh_connect_remote, ssh_run_command, \
-        per_command_check_skip_versions, remove_all_tacacs_server
-from .utils import stop_tacacs_server, start_tacacs_server, check_server_received
+        remove_all_tacacs_server
+from .utils import stop_tacacs_server, start_tacacs_server, \
+        check_server_received, per_command_accounting_skip_versions
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
@@ -141,7 +142,7 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_release(duthost, per_command_check_skip_versions)
+    skip_release(duthost, per_command_accounting_skip_versions)
 
 
 def test_accounting_tacacs_only(

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -4,7 +4,8 @@ import pytest
 from _pytest.outcomes import Failed
 
 from tests.tacacs.utils import stop_tacacs_server, start_tacacs_server
-from tests.tacacs.utils import per_command_check_skip_versions, remove_all_tacacs_server, get_ld_path
+from tests.tacacs.utils import per_command_authorization_skip_versions, \
+        remove_all_tacacs_server, get_ld_path
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
 from .utils import check_server_received
@@ -107,7 +108,7 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_release(duthost, per_command_check_skip_versions)
+    skip_release(duthost, per_command_authorization_skip_versions)
 
 
 @pytest.fixture

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -11,11 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 # per-command authorization feature not available in following versions
-per_command_check_authorization_skip_versions = ["201811", "201911", "202012", "202106"]
+per_command_authorization_skip_versions = ["201811", "201911", "202012", "202106"]
 
 
 # per-command accounting feature not available in following versions
-per_command_check_accounting_skip_versions = ["201811", "201911", "202106"]
+per_command_accounting_skip_versions = ["201811", "201911", "202106"]
 
 
 def check_output(output, exp_val1, exp_val2):

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -10,8 +10,12 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 
-# per-command authorization and accounting feature not available in following versions
-per_command_check_skip_versions = ["201811", "201911", "202012", "202106"]
+# per-command authorization feature not available in following versions
+per_command_check_authorization_skip_versions = ["201811", "201911", "202012", "202106"]
+
+
+# per-command accounting feature not available in following versions
+per_command_check_accounting_skip_versions = ["201811", "201911", "202106"]
 
 
 def check_output(output, exp_val1, exp_val2):
@@ -72,9 +76,12 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     # enable tacacs+
     duthost.shell("sudo config aaa authentication login tacacs+")
 
-    (skip, _) = check_skip_release(duthost, per_command_check_skip_versions)
+    (skip, _) = check_skip_release(duthost, per_command_authorization_skip_versions)
     if not skip:
         duthost.shell("sudo config aaa authorization local")
+
+    (skip, _) = check_skip_release(duthost, per_command_accounting_skip_versions)
+    if not skip:
         duthost.shell("sudo config aaa accounting disable")
 
     # setup local user
@@ -221,9 +228,12 @@ def cleanup_tacacs(ptfhost, tacacs_creds, duthost):
     ]
     duthost.shell_cmds(cmds=cmds)
 
-    (skip, _) = check_skip_release(duthost, per_command_check_skip_versions)
+    (skip, _) = check_skip_release(duthost, per_command_authorization_skip_versions)
     if not skip:
         duthost.shell("sudo config aaa authorization local")
+
+    (skip, _) = check_skip_release(duthost, per_command_accounting_skip_versions)
+    if not skip:
         duthost.shell("sudo config aaa accounting disable")
 
     duthost.user(


### PR DESCRIPTION
Enable TACACS accounting UT on 202012 branch

### Description of PR
Enable TACACS accounting UT on 202012 branch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
TACACS per-command accounting will be backport to 202012 branch, so enable related UT on 202012.

#### How did you do it?
Remove 202012 branch from TACACS UT skip list

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
