### PR TITLE
fix for file exists error on test_add_rack.py

### DIFF
--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -85,7 +85,8 @@ def init(duthost):
 
     for i in [data_dir, orig_db_dir, no_t0_db_dir, clet_db_dir,
               patch_add_t0_dir, patch_rm_t0_dir, files_dir]:
-        os.mkdir(i)
+        if not os.path.exists(i):
+            os.mkdir(i)
 
     init_data["files_dir"] = files_dir
     init_data["data_dir"] = data_dir


### PR DESCRIPTION
### What is the motivation for this PR?:
configlet/test_add_rack.py fails with error 'E OSError: [Errno 17] File exists: 'logs/configlet/AddRack'
This happens because init method in tests/configlet/util/base_test.py tries to create a directory already exists. This PR fixes this issue

### How did you do it?
Added a check to make sure that directory does not exist before trying to create it.

### How did you verify/test it?
Made sure that test passes after this change.

This needs to be backported to 202205 and 202305 branches also