### PR TITLE
[Mellanox][DualTor] Skip dualtor ecn test cases for inner dscp 2 and 6 on Nvidia platforms.

### DIFF
--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -264,6 +264,11 @@ def verify_ecn_on_received_packet(
         logging.info("the expected ECN: {0:02b} matching with received ECN: {1:02b}".format(exp_ecn, rec_ecn))
 
 
+def skip_inner_dscp_2_6_on_nvidia(duthost, inner_dscp):
+    if inner_dscp in [2, 6] and 'mellanox' in duthost.facts['asic_type']:
+        pytest.skip("Skip the test for inner dscp 2 or 6 on Nvidia platforms.")
+
+
 @pytest.mark.parametrize("inner_dscp", [3, 4, 2, 6])        # lossless queue is 3 or 4 or 2 or 6.
 def test_dscp_to_queue_during_decap_on_active(
     inner_dscp, ptfhost, setup_dualtor_tor_active,
@@ -274,6 +279,8 @@ def test_dscp_to_queue_during_decap_on_active(
     """
     Test if DSCP to Q mapping for inner header is matching with outer header during decap on active
     """
+    if is_tunnel_qos_remap_enabled(rand_selected_dut):
+        skip_inner_dscp_2_6_on_nvidia(rand_selected_dut, inner_dscp)
     tor = rand_selected_dut
     encapsulated_packet = build_encapsulated_ip_packet(inner_dscp, rand_selected_interface,
                                                        ptfadapter, rand_selected_dut)
@@ -342,6 +349,8 @@ def test_dscp_to_queue_during_encap_on_standby(
     """
     Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
     """
+    if is_tunnel_qos_remap_enabled(rand_selected_dut):
+        skip_inner_dscp_2_6_on_nvidia(rand_selected_dut, dscp)
     write_standby()
 
     tor = rand_selected_dut
@@ -369,6 +378,8 @@ def test_ecn_during_decap_on_active(
     """
     Test if the ECN stamping on inner header is matching with outer during decap on active
     """
+    if is_tunnel_qos_remap_enabled(rand_selected_dut):
+        skip_inner_dscp_2_6_on_nvidia(rand_selected_dut, inner_dscp)
     tor = rand_selected_dut
     encapsulated_packet = build_encapsulated_ip_packet(inner_dscp, rand_selected_interface,
                                                        ptfadapter, rand_selected_dut)
@@ -402,6 +413,8 @@ def test_ecn_during_encap_on_standby(
     """
     Test if the ECN stamping on outer header is matching with inner during encap on standby
     """
+    if is_tunnel_qos_remap_enabled(rand_selected_dut):
+        skip_inner_dscp_2_6_on_nvidia(rand_selected_dut, dscp)
     write_standby()
 
     tor = rand_selected_dut


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the dualtor scenario, when dscp remapping is enabled and packet with dscp 2 or 6 is received by the standby tor, the mapping behavior is different between Nvidia and other vendors.
On Nvidia platforms, the downstream packet with dscp 2 or 6 on the standby tor will be encapsulated with the same 2 or 6 outer dscp and bounced back to the tunnel as lossless packet. And this behavior will cause the dualtor ecn test fail.
Actually, this is not considered as a valid use case, the dscp 2 and 6 should be reserved for the remapped tunnel traffic. And this has been discussed and confirmed with the Community.
So, we need to skip the cases for dscp 2 and 6 on Nvidia platforms when dscp remapping is enabled.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Skip the dualtor ecn test cases for dscp 2 and 6 on Nvidia platforms when dscp remapping is enabled.
#### How did you do it?
Add the skip logic in the test cases.
#### How did you verify/test it?
By running the test on Nvidia 4600c dualtor testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
