### PR TITLE
Support init localhost ansible host object without supplying inventory

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -199,16 +199,18 @@ class AnsibleHostsBase(object):
             hostvars (dict, optional): Additional ansible variables for ansible hosts. Similar as using `-e` argument
                 of ansible-playbook command line to specify additional host variables. Defaults to {}.
         """
-        # Check existence of inventories
-        if isinstance(inventories, list):
-            for inventory in inventories:
-                if not os.path.exists(inventory):
-                    raise FileNotFoundError("Inventory file {} not found.".format(inventory))
-        else:
-            if not os.path.exists(inventories):
-                raise FileNotFoundError("Inventory file {} not found.".format(inventories))
-
         self.inventories = inventories
+
+        # Check existence of inventories only when host_pattern is not "localhost"
+        if host_pattern != "localhost":
+            if isinstance(self.inventories, list):
+                for inventory in self.inventories:
+                    if not os.path.exists(inventory):
+                        raise FileNotFoundError("Inventory file {} not found.".format(inventory))
+            else:
+                if not os.path.exists(self.inventories):
+                    raise FileNotFoundError("Inventory file {} not found.".format(self.inventories))
+
         self.host_pattern = host_pattern
         if loader:
             self.loader = loader
@@ -216,10 +218,10 @@ class AnsibleHostsBase(object):
             self.loader = DataLoader()
 
         if inventory_manager:
-            if isinstance(inventories, list):
-                sources = inventories
+            if isinstance(self.inventories, list):
+                sources = self.inventories
             else:
-                sources = [inventories]
+                sources = [self.inventories]
             if set(sources) != set(inventory_manager._sources):
                 inventory_manager._sources = sources
                 inventory_manager.parse_sources()

--- a/ansible/devutil/devices/factory.py
+++ b/ansible/devutil/devices/factory.py
@@ -15,7 +15,7 @@ _self_dir = os.path.dirname(os.path.abspath(__file__))
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../"))
 
 
-def init_localhost(inventories, options={}, hostvars={}):
+def init_localhost(inventories=None, options={}, hostvars={}):
     try:
         return AnsibleHost(inventories, "localhost", options=options.copy(), hostvars=hostvars.copy())
     except (NoAnsibleHostError, MultipleAnsibleHostsError) as e:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The localhost ansible host object should be created with or without supplying ansible inventory file.

#### How did you do it?
This change enhanced the libraries to support init a localhost ansible host object without supplying ansible inventory file.

#### How did you verify/test it?
```
>>> from devutil.devices import factory
>>> localhost = factory.init_localhost()
[WARNING]: No inventory was parsed, only implicit localhost is available
>>> localhost
<AnsibleHost localhost in None>
>>> localhost.command("date")
Thursday 20 July 2023  02:45:18 +0000 (0:00:30.547)       0:00:30.578 ********* 
{'hostname': 'localhost', 'reachable': True, 'failed': False, 'cmd': ['date'], 'stdout': 'Thu Jul 20 02:45:18 UTC 2023', 'stderr': '', 'rc': 0, 'start': '2023-07-20 02:45:18.195654', 'end': '2023-07-20 02:45:18.197592', 'delta': '0:00:00.001938', 'changed': True, 'invocation': {'module_args': {'_raw_params': 'date', 'warn': True, '_uses_shell': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}, 'stdout_lines': ['Thu Jul 20 02:45:18 UTC 2023'], 'stderr_lines': [], '_ansible_no_log': False}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
