### PR TITLE
[202012][advanced-reboot] Listen on peer dut during dualtor server->t1 traffic and fix loopback ping

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1,5 +1,6 @@
 #
-# ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="{\"Vlan100\": \"172.0.0.0/22\"}";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
+# ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";peer_ports_file="/tmp/peer_ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="{\"Vlan100\": \"172.0.0.0/22\"}";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
+#
 #
 #
 # This test checks that DUT is able to make FastReboot procedure
@@ -138,6 +139,8 @@ class ReloadTest(BaseTest):
         self.check_param('portchannel_ports_file', '', required=True)
         self.check_param('vlan_ports_file', '', required=True)
         self.check_param('ports_file', '', required=True)
+        self.check_param('peer_ports_file', '', required=False)
+        self.check_param('dut_mux_status', '', required=False)
         self.check_param('dut_mac', '', required=True)
         self.check_param('vlan_mac', '', required=True)
         self.check_param('default_ip_range', '', required=True)
@@ -264,8 +267,20 @@ class ReloadTest(BaseTest):
 
     def read_port_indices(self):
         port_indices = self.read_json('ports_file')
+        peer_port_indices = {}
+        if self.is_dualtor:
+            peer_port_indices = self.read_json('peer_ports_file')
 
-        return port_indices
+        return port_indices, peer_port_indices
+
+    def read_mux_status(self):
+        active_port_indices = []
+        mux_status = self.read_json('dut_mux_status')
+        for intf, port in self.port_indices.items():
+            if intf in mux_status and mux_status[intf]['status'] == 'active':
+                active_port_indices.append(port)
+        
+        return active_port_indices
 
     def read_vlan_portchannel_ports(self):
         portchannel_content = self.read_json('portchannel_ports_file')
@@ -293,7 +308,17 @@ class ReloadTest(BaseTest):
             if not pc['name'] in pc_in_vlan and pc['name'] in active_portchannels:
                 pc_ifaces.extend([self.port_indices[member] for member in pc['members']])
 
-        return ports_per_vlan, pc_ifaces
+        dualtor_pc_ifaces = []
+        if self.is_dualtor:
+            peer_active_portchannels = list()
+            for neighbor_info in list(self.peer_vm_dut_map.values()):
+                peer_active_portchannels.append(neighbor_info["dut_portchannel"])
+            dualtor_pc_ifaces.extend(pc_ifaces)
+            for pc in portchannel_content.values():
+                if not pc['name'] in pc_in_vlan and pc['name'] in peer_active_portchannels:
+                    dualtor_pc_ifaces.extend([self.peer_port_indices[member] for member in pc['members']])
+        
+        return ports_per_vlan, pc_ifaces, dualtor_pc_ifaces
 
     def check_param(self, param, default, required = False):
         if param not in self.test_params:
@@ -396,6 +421,9 @@ class ReloadTest(BaseTest):
                 self.vm_dut_map[key]['dut_ports'] = []
                 self.vm_dut_map[key]['neigh_ports'] = []
                 self.vm_dut_map[key]['ptf_ports'] = []
+                if self.is_dualtor:
+                    self.peer_vm_dut_map[key] = dict()
+                    self.peer_vm_dut_map[key]['dut_ports'] = []
 
     def get_portchannel_info(self):
         content = self.read_json('portchannel_ports_file')
@@ -405,6 +433,8 @@ class ReloadTest(BaseTest):
                     if member in self.vm_dut_map[vm_key]['dut_ports']:
                         self.vm_dut_map[vm_key]['dut_portchannel'] = str(key)
                         self.vm_dut_map[vm_key]['neigh_portchannel'] = 'Port-Channel1'
+                        if self.is_dualtor:
+                            self.peer_vm_dut_map[vm_key]['dut_portchannel'] = str(key)
                         break
 
     def get_neigh_port_info(self):
@@ -414,6 +444,8 @@ class ReloadTest(BaseTest):
                 self.vm_dut_map[content[key]['name']]['dut_ports'].append(str(key))
                 self.vm_dut_map[content[key]['name']]['neigh_ports'].append(str(content[key]['port']))
                 self.vm_dut_map[content[key]['name']]['ptf_ports'].append(self.port_indices[key])
+                if self.is_dualtor:
+                    self.peer_vm_dut_map[content[key]['name']]['dut_ports'].append(str(key))
 
     def build_peer_mapping(self):
         '''
@@ -427,6 +459,7 @@ class ReloadTest(BaseTest):
                                     }
         '''
         self.vm_dut_map = {}
+        self.peer_vm_dut_map = {}
         for file in self.test_params['preboot_files'].split(','):
             self.test_params[file] = '/tmp/' + file + '.json'
         self.get_peer_dev_info()
@@ -540,10 +573,19 @@ class ReloadTest(BaseTest):
 
     def setUp(self):
         self.fails['dut'] = set()
-        self.port_indices = self.read_port_indices()
+        self.dut_mac = self.test_params['dut_mac']
+        self.vlan_mac = self.test_params['vlan_mac']
+        self.lo_prefix = self.test_params['lo_prefix']
+        if self.vlan_mac != self.dut_mac:
+            self.is_dualtor = True
+        else:
+            self.is_dualtor = False
+        self.port_indices, self.peer_port_indices = self.read_port_indices()
+        if self.is_dualtor:
+            self.active_port_indices = self.read_mux_status()
         self.vlan_ip_range = ast.literal_eval(self.test_params['vlan_ip_range'])
         self.build_peer_mapping()
-        self.ports_per_vlan, self.portchannel_ports = self.read_vlan_portchannel_ports()
+        self.ports_per_vlan, self.portchannel_ports, self.dualtor_portchannel_ports = self.read_vlan_portchannel_ports()
         self.vlan_ports = []
         for ports in self.ports_per_vlan.values():
             self.vlan_ports += ports
@@ -556,9 +598,6 @@ class ReloadTest(BaseTest):
         self.reboot_type = self.test_params['reboot_type']
         if self.reboot_type in ['soft-reboot', 'reboot']:
             raise ValueError('Not supported reboot_type %s' % self.reboot_type)
-        self.dut_mac = self.test_params['dut_mac']
-        self.vlan_mac = self.test_params['vlan_mac']
-        self.lo_prefix = self.test_params['lo_prefix']
 
         if self.kvm_test:
             self.log("This test is for KVM platform")
@@ -587,7 +626,7 @@ class ReloadTest(BaseTest):
         self.from_server_src_addr  = random.choice(self.vlan_host_map[self.random_vlan].keys())
         self.from_server_src_mac   = self.hex_to_mac(self.vlan_host_map[self.random_vlan][self.from_server_src_addr])
         self.from_server_dst_addr  = self.random_ip(self.test_params['default_ip_range'])
-        self.from_server_dst_ports = self.portchannel_ports
+        self.from_server_dst_ports = self.dualtor_portchannel_ports if self.is_dualtor else self.portchannel_ports
 
         self.log("Test params:")
         self.log("DUT ssh: %s@%s" % (self.test_params['dut_username'], self.test_params['dut_hostname']))
@@ -741,7 +780,8 @@ class ReloadTest(BaseTest):
     def generate_ping_dut_lo(self):
         self.ping_dut_packets = []
         dut_lo_ipv4 = self.lo_prefix.split('/')[0]
-        for src_port in self.vlan_host_ping_map:
+        
+        for src_port in self.active_port_indices if self.is_dualtor else self.vlan_host_ping_map:
             src_addr = random.choice(self.vlan_host_ping_map[src_port].keys())
             src_mac = self.hex_to_mac(self.vlan_host_ping_map[src_port][src_addr])
             packet = simple_icmp_packet(eth_src=src_mac,
@@ -1901,6 +1941,11 @@ class ReloadTest(BaseTest):
                 testutils.send_packet(self, src_port, packet)
 
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.ping_dut_exp_packet, self.vlan_ports, timeout=self.PKT_TOUT)
+
+        if self.is_dualtor:
+            # handle two-for-one icmp reply for dual tor (when vlan and dut mac are diff):
+            # icmp_responder will also generate a response for this ICMP req, ignore that reply
+            total_rcv_pkt_cnt = total_rcv_pkt_cnt - self.ping_dut_pkts
 
         self.log("Send %5d Received %5d ping DUT" % (self.ping_dut_pkts, total_rcv_pkt_cnt), True)
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -15,6 +15,8 @@ from tests.common.helpers.sad_path import SadOperation
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import InterruptableThread
+from tests.common.dualtor.data_plane_utils import get_peerhost
+from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +92,12 @@ class AdvancedReboot:
         self.lagMemberCnt = 0
         self.vlanMaxCnt = 0
         self.hostMaxCnt = HOST_MAX_COUNT
+        if "dualtor" in self.getTestbedType():
+            self.dual_tor_mode = True
+            peer_duthost = get_peerhost(duthosts, duthost)
+            self.peer_duthost = peer_duthost
+        else:
+            self.dual_tor_mode = False
 
         self.__buildTestbedData(tbinfo)
 
@@ -156,6 +164,8 @@ class AdvancedReboot:
         """
 
         self.mgFacts = self.duthost.get_extended_minigraph_facts(tbinfo)
+        if self.dual_tor_mode:
+            self.peer_mgFacts = self.peer_duthost.get_extended_minigraph_facts(tbinfo)
 
         self.rebootData['arista_vms'] = [
             attr['mgmt_addr'] for dev, attr in self.mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
@@ -173,6 +183,7 @@ class AdvancedReboot:
         if vlan_table:
             vlan_name = list(vlan_table.keys())[0]
             vlan_mac = vlan_table[vlan_name].get('mac', self.rebootData['dut_mac'])
+
         self.rebootData['vlan_mac'] = vlan_mac
         self.rebootData['lo_prefix'] = "%s/%s" % (self.mgFacts['minigraph_lo_interfaces'][0]['addr'],
                                                   self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
@@ -546,7 +557,7 @@ class AdvancedReboot:
         return self.runRebootTest()
 
     def __setupRebootOper(self, rebootOper):
-        if "dualtor" in self.getTestbedType():
+        if self.dual_tor_mode:
             for device in self.duthosts:
                 device.shell("config mux mode manual all")
 
@@ -572,6 +583,13 @@ class AdvancedReboot:
             'neigh_port_info': copy.deepcopy(self.mgFacts['minigraph_neighbors']),
         }
 
+        if self.dual_tor_mode:
+            dualtor_testData = {
+                'peer_ports': copy.deepcopy(self.peer_mgFacts['minigraph_ptf_indices']),
+                'dut_mux_status': copy.deepcopy(show_muxcable_status(self.duthost)),
+            }
+            testData.update(dualtor_testData)
+
         if isinstance(rebootOper, SadOperation):
             logger.info('Running setup handler for reboot operation {}'.format(rebootOper))
             rebootOper.setup(testData)
@@ -592,7 +610,7 @@ class AdvancedReboot:
             rebootOper.verify()
 
     def __revertRebootOper(self, rebootOper):
-        if "dualtor" in self.getTestbedType():
+        if self.dual_tor_mode:
             for device in self.duthosts:
                 device.shell("config mux mode auto all")
 
@@ -635,6 +653,12 @@ class AdvancedReboot:
             "preboot_files" : self.prebootFiles,
             "alt_password": self.duthost.host.options['variable_manager']._hostvars[self.duthost.hostname].get("ansible_altpassword")
         }
+
+        if self.dual_tor_mode:
+            params.update({
+            "peer_ports_file": self.rebootData['peer_ports_file'],
+            "dut_mux_status": self.rebootData['dut_mux_status_file'],
+            })
 
         if not isinstance(rebootOper, SadOperation):
             # Non-routing neighbor/dut lag/bgp, vlan port up/down operation is performed before dut reboot process

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -8,14 +8,36 @@ from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot # lgtm[py/unused-import]
 from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
 
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder
-from tests.common.fixtures.ptfhost_utils import run_garp_service
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip, show_muxcable_status
+from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, toggle_all_simulator_ports, get_mux_status, check_mux_status, validate_check_result
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0'),
     pytest.mark.skip_check_dut_health
 ]
+
+SINGLE_TOR_MODE = 'single'
+DUAL_TOR_MODE = 'dual'
+
+logger = logging.getLogger()
+
+
+@pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
+def testing_config(request, tbinfo):
+    testing_mode = request.param
+    if 'dualtor' in tbinfo['topo']['name']:
+        if testing_mode == SINGLE_TOR_MODE:
+            pytest.skip("skip SINGLE_TOR_MODE tests on Dual ToR testbeds")
+        if testing_mode == DUAL_TOR_MODE:
+            yield testing_mode
+    else:
+        if testing_mode == DUAL_TOR_MODE:
+            pytest.skip("skip DUAL_TOR_MODE tests on Single ToR testbeds")
+        yield testing_mode
 
 
 def pytest_generate_tests(metafunc):
@@ -48,14 +70,27 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
 
 
 @pytest.mark.device_type('vs')
-def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer, capture_interface_counters):
+def test_warm_reboot(request, testing_config, get_advanced_reboot, verify_dut_health, duthosts, advanceboot_loganalyzer, 
+    capture_interface_counters, toggle_all_simulator_ports, enum_rand_one_per_hwsku_frontend_hostname, toggle_simulator_port_to_upper_tor):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
+    testing_mode = testing_config
+    if testing_mode == DUAL_TOR_MODE:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        toggle_all_simulator_ports(LOWER_TOR)
+        check_result = wait_until(120, 10, 10, check_mux_status, duthosts, LOWER_TOR)
+        validate_check_result(check_result, duthosts, get_mux_status)
+        mux_list = show_muxcable_status(duthost)
+        toggle_mux_size = len(mux_list) / 2
+        for i in range(toggle_mux_size):
+            itfs, _ = rand_selected_interface(duthost)
+            # Select half of interfaces and toggle to active on upper ToR
+            toggle_simulator_port_to_upper_tor(itfs)
+
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
         advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
@@ -134,3 +169,12 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
     add_fail_step_to_reboot('warm-reboot')
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_fail=True)
     advancedReboot.runRebootTestcase()
+
+
+def rand_selected_interface(tor):
+    """Select a random interface to test."""
+    server_ips = mux_cable_server_ip(tor)
+    iface = str(random.choice(server_ips.keys()))
+    logging.info("select DUT interface %s to test.", iface)
+    return iface, server_ips[iface]
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This is a cherry-pick of PR https://github.com/sonic-net/sonic-mgmt/pull/7532
Fixed going down part of the warmboot test on dualtor. Capture sent server->t1 traffic on both DUT in dualtor scenario and listen for icmp on active ports
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Packet drops are seen during dual tor tests due to not capturing DUT -> T1 packets.
ICMP ping packets are dropped on standby ToR

#### How did you do it?
Added standby ToR portchannel ports to portchannel port list.
Fixed ping dut packets dropped on standby ToR by sending icmp ping to active ports only

#### How did you verify/test it?
Run warm-reboot test on standby ToR and confirm server->T1 and all ping DUT are received.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
