### PR TITLE
Fix to use non RegionalHub T3 peers when selecting port. 

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -296,13 +296,13 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
             pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
 
             # Remove the interface from eths and pos if the BGP neighbor is of type RegionalHub
-            dev_rh_neigh = [neigh for neigh in cfgd_dev_neigh_md 
-                                  if cfgd_dev_neigh_md[neigh]["type"] == "RegionalHub"]
+            dev_rh_neigh = [neigh for neigh in cfgd_dev_neigh_md
+                            if cfgd_dev_neigh_md[neigh]["type"] == "RegionalHub"]
 
             # Interfaces to be excluded
             intfs_exclude = [intf for intf in cfgd_dev_neighbor if cfgd_dev_neighbor[intf]["name"] in dev_rh_neigh]
             eths = [eth for eth in eths_orig if eth not in intfs_exclude]
-           
+
             # portchannels to be excluded
             for k, v in cfgd_pc_members.items():
                 keys = v.keys()

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -288,21 +288,22 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
                 continue
             cfg_facts = asic_cfg['ansible_facts']
             cfgd_intfs = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
-            cfgd_dev_neighbor =  cfg_facts['DEVICE_NEIGHBOR'] if 'DEVICE_NEIGHBOR' in cfg_facts else {}
-            cfgd_dev_neighbor_metadata =  cfg_facts['DEVICE_NEIGHBOR_METADATA'] if 'DEVICE_NEIGHBOR_METADATA' in cfg_facts else {}
+            cfgd_dev_neighbor = cfg_facts['DEVICE_NEIGHBOR'] if 'DEVICE_NEIGHBOR' in cfg_facts else {}
+            cfgd_dev_neigh_md = cfg_facts['DEVICE_NEIGHBOR_METADATA'] if 'DEVICE_NEIGHBOR_METADATA' in cfg_facts else {}
             cfgd_pos = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
             cfgd_pc_members = cfg_facts['PORTCHANNEL_MEMBER'] if 'PORTCHANNEL_MEMBER' in cfg_facts else {}
             eths_orig = [intf for intf in cfgd_intfs if "ethernet" in intf.lower() and cfgd_intfs[intf] != {}]
             pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
 
-            #Remove the interface from eths and pos if the BGP neighbor is of type RegionalHub
-            dev_rh_neigh = [neigh for neigh in cfgd_dev_neighbor_metadata if cfgd_dev_neighbor_metadata[neigh]["type"] == "RegionalHub"]
+            # Remove the interface from eths and pos if the BGP neighbor is of type RegionalHub
+            dev_rh_neigh = [neigh for neigh in cfgd_dev_neigh_md 
+                                  if cfgd_dev_neigh_md[neigh]["type"] == "RegionalHub"]
 
-            #Interfaces to be excluded
+            # Interfaces to be excluded
             intfs_exclude = [intf for intf in cfgd_dev_neighbor if cfgd_dev_neighbor[intf]["name"] in dev_rh_neigh]
             eths = [eth for eth in eths_orig if eth not in intfs_exclude]
            
-            #portchannels to be excluded
+            # portchannels to be excluded
             for k, v in cfgd_pc_members.items():
                 keys = v.keys()
                 for intf in keys:


### PR DESCRIPTION
### Description of PR
When the minigraph/Config has T3 Peer is a "Regional Hub" type in DEVICE_NEIGHBOR_METADATA and if we select that T3 peer loopback IP for end to end ping -- the ping from T1 --> T3 loopback ip fails. This is because the the routemaps for that "Regional Hub" type filter the loopback routes advertised to SONiC T2.

Summary:
Fixes #9021

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
#### How did you do it?
Fix was to use T3 peer devices of this SONiC T2 which is of other types like AZNGHub. So filter the ethernet/portchannel interfaces based on which peer type it is connected to.

#### How did you verify/test it?
Ran the above tests which were failing earlier and it passes now.

```
collected 20 items                                                                                                                                                                                                                      

voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-my_ip] PASSED                                                                                                                                              [  5%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-my_lb_ip] PASSED                                                                                                                                           [ 10%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-inband] PASSED                                                                                                                                             [ 15%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portD-my_lb_ip] PASSED                                                                                                                                           [ 20%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portD-inband] PASSED                                                                                                                                             [ 25%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-my_ip] PASSED                                                                                                                                              [ 30%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-my_lb_ip] PASSED                                                                                                                                           [ 35%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-inband] PASSED                                                                                                                                             [ 40%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portD-my_lb_ip] PASSED                                                                                                                                           [ 45%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portD-inband] PASSED                                                                                                                                             [ 50%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-my_ip] PASSED                                                                                                                                           [ 55%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-my_lb_ip] PASSED                                                                                                                                        [ 60%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-inband] PASSED                                                                                                                                          [ 65%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portD-my_lb_ip] PASSED                                                                                                                                        [ 70%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portD-inband] PASSED                                                                                                                                          [ 75%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-my_ip] PASSED                                                                                                                                           [ 80%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-my_lb_ip] PASSED                                                                                                                                        [ 85%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-inband] PASSED                                                                                                                                          [ 90%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portD-my_lb_ip] PASSED                                                                                                                                        [ 95%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portD-inband] PASSED                                                                                                                                          [100%]

------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------
====================================================================================================== 20 passed in 618.00 seconds ======================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
