### PR TITLE
Align with master branch PR, update watermark entries

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -38,6 +38,30 @@ qos_params:
                 packet_size: 1350
                 cell_size: 384
                 pkts_num_margin: 1
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 70
+                q1_num_of_pkts: 70
+                q2_num_of_pkts: 70
+                q3_num_of_pkts: 75
+                q4_num_of_pkts: 75
+                q5_num_of_pkts: 70
+                q6_num_of_pkts: 70
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 40
+                q1_num_of_pkts: 40
+                q2_num_of_pkts: 40
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 40
+                q6_num_of_pkts: 40
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 384
             100000_300m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -422,28 +446,6 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
-                wrr:
-                    ecn: 1
-                    q0_num_of_pkts: 70
-                    q1_num_of_pkts: 70
-                    q2_num_of_pkts: 70
-                    q3_num_of_pkts: 75
-                    q4_num_of_pkts: 75
-                    q5_num_of_pkts: 70
-                    q6_num_of_pkts: 70
-                    limit: 80
-                wrr_chg:
-                    ecn: 1
-                    q0_num_of_pkts: 40
-                    q1_num_of_pkts: 40
-                    q2_num_of_pkts: 40
-                    q3_num_of_pkts: 150
-                    q4_num_of_pkts: 150
-                    q5_num_of_pkts: 40
-                    q6_num_of_pkts: 40
-                    limit: 80
-                    lossy_weight: 8
-                    lossless_weight: 30
             400000_40m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -586,28 +588,6 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 1350
                     cell_size: 384
-                wrr:
-                    ecn: 1
-                    q0_num_of_pkts: 70
-                    q1_num_of_pkts: 70
-                    q2_num_of_pkts: 70
-                    q3_num_of_pkts: 75
-                    q4_num_of_pkts: 75
-                    q5_num_of_pkts: 70
-                    q6_num_of_pkts: 70
-                    limit: 80
-                wrr_chg:
-                    ecn: 1
-                    q0_num_of_pkts: 40
-                    q1_num_of_pkts: 40
-                    q2_num_of_pkts: 40
-                    q3_num_of_pkts: 150
-                    q4_num_of_pkts: 150
-                    q5_num_of_pkts: 40
-                    q6_num_of_pkts: 40
-                    limit: 80
-                    lossy_weight: 8
-                    lossless_weight: 30
             400000_300m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -914,28 +894,6 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 1350
                     cell_size: 384
-                wrr:
-                    ecn: 1
-                    q0_num_of_pkts: 70
-                    q1_num_of_pkts: 70
-                    q2_num_of_pkts: 70
-                    q3_num_of_pkts: 75
-                    q4_num_of_pkts: 75
-                    q5_num_of_pkts: 70
-                    q6_num_of_pkts: 70
-                    limit: 80
-                wrr_chg:
-                    ecn: 1
-                    q0_num_of_pkts: 40
-                    q1_num_of_pkts: 40
-                    q2_num_of_pkts: 40
-                    q3_num_of_pkts: 150
-                    q4_num_of_pkts: 150
-                    q5_num_of_pkts: 40
-                    q6_num_of_pkts: 40
-                    limit: 80
-                    lossy_weight: 8
-                    lossless_weight: 30
             100000_120000m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -1029,6 +987,12 @@ qos_params:
                     pkts_num_trig_pfc: 6404
                     cell_size: 8192
                     packet_size: 6144
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 2048
+                    cell_size: 6144
+                    packet_size: 6144
             400000_120000m:
                 pkts_num_leak_out: 0
                 wm_buf_pool_lossless:
@@ -1040,31 +1004,39 @@ qos_params:
                     pkts_num_trig_pfc: 23044
                     cell_size: 8192
                     packet_size: 6144
-            wrr:
-                ecn: 1
-                q0_num_of_pkts: 70
-                q1_num_of_pkts: 70
-                q2_num_of_pkts: 70
-                q3_num_of_pkts: 75
-                q4_num_of_pkts: 75
-                q5_num_of_pkts: 70
-                q6_num_of_pkts: 70
-                limit: 80
-            wrr_chg:
-                ecn: 1
-                q0_num_of_pkts: 40
-                q1_num_of_pkts: 40
-                q2_num_of_pkts: 40
-                q3_num_of_pkts: 150
-                q4_num_of_pkts: 150
-                q5_num_of_pkts: 40
-                q6_num_of_pkts: 40
-                limit: 80
-                lossy_weight: 8
-                lossless_weight: 30
-            hdrm_pool_wm_multiplier: 1
-            cell_size: 384
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 6404
+                    pkts_num_margin: 2048
+                    cell_size: 6144
+                    packet_size: 6144
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 16000
+                    pkts_num_margin: 3072
+                    cell_size: 384
+                wm_q_wm_all_ports:
+                    ecn: 1
+                    pkt_count: 3000
+                    pkts_num_margin: 2048
+                    cell_size: 6144
+                    packet_size: 6144
         topo-t2:
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_trig_egr_drp: 4000
+                pkts_num_fill_egr_min: 0
+                cell_size: 384
+                packet_size: 1350
             shared_res_size_1:
                 ecn: 1
                 packet_size: 1350
@@ -1075,15 +1047,6 @@ qos_params:
                 packet_size: 1350
                 cell_size: 384
                 pkts_num_margin: 1
-            wm_buf_pool_lossy:
-                dscp: 8
-                ecn: 1
-                pg: 0
-                queue: 0
-                pkts_num_trig_egr_drp: 4000
-                pkts_num_fill_egr_min: 0
-                cell_size: 384
-                packet_size: 1350
             wrr:
                 ecn: 1
                 q0_num_of_pkts: 70
@@ -1322,7 +1285,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 12152
+                    pkts_num_trig_ingr_drp: 13660
                     pkts_num_margin: 3072
                     cell_size: 384
                 wm_q_shared_lossy:
@@ -1410,13 +1373,31 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 64
                     cell_size: 384
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 181
+                    pkts_num_trig_pfc: 642
+                    cell_size: 8192
+                    packet_size: 6144
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 3201
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    packet_size: 8156
+                    cell_size: 8192
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 3202
-                    pkts_num_margin: 2048
+                    pkts_num_trig_ingr_drp: 855
+                    pkts_num_margin: 1024
                     cell_size: 6144
                     packet_size: 6144
                 wm_q_shared_lossy:
@@ -1427,23 +1408,11 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                wm_pg_shared_lossless:
-                    dscp: 3
+                wm_q_wm_all_ports:
                     ecn: 1
-                    pg: 3
-                    pkts_num_trig_pfc: 3201
-                    pkts_num_fill_min: 0
-                    pkts_num_margin: 4
-                    packet_size: 8156
-                    cell_size: 8192
-                wm_buf_pool_lossless:
-                    dscp: 3
-                    ecn: 1
-                    pg: 3
-                    queue: 3
-                    pkts_num_fill_ingr_min: 181
-                    pkts_num_trig_pfc: 642
-                    cell_size: 8192
+                    pkt_count: 855
+                    pkts_num_margin: 1024
+                    cell_size: 6144
                     packet_size: 6144
             400000_120000m:
                 pkts_num_leak_out: 0
@@ -1472,13 +1441,22 @@ qos_params:
                     pkts_num_margin: 4
                     packet_size: 1350
                     cell_size: 384
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 181
+                    pkts_num_trig_pfc: 642
+                    cell_size: 8192
+                    packet_size: 6144
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 11522
-                    pkts_num_margin: 4096
+                    pkts_num_trig_ingr_drp: 855
+                    pkts_num_margin: 1024
                     cell_size: 6144
                     packet_size: 6144
                 wm_q_shared_lossy:
@@ -1489,12 +1467,9 @@ qos_params:
                     pkts_num_trig_egr_drp: 16000
                     pkts_num_margin: 3072
                     cell_size: 384
-                wm_buf_pool_lossless:
-                    dscp: 3
+                wm_q_wm_all_ports:
                     ecn: 1
-                    pg: 3
-                    queue: 3
-                    pkts_num_fill_ingr_min: 181
-                    pkts_num_trig_pfc: 642
-                    cell_size: 8192
+                    pkt_count: 855
+                    pkts_num_margin: 1024
+                    cell_size: 6144
                     packet_size: 6144

--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -956,7 +956,16 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 3201
+                    pkts_num_trig_pfc: 6403
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    packet_size: 8156
+                    cell_size: 8192
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 728
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156
@@ -1386,7 +1395,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 3201
+                    pkts_num_trig_pfc: 6403
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156

--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -903,8 +903,8 @@ qos_params:
                     queue: 3
                     pkts_num_trig_pfc: 262144
                     pkts_num_trig_ingr_drp: 524288
-                    pkts_num_margin: 13267
-                    iterations: 100
+                    pkts_num_margin: 30000
+                    iterations: 30
                 xoff_1:
                     dscp: 3
                     ecn: 1
@@ -975,10 +975,10 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 6404
-                    pkts_num_margin: 2048
+                    pkts_num_trig_ingr_drp: 12807
+                    pkts_num_margin: 19456
                     cell_size: 6144
-                    packet_size: 6144
+                    packet_size: 8156
                 wm_q_shared_lossy:
                     dscp: 8
                     ecn: 1
@@ -992,14 +992,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     queue: 3
-                    pkts_num_fill_ingr_min: 181
-                    pkts_num_trig_pfc: 6404
+                    pkts_num_fill_ingr_min: 140
+                    pkts_num_trig_pfc: 6412
                     cell_size: 8192
-                    packet_size: 6144
+                    packet_size: 8140
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 3000
-                    pkts_num_margin: 2048
+                    pkts_num_margin: 19456
                     cell_size: 6144
                     packet_size: 6144
             400000_120000m:
@@ -1019,7 +1019,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_min: 0
                     pkts_num_trig_ingr_drp: 6404
-                    pkts_num_margin: 2048
+                    pkts_num_margin: 19456
                     cell_size: 6144
                     packet_size: 6144
                 wm_q_shared_lossy:
@@ -1033,7 +1033,7 @@ qos_params:
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 3000
-                    pkts_num_margin: 2048
+                    pkts_num_margin: 19456
                     cell_size: 6144
                     packet_size: 6144
         topo-t2:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is to replace 202205 PR https://github.com/sonic-net/sonic-mgmt/pull/8629 for wm_q_wm_all_ports entries and wm_q_shared_lossless update, and refine some entries to align with master PR https://github.com/sonic-net/sonic-mgmt/pull/9036.

1, Adjusted the order of some entries to align with master branch.

2, Added wm_q_wm_all_ports entries for gb long-link.
Packet size 6144 is used for long-link test, 1 packet occupies 1 hbm block. Queue watermark margin is updated since new voq_hbm_threshold, congestion level 11 watermark is 1x1024x6144, level 12 watermark is 20x1024x6144, so set the pkts_num_margin to 19*1024=19456.
pkt_count 855 is for multi-asic scenario, it is the packet number to trigger pfc in 200G backplane port. This case tests queue watermark in egress asic.

3, Updated wm_q_shared_lossless pkts_num in topo-t2 section.
In multi-asic, this case tests queue watermark in egress asic.
The maximum packets in voq is related with 200G backplane port which is ingress port in egress asic, not related with ingress port in ingress asic.

4, Updated wm_pg_shared_lossless for longlink, the pkts_num_trig_pfc in this case is actually used for maximum cells in the voq, so it is cell number to trigger ingress drop -1. Each 8156B packet occupy 2 cells, 6404 packets trigger ingress drop, so pkts_num_trig_pfc = 6404*2-1=12807.

5, Updated wm_pg_shared_lossy for longlink, although lossy queue is using SMS, the SQ buffer counter is HBM based, so using packet size 8156B for this case. Each 8156B packet occupies 22 SMS buffers, so pkts_num_trig_egr_drp  is ceiling(16000/22)=ceiling(727.2)=728

6, Updated wm_buf_pool_lossless for longlink, original packet size 6144B has too higher uncertainty for SQ buffer counter statistical accounting, changed to use packet size 8140B, and updated the pkts number accordingly.

7, Updated pg_drop for longlink, calculated pkts_num_margin proportionally according to the value of 100G_300m. In 100G_300m, SQ buffer counter update probability is 25%, margin percentage is 375/14819=0.0253. In 100G_120km, SQ buffer counter update probability is (64+36)/8192=1.22%, so set margin percentage to 25%/1.22%x0.0253=0.51844, pkts_num_margin = 524,288x0.51844 = 271,813. The case will take much longer time in longlink scenario since the pkts number increased, lower the iterations to 30.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
