### PR TITLE
Enhance setup-management-network.sh to avoid break lab server connectivity

### DIFF
--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -46,6 +46,16 @@ if ! ifconfig br1; then
     echo "br1 not found, creating bridge network"
     brctl addbr br1
     brctl show br1
+else
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo
+    echo "  br1 exists, possibly lab server, are you sure you want to continue?"
+    echo
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo
+    echo
+    echo "Please double check and manually configure IP for br1 to avoid breaking lab server connectivity"
+    exit
 fi
 echo
 

--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -55,7 +55,7 @@ else
     echo
     echo
     echo "Please double check and manually configure IP for br1 to avoid breaking lab server connectivity"
-    exit
+    exit 0
 fi
 echo
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Lab server could have management IP configured on bridge "br1". If run this script on such lab server, the original mgmt IP could be changed and connectivity to the lab server may be lost.

#### How did you do it?
This change updated the setup-management-network.sh script to skip configuring mgmt IP for br1 bridge if it already exists.

#### How did you verify/test it?
Tested on local server.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
