### PR TITLE
update skip rule of test_lag_db_status_with_po_update to support t1-56-lag, and remove redundancy rule

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -645,9 +645,9 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
-    reason: "Only support t1-lag and t2 topology"
+    reason: "Only support t1-lag, t1-56-lag and t2 topology"
     conditions:
-        - "topo_name not in ['t1-lag'] and 't2' not in topo_name"
+        - "topo_name not in ['t1-lag', 't1-56-lag'] and 't2' not in topo_name"
 
 pc/test_lag_member.py:
   skip:
@@ -774,15 +774,6 @@ platform_tests/broadcom/test_ser.py::test_ser:
     conditions:
       - "platform in ['x86_64-cel_e1031-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6218
-
-#######################################
-#####             pc              #####
-#######################################
-pc/test_lag_2.py::test_lag_db_status_with_po_update:
-  skip:
-    reason: "Only support t1-lag topology"
-    conditions:
-        - "topo_name not in ['t1-lag']"
 
 #######################################
 #####         platform_tests      #####


### PR DESCRIPTION
… update it to support t1-56-lag

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

update skip rule of test_lag_db_status_with_po_update to support t1-56-lag, and remove redundancy rule

#### How did you do it?

update skip rule of test_lag_db_status_with_po_update to support t1-56-lag, and remove redundancy rule

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
