### PR TITLE
[platform_tests] add test to make sure cpuidle is off for m0 and mx

### DIFF
--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -14,10 +14,12 @@ pytestmark = [
     pytest.mark.topology('m0', 'mx'),
 ]
 
+
 def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
     if idle_driver != "none":
         cstates = duthost.shell('sed -n "s/.*C\([0-9]*\).*/\\1/p" /sys/devices/system/cpu/cpu*/cpuidle/state*/name')['stdout'].split()
         max_cstate = max([int(cstate) for cstate in cstates])
-        pytest_assert(max_cstate <= 1, "When idle driver is present, cstates higher than 1 is not allowed: max_cstate {}".format(max_cstate))
+        pytest_assert(max_cstate <= 1,
+                "When idle driver is present, cstate higher than 1 is not allowed: max_cstate {}".format(max_cstate))

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -16,9 +16,6 @@ pytestmark = [
 
 def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    is_intel = 'Intel' in duthost.shell('lscpu | grep Vendor')['stdout']
-    if not is_intel:
-        pytest.skip('CPU vendor is not Intel')
     idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
     pytest_assert(idle_driver == 'none', 'Idle driver {} is active on this m0 device'.format(idle_driver))
     cpuidle = duthost.command('ls /sys/devices/system/cpu/cpu0/cpuidle/', module_ignore_errors=True)['rc']

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -1,7 +1,7 @@
 """
-Some devices have potential problems entering idle state. So
-on m0 devices, we expect to disable both intel idle driver
-and acpi idle driver, and no available idle state for all cpu.
+Some devices have potential problems entering idle state. We
+expect to disable both intel idle driver and acpi idle driver,
+or have no available idle state higher than 1 for all cpu.
 """
 import logging
 import pytest

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -11,7 +11,7 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('m0'),
+    pytest.mark.topology('m0', 'mx'),
 ]
 
 def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -19,7 +19,9 @@ def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
     if idle_driver != "none":
-        cstates = duthost.shell('sed -n "s/.*C\([0-9]*\).*/\\1/p" /sys/devices/system/cpu/cpu*/cpuidle/state*/name')['stdout'].split()
+        cstates = duthost.shell('sed -n "s/.*C\\([0-9]*\\).*/\\1/p" '
+                                '/sys/devices/system/cpu/cpu*/cpuidle/state*/name')['stdout'].split()
         max_cstate = max([int(cstate) for cstate in cstates])
         pytest_assert(max_cstate <= 1,
-                "When idle driver is present, cstate higher than 1 is not allowed: max_cstate {}".format(max_cstate))
+                      "When idle driver is present, cstate>1 is not allowed: max_cstate {}"
+                      .format(max_cstate))

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -1,0 +1,25 @@
+"""
+Some devices have potential problems entering idle state. So
+on m0 devices, we expect to disable both intel idle driver
+and acpi idle driver, and no available idle state for all cpu.
+"""
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('m0'),
+]
+
+def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    is_intel = 'Intel' in duthost.shell('lscpu | grep Vendor')['stdout']
+    if not is_intel:
+        pytest.skip('CPU vendor is not Intel')
+    idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
+    pytest_assert(idle_driver == 'none', 'Idle driver {} is active on this m0 device'.format(idle_driver))
+    cpuidle = duthost.command('ls /sys/devices/system/cpu/cpu0/cpuidle/', module_ignore_errors=True)['rc']
+    pytest_assert(cpuidle == 2, "cpuidle directory should not exist: rc {}".format(cpuidle))

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -17,6 +17,7 @@ pytestmark = [
 def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
-    pytest_assert(idle_driver == 'none', 'Idle driver {} is active on this m0 device'.format(idle_driver))
-    cpuidle = duthost.command('ls /sys/devices/system/cpu/cpu0/cpuidle/', module_ignore_errors=True)['rc']
-    pytest_assert(cpuidle == 2, "cpuidle directory should not exist: rc {}".format(cpuidle))
+    if idle_driver != "none":
+        cstates = duthost.shell('sed -n "s/.*C\([0-9]*\).*/\\1/p" /sys/devices/system/cpu/cpu*/cpuidle/state*/name')['stdout'].split()
+        max_cstate = max([int(cstate) for cstate in cstates])
+        pytest_assert(max_cstate <= 1, "When idle driver is present, cstates higher than 1 is not allowed: max_cstate {}".format(max_cstate))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Currently some Intel CPU tends to have problem when CPU enters idle state. We expect Intel CPUs to not have an active idle driver and idle states.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Make sure Intel CPU m0 won't enter idle states.

#### How did you do it?
Check active idle driver (should be none) and available idle states (should be none)

#### How did you verify/test it?
Run test on device

#### Any platform specific information?
Intel m0 only

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
