### PR TITLE
Fix `os.mkdir` failure in test_ro_disk

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -202,7 +202,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo find /home -ls")
 
         if not os.path.exists(DATA_DIR):
-            os.mkdir(DATA_DIR)
+            os.makedirs(DATA_DIR)
 
         # Fetch files of interest
         #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix `os.mkdir()` failure in `test_ro_disk`:

```
            if not os.path.exists(DATA_DIR):
>               os.mkdir(DATA_DIR)
E               OSError: [Errno 2] No such file or directory: 'logs/tacacs'
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix `os.mkdir()` failure in `test_ro_disk`.

#### How did you do it?
Use `os.makedirs()` instead of `os.mkdir()` to create multi-level folder.

#### How did you verify/test it?
Verified by running test on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
