### PR TITLE
[dualtor] Leave `icmp_responder` running on `dualtor` topology

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -269,7 +269,7 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    # NOTE: Leave icmp_responder running for dualtor/dualtor-mixed/dualtor-aa topology
+    logger.info("Leave icmp_responder running for dualtor/dualtor-mixed/dualtor-aa topology")
     return
 
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -269,17 +269,8 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    if "dualtor-mixed" in tbinfo["topo"]["name"] or "dualtor-aa" in tbinfo["topo"]["name"]:
-        logger.info("Leave icmp_responder running for dualtor-mixed/dualtor-aa topology")
-        return
-
-    logger.info("Stop running icmp_responder")
-    ptfhost.shell("supervisorctl stop icmp_responder")
-    icmp_responder_session_started = False
-
-    logger.info("Recover linkmgrd probe interval")
-    recover_linkmgrd_probe_interval(duthosts, tbinfo)
-    duthosts.shell("config save -y")
+    # NOTE: Leave icmp_responder running for dualtor/dualtor-mixed/dualtor-aa topology
+    return
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enforcing same behavior on `dualtor`, `dualtor-aa` and `dualtor-mixed` topology. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To enforce same behavior on `dualtor`, `dualtor-aa`, `dualtor-mixed` testbeds. 

#### How did you do it?

#### How did you verify/test it?
Verified on dualtor testbed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
