### PR TITLE
cherry pick #8810 into 202205 fix python process parse_routes_process timeout

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -111,7 +111,7 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
             routes[a_route] = ""
         all_routes[hostname] = routes
 
-    all_routes = parallel_run(parse_routes_process_vsonic, (), {}, neigh_hosts.values(), timeout=120, concurrent_tasks=8)
+    all_routes = parallel_run(parse_routes_process_vsonic, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
     return all_routes
 
 
@@ -184,7 +184,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
             routes[entry] = community
         results[hostname] = routes
 
-    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=180, concurrent_tasks=8)
+    all_routes = parallel_run(parse_routes_process, (), {}, neigh_hosts.values(), timeout=240, concurrent_tasks=8)
     return all_routes
 
 


### PR DESCRIPTION

### Description of PR
[cherry pick] https://github.com/sonic-net/sonic-mgmt/pull/8810 into 202205

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
[cherry pick] https://github.com/sonic-net/sonic-mgmt/pull/8810 into 202205

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
