### PR TITLE
Fib IP range length is function instead of attribute

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -520,9 +520,9 @@ class DecapPacketTest(BaseTest):
     def check_range(self, ip_range, outer_pkt_type, inner_pkt_type, dut_index):
         dst_ips = []
         dst_ips.append(ip_range.get_first_ip())
-        if ip_range.length > 1:
+        if ip_range.length() > 1:
             dst_ips.append(ip_range.get_last_ip())
-        if ip_range.length > 2:
+        if ip_range.length() > 2:
             dst_ips.append(ip_range.get_random_ip())
 
         logging.info('Checking dst_ips={}'.format(dst_ips))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The IP_decap_test.py PTF script needs to determine destination IPs to cover based on fib IP range length. For the fib class, ip range length is a function, not an attribute.

#### How did you do it?
This change fixed the issue of calling `ip_range.length` to `ip_range.length()`.

Without this fix, for ip ranges with length 1 or 2, they are all considered as ip range with length longer than 2. Then the first, last and a random IP within the range are tested. Unnecessarily tested destination IPs repeatedly for such IP ranges.

#### How did you verify/test it?
Test run decap/test_decap.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
