### PR TITLE
Reenable IPv6 BGP neighbor check during warm-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -259,8 +259,8 @@ class Arista(host_device.HostDevice):
             data, "lacp",         "LACP session")
         cli_data['bgp_v4'] = self.check_series_status(
             data, "bgp_route_v4", "BGP v4 routes")
-        # TODO: same as above for v6_routing_ok
-        cli_data['bgp_v6'] = (1, 0)
+        cli_data['bgp_v6'] = self.check_series_status(
+            data, "bgp_route_v6", "BGP v6 routes")
         cli_data['po'] = self.check_change_time(
             samples, "po_changetime", "PortChannel interface")
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -148,10 +148,7 @@ class Arista(host_device.HostDevice):
             'interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
         samples[cur_time] = sample
 
-        # TODO: Disabling v6_routing_ok check due to IPv6 FRR issue. Re-add v6_routing_ok once either:
-        # * https://github.com/FRRouting/frr/issues/13587 is fixed and the fix gets merged into SONiC, or
-        # * https://github.com/sonic-net/sonic-buildimage/pull/12853 is reverted
-        while not (quit_enabled and v4_routing_ok):
+        while not (quit_enabled and v4_routing_ok and v6_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands
             # but wait for v4_routing_ok and v6_routing_ok

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -191,8 +191,7 @@ class Sonic(host_device.HostDevice):
         # cli_data['lacp']   = self.check_series_status(data, "lacp",         "LACP session")
         cli_data['lacp'] = (0, 0)
         cli_data['bgp_v4'] = self.check_series_status(data, "bgp_route_v4", "BGP v4 routes")
-        # TODO: same as above for v6_routing_ok
-        cli_data['bgp_v6'] = (1, 0)
+        cli_data['bgp_v6'] = self.check_series_status(data, "bgp_route_v6", "BGP v6 routes")
         cli_data['po'] = self.check_lag_flaps("PortChannel1", log_lines, start_time)
 
         if 'route_timeout' in log_data:

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -103,10 +103,7 @@ class Sonic(host_device.HostDevice):
             lacp_thread.setDaemon(True)
             lacp_thread.start()
 
-        # TODO: Disabling v6_routing_ok check due to IPv6 FRR issue. Re-add v6_routing_ok once either:
-        # * https://github.com/FRRouting/frr/issues/13587 is fixed and the fix gets merged into SONiC, or
-        # * https://github.com/sonic-net/sonic-buildimage/pull/12853 is reverted
-        while not (quit_enabled and v4_routing_ok):
+        while not (quit_enabled and v4_routing_ok and v6_routing_ok):
             cmd = None
             # quit command was received, we don't process next commands
             # but wait for v4_routing_ok and v6_routing_ok


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Now that sonic-net/sonic-buildimage#15688 has been merged, re-enable checking the IPv6 BGP neighbor status during a warm-reboot.

This reverts #8735 and #8746.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Did a warm-reboot on virtual switch, and verified that it passed.

One oddity that was noticed was that the IPv6 BGP appears to have gone down for about 23 seconds, whereas IPv4 BGP did not go down. This wasn't treated as a failure, though.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
