### PR TITLE
pfcwd function enhance for dualtor testbed

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -206,17 +206,15 @@ def setup_dut_test_params(
                         dut_test_params["basicParams"]["def_vlan_mac"] = vlan['mac']
                         break
 
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    conf_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-
     vlan_table = {}
-    for name, vlan in list(conf_facts['VLAN'].items()):
-        vlan_id = int(vlan['vlanid'])
-        vlan_table[vlan_id] = {"mac": vlan['mac'], "ifname": []} 
-
-        for ifname in list(conf_facts['VLAN_MEMBER'][name].keys()):
-            vlan_table[vlan_id]['ifname'].append(ifname)
-    logger.info("vlan_table : {}".format(vlan_table))
+    if dut_test_params['basicParams']['is_dualtor']:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        conf_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        for name, vlan in list(conf_facts['VLAN'].items()):
+            vlan_id = int(vlan['vlanid'])
+            vlan_table[vlan_id] = {"mac": vlan['mac'], "ifname": []}
+            for ifname in list(conf_facts['VLAN_MEMBER'][name].keys()):
+                vlan_table[vlan_id]['ifname'].append(ifname)
 
     dut_test_params['vlanParams'] = vlan_table
     logger.info("dut_test_params : {}".format(dut_test_params))

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -15,7 +15,6 @@ from tests.common import port_toggle
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m    # noqa F401
-from tests.common.fixtures.ptfhost_utils import pause_garp_service
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
@@ -472,7 +471,7 @@ class SendVerifyTraffic():
         src_port = self.pfc_wd_rx_port_id[0]
         router_mac = self.router_mac
 
-        if self.setup_dut_info['basicParams']['is_dualtor'] :
+        if self.setup_dut_info['basicParams']['is_dualtor']:
             for vlan_id, vlan_ifname in self.setup_dut_info['vlanParams'].items():
                 if src_ifname in vlan_ifname['ifname']:
                     router_mac = vlan_ifname['mac']
@@ -513,7 +512,7 @@ class SendVerifyTraffic():
         src_port = self.pfc_wd_test_port_id
         router_mac = self.router_mac
 
-        if self.setup_dut_info['basicParams']['is_dualtor'] :
+        if self.setup_dut_info['basicParams']['is_dualtor']:
             for vlan_id, vlan_ifname in self.setup_dut_info['vlanParams'].items():
                 if src_ifname in vlan_ifname['ifname']:
                     router_mac = vlan_ifname['mac']
@@ -552,10 +551,10 @@ class SendVerifyTraffic():
             other_queue = self.pfc_queue_index + 1
 
         src_ifname = self.pfc_wd_rx_port[0]
-        src_port =  self.pfc_wd_rx_port_id[0]
+        src_port = self.pfc_wd_rx_port_id[0]
         router_mac = self.router_mac
 
-        if self.setup_dut_info['basicParams']['is_dualtor'] :
+        if self.setup_dut_info['basicParams']['is_dualtor']:
             for vlan_id, vlan_ifname in self.setup_dut_info['vlanParams'].items():
                 if src_ifname in vlan_ifname['ifname']:
                     router_mac = vlan_ifname['mac']
@@ -594,10 +593,10 @@ class SendVerifyTraffic():
             other_pg = self.pfc_queue_index + 1
 
         src_ifname = self.pfc_wd_test_port
-        src_port =  self.pfc_wd_test_port_id
+        src_port = self.pfc_wd_test_port_id
         router_mac = self.router_mac
 
-        if self.setup_dut_info['basicParams']['is_dualtor'] :
+        if self.setup_dut_info['basicParams']['is_dualtor']:
             for vlan_id, vlan_ifname in self.setup_dut_info['vlanParams'].items():
                 if src_ifname in vlan_ifname['ifname']:
                     router_mac = vlan_ifname['mac']
@@ -748,7 +747,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         """
 
         # for debugging, check status before test
-        if self.setup_dut_info['basicParams']['is_dualtor'] :
+        if self.setup_dut_info['basicParams']['is_dualtor']:
             show_arp = dut.shell("show arp")['stdout']
             logger.debug("Pfcwd on {} action {} show_arp {} ---".format(port, action, show_arp))
             show_mac = dut.shell("show mac")['stdout']
@@ -779,8 +778,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.rx_action = action
         self.tx_action = action
 
-    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                           ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts, # noqa F811
+                           ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa F811
+                           enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         PFCwd functional test
 
@@ -809,7 +809,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.is_dualtor = setup_dut_test_params['basicParams']['is_dualtor']
         self.setup_dut_info = setup_dut_test_params
- 
+
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
@@ -846,7 +846,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.dut.command("pfcwd stop")
 
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                              ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                              ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,   # noqa F811
+                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -892,7 +893,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.is_dualtor = setup_dut_test_params['basicParams']['is_dualtor']
         self.set_traffic_action(duthost, "drop")
         self.stats = PfcPktCntrs(self.dut, self.rx_action, self.tx_action)
-        self.setup_dut_info = setup_dut_test_params        
+        self.setup_dut_info = setup_dut_test_params
 
         for count in range(2):
             try:
@@ -919,7 +920,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 self.dut.command("pfcwd stop")
 
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
-                              ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                              ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,    # noqa F811
+                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -1002,8 +1004,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             logger.info("--- Stop PFC WD ---")
             self.dut.command("pfcwd stop")
 
-    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                               tbinfo, ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,         # noqa F811
+                               tbinfo, ptfhost, duthosts, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa F811
+                               enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
         """
         Test PfCWD functionality after toggling port
 
@@ -1043,7 +1046,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.is_dualtor = setup_dut_test_params['basicParams']['is_dualtor']
         action = "dontcare"
-        self.setup_dut_info = setup_dut_test_params    
+        self.setup_dut_info = setup_dut_test_params
 
         for idx, port in enumerate(self.ports):
             logger.info("")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
23121282

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
case pfcwd/test_pfcwd_function.py failed on dualtor testbed

#### How did you do it?
enhance the test case for dualtor testbed
1. fix the active mux cable for dualtor testbed before running the case
2. stop garp_service and stop arp update before running the cass
3. using vlan mac instead of interface mac if the interface in vlan member

#### How did you verify/test it?
Run the case on dualtor testbed
collected 4 items
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[str2-7260cx3-acs-13-None]                                                                                         â”‚--------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------â”‚13:54:48 conftest.setup_dut_test_params           L0227 WARNING| GARP service not present on PTF                                                                                  â”‚PASSED                                                                                                                                                                     [ 25%] â”‚pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[str2-7260cx3-acs-13-None] PASSED                                                                        [ 50%] â”‚pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str2-7260cx3-acs-13-None] PASSED                                                                        [ 75%] â”‚pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[str2-7260cx3-acs-13-None] PASSED 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
