### PR TITLE
increase tolerance for TunnelDscpToPgMapping test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -780,6 +780,14 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         cell_size = self.test_params['cell_size']
         PKT_NUM = 100
         # There is background traffic during test, so we need to add error tolerance to ignore such pakcets
+        # and we send 100 packets every 10 seconds, if no backgound traffic impact counter value, and watermark is very
+        #   accurate, expected wartermark increasing value is 100.
+        # So for PG0, we increaset tolerance to 20, make sure it can work well even though background traffic, such as
+        #   LACP, LLDP, is 2 packet per second.
+        # For PG2/3/4/6, usually no background traffic, but watermark value's updating is a little bit inaccurate
+        #   according to previously experiments: after send 100 packets, sometime watermark value is 99, sometime
+        #   is 101. Since worry about worser scenario, we set tolerance to 10 for PG2/3/4/6. When figure out rootcause
+        #   of this symptom, will change to more reasonable value.
         ERROR_TOLERANCE = {
             0: 20,
             1: 0,

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -781,13 +781,13 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         PKT_NUM = 100
         # There is background traffic during test, so we need to add error tolerance to ignore such pakcets
         ERROR_TOLERANCE = {
-            0: 10,
+            0: 20,
             1: 0,
-            2: 0,
-            3: 0,
-            4: 0,
+            2: 10,
+            3: 10,
+            4: 10,
             5: 0,
-            6: 0,
+            6: 10,
             7: 0
         }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

In experiment, observed current tolerance value is not enough for pg0 , pg2 and pg6.
increase tolerance value for pg0, pg2, pg3, pg4 and pg6

#### How did you do it?

increase tolerance to 20 for pg0, to ignore more backgroup LACP/LLDP traffic
increase tolerance to 10 for pg2/3/4/6 as margin

#### How did you verify/test it?
pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
