### PR TITLE
[202205] Fix typo in string format

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1342,8 +1342,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg]), \


### PR DESCRIPTION
### Description of PR
Trivial test fix. .format() is intended for the entire string which was broken up by a line separator. This problem is specific to 202205 as code in master is already fixed by  miscellaneous style updates.

Summary:
Fixes # (issue)

### Type of change

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
