### PR TITLE
[chassis] [multi-asic] skip override_config_table test for multi-asic platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1153,3 +1153,12 @@ wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
     conditions:
       - "len(minigraph_portchannels) < 2"
       - "not any(len(v['members']) > 1 for _, v in minigraph_portchannels.items())"
+
+#######################################
+#####     override_config_table   #####
+#######################################
+override_config_table/test_override_config_table.py:
+  skip:
+    reason: "Skip override-config-table testing on multi-asic platforms, test provided golden config format is not compatible with multi-asics"
+    conditions:
+      - is_multi_asic == True

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -654,6 +654,15 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
+#####     override_config_table   #####
+#######################################
+override_config_table/test_override_config_table.py:
+  skip:
+    reason: "Skip override-config-table testing on multi-asic platforms, test provided golden config format is not compatible with multi-asics"
+    conditions:
+      - is_multi_asic == True
+
+#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
@@ -1153,12 +1162,3 @@ wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
     conditions:
       - "len(minigraph_portchannels) < 2"
       - "not any(len(v['members']) > 1 for _, v in minigraph_portchannels.items())"
-
-#######################################
-#####     override_config_table   #####
-#######################################
-override_config_table/test_override_config_table.py:
-  skip:
-    reason: "Skip override-config-table testing on multi-asic platforms, test provided golden config format is not compatible with multi-asics"
-    conditions:
-      - is_multi_asic == True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
test `override_config_table/test_override_config_table.py` creates empty/partial/full configuration and tries to overwrite config_db.json partially or totally, on duthost, for multi-asic platforms.

There is coming change from ndm that golden config db is going to change, so that host config and asic configs are put in the same file, distinguished by keys `localhost` and `asic0` `asic1` ... and there comes PR https://github.com/sonic-net/sonic-utilities/pull/2825 to accommodate new ndm change.

with this new change, especially with https://github.com/sonic-net/sonic-utilities/pull/2825, this `override_config_table/test_override_config_table.py` no longer works for multi-asic scenarios, because test is providing incorrect format of `golden_config_db.json`. e.g. `localhost` and `asicx` is missing in the partial config. Thus we need to skip this test.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/8974

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
After:

```

override_config_table/test_override_config_table.py::test_load_minigraph_with_golden_config SKIPPED                                                                                          [100%]

-------------------------------------------------------------- generated xml file: /var/src/private/sonic-mgmt-int/tests/logs/tr.xml ---------------------------------------------------------------
===================================================================================== short test summary info ======================================================================================
SKIPPED [1] override_config_table/test_override_config_table.py: Skip override-config-table testing on multi-asic platforms, test provided golden config format is not compatible with multi-asics
==================================================================================== 1 skipped in 21.19 seconds ====================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
