### PR TITLE
Adding watchdog parameter for cisco-8111 platform

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -149,3 +149,10 @@ x86_64-8101_32fh_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+#cisco-8111 watchdog
+x86_64-8111_32eh_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding watchdog parameter for cisco-8111 platform

#### What is the motivation for this PR?
Adding watchdog parameter for cisco-8111 platform .
This will address 1 testcase failure in /tests/platform_tests/api/test_watchdog.py

#### How did you verify/test it?
Verified this change on cisco-8111 platform and testcase now passes .

