### PR TITLE
[plt_reboot_dict] auto use fixture set_max_for_interfaces in reboot tests

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -17,7 +17,7 @@ pytestmark = [
 INTERFACE_WAIT_TIME = 300
 
 
-@pytest.fixture
+@pytest.fixture(scope="module", autouse=True)
 def set_max_time_for_interfaces(duthost):
     """
     For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
@@ -61,7 +61,7 @@ def _power_off_reboot_helper(kwargs):
 
 
 def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, conn_graph_facts,
-                          set_max_time_for_interfaces, xcvr_skip_list, pdu_controller, power_off_delay):
+                          xcvr_skip_list, pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -32,7 +32,7 @@ MAX_WAIT_TIME_FOR_INTERFACES = 300
 MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120
 
 
-@pytest.fixture
+@pytest.fixture(scope="module", autouse=True)
 def set_max_time_for_interfaces(duthost):
     """
     For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
@@ -147,7 +147,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
             return
 
 
-def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname, set_max_time_for_interfaces,
+def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform cold reboot and check platform status
@@ -217,7 +217,7 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):      # noqa F811
+                         localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -234,7 +234,7 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                           localhost, conn_graph_facts, set_max_time_for_interfaces, xcvr_skip_list):        # noqa F811
+                           localhost, conn_graph_facts, xcvr_skip_list):        # noqa F811
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR https://github.com/sonic-net/sonic-mgmt/pull/8646 added default argument `interfaces_wait_time=MAX_WAIT_TIME_FOR_INTERFACES` in `check_interfaces_and_services`, 
with this `interfaces_wait_time` is getting directly from MAX_WAIT_TIME_FOR_INTERFACES, while this function has not yet called fixture `set_max_time_for_interfaces`.

change fixture  `set_max_time_for_interfaces` to autouse fixture as we need it throughout test module
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
before:
```
  File "/azp/_work/65/s/tests/platform_tests/test_reboot.py", line 112, in check_interfaces_and_services
    interfaces_wait_time)
AssertionError: Not all transceivers are detected or interfaces are up in 300 seconds
```

after:
```
18:58:16 reboot.reboot                            L0255 INFO   | DUT str2-7804-lc7-1 up since 2023-07-12 18:55:52
18:58:16 test_reboot.reboot_and_check             L0082 INFO   | Append the latest reboot type to the queue
18:58:16 test_reboot.check_interfaces_and_service L0101 INFO   | Wait until all critical services are fully started
18:58:16 processes_utils.wait_critical_processes  L0064 INFO   | Wait until all critical processes are healthy in 600 sec
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
