### PR TITLE
fix occasional type error in test_pfc_pause_extra_lossless_active

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -468,12 +468,16 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
                                  pfc_frames_number=PFC_PKT_COUNT,
                                  peer_info=peer_info)
 
+        dst_ports = dualtor_meta['target_server_port']
+        if not isinstance(dualtor_meta['target_server_port'], list):
+            dst_ports = [dualtor_meta['target_server_port']]
+
         retry = 0
         while retry < PFC_PAUSE_TEST_RETRY_MAX:
             try:
                 if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut,
                                   dualtor_meta['selected_port'], queue, tunnel_pkt.exp_pkt, src_port, exp_pkt,
-                                  dualtor_meta['target_server_port']):
+                                  dst_ports):
                     break
             except AssertionError:
                 retry += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

observed error in test_pfc_pause_extra_lossless_active:

```
20/07/2023 15:12:12 test_tunnel_qos_remap.pfc_pause_test     L0338 INFO   | exception (<class 'TypeError'>, TypeError("object of type 'int' has no len()"), <traceback object at 0x7fe6f02cb940>)
```

RCA:

 the last parameter of pfc_pause_test() requrie list type, but, in some corner case,, "dualtor_meta['target_server_port']" is not list. so cause this error:
```
                if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut,
                                  dualtor_meta['selected_port'], queue, tunnel_pkt.exp_pkt, src_port, exp_pkt,
                                  dualtor_meta['target_server_port']):
```


#### How did you do it?

solution:
make sure the last parameter of pfc_pause_test() is list type.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
