### PR TITLE
Revert "[dualtor] Leave `icmp_responder` running on `dualtor` topology"

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -269,8 +269,17 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    logger.info("Leave icmp_responder running for dualtor/dualtor-mixed/dualtor-aa topology")
-    return
+    if "dualtor-mixed" in tbinfo["topo"]["name"] or "dualtor-aa" in tbinfo["topo"]["name"]:
+        logger.info("Leave icmp_responder running for dualtor-mixed/dualtor-aa topology")
+        return
+
+    logger.info("Stop running icmp_responder")
+    ptfhost.shell("supervisorctl stop icmp_responder")
+    icmp_responder_session_started = False
+
+    logger.info("Recover linkmgrd probe interval")
+    recover_linkmgrd_probe_interval(duthosts, tbinfo)
+    duthosts.shell("config save -y")
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#8909

The rationale of this reversion:

It appeared that leaving `icmp_responder` running will have unexpected dataplane impact:
1. with `garp_service` running, the icmp probe replies will pollute the fdb table, those tests that assigns Vlan subnet address to ptf port will be not able to verify the traffic forwarding as the fdb mapping is not correct.
2. without `garp_service` running, `linkmgrd` will send heartbeats with dest mac as zero mac, and the probe replies that has zero mac as src mac will be dropped by the root fanout.

So let's revert it for now, and add it back when we have better solutions for the above two impacts.