### PR TITLE
Delete interfaces admin_state after module `vlan/test_autostate_disabled.py` running. 

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -929,7 +929,10 @@ def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
     return original_value
 
 
-def delete_running_config(config_entry, duthost):
-    duthost.copy(src=json.dumps(config_entry, indent=4), dest="/tmp/del_config_entry.json")
+def delete_running_config(config_entry, duthost, is_json=True):
+    if is_json:
+        duthost.copy(content=json.dumps(config_entry, indent=4), dest="/tmp/del_config_entry.json")
+    else:
+        duthost.copy(scr=config_entry, dest="/tmp/del_config_entry.json")
     duthost.shell("configlet -d -j {}".format("/tmp/del_config_entry.json"))
-    # duthost.shell("rm -f {}".format("/tmp/del_config_entry.json"))
+    duthost.shell("rm -f {}".format("/tmp/del_config_entry.json"))

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -927,3 +927,9 @@ def update_pfcwd_default_state(duthost, filepath, default_pfcwd_value):
     duthost.shell(sed_command)
 
     return original_value
+
+
+def delete_running_config(config_entry, duthost):
+    duthost.copy(src=json.dumps(config_entry, indent=4), dest="/tmp/del_config_entry.json")
+    duthost.shell("configlet -d -j {}".format("/tmp/del_config_entry.json"))
+    # duthost.shell("rm -f {}".format("/tmp/del_config_entry.json"))

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -1,8 +1,9 @@
 import logging
 import pytest
+import json
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, delete_running_config
 
 
 pytestmark = [
@@ -111,6 +112,19 @@ class TestAutostateDisabled:
         logging.info('waiting for "{interfaces}" shutdown'.format(interfaces=interfaces))
         if not wait_until(60, 5, 0, self.check_interface_oper_state, duthost, interfaces, "down"):
             err_handler('shutdown "{interfaces}" failed'.format(interfaces=interfaces))
+
+        for interface in interfaces:
+            config_entry = json.loads("""
+                [{
+                    "PORT":{
+                        "%s":{
+                            "admin_status": "down"
+                        }
+                    }
+                }]
+            """ % interface)
+            delete_running_config(config_entry, duthost)
+
 
     def startup_multiple_with_confirm(self, duthost, interfaces, err_handler=logging.error):
         """

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import json
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until, delete_running_config

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -113,17 +113,16 @@ class TestAutostateDisabled:
         if not wait_until(60, 5, 0, self.check_interface_oper_state, duthost, interfaces, "down"):
             err_handler('shutdown "{interfaces}" failed'.format(interfaces=interfaces))
 
+        config_entry = []
+        config = {}
+        config["PORT"] = {}
+
         for interface in interfaces:
-            config_entry = json.loads("""
-                [{
-                    "PORT":{
-                        "%s":{
-                            "admin_status": "down"
-                        }
-                    }
-                }]
-            """ % interface)
-            delete_running_config(config_entry, duthost)
+            config["PORT"].update({interface: {"admin_status": "down"}})
+
+        config_entry.append(config)
+
+        delete_running_config(config_entry, duthost)
 
     def startup_multiple_with_confirm(self, duthost, interfaces, err_handler=logging.error):
         """

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -125,7 +125,6 @@ class TestAutostateDisabled:
             """ % interface)
             delete_running_config(config_entry, duthost)
 
-
     def startup_multiple_with_confirm(self, duthost, interfaces, err_handler=logging.error):
         """
         Startup multiple interfaces and confirm success.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `vlan/test_autostate_disabled.py`, it will change the admin_state of interfaces. Although it will restore all interfaces to their original admin_state, it will add some entries in running config, which are not exist before. So in this PR, after the module running, we will delete these additional entries. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module `vlan/test_autostate_disabled.py`, it will change the admin_state of interfaces. Although it will restore all interfaces to their original admin_state, it will add some entries in running config, which are not exist before. So in this PR, after the module running, we will delete these additional entries. 

#### How did you do it?
Delete additional entries which are not exist before.

#### How did you verify/test it?
```
06:13:11 conftest.core_dump_and_config_check      L2131 INFO   | Core dump and config check passed for vlan/test_autostate_disabled.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
