### PR TITLE
[cherry pick] #9025 Fit dualtor scenario when deleting config VLAN|mac in module vlan/test_host_vlan.py into 202205. 

### DIFF
--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -81,7 +81,7 @@ def get_new_vlan_intf_mac_mellanox(dut_vlan_intf_mac):
     return new_dut_vlan_intf_mac
 
 @pytest.fixture(scope="module")
-def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership):
+def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership, tbinfo):
     vlan_intf, _ = testbed_params
     duthost = duthosts[rand_one_dut_hostname]
     dut_vlan_mac = duthost.get_dut_iface_mac('%s' % vlan_intf["attachto"])
@@ -94,16 +94,17 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
 
     yield
 
-    del_vlan_json = json.loads("""
-                [{
-                    "VLAN":{
-                        "%s":{
-                            "mac": "%s"
+    if "dualtor" not in tbinfo["topo"]["name"]:
+        del_vlan_json = json.loads("""
+                    [{
+                        "VLAN":{
+                            "%s":{
+                                "mac": "%s"
+                            }
                         }
-                    }
-                }]
-            """ % (vlan_intf["attachto"], dut_vlan_mac))
-    delete_running_config(del_vlan_json, duthost)
+                    }]
+                """ % (vlan_intf["attachto"], dut_vlan_mac))
+        delete_running_config(del_vlan_json, duthost)
 
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == dut_vlan_mac)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix cherry pick conflict of PR #9025 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix cherry pick conflict of PR #9025 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
