### PR TITLE
[test_power_off_reboot.py] add missing fixture

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
+import tests.common.fixtures.conn_graph_facts
 from tests.common.reboot import wait_for_startup, REBOOT_TYPE_POWEROFF
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -31,7 +31,7 @@ def set_max_time_for_interfaces(duthost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def teardown_module(duthosts, enum_supervisor_dut_hostname, xcvr_skip_list):
+def teardown_module(duthosts, enum_supervisor_dut_hostname, conn_graph_facts, xcvr_skip_list):
     duthost = duthosts[enum_supervisor_dut_hostname]
     yield
 

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 import time
 
-import tests.common.fixtures.conn_graph_facts
 from tests.common.reboot import wait_for_startup, REBOOT_TYPE_POWEROFF
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -61,7 +61,7 @@ def _power_off_reboot_helper(kwargs):
         pdu_ctrl.turn_on_outlet(outlet)
 
 
-def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
+def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, conn_graph_facts,
                           set_max_time_for_interfaces, xcvr_skip_list, pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
this is to fix regression caused by https://github.com/sonic-net/sonic-mgmt/pull/8646

cherry pick PR of https://github.com/sonic-net/sonic-mgmt/pull/8646 is https://github.com/sonic-net/sonic-mgmt/pull/8892 which already has the fix in current PR.

regression:
```
platform_tests/test_power_off_reboot.py::test_power_off_reboot[5-str2-7050cx3-acs-02] 
-------------------------------- live log call ---------------------------------
12:40:46 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/azp/_work/78/s/tests/platform_tests/test_power_off_reboot.py", line 124, in test_power_off_reboot
    raise e
TypeError: 'function' object has no attribute '__getitem__'

```

after:
```
PASSED                                                                                                                                                                                       [ 50%]
platform_tests/test_power_off_reboot.py::test_power_off_reboot[15-str2-7050cx3-acs-02]
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
