### PR TITLE
[cherry pick] #8901 Delete interfaces admin_state after module vlan/test_autostate_disabled.py running into 202012.

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -635,6 +635,6 @@ def delete_running_config(config_entry, duthost, is_json=True):
     if is_json:
         duthost.copy(content=json.dumps(config_entry, indent=4), dest="/tmp/del_config_entry.json")
     else:
-        duthost.copy(scr=config_entry, dest="/tmp/del_config_entry.json")
+        duthost.copy(src=config_entry, dest="/tmp/del_config_entry.json")
     duthost.shell("configlet -d -j {}".format("/tmp/del_config_entry.json"))
     duthost.shell("rm -f {}".format("/tmp/del_config_entry.json"))

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 import traceback
+import json
 from io import BytesIO
 
 import pytest
@@ -629,3 +630,11 @@ def get_downstream_neigh_type(topo_type, is_upper=True):
         return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
 
     return None
+
+def delete_running_config(config_entry, duthost, is_json=True):
+    if is_json:
+        duthost.copy(content=json.dumps(config_entry, indent=4), dest="/tmp/del_config_entry.json")
+    else:
+        duthost.copy(scr=config_entry, dest="/tmp/del_config_entry.json")
+    duthost.shell("configlet -d -j {}".format("/tmp/del_config_entry.json"))
+    duthost.shell("rm -f {}".format("/tmp/del_config_entry.json"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix cherry pick conflict of PR (https://github.com/sonic-net/sonic-mgmt/pull/8901)
But in 202012 branch, module vlan/test_autostate_disabled.py doesn't exist, so, only add function `delete_running_config` in this PR. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix cherry pick conflict of PR (https://github.com/sonic-net/sonic-mgmt/pull/8901)
But in 202012 branch, module vlan/test_autostate_disabled.py doesn't exist, so, only add function `delete_running_config` in this PR. 

#### How did you do it?
Add function `delete_running_config` in this PR. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
