### PR TITLE
Use cEOS as default VM type

### DIFF
--- a/ansible/recover_server.py
+++ b/ansible/recover_server.py
@@ -328,8 +328,8 @@ if __name__ == '__main__':
                         help='testbed file(default: testbed.csv)')
     parser.add_argument('--vm-file', default='veos',
                         help='vm inventory file(default: veos)')
-    parser.add_argument('--vm-type', default='veos', choices=[
-                        'veos', 'ceos', 'vsonic'], help='vm type (veos|ceos|vsonic, default: veos)')
+    parser.add_argument('--vm-type', default='ceos', choices=[
+                        'veos', 'ceos', 'vsonic'], help='vm type (veos|ceos|vsonic, default: ceos)')
     parser.add_argument(
         '--inventory',
         help='Deprecated. Inventory info is already in testbed.(csv|yaml), no need to specify in argument')

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -231,9 +231,9 @@
   register: vm_list_paused
   become: true
 
-- name: Require VMs as VEOS by default
+- name: Require VMs as CEOS by default
   set_fact:
-    vm_type: "veos"
+    vm_type: "ceos"
   when: vm_type is not defined
 
 - name: Check VM type

--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -1,6 +1,6 @@
-- name: Require VMs as VEOS by default
+- name: Require VMs as CEOS by default
   set_fact:
-    vm_type: "veos"
+    vm_type: "ceos"
   when: vm_type is not defined
 
 - name: Load topo variables

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -25,7 +25,7 @@ function usage
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.csv')"
   echo "    -m <vmfile>     : virtual machine file name (default: 'veos')"
-  echo "    -k <vmtype>     : vm type (veos|ceos|vsonic|vcisco) (default: 'veos')"
+  echo "    -k <vmtype>     : vm type (veos|ceos|vsonic|vcisco) (default: 'ceos')"
   echo "    -n <vm_num>     : vm num (default: 0)"
   echo "    -s <msetnumber> : master set identifier on specified <k8s-server-name> (default: 1)"
   echo "    -d <dir>        : sonic vm directory (default: $HOME/sonic-vm)"
@@ -184,7 +184,7 @@ function read_file
 function start_vms
 {
   if [[ $vm_type == ceos ]]; then
-    echo "VM type is ceos. No need to run start-vms. Please specify VM type using the -k option. Example: -k veos"
+    echo "VM type is ceos. No need to run start-vms. Please specify VM type using the -k option. Example: -k ceos"
     exit
   fi
   server=$1
@@ -200,7 +200,7 @@ function start_vms
 function stop_vms
 {
   if [[ $vm_type == ceos ]]; then
-    echo "VM type is ceos. No need to run stop-vms. Please specify VM type using the -k option. Example: -k veos"
+    echo "VM type is ceos. No need to run stop-vms. Please specify VM type using the -k option. Example: -k ceos"
     exit
   fi
   server=$1
@@ -215,7 +215,7 @@ function stop_vms
 function start_topo_vms
 {
   if [[ $vm_type == ceos ]]; then
-    echo "VM type is ceos. No need to run start-topo-vms. Please specify VM type using the -k option. Example: -k veos"
+    echo "VM type is ceos. No need to run start-topo-vms. Please specify VM type using the -k option. Example: -k ceos"
     exit
   fi
   testbed_name=$1
@@ -233,7 +233,7 @@ function start_topo_vms
 function stop_topo_vms
 {
   if [[ $vm_type == ceos ]]; then
-    echo "VM type is ceos. No need to run stop-topo-vms. Please specify VM type using the -k option. Example: -k veos"
+    echo "VM type is ceos. No need to run stop-topo-vms. Please specify VM type using the -k option. Example: -k ceos"
     exit
   fi
   testbed_name=$1
@@ -743,9 +743,9 @@ function deploy_topo_with_cache
   echo "Done!"
 }
 
-vmfile=veos
+vmfile=ceos
 tbfile=testbed.csv
-vm_type=veos
+vm_type=ceos
 vm_num=0
 msetnumber=1
 sonic_vm_dir=""

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -122,9 +122,9 @@
         - set_fact:
             base_topo: "{{ topo.split('_') | first }}"
 
-        - name: Require VMs as VEOS by default
+        - name: Require VMs as CEOS by default
           set_fact:
-            vm_type: "veos"
+            vm_type: "ceos"
           when: vm_type is not defined
 
         - name: Check if it is a known topology


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In most cases, we use cEOS as VMs, so setting the default VM type to cEOS.
#### How did you do it?
Set default VM type to cEOS
#### How did you verify/test it?
add topo/deploy mg/remove topo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
