### PR TITLE
[202205][advanced-reboot] Listen on peer dut during dualtor server->t1 traffic and fix loopback ping

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -9,14 +9,37 @@ from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot # lgtm[py/unused-import]
 from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
 
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder
-from tests.common.fixtures.ptfhost_utils import run_garp_service
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip, show_muxcable_status
+from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, toggle_all_simulator_ports, get_mux_status, check_mux_status, validate_check_result
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0'),
     pytest.mark.skip_check_dut_health
 ]
+
+SINGLE_TOR_MODE = 'single'
+DUAL_TOR_MODE = 'dual'
+
+logger = logging.getLogger()
+
+
+@pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
+def testing_config(request, tbinfo):
+    testing_mode = request.param
+    if 'dualtor' in tbinfo['topo']['name']:
+        if testing_mode == SINGLE_TOR_MODE:
+            pytest.skip("skip SINGLE_TOR_MODE tests on Dual ToR testbeds")
+        if testing_mode == DUAL_TOR_MODE:
+            yield testing_mode
+    else:
+        if testing_mode == DUAL_TOR_MODE:
+            pytest.skip("skip DUAL_TOR_MODE tests on Single ToR testbeds")
+        yield testing_mode
+
 
 def pytest_generate_tests(metafunc):
     input_sad_cases = metafunc.config.getoption("sad_case_list")
@@ -47,14 +70,27 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
 
 
 @pytest.mark.device_type('vs')
-def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer, capture_interface_counters):
+def test_warm_reboot(request, testing_config, get_advanced_reboot, verify_dut_health, duthosts, advanceboot_loganalyzer, 
+    capture_interface_counters, toggle_all_simulator_ports, enum_rand_one_per_hwsku_frontend_hostname, toggle_simulator_port_to_upper_tor):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
+    testing_mode = testing_config
+    if testing_mode == DUAL_TOR_MODE:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        toggle_all_simulator_ports(LOWER_TOR)
+        check_result = wait_until(120, 10, 10, check_mux_status, duthosts, LOWER_TOR)
+        validate_check_result(check_result, duthosts, get_mux_status)
+        mux_list = show_muxcable_status(duthost)
+        toggle_mux_size = len(mux_list) / 2
+        for i in range(toggle_mux_size):
+            itfs, _ = rand_selected_interface(duthost)
+            # Select half of interfaces and toggle to active on upper ToR
+            toggle_simulator_port_to_upper_tor(itfs)
+
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
         advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
@@ -133,3 +169,11 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
     add_fail_step_to_reboot('warm-reboot')
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_fail=True)
     advancedReboot.runRebootTestcase()
+
+
+def rand_selected_interface(tor):
+    """Select a random interface to test."""
+    server_ips = mux_cable_server_ip(tor)
+    iface = str(random.choice(server_ips.keys()))
+    logging.info("select DUT interface %s to test.", iface)
+    return iface, server_ips[iface]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This is a cherry-pick of PR https://github.com/sonic-net/sonic-mgmt/pull/7532
Fixed going down part of the warmboot test on dualtor. Capture sent server->t1 traffic on both DUT in dualtor scenario and listen for icmp on active ports
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Packet drops are seen during dual tor tests due to not capturing DUT -> T1 packets.
ICMP ping packets are dropped on standby ToR

#### How did you do it?
Added standby ToR portchannel ports to portchannel port list.
Fixed ping dut packets dropped on standby ToR by sending icmp ping to active ports only

#### How did you verify/test it?
Run warm-reboot test on standby ToR and confirm server->T1 and all ping DUT are received.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
