### PR TITLE
[Iface loopback action] Fix loopback action reload test

### DIFF
--- a/tests/iface_loopback_action/iface_loopback_action_helper.py
+++ b/tests/iface_loopback_action/iface_loopback_action_helper.py
@@ -176,7 +176,7 @@ def remove_orig_dut_port_config(duthost, orig_ports_configuration):
             remove_dut_vlan_member(duthost, port, port_dict['vlan'])
         elif port_dict['portchannel']:
             remove_dut_portchannel_member(duthost, port, port_dict['portchannel'])
-            output = duthost.shell('show interface portchannel | grep "{} "'.format(port_dict['portchannel']))
+            output = duthost.shell('show interface portchannel | grep -w "{} "'.format(port_dict['portchannel']))
             # Empty portchannels need to be removed before warm/fast reboot
             if "Ethernet" not in output['stdout']:
                 remove_dut_portchannel_ipv4_address(duthost, port_dict['portchannel'])
@@ -412,7 +412,7 @@ def remove_dut_portchannel_member(duthost, port, lag_port):
     duthost.shell('config portchannel member del {} {}'.format(lag_port, port))
 
     def _check_portchannel_member_removed(duthost, portchannel, member):
-        output = duthost.shell('show interface portchannel | grep "{} "'.format(portchannel))
+        output = duthost.shell('show interface portchannel | grep -w "{} "'.format(portchannel))
         if member + '(' not in output['stdout']:
             return True
         else:
@@ -421,18 +421,17 @@ def remove_dut_portchannel_member(duthost, port, lag_port):
 
 
 def remove_dut_portchannel_ipv4_address(duthost, lag_port):
-    ipv4_address = re.split(r'\s+', duthost.shell('show ip interface | grep {}'.format(lag_port))['stdout'])[1]
+    ipv4_address = re.split(r'\s+', duthost.shell('show ip interface | grep -w {}'.format(lag_port))['stdout'])[1]
     if ipv4_address:
         duthost.shell('sudo config interface ip remove {} {}'.format(lag_port, ipv4_address))
 
 
 def remove_dut_portchannel_ipv6_address(duthost, lag_port):
-    output = duthost.shell('show ipv6 interface | grep {}'.format(lag_port))['stdout_lines']
+    output = duthost.shell('show ipv6 interface | grep -w {}'.format(lag_port))['stdout_lines']
     for line in output:
-        if line.startswith(lag_port):
-            ipv6_address = re.split(r'\s+', line)[1]
+        ipv6_address = re.split(r'\s+', line)[1]
+        if not ipv6_address.lower().startswith("fe80"):
             duthost.shell('sudo config interface ip remove {} {}'.format(lag_port, ipv6_address))
-            break
 
 
 def add_dut_vlan_member(duthost, port, vlan_id):

--- a/tests/iface_loopback_action/iface_loopback_action_helper.py
+++ b/tests/iface_loopback_action/iface_loopback_action_helper.py
@@ -169,16 +169,23 @@ def remove_orig_dut_port_config(duthost, orig_ports_configuration):
     :param duthost: DUT host object
     :param orig_ports_configuration: original ports configuration parameters
     """
+    remove_acl_tables(duthost)
     for _, port_dict in list(orig_ports_configuration.items()):
         port = port_dict['port']
         if port_dict['vlan']:
             remove_dut_vlan_member(duthost, port, port_dict['vlan'])
         elif port_dict['portchannel']:
             remove_dut_portchannel_member(duthost, port, port_dict['portchannel'])
+            output = duthost.shell('show interface portchannel | grep "{} "'.format(port_dict['portchannel']))
+            # Empty portchannels need to be removed before warm/fast reboot
+            if "Ethernet" not in output['stdout']:
+                remove_dut_portchannel_ipv4_address(duthost, port_dict['portchannel'])
+                remove_dut_portchannel_ipv6_address(duthost, port_dict['portchannel'])
+                duthost.shell('sudo config portchannel del {}'.format(port_dict['portchannel']))
+
         elif port_dict['ip_addr']:
             for ip in port_dict['ip_addr']:
                 remove_dut_ip_from_port(duthost, port, ip)
-    remove_acl_tables(duthost)
 
 
 def get_portchannel_peer_port_map(duthost, orig_ports_configuration, tbinfo, nbrhosts):
@@ -403,6 +410,29 @@ def remove_dut_portchannel_member(duthost, port, lag_port):
     :param lag_port: port channel
     """
     duthost.shell('config portchannel member del {} {}'.format(lag_port, port))
+
+    def _check_portchannel_member_removed(duthost, portchannel, member):
+        output = duthost.shell('show interface portchannel | grep "{} "'.format(portchannel))
+        if member + '(' not in output['stdout']:
+            return True
+        else:
+            return False
+    wait_until(10, 1, 0, _check_portchannel_member_removed, duthost, lag_port, port)
+
+
+def remove_dut_portchannel_ipv4_address(duthost, lag_port):
+    ipv4_address = re.split(r'\s+', duthost.shell('show ip interface | grep {}'.format(lag_port))['stdout'])[1]
+    if ipv4_address:
+        duthost.shell('sudo config interface ip remove {} {}'.format(lag_port, ipv4_address))
+
+
+def remove_dut_portchannel_ipv6_address(duthost, lag_port):
+    output = duthost.shell('show ipv6 interface | grep {}'.format(lag_port))['stdout_lines']
+    for line in output:
+        if line.startswith(lag_port):
+            ipv6_address = re.split(r'\s+', line)[1]
+            duthost.shell('sudo config interface ip remove {} {}'.format(lag_port, ipv6_address))
+            break
 
 
 def add_dut_vlan_member(duthost, port, vlan_id):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Warm reboot is not supported when there is empty lag in the config_db. And during the iface_loopback_action reload test, there are empty lags while doing the warm reboot test. Need to remove all empty lags in test setup phase.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Warm reboot is not supported when there is empty lag in the config_db. And during the iface_loopback_action reload test, there are empty lags while doing the warm reboot test. 
#### How did you do it?
Remove all empty lags in test setup phase. 
This check _check_portchannel_member_removed is to make sure the members are actually removed, for there is a delay after the delete member cli.
#### How did you verify/test it?
By running the test on different platforms, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
