### PR TITLE
Leave 1 ACL rule in test_crm.py::test_acl_entry

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -912,8 +912,6 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     pytest_assert(new_crm_stats_acl_entry_used - crm_stats_acl_entry_used == 4,
                   "\"crm_stats_acl_entry_used\" counter was not incremented")
 
-    crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used
-
     used_percent = get_used_percent(new_crm_stats_acl_entry_used, new_crm_stats_acl_entry_available)
     if used_percent < 1:
         # Preconfiguration needed for used percentage verification
@@ -947,13 +945,13 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
                     asicAclBindings.add(portToLag[port])
             else:
                 if asichost.port_on_asic(port):
-                    asicAclBindings.add(port) 
+                    asicAclBindings.add(port)
 
-        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
-                                        (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
+        freed_acl_entries = (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
     else:
-        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
-                                        new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
+        freed_acl_entries = new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
+
+    crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + freed_acl_entries
 
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -950,10 +950,10 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
                     asicAclBindings.add(port) 
 
         crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
-              (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
+                                        (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
     else:
         crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
-              new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
+                                        new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
 
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -939,17 +939,17 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
         portToLag = {}
         for lag, lagData in mg_facts["minigraph_portchannels"].items():
             for member in lagData['members']:
-                portToLag[ member ] = lag
+                portToLag[member] = lag
         aclBindings = mg_facts["minigraph_acls"]["DataAcl"]
         for port in aclBindings:
             if port in portToLag:
-                if asichost.portchannel_on_asic( portToLag[port] ):
-                    asicAclBindings.add( portToLag[port] )
+                if asichost.portchannel_on_asic(portToLag[port]):
+                    asicAclBindings.add(portToLag[port])
             else:
-                if asichost.port_on_asic( port ):
-                    asicAclBindings.add( port ) 
+                if asichost.port_on_asic(port):
+                    asicAclBindings.add(port) 
 
-        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + ( new_crm_stats_acl_entry_used - crm_stats_acl_entry_used ) * len( asicAclBindings )
+        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
     else:
         crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -879,14 +879,14 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
                 ports = ",".join([tmp_ports[20], tmp_ports[25]])
             recreate_acl_table(duthost, ports)
             verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
-                                 enum_frontend_asic_index, asic_collector)
+                                 enum_frontend_asic_index, asic_collector, tbinfo)
             # Rebind DATA ACL at end to recover original config
             recreate_acl_table(duthost, ports)
             apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
             duthost.command("acl-loader delete")
     else:
         verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
-                             enum_frontend_asic_index, asic_collector)
+                             enum_frontend_asic_index, asic_collector, tbinfo)
 
     pytest_assert(crm_stats_checker,
                   "\"crm_stats_acl_entry_used\" counter was not decremented or "
@@ -894,8 +894,8 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
 
 def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hostname,
-                         enum_frontend_asic_index, asic_collector):
-    apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector)
+                         enum_frontend_asic_index, asic_collector, tbinfo):
+    apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector, entry_num=2)
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
                             crm_stats_acl_entry_used \
@@ -909,7 +909,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     # Get new "crm_stats_acl_entry" used and available counter value
     new_crm_stats_acl_entry_used, new_crm_stats_acl_entry_available = get_crm_stats(get_acl_entry_stats, duthost)
     # Verify "crm_stats_acl_entry_used" counter was incremented
-    pytest_assert(new_crm_stats_acl_entry_used - crm_stats_acl_entry_used == 2,
+    pytest_assert(new_crm_stats_acl_entry_used - crm_stats_acl_entry_used == 4,
                   "\"crm_stats_acl_entry_used\" counter was not incremented")
 
     crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used
@@ -927,8 +927,32 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     # Verify thresholds for "ACL entry" CRM resource
     verify_thresholds(duthost, asichost, crm_cli_res="acl group entry", crm_cmd=get_acl_entry_stats)
 
-    # Remove ACL
-    duthost.command("acl-loader delete")
+    # Reduce ACL to one rule (plus default)
+    crm_stats_acl_entry_used = 2
+    apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector, entry_num=1)
+    if duthost.facts["platform_asic"] == "broadcom-dnx":
+        # Each ACL rule consumes an acl entry per bind point
+        asicAclBindings = set()
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+        # PCs are a single bind point
+        portToLag = {}
+        for lag, lagData in mg_facts["minigraph_portchannels"].items():
+            for member in lagData['members']:
+                portToLag[ member ] = lag
+        aclBindings = mg_facts["minigraph_acls"]["DataAcl"]
+        for port in aclBindings:
+            if port in portToLag:
+                if asichost.portchannel_on_asic( portToLag[port] ):
+                    asicAclBindings.add( portToLag[port] )
+            else:
+                if asichost.port_on_asic( port ):
+                    asicAclBindings.add( port ) 
+
+        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + ( new_crm_stats_acl_entry_used - crm_stats_acl_entry_used ) * len( asicAclBindings )
+    else:
+        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
+
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
                             crm_stats_acl_entry_used \
@@ -961,6 +985,8 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
             crm_stats_acl_entry_available,
         )
 
+    # Remove ACL
+    duthost.command("acl-loader delete")
 
 def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, collector):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -949,9 +949,11 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
                 if asichost.port_on_asic(port):
                     asicAclBindings.add(port) 
 
-        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
+        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
+              (new_crm_stats_acl_entry_used - crm_stats_acl_entry_used) * len(asicAclBindings)
     else:
-        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available + new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
+        crm_stats_acl_entry_available = new_crm_stats_acl_entry_available +\
+              new_crm_stats_acl_entry_used - crm_stats_acl_entry_used
 
     acl_tbl_key = asic_collector["acl_tbl_key"]
     get_acl_entry_stats = "{db_cli} COUNTERS_DB HMGET {acl_tbl_key} \
@@ -987,6 +989,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
 
     # Remove ACL
     duthost.command("acl-loader delete")
+
 
 def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, collector):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION
Some platforms (like broadcom-dnx) allocate ACL banks dynamically so if there are no ACL rules it returns a NULL value for CRM purposes. So leave 1 ACL rule when comparing the returned used/available CRM values.

Also on broadcom-dnx an ACL entry is used per bind point so account for that when calculating the expected available acl entries.

Summary:
Fixes #8812 

### Type of change
- [x] Test case(new/improvement)

### Back port request
- [x] 202205
- [x] 202305
