### PR TITLE
[route] Fix test_route_perf failed in m0/mx

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -54,7 +54,10 @@ def get_route_scale_per_role(tbinfo, ip_version):
 
 
 @pytest.fixture
-def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+    if tbinfo["topo"]["type"] in ["m0", "mx"]:
+        return
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
It's not need to set high test routes number for M0/MX topo, hence they don't require l3_alpm_enable.

#### How did you do it?
Skip this precheck for M0/MX topo.

#### How did you verify/test it?
Run tests.
```
route/test_route_perf.py::test_perf_add_remove_routes[4-testbed-None] PASSED                                                                                                     [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6-testbed-None] PASSED                                                                                                     [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
