### PR TITLE
[Nvidia][reboot_cause] Remove cpu reset cause from test

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -24,7 +24,6 @@ REBOOT_TYPE_POWEROFF = "power off"
 REBOOT_TYPE_WATCHDOG = "watchdog"
 REBOOT_TYPE_UNKNOWN = "Unknown"
 REBOOT_TYPE_THERMAL_OVERLOAD = "Thermal Overload"
-REBOOT_TYPE_CPU = "cpu"
 REBOOT_TYPE_BIOS = "bios"
 REBOOT_TYPE_ASIC = "asic"
 
@@ -91,12 +90,6 @@ reboot_ctrl_dict = {
         "warmboot_finalizer_timeout": 30,
         "cause": "warm-reboot",
         "test_reboot_cause_only": False
-    },
-    REBOOT_TYPE_CPU: {
-        "timeout": 300,
-        "wait": 120,
-        "cause": "CPU",
-        "test_reboot_cause_only": True
     },
     REBOOT_TYPE_BIOS: {
         "timeout": 300,

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1365,7 +1365,6 @@ class PsuPowerThresholdMocker(object):
 @mocker('RebootCauseMocker')
 class RebootCauseMocker(object):
     RESET_RELOAD_BIOS = '/var/run/hw-management/system/reset_reload_bios'
-    RESET_FROM_COMEX = '/var/run/hw-management/system/reset_from_comex'
     RESET_FROM_ASIC = '/var/run/hw-management/system/reset_from_asic'
 
     def __init__(self, dut):
@@ -1376,9 +1375,6 @@ class RebootCauseMocker(object):
 
     def mock_reset_reload_bios(self):
         self.mock_helper.mock_value(self.RESET_RELOAD_BIOS, 1)
-
-    def mock_reset_from_comex(self):
-        self.mock_helper.mock_value(self.RESET_FROM_COMEX, 1)
 
     def mock_reset_from_asic(self):
         self.mock_helper.mock_value(self.RESET_FROM_ASIC, 1)

--- a/tests/platform_tests/mellanox/test_reboot_cause.py
+++ b/tests/platform_tests/mellanox/test_reboot_cause.py
@@ -1,7 +1,7 @@
 import allure
 import logging
 import pytest
-from tests.common.reboot import REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC, check_reboot_cause
+from tests.common.reboot import REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC, check_reboot_cause
 from tests.platform_tests.thermal_control_test_helper import mocker_factory  # noqa: F401
 
 pytestmark = [
@@ -12,7 +12,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 mocker = None
-REBOOT_CAUSE_TYPES = [REBOOT_TYPE_CPU, REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC]
+REBOOT_CAUSE_TYPES = [REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC]
 
 
 @pytest.mark.parametrize("reboot_cause", REBOOT_CAUSE_TYPES)
@@ -28,9 +28,7 @@ def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause):  # noqa:
         mocker = mocker_factory(duthost, 'RebootCauseMocker')
 
     with allure.step('Mock reset from {}'.format(reboot_cause)):
-        if reboot_cause == REBOOT_TYPE_CPU:
-            mocker.mock_reset_from_comex()
-        elif reboot_cause == REBOOT_TYPE_BIOS:
+        if reboot_cause == REBOOT_TYPE_BIOS:
             mocker.mock_reset_reload_bios()
         elif reboot_cause == REBOOT_TYPE_ASIC:
             mocker.mock_reset_from_asic()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR has to be merged after https://github.com/sonic-net/sonic-buildimage/pull/15793

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Changes in https://github.com/sonic-net/sonic-buildimage/pull/15793
#### How did you do it?
Remove parts relates to cpu reboot cause
#### How did you verify/test it?
Run TC, TC passed
#### Any platform specific information?
Nvidia (Mellanox)
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
