### PR TITLE
Skip check_bgp_router_id on T2 devices

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -232,7 +232,7 @@ def check_bgp(duthosts, tbinfo):
             logger.info('No BGP neighbors are down on %s' % dut.hostname)
 
         mgFacts = dut.get_extended_minigraph_facts(tbinfo)
-        if dut.num_asics() == 1 and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
+        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
             check_result['failed'] = True
             logger.info("Failed to verify BGP router identifier is Loopback0 address on %s" % dut.hostname)
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -232,8 +232,8 @@ def check_bgp(duthosts, tbinfo):
             logger.info('No BGP neighbors are down on %s' % dut.hostname)
 
         mgFacts = dut.get_extended_minigraph_facts(tbinfo)
-        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' 
-                and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
+        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' and \
+           not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
             check_result['failed'] = True
             logger.info("Failed to verify BGP router identifier is Loopback0 address on %s" % dut.hostname)
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -232,7 +232,8 @@ def check_bgp(duthosts, tbinfo):
             logger.info('No BGP neighbors are down on %s' % dut.hostname)
 
         mgFacts = dut.get_extended_minigraph_facts(tbinfo)
-        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
+        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' 
+                and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
             check_result['failed'] = True
             logger.info("Failed to verify BGP router identifier is Loopback0 address on %s" % dut.hostname)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip check_bgp_router_id on T2 devices
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
In chassis the a different Loopback ip is used as bgp router_id

#### How did you do it?
Skip check_bgp_router_id on t2 topo

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
