### PR TITLE
fix tests/bgp/test_traffic_shift_sup.py failure

### DIFF
--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -59,7 +59,8 @@ class TestTrafficShiftOnSup:
                          self.dutuser, self.dutip),
                      timeout=300)
             client.expect(["admin@{}'s password:".format(self.dutip)])
-
+            client.sendline(self.dutpass)
+            client.expect("admin*")
             client.sendline(cmd)
             client.expect("Password .*")
             client.sendline(self.dutpass)


### PR DESCRIPTION



### Description of PR
In test case tests/bgp/test_traffic_shift_sup.py, the module def run_cmd_on_sup(self, cmd): 
it spaws ssh connection to supervisor and expects password prompt but password is not send
instead the cmd is send which leads to error. In order to fix the test I am adding code to send
dutpass and expect prompt after successful login.

Summary:
Fixes # (issue)

### Type of change



- [x ] Bug fix



### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?
In test case tests/bgp/test_traffic_shift_sup.py, the module def run_cmd_on_sup(self, cmd): 
it spaws ssh connection to supervisor and expects password prompt but password is not send
instead the cmd is send which leads to error. In order to fix the test I am adding code to send
dutpass and expect prompt after successful login.
#### How did you do it?
added lines:
client.sendline(self.dutpass)
 client.expect("admin*")
to complete ssh login

#### How did you verify/test it?
tested with topo t2
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation

