### PR TITLE
[202205] Fix regression in test_reload_config.py

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -27,7 +27,7 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     """
     @summary: This test case is to reload the configuration and check platform status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     asic_type = duthost.facts["asic_type"]
 
@@ -81,7 +81,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     """
     @summary: This test case is to test various system checks in config reload
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     if not config_force_option_supported(duthost):
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes regression caused by PR https://github.com/sonic-net/sonic-mgmt/pull/8843
```
>       duthost = duthosts[rand_one_dut_hostname]
E       NameError: global name 'rand_one_dut_hostname' is not defined
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix regression caused by PR https://github.com/sonic-net/sonic-mgmt/pull/8843.

#### How did you do it?
Replace `rand_one_dut_hostname` with `enum_rand_one_per_hwsku_hostname`.

#### How did you verify/test it?
Verified on a Mellanox testbed. The test can pass after this change.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
