### PR TITLE
cherry pick #8808 to 202205 improve dhcpv6 test packets to cover option parse cases

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -28,6 +28,8 @@ DHCP6OptOptReq = scapy.layers.dhcp6.DHCP6OptOptReq
 DHCP6OptElapsedTime = scapy.layers.dhcp6.DHCP6OptElapsedTime
 DHCP6OptIA_NA = scapy.layers.dhcp6.DHCP6OptIA_NA
 DUID_LLT = scapy.layers.dhcp6.DUID_LLT
+DHCP6OptIfaceId = scapy.layers.dhcp6.DHCP6OptIfaceId
+DHCP6OptServerId = scapy.layers.dhcp6.DHCP6OptServerId
 
 
 class DataplaneBaseTest(BaseTest):
@@ -238,6 +240,8 @@ class DHCPTest(DataplaneBaseTest):
         reply_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,
                                                      peeraddr=self.client_link_local)
         reply_relay_reply_packet /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
+        ipv6_bytes = ipaddress.IPv6Address(self.vlan_ip).packed
+        reply_relay_reply_packet /= DHCP6OptIfaceId(ifaceid=ipv6_bytes)
 
         return reply_relay_reply_packet
 
@@ -247,6 +251,7 @@ class DHCPTest(DataplaneBaseTest):
         relay_forward_packet /= packet.UDP(sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
         relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         relay_forward_packet /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)])
+        relay_forward_packet /= DHCP6OptElapsedTime(elapsedtime=0)
 
         return relay_forward_packet
 
@@ -256,6 +261,7 @@ class DHCPTest(DataplaneBaseTest):
         relayed_relay_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet_inside = DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)])
+        packet_inside /= DHCP6OptElapsedTime(elapsedtime=0)
         relayed_relay_packet /= DHCP6_RelayForward(msgtype=12, hopcount=1, linkaddr=self.relay_linkaddr,
                                                    peeraddr=self.client_link_local)
         relayed_relay_packet /= DHCP6OptRelayMsg(message=[packet_inside])
@@ -270,6 +276,7 @@ class DHCPTest(DataplaneBaseTest):
                                                      peeraddr=self.client_link_local)
         packet_inside = DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
+        relay_relay_reply_packet /= DHCP6OptServerId(duid=DUID_LLT(lladdr="00:11:22:33:44:55"))
         relay_relay_reply_packet /= DHCP6OptRelayMsg(message=[packet_inside])
 
         return relay_relay_reply_packet

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -2,6 +2,7 @@ import os
 import ast
 import subprocess
 import scapy
+import ipaddress
 # Packet Test Framework imports
 import ptf
 import ptf.packet as packet


### PR DESCRIPTION
### Description of PR
Cherry-Pick #8808 into 202205

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Cherry-Pick #8808 into 202205


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
