### PR TITLE
Fix TypeError: 'list' object is not an iterator for test_cacl_application

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -322,7 +322,7 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
                         # There are non-ip_address keys in ifaces. We ignore them with the except
                         ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
                     except ValueError:
-                        pass
+                        continue
                     # For VLAN interfaces, the IP address we want to block is the default gateway (i.e.,
                     # the first available host IP address of the VLAN subnet)
                     ip_addr = next(ip_ntwrk.hosts()) if iface_table_name == "VLAN_INTERFACE" \


### PR DESCRIPTION
…tion

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_cacl_application failed on dualtor testbed due to TypeError: 'list' object is not an iterator.
That's because the type of `ip_ntwrk.hosts()` is list for LOOPBACK_INTERFACE ip address FC00:1::38/128, can't be called for next() function.
For VLAN_INTERFACE, it has some non-ip address key for dualtor testbed, such as grat_arp or proxy_arp, if call `ipaddress.ip_network` for them, it will throw ValueError exception, but in existing code, it executes pass next. At this time, the iface_table_name == "VLAN_INTERFACE", the code will execute next() function for previous ip_ntwrk which is got from LOOPBACK_INTERFACE. According to previous saying, the TypeError: 'list' object is not an iterator will happen here.

```
"VLAN_INTERFACE": {
  "Vlan1000": {
    "grat_arp": "enabled",
    "proxy_arp": "enabled",
    "192.168.0.1/21": {
      
    },
    "fc02:1000::1/64": {
      
    }
  }
}
```

```
>>> ipaddress.ip_network('FC00:1::38/128', strict=False).hosts()
[IPv6Address('fc00:1::38')]
```

```
    for iface_table_name in INTERFACE_TABLE_NAME_LIST:
        if iface_table_name in cfg_facts:
            ifaces = cfg_facts[iface_table_name]
            for iface_name in ifaces:
                for iface_cidr in ifaces[iface_name]:
                    try:
                        # There are non-ip_address keys in ifaces. We ignore them with the except
                        ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
                    except ValueError:
                        pass
                    # For VLAN interfaces, the IP address we want to block is the default gateway (i.e.,
                    # the first available host IP address of the VLAN subnet)
                    ip_addr = next(ip_ntwrk.hosts()) if iface_table_name == "VLAN_INTERFACE" \
                        else ip_ntwrk.network_address
```

#### How did you do it?
For fix this issue, we need to replace pass to continue, if the key is not ip address, we skip it and loop the next one.
Then ip_ntwrk will be correct value and will not goes to the wrong logic.

#### How did you verify/test it?
Run `cacl/test_cacl_application.py` on dualtor

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
