### PR TITLE
[fib] Fix test_fib failed in Nokia 7215

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -93,7 +93,8 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
 
     # do not test load balancing for vs platform as kernel 4.9
     # can only do load balance base on L3
-    if duthosts[0].facts['asic_type'] in ["vs"]:
+    asic_type = duthosts[0].facts['asic_type']
+    if asic_type in ["vs"]:
         test_balancing = False
     else:
         test_balancing = True
@@ -121,7 +122,8 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
             "test_balancing": test_balancing,
             "ignore_ttl": ignore_ttl,
             "single_fib_for_duts": single_fib_for_duts,
-            "switch_type": switch_type
+            "switch_type": switch_type,
+            "asic_type": asic_type
         },
         log_file=log_file,
         qlen=PTF_QLEN,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_fib will randomly fail in marvell asic. To fix it.

#### How did you do it?
It failed because "240.0.0.0/24" is not excluded in test ip ranges. This PR [7030](https://github.com/sonic-net/sonic-mgmt/pull/7030) has added it but not let it take effect due to missing `asic_type` in the parameter.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
