### PR TITLE
Stability of Voq tests (#4951, #4953)

### DIFF
--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -96,6 +96,9 @@ class FanoutHost(object):
 
         return self.host.no_shutdown(interface_name)
 
+    def check_intf_link_state(self, interface_name):
+        return self.host.check_intf_link_state(interface_name)
+
     def __str__(self):
         return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1217,6 +1217,10 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
 
         return True
 
+    def check_intf_link_state(self, interface_name):
+        intf_status = self.show_interface(command="status", interfaces=[interface_name])["ansible_facts"]['int_status']
+        return intf_status[interface_name]['oper_state'] == 'up'
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info

--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -199,6 +199,10 @@ def delete_lag_members_ip(duthost, asic, portchannel_members,
     """
     deletes lag members and ip
     """
+    if portchannel_ip:
+        duthost.shell("config interface {} ip remove {} {}"
+                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
+
     logging.info('Deleting lag members {} from lag {} on dut {}'
                  .format(portchannel_members, portchannel, duthost.hostname))
     for member in portchannel_members:
@@ -206,10 +210,7 @@ def delete_lag_members_ip(duthost, asic, portchannel_members,
                       .format(asic.cli_ns_option, portchannel, member))
 
     if portchannel_ip:
-        duthost.shell("config interface {} ip remove {} {}"
-                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
-
-        pytest_assert(wait_until(30,5, 0, verify_lag_interface, duthost, asic, portchannel, expected=False),
+        pytest_assert(wait_until(30, 5, 0, verify_lag_interface, duthost, asic, portchannel, expected=False),
                       'For deleted Portchannel {} ip link is not down'.format(portchannel))
 
 

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -681,7 +681,10 @@ class TestVoqIPFwd(object):
         check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_lb',
                      dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
 
-    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456), (1, 1456)])
+    @pytest.mark.parametrize('ttl, size', [(2, 64),
+                                           pytest.param(128, 64, marks=pytest.mark.express),
+                                           (255, 1456),
+                                           (1, 1456)])  # (1, 1500), ,(255, 1500), (128, 64), (128, 9000) (1, 1456)
     @pytest.mark.parametrize('version', [4, 6])
     @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
     def test_voq_inband_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts, tbinfo):

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -841,6 +841,9 @@ class LinkFlap(object):
         logging.info("status: %s", status)
         return status[dut_intf]['oper_state'] == exp_status
 
+    def check_fanout_link_state(self, fanout, fanout_port):
+        return fanout.check_intf_link_state(fanout_port)
+
     def linkflap_down(self, fanout, fanport, dut, dut_intf):
         """
         Brings down an interface on a fanout and polls the DUT for the interface to be operationally down.
@@ -883,6 +886,8 @@ class LinkFlap(object):
             sleep_time = 90
         pytest_assert(wait_until(sleep_time, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        pytest_assert(wait_until(30, 1, 0, self.check_fanout_link_state, fanout, fanport),
+                      "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
 
     def localport_admindown(self, dut, asic, dut_intf):
         """
@@ -902,7 +907,7 @@ class LinkFlap(object):
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'down'),
                       "dut port {} didn't go down as expected".format(dut_intf))
 
-    def localport_adminup(self, dut, asic, dut_intf):
+    def localport_adminup(self, dut, asic, dut_intf, fanouthosts):
         """
         Admins up a port on the DUT and polls for oper status to be up.
 
@@ -919,6 +924,13 @@ class LinkFlap(object):
         asic.startup_interface(dut_intf)
         pytest_assert(wait_until(30, 1, 0, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
+        if "portchannel" not in dut_intf.lower():
+            # Wait for fanout port to be operationally up as well.
+            fanout, fanport = fanout_switch_port_lookup(fanouthosts, dut.hostname, dut_intf)
+            pytest_assert(wait_until(30, 1, 0, self.check_fanout_link_state, fanout, fanport),
+                          "fanout port {} on {} didn't go up as expected".format(fanport, fanout.hostname))
+
+        time.sleep(2)
 
 
 
@@ -1009,7 +1021,7 @@ class TestNeighborLinkFlap(LinkFlap):
             try:
                 check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
             finally:
-                self.localport_adminup(per_host, asic, intf)
+                self.localport_adminup(per_host, asic, intf, fanouthosts)
 
             for neighbor in neighbors:
                 sonic_ping(asic, neighbor, verbose=True)

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -954,8 +954,9 @@ def pick_ports(cfg_facts):
 
 class TestNeighborLinkFlap(LinkFlap):
 
-    def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                                        all_cfg_facts, setup, teardown, nbrhosts, nbr_macs, established_arp):
+    def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                        enum_rand_one_frontend_asic_index, all_cfg_facts, setup, teardown,
+                                        nbrhosts, nbr_macs, established_arp, fanouthosts):
         """
         Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
 


### PR DESCRIPTION
Stability of Voq tests (#4951, #4953) (#8468)

* Stability of Voq tests (#4951, #4953)

- Removed down/up interface from bash
- Check operational status of ports on fanout when we bring up ports on DUT as part of link flap

    This is the fix for SON-386, where we are sometimes seeing 5-6 seconds delay before
    which the ping to the neighbor works after the port on the DUT is brought up as
    part of the voq link flap tests.

    Currently, when we bring the link up on either the DUT or the fanout, we would
    only check if the link is up on the DUT.

    What we see is that even though the DUT (egl port) becomes operationally up, the remote
    peer (H3 port) doesn't become operationally up right away at the same time. It seems to take
    2-6 seconds more than the eagle port. If the port is not up on the fanout, then the packets from
    the DUT is not forwarded to the testbed server, and thus the ping fails.

    Fix is to check the link status on the fanout port as well, whenever we bring a port up.

- Use regular expression to handle new feild in the output of "ip route"

- Fixes to voq_nbr tests based on new kernel and removal of ENCAP_IMPOSE_INDEX
  -  With the latest kernel (version: 5.10.0-8-2-amd64 - bullseye), when a link goes down, the arp entries learnt on that link are immediately removed, and thus also removed from the local asic and app db. This was not the case with linux kernel version 4.19. Thus, in test_front_panel_linkflap_ports, we need to now - check that the neighbor entries are gone from local and remote asics when the link on the fanout is brought down. Up - Upon recovery, need to ping the local neighbor to allow for the arp and entries to re-added.
   - With latest github code, the 'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX' is removed from 'SAI_OBJECT_TYPE_NEIGHBOR_ENTRY' in the asic_db. - Remove validation based on this field from voq_helpers.py

- Poll for arp entries deleted on all asics when neighbor goes down
- Use wait_until in poll_neighbor_table_delete in voq tests
- When checking local arp entries present, just check if the ip neigh entry is present, and ignore the state.

- Adding enum_rand_one_frontend_asic_index to select one of the frontend asics

  Some tests (like tests in voq/test_voq_nbr) were being repeating for all the asics in a multi-asic linecard. However, test coverage is the same on all the asics. So, need capability to run the test only on a randomly selected asic from all the frontend asics.

  There was already enum_rand_one_asic_index, but that would include both frontend and backend asics

- Fixed voq_ip_fwd tests to be the same as before rebase

- Added enum_rand_one_frontend_asic_index fixure

* Fixed flake8 issues - PR# 8468

---------

Co-authored-by: sanmalho <sandeep.malhotra@nokia.com>

(cherry picked from commit 9a5f20c4bee254d4e8c16b2ff9080835ff68b7f6)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
