### PR TITLE
[Double commit] PR8844: Add output all and drop all HTTP API in mux simulator in dualtor_io testcase

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.md
+++ b/ansible/roles/vm_set/files/mux_simulator.md
@@ -257,6 +257,36 @@ No json data required in POST. This API is to recover flows of all the mux bridg
 
 Response: `all_mux_status`
 
+### POST `/mux/<vm_set>/output`
+
+Set flow action of all mux bridges belong to `vm_set` to `output`.
+
+Format of json data required in POST:
+```
+{
+    "out_sides": ["nic", "upper_tor", "lower_tor"],
+}
+```
+
+* `out_sides` is a list. It can contain single or multiple items from: `nic`, `upper_tor`, `lower_tor`.
+
+Response: `all_mux_status`
+
+### POST `/mux/<vm_set>/drop`
+
+Set flow action of all mux bridges belong to `vm_set` to `drop`.
+
+Format of json data required in POST:
+```
+{
+    "out_sides": ["nic", "upper_tor", "lower_tor"],
+}
+```
+
+* `out_sides` is a list. It can contain single or multiple items from: `nic`, `upper_tor`, `lower_tor`.
+
+Response: `all_mux_status`
+
 ### GET `/mux/<vm_set>/port_index>/flap_counter`
 
 Get flap counter of bridge specified by `vm_set` and `port_index`.

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -789,6 +789,46 @@ def reset_flow_handler(vm_set):
     return g_muxes.reset_flows()
 
 
+@app.route('/mux/<vm_set>/output', methods=['POST'])
+def output_flow_handler(vm_set):
+    """Handler for updating flow action to output
+
+    Args:
+        vm_set (string): The vm_set of test setup. Parsed by flask from request URL.
+
+    Posted json data should be like:
+        {"out_sides": [<side>, <side>, ...]}
+    where <side> could be "nic", "upper_tor" or "lower_tor".
+
+    Returns:
+        object: Return a flask response object.
+    """
+    _validate_vm_set(vm_set)
+    data = _validate_out_sides(request)
+    app.logger.info('===== {} POST {} with {} ====='.format(request.remote_addr, request.url, json.dumps(data)))
+    return g_muxes.update_flows('output', data['out_sides'])
+
+
+@app.route('/mux/<vm_set>/drop', methods=['POST'])
+def drop_flow_handler(vm_set):
+    """Handler for updating all flow to drop
+
+    Args:
+        vm_set (string): The vm_set of test setup. Parsed by flask from request URL.
+
+    Posted json data should be like:
+        {"out_sides": [<side>, <side>, ...]}
+    where <side> could be "nic", "upper_tor" or "lower_tor".
+
+    Returns:
+        object: Return a flask response object.
+    """
+    _validate_vm_set(vm_set)
+    data = _validate_out_sides(request)
+    app.logger.info('===== {} POST {} with {} ====='.format(request.remote_addr, request.url, json.dumps(data)))
+    return g_muxes.update_flows('drop', data['out_sides'])
+
+
 @app.route('/mux/<vm_set>/<int:port_index>/flap_counter', methods=['GET'])
 def flap_counter_port(vm_set, port_index):
     """

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -21,8 +21,11 @@ __all__ = [
     'get_mux_status',
     'check_simulator_read_side',
     'set_output',
+    'set_output_all',
     'set_drop',
-    'recover_all_directions',
+    'set_drop_all',
+    'recover_directions',
+    'recover_directions_all',
     'reset_simulator_port',
     'toggle_all_simulator_ports_to_upper_tor',
     'toggle_all_simulator_ports_to_lower_tor',
@@ -118,7 +121,7 @@ def url(mux_server_url, duthost, tbinfo):
         """
         if not interface_name:
             if action:
-                # Only for flap_counter, clear_flap_counter, or reset
+                # For flap_counter, clear_flap_counter, drop(for all), output(for all) or reset
                 return mux_server_url + "/{}".format(action)
             return mux_server_url
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -177,7 +180,7 @@ def _post(server_url, data):
 
 
 @pytest.fixture(scope='function')
-def set_drop(url, recover_all_directions):
+def set_drop(url, recover_directions):
     """
     A helper function is returned to make fixture accept arguments
     """
@@ -200,7 +203,23 @@ def set_drop(url, recover_all_directions):
     yield _set_drop
 
     for intf in drop_intfs:
-        recover_all_directions(intf)
+        recover_directions(intf)
+
+
+@pytest.fixture(scope='function')
+def set_drop_all(url, recover_directions_all):
+    """
+    A helper function is returned to make fixture accept arguments
+    """
+    def _set_drop_all(directions):
+        server_url = url(action=DROP)
+        data = {"out_sides": directions}
+        logger.info("Dropping all packets to {}".format(directions))
+        pytest_assert(_post(server_url, data), "Failed to set drop all on {}".format(directions))
+
+    yield _set_drop_all
+
+    recover_directions_all()
 
 
 @pytest.fixture(scope='function')
@@ -222,6 +241,21 @@ def set_output(url):
         pytest_assert(_post(server_url, data), "Failed to set output on {}".format(directions))
 
     return _set_output
+
+
+@pytest.fixture(scope='function')
+def set_output_all(url):
+    """
+    A helper function is returned to make fixture accept arguments
+    """
+    def _set_output_all(directions):
+        server_url = url(action=OUTPUT)
+        data = {"out_sides": directions}
+        logger.info("Output all packets to {}".format(directions))
+        pytest_assert(_post(server_url, data), "Failed to set output all on {}".format(directions))
+
+    return _set_output_all
+
 
 @pytest.fixture(scope='module')
 def toggle_simulator_port_to_upper_tor(url, tbinfo, active_standby_ports):
@@ -265,11 +299,12 @@ def toggle_simulator_port_to_lower_tor(url, tbinfo):
     return _toggle_simulator_port_to_lower_tor
 
 @pytest.fixture(scope='module')
-def recover_all_directions(url):
+def recover_directions(url):
     """
-    A function level fixture, will return _recover_all_directions to make fixture accept arguments
+    A function level fixture, will return _recover_directions to make fixture accept arguments
     """
-    def _recover_all_directions(interface_name):
+
+    def _recover_directions(interface_name):
         """
         Function to recover all traffic on all directions on a certain port
         Args:
@@ -281,7 +316,29 @@ def recover_all_directions(url):
         data = {"out_sides": [UPPER_TOR, LOWER_TOR, NIC]}
         pytest_assert(_post(server_url, data), "Failed to set output on all directions for interface {}".format(interface_name))
 
-    return _recover_all_directions
+    return _recover_directions
+
+
+@pytest.fixture(scope='module')
+def recover_directions_all(url):
+    """
+    A function level fixture, will return recover_directions_all to make fixture accept arguments
+    """
+
+    def _recover_directions_all():
+        """
+        Function to recover all traffic on all directions on a certain port
+        Args:
+            interface_name: a str, the name of interface to control
+        Returns:
+            None.
+        """
+        server_url = url(action=OUTPUT)
+        data = {"out_sides": [UPPER_TOR, LOWER_TOR, NIC]}
+        pytest_assert(_post(server_url, data),
+                      "Failed to set output on all directions for all interfaces")
+
+    return _recover_directions_all
 
 @pytest.fixture(scope='module')
 def check_simulator_read_side(url):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is no mux simulator API to drop flow for all ports.
Currently, there is a loop to drop every port's flow one by one. This is too time-consuming.
In this PR, add output all and drop all mux simulator API and use the API in dualtor_io testcases
/mux/<vm_set>/output
/mux/<vm_set>/drop

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Currently, there is no API to drop all flow. There is a loop to drop every port one by one. This is too time consuming.

#### How did you do it?
Add two APIs to output/drop all ports in one API call.

#### How did you verify/test it?
Test with physical testbed with testcases in dualtor_io/test_link_drop.py
6 passed, 6 skipped, 2 warnings in 2019.75s (0:33:39)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
