### PR TITLE
Fit dualtor scenario when deleting config `VLAN|mac` in module `vlan/test_host_vlan.py`

### DIFF
--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -84,7 +84,7 @@ def get_new_vlan_intf_mac_mellanox(dut_vlan_intf_mac):
 
 
 @pytest.fixture(scope="module")
-def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership):
+def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership, tbinfo):
     vlan_intf, _ = testbed_params
     duthost = duthosts[rand_one_dut_hostname]
     dut_vlan_mac = duthost.get_dut_iface_mac('%s' % vlan_intf["attachto"])
@@ -98,16 +98,17 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
 
     yield
 
-    del_vlan_json = json.loads("""
-            [{
-                "VLAN":{
-                    "%s":{
-                        "mac": "%s"
+    if "dualtor" not in tbinfo["topo"]["name"]:
+        del_vlan_json = json.loads("""
+                [{
+                    "VLAN":{
+                        "%s":{
+                            "mac": "%s"
+                        }
                     }
-                }
-            }]
-        """ % (vlan_intf["attachto"], dut_vlan_mac))
-    delete_running_config(del_vlan_json, duthost)
+                }]
+            """ % (vlan_intf["attachto"], dut_vlan_mac))
+        delete_running_config(del_vlan_json, duthost)
 
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == dut_vlan_mac)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR (https://github.com/sonic-net/sonic-mgmt/pull/8728), we delete the vlan mac running config in the teardown period. But in dualtor scenario, it already has mac address in original config. So in this PR, when the testbed is dualtor, we skip deleting the vlan mac running config in the teardown period.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR (https://github.com/sonic-net/sonic-mgmt/pull/8728), we delete the vlan mac running config in the teardown period. But in dualtor scenario, it already has mac address in original config. So in this PR, when the testbed is dualtor, we skip deleting the vlan mac running config in the teardown period.

#### How did you do it?
Skip deleting the vlan mac running config in the teardown period when the testbed is dualtor.

#### How did you verify/test it?
```
08:25:47 conftest.core_dump_and_config_check      L2131 INFO   | Core dump and config check passed for vlan/test_host_vlan.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
