### PR TITLE
Ignore err log SAI_API_UNSPECIFIED:sai_bulk_object_get_stats

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -177,3 +177,6 @@ r, ".* ERR .*CounterCheck: Invalid port oid.*"
 # https://msazure.visualstudio.com/One/_workitems/edit/17617756
 # https://msazure.visualstudio.com/One/_workitems/edit/17863895
 r, ".* ERR syncd\d*#syncd.*SAI_API_ACL:_brcm_sai_acl_entry_bind.*"
+
+# https://msazure.visualstudio.com/One/_workitems/edit/24444744/
+r, ".* ERR syncd\d*#syncd.*SAI_API_UNSPECIFIED:sai_bulk_object_get_stats.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Many cases failed due to following ERR syslog with the latest master image, ignore them for now until the test cases are fixed.
`Jul  3 05:58:36.447220 str2-7260cx3-acs-9 ERR syncd#syncd: message repeated 119 times: [ [none] SAI_API_UNSPECIFIED:sai_bulk_object_get_stats:671 Unsupported object type type 1]`

Workitem: https://msazure.visualstudio.com/One/_workitems/edit/24444744/
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Ignore the error message of SAI_API_UNSPECIFIED:sai_bulk_object_get_stats:671 Unsupported object type*
#### How did you do it?
Add the regular expression of this error message into loganalyzer_common_ignore.txt
#### How did you verify/test it?
Run the test locally.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
