### PR TITLE
[202205 cherry-pick][advanced-reboot] Check IO threads have started before joining (#8089)

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -247,6 +247,9 @@ class ReloadTest(BaseTest):
             alt_password=self.test_params.get('alt_password')
         )
 
+        self.sender_thr = threading.Thread(target=self.send_in_background)
+        self.sniff_thr = threading.Thread(target=self.sniff_in_background)
+
         # Check if platform type is kvm
         stdout, stderr, return_code = self.dut_connection.execCommand("show platform summary | grep Platform | awk '{print $2}'")
         platform_type = str(stdout[0]).replace('\n', '')
@@ -995,6 +998,11 @@ class ReloadTest(BaseTest):
             self.no_routing_stop  = self.reboot_start
 
     def handle_warm_reboot_health_check(self):
+        # wait until sniffer and sender threads have started
+        while not (self.sniff_thr.isAlive() and self.sender_thr.isAlive()):
+            time.sleep(1)
+
+        self.log("IO sender and sniffer threads have started, wait until completion")
         self.sniff_thr.join()
         self.sender_thr.join()
 
@@ -1323,10 +1331,10 @@ class ReloadTest(BaseTest):
         time.sleep(self.reboot_delay)
 
         if not self.kvm_test and\
-            (self.reboot_type == 'fast-reboot' or 'warm-reboot' in self.reboot_type or 'service-warm-restart' in self.reboot_type):
-            self.sender_thr = threading.Thread(target = self.send_in_background)
-            self.sniff_thr = threading.Thread(target = self.sniff_in_background)
-            self.sniffer_started = threading.Event()    # Event for the sniff_in_background status.
+                (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
+                 self.reboot_type or 'service-warm-restart' in self.reboot_type):
+            # Event for the sniff_in_background status.
+            self.sniffer_started = threading.Event()
             self.sniff_thr.start()
             self.sender_thr.start()
 
@@ -1533,19 +1541,6 @@ class ReloadTest(BaseTest):
         subprocess.call(sniffer_command)
         self.packets = scapyall.rdpcap(capture_pcap)
         self.log("Number of all packets captured: {}".format(len(self.packets)))
-
-    def send_and_sniff(self):
-        """
-        This method starts two background threads in parallel:
-        one for sending, another for collecting the sent packets.
-        """
-        self.sender_thr = threading.Thread(target = self.send_in_background)
-        self.sniff_thr = threading.Thread(target = self.sniff_in_background)
-        self.sniffer_started = threading.Event()    # Event for the sniff_in_background status.
-        self.sniff_thr.start()
-        self.sender_thr.start()
-        self.sniff_thr.join()
-        self.sender_thr.join()
 
     def check_tcp_payload(self, packet):
         """


### PR DESCRIPTION
Cherry pick of https://github.com/sonic-net/sonic-mgmt/pull/8089

What is the motivation for this PR?
To fix a rare issue when control plane is detected to be down before reboot is issued. This happens if any out of 10 ping packets are dropped (cause unknown). When this happens, the logic proceeds to wait (join) for sender and sniffer threads to complete. Since the device never really rebooted, there is a chance sender and sniffer threads are not initialized and started.

Additonally, removed the unused method send_and_sniff

How did you do it?
Fix the issue by:
Initializing sender and sniffer threads in init.
Before joining the IO threads wait for them to start -- keep checking isAlive()

How did you verify/test it?
Tested on physical testbed and fix works.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
