### PR TITLE
[Fanout] Remove `teamd` container before loading new config

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -22,7 +22,7 @@
 
 - name: Disable feature teamd and remove teamd container (avoid swss crash after config reload)
   block:
-    - name: Chekc if teamd container exists
+    - name: Check if teamd container exists
       shell: "docker ps -a -q -f name=teamd"
       register: teamd_container
 

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -20,6 +20,17 @@
     dest: "/usr/share/sonic/templates/copp_cfg.j2"
   become: yes
 
+- name: Disable feature teamd and remove teamd container (avoid swss crash after config reload)
+  block:
+    - name: Chekc if teamd container exists
+      shell: "docker ps -a -q -f name=teamd"
+      register: teamd_container
+
+    - name: disable feature teamd and remove container
+      shell: "config feature state teamd disabled && sleep 10 && docker rm teamd"
+      become: true
+      when: teamd_container.stdout != ""
+
 - name: SONiC update config db
   shell: config reload -y -f
   become: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In issue https://github.com/sonic-net/sonic-buildimage/issues/15649, we found container `swss` crash after feature teamd is disabled. Currently, the only way to mitigate this issue is delete the `teamd` container before loading new config on SONiC 202205 fanout switches.

In this PR, I add some steps to check if container `teamd` exists and remove it before loading new config_db.json.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

In issue https://github.com/sonic-net/sonic-buildimage/issues/15649, we found container `swss` crash after feature teamd is disabled. Currently, the only way to mitigate this issue is delete the `teamd` container before loading new config on SONiC 202205 fanout switches.

#### How did you do it?

Add some steps to check if container `teamd` exists and remove it before loading new config_db.json.

#### How did you verify/test it?

Verified on Nokia-7215 fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
