### PR TITLE
Reg: test_route_flap_voq_chassis_update

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -663,27 +663,27 @@ class MultiAsicSonicHost(object):
         return bgp_internal_neighbors
 
     def get_voq_inband_interfaces(self):
-    """
-    This Function is only applicable on VOQ Chassis.
-    Get VOQ Internal Inband Interfaces. API iterates through frontend ASIC
-    index to get the VOQ Inband Interfaces from running configuration.
-    Not using BGP_VOQ_CHASSIS_NEIGHBOUR peer ips  since they are not referenced in
-    next hops of route.
-    Returns:
-          List of [voq_inband_interfaces]
-    """
-    if not duthost.sonichost.is_multi_asic:
-        return {}
-    voq_inband_interfaces = {}
-    for asic in duthost.frontend_asics:
-        config_facts = duthost.config_facts(
-            host=duthost.hostname, source="running",
-            namespace=asic.namespace
-        )['ansible_facts']
-        voq_inband_interfaces.update(
-            config_facts.get("VOQ_INBAND_INTERFACE", {})
-        )
-    return voq_inband_interfaces.keys()
+        """
+        This Function is only applicable on VOQ Chassis.
+        Get VOQ Internal Inband Interfaces. API iterates through frontend ASIC
+        index to get the VOQ Inband Interfaces from running configuration.
+        Not using BGP_VOQ_CHASSIS_NEIGHBOUR peer ips  since they are not referenced in
+        next hops of route.
+        Returns:
+              List of [voq_inband_interfaces]
+        """
+        if not duthost.sonichost.is_multi_asic:
+            return {}
+        voq_inband_interfaces = {}
+        for asic in duthost.frontend_asics:
+            config_facts = duthost.config_facts(
+                host=duthost.hostname, source="running",
+                namespace=asic.namespace
+            )['ansible_facts']
+            voq_inband_interfaces.update(
+                config_facts.get("VOQ_INBAND_INTERFACE", {})
+            )
+        return voq_inband_interfaces.keys()
 
     def docker_cmds_on_all_asics(self, cmd, container_name):
         """This function iterate for ALL asics and execute cmds"""

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -672,12 +672,12 @@ class MultiAsicSonicHost(object):
         Returns:
               List of [voq_inband_interfaces]
         """
-        if not duthost.sonichost.is_multi_asic:
+        if not self.sonichost.is_multi_asic:
             return {}
         voq_inband_interfaces = {}
-        for asic in duthost.frontend_asics:
-            config_facts = duthost.config_facts(
-                host=duthost.hostname, source="running",
+        for asic in self.frontend_asics:
+            config_facts = self.config_facts(
+                host=self.hostname, source="running",
                 namespace=asic.namespace
             )['ansible_facts']
             voq_inband_interfaces.update(

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -662,6 +662,29 @@ class MultiAsicSonicHost(object):
             )
         return bgp_internal_neighbors
 
+    def get_voq_inband_interfaces(self):
+    """
+    This Function is only applicable on VOQ Chassis.
+    Get VOQ Internal Inband Interfaces. API iterates through frontend ASIC
+    index to get the VOQ Inband Interfaces from running configuration.
+    Not using BGP_VOQ_CHASSIS_NEIGHBOUR peer ips  since they are not referenced in
+    next hops of route.
+    Returns:
+          List of [voq_inband_interfaces]
+    """
+    if not duthost.sonichost.is_multi_asic:
+        return {}
+    voq_inband_interfaces = {}
+    for asic in duthost.frontend_asics:
+        config_facts = duthost.config_facts(
+            host=duthost.hostname, source="running",
+            namespace=asic.namespace
+        )['ansible_facts']
+        voq_inband_interfaces.update(
+            config_facts.get("VOQ_INBAND_INTERFACE", {})
+        )
+    return voq_inband_interfaces.keys()
+
     def docker_cmds_on_all_asics(self, cmd, container_name):
         """This function iterate for ALL asics and execute cmds"""
         duthost = self.sonichost

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -212,7 +212,7 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
     # Get internal bgp ips for later filtering
     internal_bgp_ips = duthost.get_internal_bgp_peers().keys()
     # Get voq inband interface for later filtering
-    voq_inband_interfaces = get_voq_inband_interfaces(duthost)
+    voq_inband_interfaces = duthost.get_voq_inband_interfaces()
     dev_port = None
     route_to_ping = None
     for dst_prefix in dst_prefix_set:
@@ -352,28 +352,3 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
         loop_times -= 1
 
     logger.info("End")
-
-
-def get_voq_inband_interfaces(duthost):
-    """
-    This Function is only applicable on VOQ Chassis.
-    Get VOQ Internal Inband Interfaces. API iterates through frontend ASIC
-    index to get the VOQ Inband Interfaces from running configuration.
-    Not using BGP_VOQ_CHASSIS_NEIGHBOUR peer ips  since they are not referenced in
-    next hops of route.
-
-    Returns:
-          List of [voq_inband_interfaces]
-    """
-    if not duthost.sonichost.is_multi_asic:
-        return {}
-    voq_inband_interfaces = {}
-    for asic in duthost.frontend_asics:
-        config_facts = duthost.config_facts(
-            host=duthost.hostname, source="running",
-            namespace=asic.namespace
-        )['ansible_facts']
-        voq_inband_interfaces.update(
-            config_facts.get("VOQ_INBAND_INTERFACE", {})
-        )
-    return voq_inband_interfaces.keys()

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -211,6 +211,8 @@ def is_dualtor(tbinfo):
 def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
     # Get internal bgp ips for later filtering
     internal_bgp_ips = duthost.get_internal_bgp_peers().keys()
+    # Get voq inband interface for later filtering
+    voq_inband_interfaces = get_voq_inband_interfaces(duthost)
     dev_port = None
     route_to_ping = None
     for dst_prefix in dst_prefix_set:
@@ -230,13 +232,17 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                         continue
                     if per_hop['ip'] in internal_bgp_ips:
                         continue
+                    if per_hop['interfaceName'] in voq_inband_interfaces:
+                        continue
                     dev_port = per_hop['interfaceName']
+                    break
         else:
             dev = json.loads(asichost.run_vtysh(cmd)['stdout'])
             for per_hop in dev[route_to_ping][0]['nexthops']:
                 if 'interfaceName' not in per_hop.keys():
                     continue
                 dev_port = per_hop['interfaceName']
+                break
     pytest_assert(dev_port, "dev_port not exist")
     return dev_port, route_to_ping
 
@@ -346,3 +352,28 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
         loop_times -= 1
 
     logger.info("End")
+
+
+def get_voq_inband_interfaces(duthost):
+    """
+    This Function is only applicable on VOQ Chassis.
+    Get VOQ Internal Inband Interfaces. API iterates through frontend ASIC
+    index to get the VOQ Inband Interfaces from running configuration.
+    Not using BGP_VOQ_CHASSIS_NEIGHBOUR peer ips  since they are not referenced in
+    next hops of route.
+
+    Returns:
+          List of [voq_inband_interfaces]
+    """
+    if not duthost.sonichost.is_multi_asic:
+        return {}
+    voq_inband_interfaces = {}
+    for asic in duthost.frontend_asics:
+        config_facts = duthost.config_facts(
+            host=duthost.hostname, source="running",
+            namespace=asic.namespace
+        )['ansible_facts']
+        voq_inband_interfaces.update(
+            config_facts.get("VOQ_INBAND_INTERFACE", {})
+        )
+    return voq_inband_interfaces.keys()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- This PR fixes "test_route_flap" test under route test suite.
"'route/test_route_flap.py::test_route_flap"
- For VOQ Chassis with Multi-Asic, there is no Key as "BGP_INTERNAL_NEIGHBOR" and hence the Test Case is failing if Next hop selected is peer asic. A filter with "VOQ_INBAND_INTERFACE" for Ethernert-IBs is added as well in order to support the VOQ Chassis
- Fixes issue Refer: https://github.com/sonic-net/sonic-mgmt/issues/8840
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently the Test Case fails for VOQ Chassis(Muilti-Asic) as there is no key "BGP_INTERNAL_NEIGHBOR" in config facts.
Refer: https://github.com/sonic-net/sonic-mgmt/issues/8840



#### How did you do it?
Create a new function get_voq_inband_interfaces in order to get VOQ_INBAND_INTERFACE from running config facts to exclude it from the list of hops.


#### How did you verify/test it?
Ran the test_route_flap test cases against a multi-asic line card in a T2 chassis.
#### Any platform specific information?
 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
- Refer: https://github.com/sonic-net/sonic-mgmt/issues/8840
- 
![image](https://github.com/sonic-net/sonic-mgmt/assets/135994174/e6925b69-7afa-403c-a4bf-0d81ef87c723)

