### PR TITLE
Increase wait time for restapi service startup

### DIFF
--- a/tests/restapi/helper.py
+++ b/tests/restapi/helper.py
@@ -1,6 +1,7 @@
 import time
 
-RESTAPI_SERVER_START_WAIT_TIME = 15
+# The restapi service requires around 30 seconds to start
+RESTAPI_SERVER_START_WAIT_TIME = 40
 
 
 def apply_cert_config(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to increase the wait time for restapi service startup.
On SN2700 platform, the restart of restapi service costs 26 seconds. In this PR, I increase the wait time to 40 seconds to ensure the service is running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to increase the wait time for restapi service startup.

#### How did you do it?
Update `RESTAPI_SERVER_START_WAIT_TIME` from `15` to `40`.

#### How did you verify/test it?
The change is verified on SN2700 testbed. Now the test case is consistently passing.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
