### PR TITLE
[advanced-reboot] Enhance IO: start traffic when teamd goes down and run until FINALIZER is active

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1475,13 +1475,13 @@ class ReloadTest(BaseTest):
             dut_datetime_during_shutdown = self.get_now_time()
             time_passed = float(dut_datetime_during_shutdown.strftime(
                 "%s")) - float(dut_datetime.strftime("%s"))
-            self.log('teamd service state time passed: {}'.format(str(time_passed)))
             if time_passed > teamd_shutdown_timeout:
                 self.fails['dut'].add(
                     'Teamd service did not go down')
                 raise TimeoutError
             teamd_state = self.get_teamd_state()
-            self.log('teamd service state: {}'.format(teamd_state))
+
+        self.log('teamd service state: {}'.format(teamd_state))
 
     def reboot_dut(self):
         time.sleep(self.reboot_delay)
@@ -1521,7 +1521,6 @@ class ReloadTest(BaseTest):
 
             self.sniff_thr.start()
             self.sender_thr.start()
-
 
         if stdout != []:
             self.log("stdout from %s: %s" % (self.reboot_type, str(stdout)))
@@ -1760,7 +1759,7 @@ class ReloadTest(BaseTest):
             self.create_single_pcap(capture_pcap)
             self.packets = scapyall.rdpcap(capture_pcap)
             self.log("Number of all packets captured: {}".format(len(self.packets)))
-        except Exception as err:
+        except Exception:
             traceback_msg = traceback.format_exc()
             self.log("Error in tcpdump_sniff: {}".format(traceback_msg))
 
@@ -1793,7 +1792,6 @@ class ReloadTest(BaseTest):
             process.join()
 
         self.log("Killed all tcpdump processes by SIGINT")
-
 
     def start_dump_process(self, iface, pcap_path, tcpdump_filter):
         """

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -239,10 +239,7 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
-        # How many packets to be sent in send_in_background method
-        self.packets_to_send = min(
-            int(self.time_to_listen / (self.send_interval + 0.0015)), 45000)
-
+        self.sent_packet_count = 0
         # Thread pool for background watching operations
         self.pool = ThreadPool(processes=3)
 
@@ -255,6 +252,7 @@ class ReloadTest(BaseTest):
         self.asic_state_time = {}  # Recording last asic state entering time
         self.asic_vlan_reach = []  # Recording asic vlan reachability
         self.recording = False  # Knob for recording asic_vlan_reach
+        self.finalizer_state = ''
         # light_probe:
         #    True : when one direction probe fails, don't probe another.
         #    False: when one direction probe fails, continue probe another.
@@ -710,13 +708,6 @@ class ReloadTest(BaseTest):
         if 'warm-reboot' in self.reboot_type:
             self.log(self.get_sad_info())
 
-        # Pre-generate list of packets to be sent in send_in_background method.
-        generate_start = datetime.datetime.now()
-        if not self.vnet:
-            self.generate_bidirectional()
-        self.log("%d packets are ready after: %s" % (
-            len(self.packets_list), str(datetime.datetime.now() - generate_start)))
-
         self.dataplane = ptf.dataplane_instance
         for p in self.dataplane.ports.values():
             port = p.get_packet_source()
@@ -897,36 +888,6 @@ class ReloadTest(BaseTest):
         self.arp_resp.set_do_not_care_scapy(scapy.ARP,   'hwsrc')
         self.arp_src_port = src_port
 
-    def generate_bidirectional(self):
-        """
-        This method is used to pre-generate packets to be sent in background thread.
-        Packets are composed into a list, and present a bidirectional flow as next:
-        five packet from T1, one packet from vlan.
-        Each packet has sequential TCP Payload - to be identified later.
-        """
-
-        self.send_interval = self.time_to_listen / self.packets_to_send
-        self.packets_list = []
-        from_t1_iter = itertools.cycle(self.from_t1)
-        sent_count_vlan_to_t1 = 0
-        sent_count_t1_to_vlan = 0
-        for i in range(self.packets_to_send):
-            payload = '0' * 60 + str(i)
-            if (i % 5) == 0:   # From vlan to T1.
-                packet = scapyall.Ether(self.from_vlan_packet)
-                packet.load = payload
-                from_port = self.from_server_src_port
-                sent_count_vlan_to_t1 += 1
-            else:   # From T1 to vlan.
-                src_port, packet = next(from_t1_iter)
-                packet = scapyall.Ether(packet)
-                packet.load = payload
-                from_port = src_port
-                sent_count_t1_to_vlan += 1
-            self.packets_list.append((from_port, str(packet)))
-        self.log("Sent prep count vlan to t1: {}".format(sent_count_vlan_to_t1))
-        self.log("Sent prep count t1 to vlan: {}".format(sent_count_t1_to_vlan))
-
     def put_nowait(self, queue, data):
         try:
             queue.put_nowait(data)
@@ -1008,9 +969,9 @@ class ReloadTest(BaseTest):
         self.wait_until_control_plane_up()
         dut_datetime = self.get_now_time()
         self.log('waiting for warmboot-finalizer service to become activating')
-        finalizer_state = self.get_warmboot_finalizer_state()
+        self.finalizer_state = self.get_warmboot_finalizer_state()
 
-        while finalizer_state != 'activating':
+        while self.finalizer_state != 'activating':
             time.sleep(1)
             dut_datetime_after_ssh = self.get_now_time()
             time_passed = float(dut_datetime_after_ssh.strftime(
@@ -1019,15 +980,15 @@ class ReloadTest(BaseTest):
                 self.fails['dut'].add(
                     'warmboot-finalizer never reached state "activating"')
                 raise TimeoutError
-            finalizer_state = self.get_warmboot_finalizer_state()
+            self.finalizer_state = self.get_warmboot_finalizer_state()
 
         self.log('waiting for warmboot-finalizer service to finish')
-        finalizer_state = self.get_warmboot_finalizer_state()
-        self.log('warmboot finalizer service state {}'.format(finalizer_state))
+        self.finalizer_state = self.get_warmboot_finalizer_state()
+        self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
         count = 0
-        while finalizer_state == 'activating':
-            finalizer_state = self.get_warmboot_finalizer_state()
-            self.log('warmboot finalizer service state {}'.format(finalizer_state))
+        while self.finalizer_state == 'activating':
+            self.finalizer_state = self.get_warmboot_finalizer_state()
+            self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
             time.sleep(10)
             if count * 10 > int(self.test_params['warm_up_timeout_secs']):
                 self.fails['dut'].add(
@@ -1487,16 +1448,43 @@ class ReloadTest(BaseTest):
         else:
             return non_zero[-1]
 
+    def get_teamd_state(self):
+        stdout, stderr, _ = self.dut_connection.execCommand(
+            'sudo systemctl is-active teamd.service')
+        if stderr:
+            self.fails['dut'].add("Error collecting teamd state. stderr: {}, stdout:{}".format(
+                str(stderr), str(stdout)))
+            raise Exception("Error collecting teamd state. stderr: {}, stdout:{}".format(
+                str(stderr), str(stdout)))
+        if not stdout:
+            self.log('teamd state not returned from DUT')
+            return ''
+
+        teamd_state = stdout[0].strip()
+        return teamd_state
+
+    def wait_until_teamd_goes_down(self):
+        self.log('Waiting for teamd service to go down')
+        teamd_state = self.get_teamd_state()
+        self.log('teamd service state: {}'.format(teamd_state))
+        dut_datetime = self.get_now_time()
+        teamd_shutdown_timeout = 300
+
+        while teamd_state == 'active':
+            time.sleep(1)
+            dut_datetime_during_shutdown = self.get_now_time()
+            time_passed = float(dut_datetime_during_shutdown.strftime(
+                "%s")) - float(dut_datetime.strftime("%s"))
+            self.log('teamd service state time passed: {}'.format(str(time_passed)))
+            if time_passed > teamd_shutdown_timeout:
+                self.fails['dut'].add(
+                    'Teamd service did not go down')
+                raise TimeoutError
+            teamd_state = self.get_teamd_state()
+            self.log('teamd service state: {}'.format(teamd_state))
+
     def reboot_dut(self):
         time.sleep(self.reboot_delay)
-
-        if not self.kvm_test and\
-                (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
-                 self.reboot_type or 'service-warm-restart' in self.reboot_type):
-            # Event for the sniff_in_background status.
-            self.sniffer_started = threading.Event()
-            self.sniff_thr.start()
-            self.sender_thr.start()
 
         self.log("Rebooting remote side")
         if self.reboot_type != 'service-warm-restart' and self.test_params['other_vendor_flag'] is False:
@@ -1506,22 +1494,34 @@ class ReloadTest(BaseTest):
             if "retry count" in stdout:
                 if self.test_params['neighbor_type'] == "sonic":
                     stdout, stderr, return_code = self.dut_connection.execCommand(
-                        "sudo " + self.reboot_type + " -N", timeout=30)
+                        "sudo " + self.reboot_type + " -N", timeout=10)
                 else:
                     stdout, stderr, return_code = self.dut_connection.execCommand(
-                        "sudo " + self.reboot_type + " -n", timeout=30)
+                        "sudo " + self.reboot_type + " -n", timeout=10)
             else:
                 stdout, stderr, return_code = self.dut_connection.execCommand(
-                    "sudo " + self.reboot_type, timeout=30)
+                    "sudo " + self.reboot_type, timeout=10)
 
         elif self.test_params['other_vendor_flag'] is True:
             ignore_db_integrity_check = " -d"
             stdout, stderr, return_code = self.dut_connection.execCommand(
-                "sudo " + self.reboot_type + ignore_db_integrity_check, timeout=30)
+                "sudo " + self.reboot_type + ignore_db_integrity_check, timeout=10)
 
         else:
             self.restart_service()
             return
+
+        if not self.kvm_test and\
+                (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
+                 self.reboot_type or 'service-warm-restart' in self.reboot_type):
+            # Event for the sniff_in_background status.
+            self.sniffer_started = threading.Event()
+
+            self.wait_until_teamd_goes_down()
+
+            self.sniff_thr.start()
+            self.sender_thr.start()
+
 
         if stdout != []:
             self.log("stdout from %s: %s" % (self.reboot_type, str(stdout)))
@@ -1661,17 +1661,14 @@ class ReloadTest(BaseTest):
             port = p.get_packet_source()
             scapyall.attach_filter(port.socket, filter_expression)
 
-    def send_in_background(self, packets_list=None, interval=None):
+    def send_in_background(self, packets_list=None):
         """
         This method sends predefined list of packets with predefined interval.
         """
-        if not interval:
-            interval = self.send_interval
         if not packets_list:
             packets_list = self.packets_list
         self.sniffer_started.wait(timeout=10)
         with self.dataplane_io_lock:
-            sent_packet_count = 0
             # While running fast data plane sender thread there are two reasons for filter to be applied
             #  1. filter out data plane traffic which is tcp to free up the load
             #     on PTF socket (sniffer thread is using a different one)
@@ -1681,17 +1678,37 @@ class ReloadTest(BaseTest):
                 'not (arp and ether src {}) and not tcp'.format(self.test_params['dut_mac']))
             sender_start = datetime.datetime.now()
             self.log("Sender started at %s" % str(sender_start))
-            for entry in packets_list:
-                time.sleep(interval)
-                if self.vnet:
-                    testutils.send_packet(
-                        self, entry[0], entry[1].decode("base64"))
-                else:
-                    testutils.send_packet(self, *entry)
-                sent_packet_count += 1
+
+            self.packets_list = []
+            from_t1_iter = itertools.cycle(self.from_t1)
+            sent_count_vlan_to_t1 = 0
+            sent_count_t1_to_vlan = 0
+
+            while True:
+                time.sleep(self.send_interval)
+                if self.reboot_start and self.finalizer_state == "inactive":
+                    # keep sending packets until device reboots and finalizer enters inactive state
+                    break
+                payload = '0' * 60 + str(self.sent_packet_count)
+                if (self.sent_packet_count % 5) == 0:   # From vlan to T1.
+                    packet = scapyall.Ether(self.from_vlan_packet)
+                    packet.load = payload
+                    from_port = self.from_server_src_port
+                    sent_count_vlan_to_t1 += 1
+                else:   # From T1 to vlan.
+                    src_port, packet = next(from_t1_iter)
+                    packet = scapyall.Ether(packet)
+                    packet.load = payload
+                    from_port = src_port
+                    sent_count_t1_to_vlan += 1
+                testutils.send_packet(self, from_port, str(packet))
+                self.sent_packet_count = self.sent_packet_count + 1
+
+            self.log("Sent count vlan to t1: {}".format(sent_count_vlan_to_t1))
+            self.log("Sent count t1 to vlan: {}".format(sent_count_t1_to_vlan))
             self.log("Sender has been running for %s" %
                      str(datetime.datetime.now() - sender_start))
-            self.log("Total sent packets by sender: {}".format(sent_packet_count))
+            self.log("Total sent packets by sender: {}".format(self.sent_packet_count))
 
             # Signal sniffer thread to allow early finish.
             # Without this signalling mechanism, the sniffer thread can continue for a hardcoded max time.
@@ -1734,14 +1751,18 @@ class ReloadTest(BaseTest):
             wait (int): Duration in seconds to sniff the traffic
             sniff_filter (str): Filter that tcpdump will use to collect only relevant packets
         """
-        capture_pcap = ("/tmp/capture_%s.pcap" % self.logfile_suffix
-                        if self.logfile_suffix is not None else "/tmp/capture.pcap")
-        subprocess.call(["rm", "-rf", capture_pcap])  # remove old capture
-        self.kill_sniffer = False
-        self.start_sniffer(capture_pcap, sniff_filter, wait)
-        self.create_single_pcap(capture_pcap)
-        self.packets = scapyall.rdpcap(capture_pcap)
-        self.log("Number of all packets captured: {}".format(len(self.packets)))
+        try:
+            capture_pcap = ("/tmp/capture_%s.pcap" % self.logfile_suffix
+                            if self.logfile_suffix is not None else "/tmp/capture.pcap")
+            subprocess.call(["rm", "-rf", capture_pcap])  # remove old capture
+            self.kill_sniffer = False
+            self.start_sniffer(capture_pcap, sniff_filter, wait)
+            self.create_single_pcap(capture_pcap)
+            self.packets = scapyall.rdpcap(capture_pcap)
+            self.log("Number of all packets captured: {}".format(len(self.packets)))
+        except Exception as err:
+            traceback_msg = traceback.format_exc()
+            self.log("Error in tcpdump_sniff: {}".format(traceback_msg))
 
     def start_sniffer(self, pcap_path, tcpdump_filter, timeout):
         """
@@ -1770,6 +1791,9 @@ class ReloadTest(BaseTest):
 
         for process in processes_list:
             process.join()
+
+        self.log("Killed all tcpdump processes by SIGINT")
+
 
     def start_dump_process(self, iface, pcap_path, tcpdump_filter):
         """
@@ -1827,12 +1851,11 @@ class ReloadTest(BaseTest):
     def check_tcp_payload(self, packet):
         """
         This method is used by examine_flow() method.
-        It returns True if a packet is not corrupted and has a valid TCP sequential TCP Payload,
-        as created by generate_bidirectional() method'.
+        It returns True if a packet is not corrupted and has a valid TCP sequential TCP Payload
         """
         try:
             int(str(packet[scapyall.TCP].payload)
-                ) in range(self.packets_to_send)
+                ) in range(self.sent_packet_count)
             return True
         except Exception:
             return False
@@ -2012,7 +2035,7 @@ class ReloadTest(BaseTest):
             self.fails["dut"].add("Data traffic loss not found but reboot test type is '%s' which "
                                   "must have data traffic loss" % self.reboot_type)
 
-        if len(self.packets_list) > sent_counter:
+        if self.sent_packet_count > sent_counter:
             self.dataplane_loss_checked_successfully = False
             self.fails["dut"].add("Not all sent packets counted by receiver process. "
                                   "Could be issue with sniffer performance")
@@ -2026,7 +2049,7 @@ class ReloadTest(BaseTest):
             self.fails["dut"].add("Unexpected count of sent packets available in pcap file. "
                                   "Could be issue with DUT flooding for original packets which was sent to DUT")
 
-        if prev_payload != (self.packets_to_send - 1):
+        if prev_payload != (self.sent_packet_count - 1):
             # Specific case when packet loss started but final lost packet not detected
             self.dataplane_loss_checked_successfully = False
             message = "Unable to calculate the dataplane traffic loss time. The traffic did not restore after " \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enhance IO: start traffic when teamd goes down and run until FINALIZER is active
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

The test always sends pre-defined number of packets.
If the warm reboot shutdown or warm recovery takes more time then the IO stops before warm recovery finishes.

This leads to cases when test fails to evaluate dataplane impact completely.
The test could lead to false negatives w/ 0s downtime when in fact there are drops.

This issue is highlighted recently when lag_keepalive script was added to warm shutdown path. Keepalive script added sleep of 60s and running IO test during this duration leads to IO finishing up much earlier.

#### How did you do it?

Start the IO when teamd goes down.
Run the IO continuously until FINALIZER service remains active.

#### How did you verify/test it?

Tested on KVM and physical device.

```
2023-07-14 18:38:52 : Rebooting remote side

2023-07-14 18:39:04 : Waiting for teamd service to go down
2023-07-14 18:39:05 : teamd service state: active <--------------- WAITING for teamd to down --------------------
2023-07-14 18:40:51 : teamd service state time passed: 104.0
2023-07-14 18:40:51 : teamd service state: inactive <--------------- teamd goes down ------------------
2023-07-14 18:40:51 : Sniffer started at 2023-07-14 18:40:51.673321 <---------------Sender and sniffer started------------------
2023-07-14 18:41:01 : Sender started at 2023-07-14 18:41:01.052229
2023-07-14 18:41:01 : IO sender and sniffer threads have started, wait until completion

2023-07-14 18:42:26 : waiting for warmboot-finalizer service to finish
2023-07-14 18:44:04 : warmboot finalizer service state activating
2023-07-14 18:44:15 : warmboot finalizer service state inactive <--------------- IO runs until FINALIZER is active ------------------

2023-07-14 18:44:15 : Sent count vlan to t1: 6244
2023-07-14 18:44:15 : Sent count t1 to vlan: 24973
2023-07-14 18:44:15 : Sender has been running for 0:03:14.694631
2023-07-14 18:44:15 : Total sent packets by sender: 31217
2023-07-14 18:44:17 : Killed all tcpdump processes by SIGINT

2023-07-14 18:47:32 : Packet flow examine started 0:06:30.593055 after the reboot
2023-07-14 18:53:05 : **************** Packet received summary: ********************
2023-07-14 18:53:05 : *********** Sent packets captured - 31217
2023-07-14 18:53:05 : *********** received packets captured - t1-to-vlan - 24973
2023-07-14 18:53:05 : *********** received packets captured - vlan-to-t1 - 6244
2023-07-14 18:53:05 : *********** Missed received packets - t1-to-vlan - 0
2023-07-14 18:53:05 : *********** Missed received packets - vlan-to-t1 - 0
2023-07-14 18:53:05 : **************************************************************
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
