### PR TITLE
[chassis] accomodate test_memory_exhaustion.py if random dut is chassis sup

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -63,6 +63,10 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     timeout = reset_timeout(dut)
+    # No matter what we set in inventory file, we always set sup timeout to 800
+    # because most SUPs have 10+ dockers that need to come up
+    if dut.is_supervisor_node():
+        timeout = 800
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -63,10 +63,10 @@ def wait_critical_processes(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     timeout = reset_timeout(dut)
-    # No matter what we set in inventory file, we always set sup timeout to 800
+    # No matter what we set in inventory file, we always set sup timeout to 900
     # because most SUPs have 10+ dockers that need to come up
     if dut.is_supervisor_node():
-        timeout = 800
+        timeout = 900
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -50,7 +50,7 @@ class TestMemoryExhaustion:
                 for lc in duthosts.frontend_nodes:
                     wait_for_startup(lc, localhost, delay=10, timeout=300)
                     check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname], 
-                                                  xcvr_skip_list, reboot_type=reboot_type)
+                                                  xcvr_skip_list)
 
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -22,7 +22,7 @@ class TestMemoryExhaustion:
     """
     This test case is used to verify that DUT will reboot when it runs out of memory.
     """
-    def wait_lc_healthy_if_sup(duthost, duthosts, localhost):
+    def wait_lc_healthy_if_sup(self, duthost, duthosts, localhost):
         # For sup, we also need to ensure linecards are back and healthy for following tests
         is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
         if is_sup:

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -49,7 +49,7 @@ class TestMemoryExhaustion:
             if is_sup:
                 for lc in duthosts.frontend_nodes:
                     wait_for_startup(lc, localhost, delay=10, timeout=300)
-                    check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname], 
+                    check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname],
                                                   xcvr_skip_list)
 
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -5,7 +5,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX, wait_for_startup
-
+from tests.common.platform_tests.test_reboot import check_interfaces_and_services
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any')
@@ -24,7 +24,8 @@ class TestMemoryExhaustion:
     """
 
     @pytest.fixture(autouse=True)
-    def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, pdu_controller):
+    def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                 localhost, pdu_controller, xcvr_skip_list, conn_graph_facts):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.
@@ -48,8 +49,8 @@ class TestMemoryExhaustion:
             if is_sup:
                 for lc in duthosts.frontend_nodes:
                     wait_for_startup(lc, localhost, delay=10, timeout=300)
-                    check_interfaces_and_services(lc, interfaces, xcvr_skip_list,
-                                                  reboot_type=reboot_type)
+                    check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname], 
+                                                  xcvr_skip_list, reboot_type=reboot_type)
 
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -50,9 +50,8 @@ class TestMemoryExhaustion:
                     check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname],
                                                   xcvr_skip_list)
 
-
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                               localhost, xcvr_skip_list):
+                               conn_graph_facts, localhost, xcvr_skip_list):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         dut_ip = duthost.mgmt_ip
         hostname = duthost.hostname

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -22,10 +22,17 @@ class TestMemoryExhaustion:
     """
     This test case is used to verify that DUT will reboot when it runs out of memory.
     """
+    def wait_lc_healthy_if_sup(duthost, duthosts):
+        # For sup, we also need to ensure linecards are back and healthy for following tests
+        is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
+        if is_sup:
+            for lc in duthosts.frontend_nodes:
+                wait_for_startup(lc, localhost, delay=10, timeout=300)
+                wait_critical_processes(lc)
 
     @pytest.fixture(autouse=True)
     def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                 localhost, pdu_controller,):
+                 localhost, pdu_controller):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.
@@ -42,12 +49,7 @@ class TestMemoryExhaustion:
                           'Recover {} by PDU reboot failed'.format(hostname))
             # Wait until all critical processes are healthy.
             wait_critical_processes(duthost)
-            # For sup, we also need to ensure linecards are back and healthy for following tests
-            is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
-            if is_sup:
-                for lc in duthosts.frontend_nodes:
-                    wait_for_startup(lc, localhost, delay=10, timeout=300)
-                    wait_critical_processes(lc)
+            wait_lc_healthy_if_sup(duthost, duthosts)
 
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -75,11 +77,7 @@ class TestMemoryExhaustion:
                       'DUT {} did not startup'.format(hostname))
         # Wait until all critical processes are healthy.
         wait_critical_processes(duthost)
-        is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
-        if is_sup:
-            for lc in duthosts.frontend_nodes:
-                wait_for_startup(lc, localhost, delay=10, timeout=300)
-                wait_critical_processes(lc)
+        wait_lc_healthy_if_sup(duthost, duthosts)
         # Verify DUT uptime is later than the time when the test case started running.
         dut_uptime = duthost.get_up_time()
         pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -5,7 +5,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX, wait_for_startup
-from tests.common.platform_tests.test_reboot import check_interfaces_and_services
+
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any')
@@ -25,7 +25,7 @@ class TestMemoryExhaustion:
 
     @pytest.fixture(autouse=True)
     def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                 localhost, pdu_controller, xcvr_skip_list, conn_graph_facts):
+                 localhost, pdu_controller,):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.
@@ -47,11 +47,9 @@ class TestMemoryExhaustion:
             if is_sup:
                 for lc in duthosts.frontend_nodes:
                     wait_for_startup(lc, localhost, delay=10, timeout=300)
-                    check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname],
-                                                  xcvr_skip_list)
+                    wait_critical_processes(lc)
 
-    def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                               conn_graph_facts, localhost, xcvr_skip_list):
+    def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         dut_ip = duthost.mgmt_ip
         hostname = duthost.hostname
@@ -81,8 +79,7 @@ class TestMemoryExhaustion:
         if is_sup:
             for lc in duthosts.frontend_nodes:
                 wait_for_startup(lc, localhost, delay=10, timeout=300)
-                check_interfaces_and_services(lc, conn_graph_facts["device_conn"][lc.hostname],
-                                              xcvr_skip_list)
+                wait_critical_processes(lc)
         # Verify DUT uptime is later than the time when the test case started running.
         dut_uptime = duthost.get_up_time()
         pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -22,7 +22,7 @@ class TestMemoryExhaustion:
     """
     This test case is used to verify that DUT will reboot when it runs out of memory.
     """
-    def wait_lc_healthy_if_sup(duthost, duthosts):
+    def wait_lc_healthy_if_sup(duthost, duthosts, localhost):
         # For sup, we also need to ensure linecards are back and healthy for following tests
         is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
         if is_sup:
@@ -49,7 +49,7 @@ class TestMemoryExhaustion:
                           'Recover {} by PDU reboot failed'.format(hostname))
             # Wait until all critical processes are healthy.
             wait_critical_processes(duthost)
-            wait_lc_healthy_if_sup(duthost, duthosts)
+            self.wait_lc_healthy_if_sup(duthost, duthosts)
 
     def test_memory_exhaustion(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -77,7 +77,7 @@ class TestMemoryExhaustion:
                       'DUT {} did not startup'.format(hostname))
         # Wait until all critical processes are healthy.
         wait_critical_processes(duthost)
-        wait_lc_healthy_if_sup(duthost, duthosts)
+        self.wait_lc_healthy_if_sup(duthost, duthosts)
         # Verify DUT uptime is later than the time when the test case started running.
         dut_uptime = duthost.get_up_time()
         pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

There are 2 fixes in this PR to enhance for chassis:
1. Right now in processes_utils.py when check_critical_services, we rely on what is pre-defined in inventory file, otherwise it is 300 sec, but for SUP, we should give 900sec as most SUPs have 10+ dockers that need to come back up, it should differ from linecards or any single-dut. magic 900 sec comes from experientment, where I had run twice the test, 1st time need 800+sec, 2nd time needs ~702sec
2. During memory exhaustion test, if the random selected dut is chassis SUP, we also need to check linecards bootup and critical services are up.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/9087
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
```
/azp/_work/12/s/tests/platform_tests/test_memory_exhaustion.py::check_ssh_state#92: [localhost] AnsibleModule::wait_for Result => {"match_groups": [], "_ansible_no_log": false, "changed": false, "elapsed": 76, "failed": false, "state": "started", "match_groupdict": {}, "invocation": {"module_args": {"active_connection_states": ["ESTABLISHED", "FIN_WAIT1", "FIN_WAIT2", "SYN_RECV", "SYN_SENT", "TIME_WAIT"], "state": "started", "connect_timeout": 5, "delay": 10, "msg": null, "host": "10.3.146.249", "sleep": 1, "timeout": 420, "exclude_hosts": null, "search_regex": "OpenSSH_[\\w\\.]+ Debian", "path": null, "port": 22}}, "path": null, "search_regex": "OpenSSH_[\\w\\.]+ Debian", "port": 22}
20/07/2023 12:18:12 processes_utils.wait_critical_processes  L0064 INFO   | Wait until all critical processes are healthy in 600 sec
20/07/2023 12:18:12 utilities.wait_until                     L0129 DEBUG  | Wait until _all_critical_processes_healthy is True, timeout is 600 seconds, checking interval is 20, delay is 0 seconds
20/07/2023 12:18:12 utilities.wait_until                     L0138 DEBUG  | Time elapsed: 0.000000 seconds
20/07/2023 12:18:12 processes_utils._all_critical_processes_ L0038 INFO   | Check critical processes status
20/07/2023 12:18:16 base._run                                L0082 DEBUG  | /azp/_work/12/s/tests/common/devices/sonic.py::critical_group_process#555: [str2-7804-sup-1] AnsibleModule::shell_cmds Result => {"end": "2023-07-20 12:18:16.419795", "_ansible_no_log": false, "failed": true, "changed": false, "results": [{"stderr_lines": ["Error response from daemon: Container be66b6f2c4cc77822feeefd8e45387d32aeba1e575dfbd76762f41872ac95f4e is not running"], "stderr": "Error response from daemon: Container be66b6f2c4cc77822feeefd8e45387d32aeba1e575dfbd76762f41872ac95f4e is not running\n", "stdout": "", "stdout_lines": [], "cmd": "docker exec pmon bash -c '[ -f /etc/supervisor/critical_processes ] 
...
20/07/2023 12:28:36 utilities.wait_until                     L0156 DEBUG  | _all_critical_processes_healthy is False, wait 20 seconds and check again
20/07/2023 12:28:56 utilities.wait_until                     L0161 DEBUG  | _all_critical_processes_healthy is still False after 600 seconds, exit with False
20/07/2023 12:28:56 __init__._log_sep_line                   L0170 INFO   | ==================== platform_tests/test_memory_exhaustion.py::TestMemoryExhaustion::test_memory_exhaustion[str2-7804-sup-1] teardown ====================
```

where `"stderr": "Error response from daemon: Container b993a2531f024ff11c073ad5b80ac2f7e2ec354041f0bd66243ac65c54e919cf is not running\n"` indicates `snmp` docker


After:
```
21/07/2023 20:58:37 utilities.wait_until                     L0138 DEBUG  | Time elapsed: 679.610809 seconds
21/07/2023 20:58:37 processes_utils._all_critical_processes_ L0038 INFO   | Check critical processes status
21/07/2023 20:58:37 base._run                                L0063 DEBUG  | /var/src/private/sonic-mgmt-int/tests/common/devices/sonic.py::critical_group_process#555: [str2-7804-sup-1] AnsibleModule::shell_cmds, args=[], kwargs={"continue_on_fail": true, "module_ignore_errors": true, "cmds": ["docker exec pmon bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec snmp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec lldp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'"]}
21/07/2023 20:58:43 base._run                                L0082 DEBUG  | /var/src/private/sonic-mgmt-int/tests/common/devices/sonic.py::critical_group_process#555: [str2-7804-sup-1] AnsibleModule::shell_cmds Result => {"end": "2023-07-21 20:58:44.265642", "_ansible_no_log": false, "start": "2023-07-21 20:58:39.586372", "changed": false, "results": [{"stderr_lines": [], "stderr": "", "stdout": "", "stdout_lines": [], "cmd": "docker exec pmon bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:snmpd\nprogram:snmp-subagent\n", "stdout_lines": ["program:snmpd", "program:snmp-subagent"], "cmd": "docker exec snmp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:lldpd\nprogram:lldp-syncd\nprogram:lldpmgrd\n", "stdout_lines": ["program:lldpd", "program:lldp-syncd", "program:lldpmgrd"], "cmd": "docker exec lldp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:redis\n", "stdout_lines": ["program:redis"], "cmd": "docker exec database8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:orchagent\n\n", "stdout_lines": ["program:orchagent", ""], "cmd": "docker exec swss8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:dsserve\nprogram:syncd\n", "stdout_lines": ["program:dsserve", "program:syncd"], "cmd": "docker exec syncd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "program:teammgrd\nprogram:teamsyncd\nprogram:tlm_teamd", "stdout_lines": ["program:teammgrd", "program:teamsyncd", "program:tlm_teamd"], "cmd": "docker exec teamd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "rc": 0}], "cmds": ["docker exec pmon bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec snmp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec lldp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'"], "failed": false, "delta": "0:00:04.679270", "invocation": {"module_args": {"continue_on_fail": true, "cmds": ["docker exec pmon bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec snmp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec lldp bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd6 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd1 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd2 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd9 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd3 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd10 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd11 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd0 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd7 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd4 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd5 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec database8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec swss8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec syncd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'", "docker exec teamd8 bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'"]}}}
21/07/2023 20:58:43 base._run                                L0063 DEBUG  | /var/src/private/sonic-mgmt-int/tests/common/devices/sonic.py::all_critical_process_status#635: [str2-7804-sup-1] AnsibleModule::shell_cmds, args=[], kwargs={"continue_on_fail": true, "module_ignore_errors": true, "cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec database6 supervisorctl status", "docker exec swss6 supervisorctl status", "docker exec syncd6 supervisorctl status", "docker exec teamd6 supervisorctl status", "docker exec database1 supervisorctl status", "docker exec swss1 supervisorctl status", "docker exec syncd1 supervisorctl status", "docker exec teamd1 supervisorctl status", "docker exec database2 supervisorctl status", "docker exec swss2 supervisorctl status", "docker exec syncd2 supervisorctl status", "docker exec teamd2 supervisorctl status", "docker exec database9 supervisorctl status", "docker exec swss9 supervisorctl status", "docker exec syncd9 supervisorctl status", "docker exec teamd9 supervisorctl status", "docker exec database3 supervisorctl status", "docker exec swss3 supervisorctl status", "docker exec syncd3 supervisorctl status", "docker exec teamd3 supervisorctl status", "docker exec database10 supervisorctl status", "docker exec swss10 supervisorctl status", "docker exec syncd10 supervisorctl status", "docker exec teamd10 supervisorctl status", "docker exec database11 supervisorctl status", "docker exec swss11 supervisorctl status", "docker exec syncd11 supervisorctl status", "docker exec teamd11 supervisorctl status", "docker exec database0 supervisorctl status", "docker exec swss0 supervisorctl status", "docker exec syncd0 supervisorctl status", "docker exec teamd0 supervisorctl status", "docker exec database7 supervisorctl status", "docker exec swss7 supervisorctl status", "docker exec syncd7 supervisorctl status", "docker exec teamd7 supervisorctl status", "docker exec database4 supervisorctl status", "docker exec swss4 supervisorctl status", "docker exec syncd4 supervisorctl status", "docker exec teamd4 supervisorctl status", "docker exec database5 supervisorctl status", "docker exec swss5 supervisorctl status", "docker exec syncd5 supervisorctl status", "docker exec teamd5 supervisorctl status", "docker exec database8 supervisorctl status", "docker exec swss8 supervisorctl status", "docker exec syncd8 supervisorctl status", "docker exec teamd8 supervisorctl status"]}
21/07/2023 20:59:00 base._run                                L0082 DEBUG  | /var/src/private/sonic-mgmt-int/tests/common/devices/sonic.py::all_critical_process_status#635: [str2-7804-sup-1] AnsibleModule::shell_cmds Result => {"end": "2023-07-21 20:59:01.446509", "_ansible_no_log": false, "failed": true, "changed": false, "results": [{"stderr_lines": [], "stderr": "", "stdout": "chassis_db_init                  EXITED    Jul 21 08:56 PM\nchassisd                         RUNNING   pid 22, uptime 0:02:25\ndependent-startup                EXITED    Jul 21 08:56 PM\npcied                            RUNNING   pid 26, uptime 0:02:25\npsud                             RUNNING   pid 23, uptime 0:02:25\nrsyslogd                         RUNNING   pid 17, uptime 0:02:28\nsupervisor-proc-exit-listener    RUNNING   pid 16, uptime 0:02:29\nsyseepromd                       RUNNING   pid 24, uptime 0:02:25\nthermalctld                      RUNNING   pid 25, uptime 0:02:25\n", "stdout_lines": ["chassis_db_init                  EXITED    Jul 21 08:56 PM", "chassisd                         RUNNING   pid 22, uptime 0:02:25", "dependent-startup                EXITED    Jul 21 08:56 PM", "pcied                            RUNNING   pid 26, uptime 0:02:25", "psud                             RUNNING   pid 23, uptime 0:02:25", "rsyslogd                         RUNNING   pid 17, uptime 0:02:28", "supervisor-proc-exit-listener    RUNNING   pid 16, uptime 0:02:29", "syseepromd                       RUNNING   pid 24, uptime 0:02:25", "thermalctld                      RUNNING   pid 25, uptime 0:02:25"], "cmd": "docker exec pmon supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:58 PM\nrsyslogd                         RUNNING   pid 15, uptime 0:00:28\nsnmp-subagent                    RUNNING   pid 20, uptime 0:00:26\nsnmpd                            RUNNING   pid 19, uptime 0:00:28\nstart                            EXITED    Jul 21 08:58 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:00:30\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:58 PM", "rsyslogd                         RUNNING   pid 15, uptime 0:00:28", "snmp-subagent                    RUNNING   pid 20, uptime 0:00:26", "snmpd                            RUNNING   pid 19, uptime 0:00:28", "start                            EXITED    Jul 21 08:58 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:00:30"], "cmd": "docker exec snmp supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nlldp-syncd                       RUNNING   pid 30, uptime 0:02:24\nlldpd                            RUNNING   pid 21, uptime 0:02:26\nlldpmgrd                         RUNNING   pid 34, uptime 0:02:21\nrsyslogd                         RUNNING   pid 12, uptime 0:02:29\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 11, uptime 0:02:30\nwaitfor_lldp_ready               EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "lldp-syncd                       RUNNING   pid 30, uptime 0:02:24", "lldpd                            RUNNING   pid 21, uptime 0:02:26", "lldpmgrd                         RUNNING   pid 34, uptime 0:02:21", "rsyslogd                         RUNNING   pid 12, uptime 0:02:29", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 11, uptime 0:02:30", "waitfor_lldp_ready               EXITED    Jul 21 08:56 PM"], "cmd": "docker exec lldp supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 47, uptime 0:03:40\nredis                            RUNNING   pid 46, uptime 0:03:40\nrsyslogd                         RUNNING   pid 45, uptime 0:03:40\nsupervisor-proc-exit-listener    RUNNING   pid 44, uptime 0:03:40\n", "stdout_lines": ["flushdb                          RUNNING   pid 47, uptime 0:03:40", "redis                            RUNNING   pid 46, uptime 0:03:40", "rsyslogd                         RUNNING   pid 45, uptime 0:03:40", "supervisor-proc-exit-listener    RUNNING   pid 44, uptime 0:03:40"], "cmd": "docker exec database supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 39, uptime 0:03:34\nredis                            RUNNING   pid 38, uptime 0:03:34\nrsyslogd                         RUNNING   pid 37, uptime 0:03:34\nsupervisor-proc-exit-listener    RUNNING   pid 36, uptime 0:03:34\n", "stdout_lines": ["flushdb                          RUNNING   pid 39, uptime 0:03:34", "redis                            RUNNING   pid 38, uptime 0:03:34", "rsyslogd                         RUNNING   pid 37, uptime 0:03:34", "supervisor-proc-exit-listener    RUNNING   pid 36, uptime 0:03:34"], "cmd": "docker exec database6 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 70, uptime 0:01:52\norchagent                        RUNNING   pid 32, uptime 0:01:59\nrsyslogd                         RUNNING   pid 31, uptime 0:02:01\nsupervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:02\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 70, uptime 0:01:52", "orchagent                        RUNNING   pid 32, uptime 0:01:59", "rsyslogd                         RUNNING   pid 31, uptime 0:02:01", "supervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:02", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss6 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 10, uptime 0:02:04\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 9, uptime 0:02:06\nsyncd                            RUNNING   pid 15, uptime 0:02:02\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 10, uptime 0:02:04", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 9, uptime 0:02:06", "syncd                            RUNNING   pid 15, uptime 0:02:02"], "cmd": "docker exec syncd6 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:05\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:06\nteammgrd                         RUNNING   pid 13, uptime 0:02:04\nteamsyncd                        RUNNING   pid 17, uptime 0:02:02\ntlm_teamd                        RUNNING   pid 15, uptime 0:02:04\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:05", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:06", "teammgrd                         RUNNING   pid 13, uptime 0:02:04", "teamsyncd                        RUNNING   pid 17, uptime 0:02:02", "tlm_teamd                        RUNNING   pid 15, uptime 0:02:04"], "cmd": "docker exec teamd6 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 40, uptime 0:03:34\nredis                            RUNNING   pid 39, uptime 0:03:34\nrsyslogd                         RUNNING   pid 38, uptime 0:03:34\nsupervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:34\n", "stdout_lines": ["flushdb                          RUNNING   pid 40, uptime 0:03:34", "redis                            RUNNING   pid 39, uptime 0:03:34", "rsyslogd                         RUNNING   pid 38, uptime 0:03:34", "supervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:34"], "cmd": "docker exec database1 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 72, uptime 0:01:52\norchagent                        RUNNING   pid 34, uptime 0:01:59\nrsyslogd                         RUNNING   pid 33, uptime 0:02:01\nsupervisor-proc-exit-listener    RUNNING   pid 32, uptime 0:02:03\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 72, uptime 0:01:52", "orchagent                        RUNNING   pid 34, uptime 0:01:59", "rsyslogd                         RUNNING   pid 33, uptime 0:02:01", "supervisor-proc-exit-listener    RUNNING   pid 32, uptime 0:02:03", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss1 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:06\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:07\nsyncd                            RUNNING   pid 14, uptime 0:02:04\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:06", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:07", "syncd                            RUNNING   pid 14, uptime 0:02:04"], "cmd": "docker exec syncd1 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:11\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:12\nteammgrd                         RUNNING   pid 13, uptime 0:02:11\nteamsyncd                        RUNNING   pid 17, uptime 0:02:08\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:11\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:11", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:12", "teammgrd                         RUNNING   pid 13, uptime 0:02:11", "teamsyncd                        RUNNING   pid 17, uptime 0:02:08", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:11"], "cmd": "docker exec teamd1 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 41, uptime 0:03:35\nredis                            RUNNING   pid 40, uptime 0:03:35\nrsyslogd                         RUNNING   pid 39, uptime 0:03:35\nsupervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:35\n", "stdout_lines": ["flushdb                          RUNNING   pid 41, uptime 0:03:35", "redis                            RUNNING   pid 40, uptime 0:03:35", "rsyslogd                         RUNNING   pid 39, uptime 0:03:35", "supervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:35"], "cmd": "docker exec database2 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 69, uptime 0:01:54\norchagent                        RUNNING   pid 31, uptime 0:02:01\nrsyslogd                         RUNNING   pid 30, uptime 0:02:03\nsupervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:04\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 69, uptime 0:01:54", "orchagent                        RUNNING   pid 31, uptime 0:02:01", "rsyslogd                         RUNNING   pid 30, uptime 0:02:03", "supervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:04", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss2 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:10\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:12\nsyncd                            RUNNING   pid 18, uptime 0:02:07\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:10", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:12", "syncd                            RUNNING   pid 18, uptime 0:02:07"], "cmd": "docker exec syncd2 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:08\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:10\nteammgrd                         RUNNING   pid 13, uptime 0:02:08\nteamsyncd                        RUNNING   pid 17, uptime 0:02:06\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:08\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:08", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:10", "teammgrd                         RUNNING   pid 13, uptime 0:02:08", "teamsyncd                        RUNNING   pid 17, uptime 0:02:06", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:08"], "cmd": "docker exec teamd2 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 42, uptime 0:03:36\nredis                            RUNNING   pid 41, uptime 0:03:36\nrsyslogd                         RUNNING   pid 40, uptime 0:03:36\nsupervisor-proc-exit-listener    RUNNING   pid 39, uptime 0:03:36\n", "stdout_lines": ["flushdb                          RUNNING   pid 42, uptime 0:03:36", "redis                            RUNNING   pid 41, uptime 0:03:36", "rsyslogd                         RUNNING   pid 40, uptime 0:03:36", "supervisor-proc-exit-listener    RUNNING   pid 39, uptime 0:03:36"], "cmd": "docker exec database9 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 69, uptime 0:01:54\norchagent                        RUNNING   pid 31, uptime 0:02:01\nrsyslogd                         RUNNING   pid 30, uptime 0:02:03\nsupervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:05\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 69, uptime 0:01:54", "orchagent                        RUNNING   pid 31, uptime 0:02:01", "rsyslogd                         RUNNING   pid 30, uptime 0:02:03", "supervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:05", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss9 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:09\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:10\nsyncd                            RUNNING   pid 14, uptime 0:02:07\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:09", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:10", "syncd                            RUNNING   pid 14, uptime 0:02:07"], "cmd": "docker exec syncd9 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:13\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:14\nteammgrd                         RUNNING   pid 12, uptime 0:02:13\nteamsyncd                        RUNNING   pid 16, uptime 0:02:10\ntlm_teamd                        RUNNING   pid 13, uptime 0:02:13\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:13", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:14", "teammgrd                         RUNNING   pid 12, uptime 0:02:13", "teamsyncd                        RUNNING   pid 16, uptime 0:02:10", "tlm_teamd                        RUNNING   pid 13, uptime 0:02:13"], "cmd": "docker exec teamd9 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 40, uptime 0:03:37\nredis                            RUNNING   pid 39, uptime 0:03:37\nrsyslogd                         RUNNING   pid 38, uptime 0:03:37\nsupervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:37\n", "stdout_lines": ["flushdb                          RUNNING   pid 40, uptime 0:03:37", "redis                            RUNNING   pid 39, uptime 0:03:37", "rsyslogd                         RUNNING   pid 38, uptime 0:03:37", "supervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:37"], "cmd": "docker exec database3 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 71, uptime 0:01:57\norchagent                        RUNNING   pid 33, uptime 0:02:04\nrsyslogd                         RUNNING   pid 32, uptime 0:02:06\nsupervisor-proc-exit-listener    RUNNING   pid 31, uptime 0:02:08\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 71, uptime 0:01:57", "orchagent                        RUNNING   pid 33, uptime 0:02:04", "rsyslogd                         RUNNING   pid 32, uptime 0:02:06", "supervisor-proc-exit-listener    RUNNING   pid 31, uptime 0:02:08", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss3 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:14\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:16\nsyncd                            RUNNING   pid 14, uptime 0:02:12\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:14", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:16", "syncd                            RUNNING   pid 14, uptime 0:02:12"], "cmd": "docker exec syncd3 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:13\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:15\nteammgrd                         RUNNING   pid 12, uptime 0:02:13\nteamsyncd                        RUNNING   pid 16, uptime 0:02:10\ntlm_teamd                        RUNNING   pid 13, uptime 0:02:13\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:13", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:15", "teammgrd                         RUNNING   pid 12, uptime 0:02:13", "teamsyncd                        RUNNING   pid 16, uptime 0:02:10", "tlm_teamd                        RUNNING   pid 13, uptime 0:02:13"], "cmd": "docker exec teamd3 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 40, uptime 0:03:40\nredis                            RUNNING   pid 39, uptime 0:03:40\nrsyslogd                         RUNNING   pid 38, uptime 0:03:40\nsupervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:40\n", "stdout_lines": ["flushdb                          RUNNING   pid 40, uptime 0:03:40", "redis                            RUNNING   pid 39, uptime 0:03:40", "rsyslogd                         RUNNING   pid 38, uptime 0:03:40", "supervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:40"], "cmd": "docker exec database10 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 70, uptime 0:01:57\norchagent                        RUNNING   pid 32, uptime 0:02:04\nrsyslogd                         RUNNING   pid 31, uptime 0:02:06\nsupervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:08\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 70, uptime 0:01:57", "orchagent                        RUNNING   pid 32, uptime 0:02:04", "rsyslogd                         RUNNING   pid 31, uptime 0:02:06", "supervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:08", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss10 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:14\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:15\nsyncd                            RUNNING   pid 14, uptime 0:02:11\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:14", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:15", "syncd                            RUNNING   pid 14, uptime 0:02:11"], "cmd": "docker exec syncd10 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:16\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:17\nteammgrd                         RUNNING   pid 13, uptime 0:02:15\nteamsyncd                        RUNNING   pid 17, uptime 0:02:12\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:15\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:16", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:17", "teammgrd                         RUNNING   pid 13, uptime 0:02:15", "teamsyncd                        RUNNING   pid 17, uptime 0:02:12", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:15"], "cmd": "docker exec teamd10 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 41, uptime 0:03:41\nredis                            RUNNING   pid 40, uptime 0:03:41\nrsyslogd                         RUNNING   pid 39, uptime 0:03:41\nsupervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:41\n", "stdout_lines": ["flushdb                          RUNNING   pid 41, uptime 0:03:41", "redis                            RUNNING   pid 40, uptime 0:03:41", "rsyslogd                         RUNNING   pid 39, uptime 0:03:41", "supervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:41"], "cmd": "docker exec database11 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 70, uptime 0:01:58\norchagent                        RUNNING   pid 32, uptime 0:02:05\nrsyslogd                         RUNNING   pid 31, uptime 0:02:07\nsupervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:09\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 70, uptime 0:01:58", "orchagent                        RUNNING   pid 32, uptime 0:02:05", "rsyslogd                         RUNNING   pid 31, uptime 0:02:07", "supervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:09", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss11 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:15\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:18\nsyncd                            RUNNING   pid 18, uptime 0:02:13\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:15", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:18", "syncd                            RUNNING   pid 18, uptime 0:02:13"], "cmd": "docker exec syncd11 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:15\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:17\nteammgrd                         RUNNING   pid 12, uptime 0:02:15\nteamsyncd                        RUNNING   pid 16, uptime 0:02:12\ntlm_teamd                        RUNNING   pid 13, uptime 0:02:15\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:15", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:17", "teammgrd                         RUNNING   pid 12, uptime 0:02:15", "teamsyncd                        RUNNING   pid 16, uptime 0:02:12", "tlm_teamd                        RUNNING   pid 13, uptime 0:02:15"], "cmd": "docker exec teamd11 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 42, uptime 0:03:42\nredis                            RUNNING   pid 41, uptime 0:03:42\nrsyslogd                         RUNNING   pid 40, uptime 0:03:42\nsupervisor-proc-exit-listener    RUNNING   pid 39, uptime 0:03:42\n", "stdout_lines": ["flushdb                          RUNNING   pid 42, uptime 0:03:42", "redis                            RUNNING   pid 41, uptime 0:03:42", "rsyslogd                         RUNNING   pid 40, uptime 0:03:42", "supervisor-proc-exit-listener    RUNNING   pid 39, uptime 0:03:42"], "cmd": "docker exec database0 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 69, uptime 0:02:04\norchagent                        RUNNING   pid 31, uptime 0:02:11\nrsyslogd                         RUNNING   pid 30, uptime 0:02:14\nsupervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:15\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 69, uptime 0:02:04", "orchagent                        RUNNING   pid 31, uptime 0:02:11", "rsyslogd                         RUNNING   pid 30, uptime 0:02:14", "supervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:15", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss0 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:13\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 10, uptime 0:02:15\nsyncd                            RUNNING   pid 16, uptime 0:02:11\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:13", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 10, uptime 0:02:15", "syncd                            RUNNING   pid 16, uptime 0:02:11"], "cmd": "docker exec syncd0 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:17\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:19\nteammgrd                         RUNNING   pid 13, uptime 0:02:17\nteamsyncd                        RUNNING   pid 17, uptime 0:02:14\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:17\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:17", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:19", "teammgrd                         RUNNING   pid 13, uptime 0:02:17", "teamsyncd                        RUNNING   pid 17, uptime 0:02:14", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:17"], "cmd": "docker exec teamd0 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 44, uptime 0:03:42\nredis                            RUNNING   pid 43, uptime 0:03:42\nrsyslogd                         RUNNING   pid 42, uptime 0:03:42\nsupervisor-proc-exit-listener    RUNNING   pid 41, uptime 0:03:42\n", "stdout_lines": ["flushdb                          RUNNING   pid 44, uptime 0:03:42", "redis                            RUNNING   pid 43, uptime 0:03:42", "rsyslogd                         RUNNING   pid 42, uptime 0:03:42", "supervisor-proc-exit-listener    RUNNING   pid 41, uptime 0:03:42"], "cmd": "docker exec database7 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 69, uptime 0:02:01\norchagent                        RUNNING   pid 31, uptime 0:02:08\nrsyslogd                         RUNNING   pid 30, uptime 0:02:10\nsupervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:12\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 69, uptime 0:02:01", "orchagent                        RUNNING   pid 31, uptime 0:02:08", "rsyslogd                         RUNNING   pid 30, uptime 0:02:10", "supervisor-proc-exit-listener    RUNNING   pid 29, uptime 0:02:12", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss7 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:17\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:18\nsyncd                            RUNNING   pid 14, uptime 0:02:14\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:17", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:18", "syncd                            RUNNING   pid 14, uptime 0:02:14"], "cmd": "docker exec syncd7 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 13, uptime 0:02:19\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 9, uptime 0:02:21\nteammgrd                         RUNNING   pid 14, uptime 0:02:18\nteamsyncd                        RUNNING   pid 18, uptime 0:02:15\ntlm_teamd                        RUNNING   pid 15, uptime 0:02:18\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 13, uptime 0:02:19", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 9, uptime 0:02:21", "teammgrd                         RUNNING   pid 14, uptime 0:02:18", "teamsyncd                        RUNNING   pid 18, uptime 0:02:15", "tlm_teamd                        RUNNING   pid 15, uptime 0:02:18"], "cmd": "docker exec teamd7 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 41, uptime 0:03:44\nredis                            RUNNING   pid 40, uptime 0:03:44\nrsyslogd                         RUNNING   pid 39, uptime 0:03:44\nsupervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:44\n", "stdout_lines": ["flushdb                          RUNNING   pid 41, uptime 0:03:44", "redis                            RUNNING   pid 40, uptime 0:03:44", "rsyslogd                         RUNNING   pid 39, uptime 0:03:44", "supervisor-proc-exit-listener    RUNNING   pid 38, uptime 0:03:44"], "cmd": "docker exec database4 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 70, uptime 0:02:02\norchagent                        RUNNING   pid 32, uptime 0:02:09\nrsyslogd                         RUNNING   pid 31, uptime 0:02:11\nsupervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:13\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 70, uptime 0:02:02", "orchagent                        RUNNING   pid 32, uptime 0:02:09", "rsyslogd                         RUNNING   pid 31, uptime 0:02:11", "supervisor-proc-exit-listener    RUNNING   pid 30, uptime 0:02:13", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss4 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:19\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:21\nsyncd                            RUNNING   pid 18, uptime 0:02:16\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:19", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:21", "syncd                            RUNNING   pid 18, uptime 0:02:16"], "cmd": "docker exec syncd4 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:18\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:19\nteammgrd                         RUNNING   pid 12, uptime 0:02:17\nteamsyncd                        RUNNING   pid 16, uptime 0:02:15\ntlm_teamd                        RUNNING   pid 13, uptime 0:02:17\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:18", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 7, uptime 0:02:19", "teammgrd                         RUNNING   pid 12, uptime 0:02:17", "teamsyncd                        RUNNING   pid 16, uptime 0:02:15", "tlm_teamd                        RUNNING   pid 13, uptime 0:02:17"], "cmd": "docker exec teamd4 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 40, uptime 0:03:47\nredis                            RUNNING   pid 39, uptime 0:03:47\nrsyslogd                         RUNNING   pid 38, uptime 0:03:47\nsupervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:47\n", "stdout_lines": ["flushdb                          RUNNING   pid 40, uptime 0:03:47", "redis                            RUNNING   pid 39, uptime 0:03:47", "rsyslogd                         RUNNING   pid 38, uptime 0:03:47", "supervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:47"], "cmd": "docker exec database5 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 71, uptime 0:02:08\norchagent                        RUNNING   pid 33, uptime 0:02:15\nrsyslogd                         RUNNING   pid 32, uptime 0:02:17\nsupervisor-proc-exit-listener    RUNNING   pid 31, uptime 0:02:18\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 71, uptime 0:02:08", "orchagent                        RUNNING   pid 33, uptime 0:02:15", "rsyslogd                         RUNNING   pid 32, uptime 0:02:17", "supervisor-proc-exit-listener    RUNNING   pid 31, uptime 0:02:18", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss5 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 11, uptime 0:02:16\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 10, uptime 0:02:18\nsyncd                            RUNNING   pid 16, uptime 0:02:14\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 11, uptime 0:02:16", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 10, uptime 0:02:18", "syncd                            RUNNING   pid 16, uptime 0:02:14"], "cmd": "docker exec syncd5 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:22\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:24\nteammgrd                         RUNNING   pid 13, uptime 0:02:22\nteamsyncd                        RUNNING   pid 17, uptime 0:02:19\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:22\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:22", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:24", "teammgrd                         RUNNING   pid 13, uptime 0:02:22", "teamsyncd                        RUNNING   pid 17, uptime 0:02:19", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:22"], "cmd": "docker exec teamd5 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "flushdb                          RUNNING   pid 40, uptime 0:03:47\nredis                            RUNNING   pid 39, uptime 0:03:47\nrsyslogd                         RUNNING   pid 38, uptime 0:03:47\nsupervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:47\n", "stdout_lines": ["flushdb                          RUNNING   pid 40, uptime 0:03:47", "redis                            RUNNING   pid 39, uptime 0:03:47", "rsyslogd                         RUNNING   pid 38, uptime 0:03:47", "supervisor-proc-exit-listener    RUNNING   pid 37, uptime 0:03:47"], "cmd": "docker exec database8 supervisorctl status", "rc": 0}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nenable_counters                  RUNNING   pid 74, uptime 0:02:04\norchagent                        RUNNING   pid 36, uptime 0:02:12\nrsyslogd                         RUNNING   pid 35, uptime 0:02:14\nsupervisor-proc-exit-listener    RUNNING   pid 34, uptime 0:02:15\nswssconfig                       EXITED    Jul 21 08:56 PM\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "enable_counters                  RUNNING   pid 74, uptime 0:02:04", "orchagent                        RUNNING   pid 36, uptime 0:02:12", "rsyslogd                         RUNNING   pid 35, uptime 0:02:14", "supervisor-proc-exit-listener    RUNNING   pid 34, uptime 0:02:15", "swssconfig                       EXITED    Jul 21 08:56 PM"], "cmd": "docker exec swss8 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nledinit                          EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 9, uptime 0:02:19\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:20\nsyncd                            RUNNING   pid 14, uptime 0:02:16\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "ledinit                          EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 9, uptime 0:02:19", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:20", "syncd                            RUNNING   pid 14, uptime 0:02:16"], "cmd": "docker exec syncd8 supervisorctl status", "rc": 3}, {"stderr_lines": [], "stderr": "", "stdout": "dependent-startup                EXITED    Jul 21 08:56 PM\nrsyslogd                         RUNNING   pid 12, uptime 0:02:18\nstart                            EXITED    Jul 21 08:56 PM\nsupervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:21\nteammgrd                         RUNNING   pid 13, uptime 0:02:18\nteamsyncd                        RUNNING   pid 17, uptime 0:02:16\ntlm_teamd                        RUNNING   pid 14, uptime 0:02:18\n", "stdout_lines": ["dependent-startup                EXITED    Jul 21 08:56 PM", "rsyslogd                         RUNNING   pid 12, uptime 0:02:18", "start                            EXITED    Jul 21 08:56 PM", "supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:02:21", "teammgrd                         RUNNING   pid 13, uptime 0:02:18", "teamsyncd                        RUNNING   pid 17, uptime 0:02:16", "tlm_teamd                        RUNNING   pid 14, uptime 0:02:18"], "cmd": "docker exec teamd8 supervisorctl status", "rc": 3}], "cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec database6 supervisorctl status", "docker exec swss6 supervisorctl status", "docker exec syncd6 supervisorctl status", "docker exec teamd6 supervisorctl status", "docker exec database1 supervisorctl status", "docker exec swss1 supervisorctl status", "docker exec syncd1 supervisorctl status", "docker exec teamd1 supervisorctl status", "docker exec database2 supervisorctl status", "docker exec swss2 supervisorctl status", "docker exec syncd2 supervisorctl status", "docker exec teamd2 supervisorctl status", "docker exec database9 supervisorctl status", "docker exec swss9 supervisorctl status", "docker exec syncd9 supervisorctl status", "docker exec teamd9 supervisorctl status", "docker exec database3 supervisorctl status", "docker exec swss3 supervisorctl status", "docker exec syncd3 supervisorctl status", "docker exec teamd3 supervisorctl status", "docker exec database10 supervisorctl status", "docker exec swss10 supervisorctl status", "docker exec syncd10 supervisorctl status", "docker exec teamd10 supervisorctl status", "docker exec database11 supervisorctl status", "docker exec swss11 supervisorctl status", "docker exec syncd11 supervisorctl status", "docker exec teamd11 supervisorctl status", "docker exec database0 supervisorctl status", "docker exec swss0 supervisorctl status", "docker exec syncd0 supervisorctl status", "docker exec teamd0 supervisorctl status", "docker exec database7 supervisorctl status", "docker exec swss7 supervisorctl status", "docker exec syncd7 supervisorctl status", "docker exec teamd7 supervisorctl status", "docker exec database4 supervisorctl status", "docker exec swss4 supervisorctl status", "docker exec syncd4 supervisorctl status", "docker exec teamd4 supervisorctl status", "docker exec database5 supervisorctl status", "docker exec swss5 supervisorctl status", "docker exec syncd5 supervisorctl status", "docker exec teamd5 supervisorctl status", "docker exec database8 supervisorctl status", "docker exec swss8 supervisorctl status", "docker exec syncd8 supervisorctl status", "docker exec teamd8 supervisorctl status"], "start": "2023-07-21 20:58:45.497510", "delta": "0:00:15.948999", "invocation": {"module_args": {"continue_on_fail": true, "cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec database6 supervisorctl status", "docker exec swss6 supervisorctl status", "docker exec syncd6 supervisorctl status", "docker exec teamd6 supervisorctl status", "docker exec database1 supervisorctl status", "docker exec swss1 supervisorctl status", "docker exec syncd1 supervisorctl status", "docker exec teamd1 supervisorctl status", "docker exec database2 supervisorctl status", "docker exec swss2 supervisorctl status", "docker exec syncd2 supervisorctl status", "docker exec teamd2 supervisorctl status", "docker exec database9 supervisorctl status", "docker exec swss9 supervisorctl status", "docker exec syncd9 supervisorctl status", "docker exec teamd9 supervisorctl status", "docker exec database3 supervisorctl status", "docker exec swss3 supervisorctl status", "docker exec syncd3 supervisorctl status", "docker exec teamd3 supervisorctl status", "docker exec database10 supervisorctl status", "docker exec swss10 supervisorctl status", "docker exec syncd10 supervisorctl status", "docker exec teamd10 supervisorctl status", "docker exec database11 supervisorctl status", "docker exec swss11 supervisorctl status", "docker exec syncd11 supervisorctl status", "docker exec teamd11 supervisorctl status", "docker exec database0 supervisorctl status", "docker exec swss0 supervisorctl status", "docker exec syncd0 supervisorctl status", "docker exec teamd0 supervisorctl status", "docker exec database7 supervisorctl status", "docker exec swss7 supervisorctl status", "docker exec syncd7 supervisorctl status", "docker exec teamd7 supervisorctl status", "docker exec database4 supervisorctl status", "docker exec swss4 supervisorctl status", "docker exec syncd4 supervisorctl status", "docker exec teamd4 supervisorctl status", "docker exec database5 supervisorctl status", "docker exec swss5 supervisorctl status", "docker exec syncd5 supervisorctl status", "docker exec teamd5 supervisorctl status", "docker exec database8 supervisorctl status", "docker exec swss8 supervisorctl status", "docker exec syncd8 supervisorctl status", "docker exec teamd8 supervisorctl status"]}}, "msg": "At least running one of the commands failed"}
21/07/2023 20:59:00 utilities.wait_until                     L0153 DEBUG  | _all_critical_processes_healthy is True, exit early with True
...
PASSED                                                                                                                                                                                       [100%]
---------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
