### PR TITLE
Ignoring API connection failure to mux simulator

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -21,6 +21,17 @@ SONIC_SSH_REGEX = "OpenSSH_[\\w\\.]+ Debian"
 SONIC_SSH_PORT = 22
 
 
+@pytest.fixture(autouse=True)
+def _ignore_mux_errlogs(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(
+            [
+                ".*ERR pmon#CCmisApi.*y_cable_port.*GET http.*"
+            ])
+    return
+
+
 def restore_config_db(duthost):
     # Restore the original config_db to override the config_db with mgmt vrf config
     duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ignoring API connection failure to mux simulator because this is ought to happen when mvrf/test_mgmtvrf.py is run and currently it throws a loganalyzer error 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
when mgmt vrf is configured, by default eth0 and loopback0 is placed under it. All the routes from global default routes are removed. This explains why UCS is no longer reachable normally. Hence requests to mux server times out. We will have to ignore these errors.

E May 19 22:54:34.911514 tor40-2 ERR pmon#CCmisApi: y_cable_port 26: attempt=6, GET http://1.75.43.7:8080/mux/tor-40/26 for physical_port 26 failed with URLError(timeout('timed out'))
E
E May 19 22:54:34.911514 tor40-2 ERR pmon#CCmisApi: y_cable_port 26: Retry GET http://1.75.43.7:8080/mux/tor-40/26 for physical port 26 timeout after 30 seconds, attempted=6
E
E May 19 22:54:38.640960 tor40-2 ERR pmon#CCmisApi: y_cable_port 6: attempt=6, GET http://1.75.43.7:8080/mux/tor-40/6 for physical_port 6 failed with URLError(timeout('timed out'))
E
E May 19 22:54:38.640960 tor40-2 ERR pmon#CCmisApi: y_cable_port 6: Retry GET http://1.75.43.7:8080/mux/tor-40/6 for physical port 6 timeout after 30 seconds, attempted=6
E
E May 19 22:54:39.920964 tor40-2 ERR pmon#CCmisApi: y_cable_port 8: attempt=1, GET http://1.75.43.7:8080/mux/tor-40/8 for physical_port 8 failed with URLError(timeout('timed out'))
E
E May 19 22:54:43.645111 tor40-2 ERR pmon#CCmisApi: y_cable_port 6: attempt=1, GET http://1.75.43.7:8080/mux/tor-40/6 for physical_port 6 failed with URLError(timeout('timed out'))
Below is the ping output that shows this ip is only reachable via VRF now:

root@tor40-2:/home/cisco# sudo ip vrf exec mgmt ping -c 3 1.75.43.7
PING 1.75.43.7 (1.75.43.7) 56(84) bytes of data.
64 bytes from 1.75.43.7: icmp_seq=1 ttl=64 time=0.556 ms
64 bytes from 1.75.43.7: icmp_seq=2 ttl=64 time=0.548 ms
64 bytes from 1.75.43.7: icmp_seq=3 ttl=64 time=0.550 ms

--- 1.75.43.7 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2030ms
rtt min/avg/max/mdev = 0.548/0.551/0.556/0.003 ms
root@tor40-2:/home/cisco# ^C
root@tor40-2:/home/cisco# ping -c 1 1.75.43.7
PING 1.75.43.7 (1.75.43.7) 56(84) bytes of data.

--- 1.75.43.7 ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms

#### How did you do it?
By adding the syslog to ignore list

