### PR TITLE
[202205] Enhance LogAnalyzer to support parsing long log lines

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -48,6 +48,11 @@ err_invalid_input = -6
 err_end_ignore_marker = -7
 err_start_ignore_marker = -8
 
+#-- Max log message length
+# If allow_long_line is False, then any line longer than MAX_LOG_MESSAGE_LENGTH
+# will not be picked up by the analyzer.
+MAX_LOG_MESSAGE_LENGTH = 1000
+
 class AnsibleLogAnalyzer:
     '''
     @summary: Overview of functionality
@@ -390,7 +395,7 @@ class AnsibleLogAnalyzer:
 
         return ret_code
 
-    def analyze_file(self, log_file_path, match_messages_regex, ignore_messages_regex, expect_messages_regex):
+    def analyze_file(self, log_file_path, match_messages_regex, ignore_messages_regex, expect_messages_regex, allow_long_line=False, keyword=None):
         '''
         @summary: Analyze input file content for messages matching input regex
                   expressions. See line_matches() for details on matching criteria.
@@ -407,6 +412,10 @@ class AnsibleLogAnalyzer:
             regex class instance containing messages that are expected to appear in logfile.
 
         @param end_marker_regex - end marker
+
+        @param allow_long_line - Skip parsing long log message if allow_long_line is False.
+
+        @keyword - a keyword for a fast search in long log message before doing regex search
 
         @return: List of strings match search criteria.
         '''
@@ -482,8 +491,16 @@ class AnsibleLogAnalyzer:
             if in_analysis_range:
                 # Skip long logs in sairedis recording since most likely they are bulk set operations for non-default routes
                 # without much insight while they are time consuming to analyze
-                if not check_marker and len(rev_line) > 1000:
-                    continue
+                # In advanced_reboot test, we need to analyze the bulk operations for mac learning
+                # So we need to allow long lines
+                if len(rev_line) > MAX_LOG_MESSAGE_LENGTH:
+                    if not check_marker and not allow_long_line:
+                        continue
+                    # Skip the line if keyword is not None and keyword not in rev_line
+                    # This is for fast search before doing regex matching
+                    if keyword is not None and keyword not in rev_line:
+                        continue
+
                 if self.line_is_expected(rev_line, expect_messages_regex):
                     expected_lines.append(rev_line)
 
@@ -503,7 +520,7 @@ class AnsibleLogAnalyzer:
         return matching_lines, expected_lines
     #---------------------------------------------------------------------
 
-    def analyze_file_list(self, log_file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex):
+    def analyze_file_list(self, log_file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex, allow_long_line=False, keyword=None):
         '''
         @summary: Analyze input files messages matching input regex expressions.
             See line_matches() for details on matching criteria.
@@ -519,6 +536,12 @@ class AnsibleLogAnalyzer:
         @param expect_messages_regex:
             regex class instance containing messages that are expected to appear in logfile.
 
+        @param allow_long_line
+            if True, do not skip long lines
+
+        @param keyword
+            if not None, only analyze the lines containing keyword in order to speed up the regex matching
+
         @return: Returns map <file_name, list_of_matching_strings>
         '''
         res = {}
@@ -526,7 +549,8 @@ class AnsibleLogAnalyzer:
         for log_file in log_file_list:
             if not len(log_file):
                 continue
-            match_strings, expect_strings = self.analyze_file(log_file, match_messages_regex, ignore_messages_regex, expect_messages_regex)
+            match_strings, expect_strings = self.analyze_file(log_file, match_messages_regex, ignore_messages_regex, expect_messages_regex,
+                                                                allow_long_line=allow_long_line, keyword=keyword)
 
             match_strings.reverse()
             expect_strings.reverse()

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -49,7 +49,7 @@ err_end_ignore_marker = -7
 err_start_ignore_marker = -8
 
 #-- Max log message length
-# If allow_long_line is False, then any line longer than MAX_LOG_MESSAGE_LENGTH
+# The default maximum length of a single log message. Any line longer than MAX_LOG_MESSAGE_LENGTH
 # will not be picked up by the analyzer.
 MAX_LOG_MESSAGE_LENGTH = 1000
 
@@ -395,7 +395,7 @@ class AnsibleLogAnalyzer:
 
         return ret_code
 
-    def analyze_file(self, log_file_path, match_messages_regex, ignore_messages_regex, expect_messages_regex, allow_long_line=False, keyword=None):
+    def analyze_file(self, log_file_path, match_messages_regex, ignore_messages_regex, expect_messages_regex, maximum_log_length=None):
         '''
         @summary: Analyze input file content for messages matching input regex
                   expressions. See line_matches() for details on matching criteria.
@@ -413,9 +413,7 @@ class AnsibleLogAnalyzer:
 
         @param end_marker_regex - end marker
 
-        @param allow_long_line - Skip parsing long log message if allow_long_line is False.
-
-        @keyword - a keyword for a fast search in long log message before doing regex search
+        @param maximum_log_length - The long log message (length > maximum_log_length) will be dropped by LogAnalyzer.
 
         @return: List of strings match search criteria.
         '''
@@ -493,13 +491,10 @@ class AnsibleLogAnalyzer:
                 # without much insight while they are time consuming to analyze
                 # In advanced_reboot test, we need to analyze the bulk operations for mac learning
                 # So we need to allow long lines
-                if len(rev_line) > MAX_LOG_MESSAGE_LENGTH:
-                    if not check_marker and not allow_long_line:
-                        continue
-                    # Skip the line if keyword is not None and keyword not in rev_line
-                    # This is for fast search before doing regex matching
-                    if keyword is not None and keyword not in rev_line:
-                        continue
+                if maximum_log_length is None:
+                    maximum_log_length = MAX_LOG_MESSAGE_LENGTH
+                if not check_marker and len(rev_line) > maximum_log_length:
+                    continue
 
                 if self.line_is_expected(rev_line, expect_messages_regex):
                     expected_lines.append(rev_line)
@@ -520,7 +515,7 @@ class AnsibleLogAnalyzer:
         return matching_lines, expected_lines
     #---------------------------------------------------------------------
 
-    def analyze_file_list(self, log_file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex, allow_long_line=False, keyword=None):
+    def analyze_file_list(self, log_file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex, maximum_log_length=None):
         '''
         @summary: Analyze input files messages matching input regex expressions.
             See line_matches() for details on matching criteria.
@@ -536,11 +531,8 @@ class AnsibleLogAnalyzer:
         @param expect_messages_regex:
             regex class instance containing messages that are expected to appear in logfile.
 
-        @param allow_long_line
-            if True, do not skip long lines
-
-        @param keyword
-            if not None, only analyze the lines containing keyword in order to speed up the regex matching
+        @param maximum_log_length
+            The maximum length of the log message. If the length of the log message is greater than this value,
 
         @return: Returns map <file_name, list_of_matching_strings>
         '''
@@ -550,7 +542,7 @@ class AnsibleLogAnalyzer:
             if not len(log_file):
                 continue
             match_strings, expect_strings = self.analyze_file(log_file, match_messages_regex, ignore_messages_regex, expect_messages_regex,
-                                                                allow_long_line=allow_long_line, keyword=keyword)
+                                                                maximum_log_length=maximum_log_length)
 
             match_strings.reverse()
             expect_strings.reverse()

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -276,14 +276,13 @@ class LogAnalyzer:
         self.ansible_host.command(cmd)
         return start_marker
 
-    def analyze(self, marker, fail=True, allow_long_line=False, keyword=None):
+    def analyze(self, marker, fail=True, maximum_log_length=None):
         """
         @summary: Extract syslog logs based on the start/stop markers and compose one file. Download composed file, analyze file based on defined regular expressions.
 
         @param marker: Marker obtained from "init" method.
         @param fail: Flag to enable/disable raising exception when loganalyzer find error messages.
-        @param allow_long_line: The long message (length > 1000) will be skipped if allow_long_line is False.
-        @param keyword: Keyword to search in the log file. The log messages without keyword will be skipped if keyword is not None.
+        @param maximum_log_length: The long message (length > maximum_log_length) will be skipped.
         @return: If "fail" is False - return dictionary of parsed syslog summary, if dictionary can't be parsed - return empty dictionary. If "fail" is True and if found match messages - raise exception.
         """
         logging.debug("Loganalyzer analyze")
@@ -340,7 +339,7 @@ class LogAnalyzer:
         logging.debug('    ignore_regex="{}"'.format(ignore_messages_regex.pattern if ignore_messages_regex else ''))
         logging.debug('    expect_regex="{}"'.format(expect_messages_regex.pattern if expect_messages_regex else ''))
         analyzer_parse_result = self.ansible_loganalyzer.analyze_file_list(file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex,
-                                                                           allow_long_line=allow_long_line, keyword=keyword)
+                                                                           maximum_log_length=maximum_log_length)
         # Print file content and remove the file
         for folder in file_list:
             with open(folder) as fo:

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -276,13 +276,14 @@ class LogAnalyzer:
         self.ansible_host.command(cmd)
         return start_marker
 
-    def analyze(self, marker, fail=True):
+    def analyze(self, marker, fail=True, allow_long_line=False, keyword=None):
         """
         @summary: Extract syslog logs based on the start/stop markers and compose one file. Download composed file, analyze file based on defined regular expressions.
 
         @param marker: Marker obtained from "init" method.
         @param fail: Flag to enable/disable raising exception when loganalyzer find error messages.
-
+        @param allow_long_line: The long message (length > 1000) will be skipped if allow_long_line is False.
+        @param keyword: Keyword to search in the log file. The log messages without keyword will be skipped if keyword is not None.
         @return: If "fail" is False - return dictionary of parsed syslog summary, if dictionary can't be parsed - return empty dictionary. If "fail" is True and if found match messages - raise exception.
         """
         logging.debug("Loganalyzer analyze")
@@ -338,7 +339,8 @@ class LogAnalyzer:
         logging.debug('    match_regex="{}"'.format(match_messages_regex.pattern if match_messages_regex else ''))
         logging.debug('    ignore_regex="{}"'.format(ignore_messages_regex.pattern if ignore_messages_regex else ''))
         logging.debug('    expect_regex="{}"'.format(expect_messages_regex.pattern if expect_messages_regex else ''))
-        analyzer_parse_result = self.ansible_loganalyzer.analyze_file_list(file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex)
+        analyzer_parse_result = self.ansible_loganalyzer.analyze_file_list(file_list, match_messages_regex, ignore_messages_regex, expect_messages_regex,
+                                                                           allow_long_line=allow_long_line, keyword=keyword)
         # Print file content and remove the file
         for folder in file_list:
             with open(folder) as fo:

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -484,17 +484,14 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             # restore original script. If the ".orig" file does not exist (upgrade path case), ignore the error.
             duthost.shell("mv {} {}".format(reboot_script_path + ".orig", reboot_script_path), module_ignore_errors=True)
         # For mac jump test, the log message we care about is uaually combined with other messages in one line, which makes
-        # the length of the line longer than 1000 and get dropped by Logananlyzer. So we need to set allow_long_line to True
-        # However, we found that the regex library in Python 2 takes a long time (over 10 minutes) to match a long string.
-        # To speed up the log searching in long log message, the keyword is set to scapy default MAC '00:06:07:08:09:0A'
-        # if the log message length is longer than 1000, but the keyword is not found, then the log message is dropped.
+        # the length of the line longer than 1000 and get dropped by Logananlyzer. So we need to increase the max allowed length.
+        # The regex library in Python 2 takes very long time (over 10 minutes) to process long lines. In our test, most of the combined
+        # log message for mac jump test is around 5000 characters. So we set the max allowed length to 6000.
         if "mac_jump" in test_name:
-            allow_long_line = True
-            keyword = "00:06:07:08:09:0A"
+            maxmum_log_len = 6000
         else:
-            allow_long_line = False
-            keyword = None
-        result = loganalyzer.analyze(marker, fail=False, allow_long_line=allow_long_line, keyword=keyword)
+            maxmum_log_len = None
+        result = loganalyzer.analyze(marker, fail=False, maximum_log_length=maxmum_log_len)
         analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
         offset_from_kexec = dict()
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -495,7 +495,17 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
         offset_from_kexec = dict()
 
-        for key, messages in result["expect_messages"].items():
+        # Parsing sairedis shall happen after parsing syslog because FDB_AGING_DISABLE is required
+        # when analysing sairedis.rec log, so we need to sort the keys
+        key_list = ["syslog", "bgpd.log", "sairedis.rec"]
+        for i in range(0, len(key_list)):
+            for message_key in result["expect_messages"].keys():
+                if key_list[i] in message_key:
+                    key_list[i] = message_key
+                    break
+    
+        for key in key_list:
+            messages = result["expect_messages"][key]
             if "syslog" in key:
                 get_kexec_time(duthost, messages, analyze_result)
                 reboot_start_time = analyze_result.get("reboot_time", {}).get("timestamp", {}).get("Start")

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -487,11 +487,7 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         # the length of the line longer than 1000 and get dropped by Logananlyzer. So we need to increase the max allowed length.
         # The regex library in Python 2 takes very long time (over 10 minutes) to process long lines. In our test, most of the combined
         # log message for mac jump test is around 5000 characters. So we set the max allowed length to 6000.
-        if "mac_jump" in test_name:
-            maxmum_log_len = 6000
-        else:
-            maxmum_log_len = None
-        result = loganalyzer.analyze(marker, fail=False, maximum_log_length=maxmum_log_len)
+        result = loganalyzer.analyze(marker, fail=False, maximum_log_length=6000)
         analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
         offset_from_kexec = dict()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
**This PR is to backport PR  #8940 into `202205` branch.**

This PR is to fix flaky test case `test_warm_reboot_mac_jump`.
The test failed because the MAC jump log was not found in sairedis log. The error message is
```
['MAC jumping not detected when expected for address: 00-06-07-08-09-0A'])]
```
However, the log we are looking for is in sairedis log. Because it was dropped by LogAnalyzer because long log message (length > 1000) is skipped by default.
```
            if in_analysis_range:
                # Skip long logs in sairedis recording since most likely
                # they are bulk set operations for non-default routes
                # without much insight while they are time consuming to analyze
                if not check_marker and len(rev_line) > 1000:
                    continue
                if self.line_is_expected(rev_line, expect_messages_regex):
                    expected_lines.append(rev_line)

                elif self.line_matches(rev_line, match_messages_regex, ignore_messages_regex):
                    matching_lines.append(rev_line)
```
https://github.com/sonic-net/sonic-mgmt/blob/9fef739a0ec33c8dce84b5d5bcd61afd0b73b54e/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py#L499C1-L509C52

This PR addressed the issue by enhancing LogAnalyzer. For `test_warm_reboot_mac_jump`, the log message with length <= 6000 is picked and parsed by LogAnalyzer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_warm_reboot_mac_jump`.

#### How did you do it?
This PR addressed the issue by enhancing LogAnalyzer. For `test_warm_reboot_mac_jump`, the log message with length <= 6000 is picked and parsed by LogAnalyzer.

#### How did you verify/test it?
The change is verified by running `test_warm_reboot_mac_jump`. Now the test is consistently passing.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
