### PR TITLE
Add param timeout to ansible library shell_cmds

### DIFF
--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -66,7 +66,7 @@ description:
 options:
     cmds: List of commands. Each command should be a string.
     continue_on_fail: Bool. Specify whether to continue running rest of the commands if any of the command failed.
-    timeout: Integer. Specify time limit (in second) for each command. Default value is 30. 0 means no limit.
+    timeout: Integer. Specify time limit (in second) for each command. 0 means no limit. Default value is 0.
 '''
 
 EXAMPLES = r'''
@@ -82,17 +82,20 @@ EXAMPLES = r'''
 
 
 def run_cmd(module, cmd, timeout):
-    # wrap the shell command with timeout
-    cmd_with_timeout = "echo '{}' | timeout {} bash".format(cmd, timeout)
-    rc, out, err = module.run_command(cmd_with_timeout, use_unsafe_shell=True)
+    cmd_with_timeout = "echo '{}' | timeout --preserve-status {} bash".format(cmd, timeout)
+    if int(timeout) == 0:
+        rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
+    else:
+        rc, out, err = module.run_command(cmd_with_timeout, use_unsafe_shell=True)
     result = dict(
-        cmd=cmd,  # original command
-        cmd_with_timeout=cmd_with_timeout,  # command wrapped with timeout
+        cmd=cmd,
+        cmd_with_timeout=cmd_with_timeout,
         rc=rc,
         stdout=out,
         stderr=err,
         stdout_lines=out.splitlines(),
-        stderr_lines=err.splitlines()
+        stderr_lines=err.splitlines(),
+        timeout=timeout
     )
     return result
 
@@ -103,7 +106,7 @@ def main():
         argument_spec=dict(
             cmds=dict(type='list', required=True),
             continue_on_fail=dict(type='bool', default=True),
-            timeout=dict(type='int', default=30)
+            timeout=dict(type='int', default=0)
         )
     )
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -21,7 +21,10 @@
 #         "admin"
 #       ],
 #       "cmd": "ls /home",
-#       "rc": 0
+#       "cmd_with_timeout": "",
+#       "rc": 0,
+#       "timeout": 0,
+#       "err_msg": ""
 #     },
 #     {
 #       "stderr_lines": [],
@@ -31,7 +34,10 @@
 #         "/home/admin"
 #       ],
 #       "cmd": "pwd",
-#       "rc": 0
+#       "cmd_with_timeout": "",
+#       "rc": 0,
+#       "timeout": 0,
+#       "err_msg": ""
 #     }
 #   ],
 #   "cmds": [
@@ -52,7 +58,6 @@
 # }
 
 import datetime
-import logging
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -84,9 +89,10 @@ EXAMPLES = r'''
 
 def run_cmd(module, cmd, timeout):
     cmd_with_timeout = ''
+    err_msg = ''
 
     if int(timeout) != 0 and "'" in cmd:
-        logging.warning("timeout is not supported for command contains single quote, will run without timeout. cmd={}".format(cmd))
+        err_msg = "timeout is not supported for command contains single quote, ran without time limit"
         timeout = 0
 
     if int(timeout) == 0:
@@ -98,6 +104,7 @@ def run_cmd(module, cmd, timeout):
     result = dict(
         cmd=cmd,
         cmd_with_timeout=cmd_with_timeout,
+        err_msg=err_msg,
         rc=rc,
         stdout=out,
         stderr=err,

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -52,6 +52,7 @@
 # }
 
 import datetime
+import logging
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -82,11 +83,18 @@ EXAMPLES = r'''
 
 
 def run_cmd(module, cmd, timeout):
-    cmd_with_timeout = "echo '{}' | timeout --preserve-status {} bash".format(cmd, timeout)
+    cmd_with_timeout = ''
+
+    if int(timeout) != 0 and "'" in cmd:
+        logging.warning("timeout is not supported for command contains single quote, will run without timeout. cmd={}".format(cmd))
+        timeout = 0
+
     if int(timeout) == 0:
         rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
     else:
+        cmd_with_timeout = "echo '{}' | timeout --preserve-status {} bash".format(cmd, timeout)
         rc, out, err = module.run_command(cmd_with_timeout, use_unsafe_shell=True)
+
     result = dict(
         cmd=cmd,
         cmd_with_timeout=cmd_with_timeout,

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -92,7 +92,7 @@ def run_cmd(module, cmd, timeout):
     err_msg = ''
 
     if int(timeout) != 0 and "'" in cmd:
-        err_msg = "timeout is not supported for command contains single quote, ran without time limit"
+        err_msg = "[WARNING] timeout is not supported for command contains single quote, ran without time limit"
         timeout = 0
 
     if int(timeout) == 0:

--- a/docs/api_wiki/ansible_methods/shell_cmds.md
+++ b/docs/api_wiki/ansible_methods/shell_cmds.md
@@ -25,12 +25,16 @@ def test_fun(duthosts, rand_one_dut_hostname):
     - Reguired: `False`
     - Type: `Boolean`
     - Default: `True`
+- `timeout` - Specify time limit (in second) for each command. 0 means no limit.
+    - Reguired: `False`
+    - Type: `Integer`
+    - Default: `0`
 
 ## Expected Output
 A dictionary with results from commands run. The dictionary hierarchy is described below, with each indentation describing a sub-dictionary:
 
 - `end` - Datetime for when the commands finished running
-- `cmds` - the list of commands that were run
+- `cmds` - the list of commands that user input.
 - `start` - Datetime for when the commands started running
 - `delta` - difference between `start` and `end`
 - `results` - List of dictionaries, each corresponding to the results for one of the commands run
@@ -38,5 +42,7 @@ A dictionary with results from commands run. The dictionary hierarchy is describ
     - `stderr` - What was printed to stderr (as one string) during execution of command
     - `stdout_lines` - What was printed to stdout (split by line) during execution of command
     - `stdout` - What was printed to stdout (as one string) during execution of command
-    - `cmd` - command that was run
+    - `cmd` - command that user input. It's what actaully ran if `timeout == 0`.
+    - `cmd_with_timeout` - command wrapped with `timeout`. It's what actually ran if `timeout != 0`.
     - `rc` - return code
+    - `timeout` - time limit (in second) for each command. 0 means no limit.

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -465,12 +465,12 @@ class MultiAsicSonicHost(object):
                 continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
-                r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "
+                r'"s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g" '
                 r"/etc/rsyslog.conf"
             )
             cmd_enable_rate_limit = (
                 r"docker exec -i {} sed -i "
-                r"'s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' "
+                r'"s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g" '
                 r"/etc/rsyslog.conf"
             )
             cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -465,12 +465,12 @@ class MultiAsicSonicHost(object):
                 continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
-                r'"s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g" '
+                r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "
                 r"/etc/rsyslog.conf"
             )
             cmd_enable_rate_limit = (
                 r"docker exec -i {} sed -i "
-                r'"s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g" '
+                r"'s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' "
                 r"/etc/rsyslog.conf"
             )
             cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -570,7 +570,7 @@ class SonicHost(AnsibleHostBase):
                   ' && cat /etc/supervisor/critical_processes"'.format(service)
 
             cmds.append(cmd)
-        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True)['results']
+        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
 
         # Extract service name of each command result, transform results list to a dict keyed by service name
         service_results = {}
@@ -650,7 +650,7 @@ class SonicHost(AnsibleHostBase):
         for service in self.critical_services:
             cmd = 'docker exec {} supervisorctl status'.format(service)
             cmds.append(cmd)
-        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True)['results']
+        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
 
         # Extract service name of each command result, transform results list to a dict keyed by service name
         service_results = {}

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -566,8 +566,8 @@ class SonicHost(AnsibleHostBase):
         # Get critical group and process definitions by running cmds in batch to save overhead
         cmds = []
         for service in self.critical_services:
-            cmd = "docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ]" \
-                  " && cat /etc/supervisor/critical_processes'".format(service)
+            cmd = 'docker exec {} bash -c "[ -f /etc/supervisor/critical_processes ]' \
+                  ' && cat /etc/supervisor/critical_processes"'.format(service)
 
             cmds.append(cmd)
         results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True)['results']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Add a parameter `timeout` to ansible library `shell_cmds`. The default value is `0` which means no limitation. **(However, this update also introduce a limitation. If the timeout is not 0, then the command should not contain single quotes `'`)**
2. Set the timeout of some commands to 30s to avoid costing too much time, also updated the command to adapt the timeout wrapper.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
1. Add a parameter `timeout` to ansible library `shell_cmds`. The default value is `0` which means no limitation.
2. Set the timeout of some commands to 30s to avoid costing too much time, also updated the command to adapt the timeout wrapper.

#### How did you do it?

#### How did you verify/test it?
1. Verified by run `test_pretest` and `test_memory_exhaustion` on physical testbeds.
2. Verified by PR test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
