### PR TITLE
Fix global name defaultdict is not defined

### DIFF
--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -3,6 +3,7 @@ import time
 import math
 import pytest
 
+from collections import defaultdict
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from utils import MacToInt, IntToMac, fdb_cleanup, get_crm_resources, send_arp_request, get_fdb_dynamic_mac_count

--- a/tests/vxlan/test_vnet_route_leak.py
+++ b/tests/vxlan/test_vnet_route_leak.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import re
 
+from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from vnet_constants import *


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes "global name defaultdict is not defined" error in a few testcases

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Testcase failed with error "global name defaultdict is not defined"

#### How did you do it?
Add "from collections import defaultdict"

#### How did you verify/test it?
Run the testcase with physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
