### PR TITLE
[chassis] [test_platform_info.py] accommodate PSU 'NOT PRESENT' case

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -293,7 +293,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
         for line in cli_psu_status["stdout_lines"][2:]:
             psu_match = psu_line_pattern.match(line)
             pytest_assert(psu_match, "Unexpected PSU status output")
-            if psu_match.group(2) != "OK":
+            # also make sure psustatus is not 'NOT PRESENT', which cannot be turned on/off
+            if psu_match.group(2) != "OK" and psu_match.group(2) != "NOT PRESENT":
                 psu_under_test = psu_match.group(1)
             check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
         pytest_assert(psu_under_test is not None, "No PSU is turned off")

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -220,7 +220,8 @@ def check_all_psu_on(dut, psu_test_results):
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
             fields = line.split()
-            psu_test_results[fields[1]] = line
+            if " ".join(fields[2:]) != 'NOT PRESENT':
+                psu_test_results[fields[1]] = line
             if " ".join(fields[2:]) == "NOT OK":
                 power_off_psu_list.append(fields[1])
     else:

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -178,7 +178,7 @@ def get_healthy_psu_num(duthost):
     psus_status = psuutil_status_output["stdout_lines"][2:]
     for iter in psus_status:
         fields = iter.split()
-        if 'OK' in fields:
+        if 'OK' in fields and 'NOT' not in fields:
             healthy_psus += 1
 
     return healthy_psus
@@ -228,7 +228,8 @@ def check_all_psu_on(dut, psu_test_results):
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS_JSON)
         psu_info_list = json.loads(cli_psu_status["stdout"])
         for psu_info in psu_info_list:
-            psu_test_results[psu_info['name']] = psu_info
+            if psu_info["status"] != 'NOT PRESENT':
+                psu_test_results[psu_info['name']] = psu_info
             if psu_info["status"] == "NOT OK":
                 power_off_psu_list.append(psu_info["index"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes 3 issues:
1. https://github.com/sonic-net/sonic-mgmt/pull/8670 intends to get good PSU numbers not rely on output format. Because devices have different output format depending on image version.
e.g. 
image <= 201911
```
PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK
```
image >201911:
```
PSU    Model    Serial                          Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------  ----------------------------  -------------  -------------  -----------  --------  -----
PSU 1  xx          xx                               11.93           0.53         xxx  OK        green
PSU 2  xx         xx                                 11.93           0.49         xxx  NOT OK        green
```

`fields`: split output of `sudo psuutil status` by whitespaces, if status is 'NOT OK', we can still find 'OK' in fileds, however, , we should also make sure `NOT` is not in fields.

2. function `check_all_psu_on` wants to assert if there are any PSU `NOT OK`, it also adds all PSUs to the return list, no matter this PSU is healthy or not. However this PSU can be `NOT PRESENT`.
```
PSU    Status
-----  -----------
PSU 1  NOT PRESENT
PSU 2  NOT PRESENT
```

```
PSU 8   xxx                    xxx             P00       12.359         30.437         376.5        OK           off
PSU 9   N/A                  N/A            N/A       N/A            N/A            N/A          NOT PRESENT  off
```
3. `test_turn_on_off_psu_and_check_psustatus` test by turning off outlet, find PSU that is turned off, then turn on the outlet and confirm this PSU is turned on. however, psu status is not `OK` does not mean the PSU is off, we also need to confirm this PSU is present.

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/9058

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
before:
```
pytest_require(check_all_psu_on(duthost, psu_test_results), "Some PSU are still down, skip rest of the testing in this case")
pytest_assert(len(psu_test_results.keys()) == psu_num, \
>           "In consistent PSU number output by '%s' and '%s'" % (CMD_PLATFORM_PSUSTATUS, "sudo psuutil numpsus"))
E       Failed: In consistent PSU number output by 'show platform psustatus' and 'sudo psuutil numpsus'
duthost    = <MultiAsicSonicHost str2-7804-sup-1>
duthosts   = [<MultiAsicSonicHost str2-7804-lc5-1>, <MultiAsicSonicHost str2-7804-lc3-1>, <MultiAsicSonicHost str2-7804-lc7-1>, <MultiAsicSonicHost str2-7804-sup-1>]
ignore_particular_error_log = None
pdu_controller = <tests.common.plugins.pdu_controller.pdu_manager.PduManager instance at 0x7f9a5d096a50>
pdu_ctrl   = <tests.common.plugins.pdu_controller.pdu_manager.PduManager instance at 0x7f9a5d096a50>
psu_line_pattern = <_sre.SRE_Pattern object at 0x555ed53cdd70>
psu_num    = 8
[psu_test_results = {'PSU 1': {'current': '31.0', 'index': '1', 'led_status': 'off', 'model': 'PWR-D1-3041-AC-BLUE', ...}, 'PSU 10': {'cur...off', 'model': 'N/A', ...}, 'PSU 12': {'current': 'N/A', 'index': '12', 'led_status': 'off', 'model': 'N/A', ...}, ...}]
```

after:
```
platform_tests/test_memory_exhaustion.py::TestMemoryExhaustion::test_memory_exhaustion[str2-xxx-sup-1]
  /usr/local/lib/python2.7/dist-packages/pysnmp/carrier/base.py:109: DeprecationWarning: UdpSocketTransport.__hash__ is deprecated. Use UdpSocketTransport.socket.__hash__ instead.
    del self.__transportDomainMap[self.__transports[tDomain]]

-- Docs: https://docs.pytest.org/en/latest/warnings.html
-------------------------------------------------------------- generated xml file: /var/src/private/sonic-mgmt-int/tests/logs/tr.xml ---------------------------------------------------------------
-------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
21:14:42 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=================== 1 passed, 254 warnings in 454.31 seconds ===================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
