### PR TITLE
[qos][202205] fix type error in get_multiple_flows

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -203,7 +203,7 @@ def get_multiple_flows(dp, dst_mac, dst_id, dst_ip, src_vlan, dscp, ecn, ttl, pk
                 'tcp_dport':next(TCP_PORT_GEN)}
             if src_vlan:
                 pkt_args.update({dl_vlan_enable:True})
-                pkt_args.update({vlan_vid:src_vlan})
+                pkt_args.update({vlan_vid:int(src_vlan)})
             pkt = simple_tcp_packet(**pkt_args)
 
             masked_exp_pkt = Mask(pkt, ignore_extra_bytes=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

double commit PR https://github.com/sonic-net/sonic-mgmt/pull/9024
(there is no get_multiple_flows relevant code, so directly double commit to 202205 branch)

observed type error:

```
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "saitests/sai_qos_tests.py", line 1722, in runTest
    1)[0][0]
  File "saitests/sai_qos_tests.py", line 379, in get_multiple_flows
    pkt = simple_tcp_packet(**pkt_args)
  File "/usr/lib/python2.7/dist-packages/ptf/testutils.py", line 239, in simple_tcp_packet
    with_tcp_chksum = with_tcp_chksum)
  File "/usr/lib/python2.7/dist-packages/ptf/testutils.py", line 153, in simple_tcp_packet_ext_taglist
    pkt = pkt/("".join([chr(x % 256) for x in xrange(pktlen - len(pkt))]))
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 290, in __len__
    return len(self.__str__())
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 263, in __str__
    return self.build()
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 321, in build
    p = self.do_build()
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 313, in do_build
    pay = self.do_build_payload()
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 305, in do_build_payload
    return self.payload.do_build()
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 310, in do_build
    pkt = self.self_build()
  File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 301, in self_build
    p = f.addfield(self, p, val)
  File "/usr/local/lib/python2.7/dist-packages/scapy/fields.py", line 647, in addfield
    v |= val & ((1L<<self.size) - 1)
TypeError: unsupported operand type(s) for &: 'unicode' and 'long'
```

RCA:

```
> /root/saitests/sai_qos_tests.py(380)get_multiple_flows()                                                                                                                                                   
-> pkt = simple_tcp_packet(**pkt_args)                                                                                                                                                                       
(Pdb) p pkt_args                                                                                                                                                                                             
{'dl_vlan_enable': True, 'eth_dst': '98:03:9b:03:22:04', 'ip_dst': '192.168.0.6', 'pktlen': 64, 'ip_ttl': 64, 'ip_ecn': 1, 'vlan_vid': u'1000', 'eth_src': '98:03:9b:03:22:05', 'ip_dscp': 3, 'tcp_dport': 12
44, 'ip_src': '192.0.0.2', 'tcp_sport': 1234}     
```
as above, 'vlan_vid''s value is unicode string rather than integer.

#### How did you do it?

not see type error, after convert value of "vlan_vid" to integer.

#### How did you verify/test it?

convert value of "vlan_vid" to integer.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
