### PR TITLE
fix syntax error in device_mocker_factory

### DIFF
--- a/tests/system_health/device_mocker.py
+++ b/tests/system_health/device_mocker.py
@@ -54,7 +54,7 @@ def device_mocker_factory():
             mocker_object = MellanoxDeviceMocker(dut)
             mockers.append(mocker_object)
         else:
-            pytest.skip("No mocker defined for this platform %s")
+            pytest.skip("No mocker defined for this platform {}".format(asic))
         return mocker_object
 
     yield _create_mocker


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

observed syntax error in device_mocker_factory(), 
and cause outputting incompleted skip reason:
```
No mocker defined for this platform %s
```

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
