### PR TITLE
Fix import issue of test_add_rack.py

### DIFF
--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -3,11 +3,9 @@
 import json
 import os
 
-from helpers import *
-from common import *
-import strip
-import configlet
-import generic_patch
+from tests.configlet.util import configlet, strip, generic_patch
+from tests.configlet.util.common import *
+from tests.configlet.util.helpers import *
 
 if os.path.exists("/etc/sonic/sonic-environment"):
     from mock_for_switch import config_reload, wait_until
@@ -291,5 +289,3 @@ def do_test_add_rack(duthost, is_storage_backend = False, skip_load=False,
                 hack_apply=hack_apply)
 
     log_info("Test run is good!")
-
-

--- a/tests/configlet/util/strip.py
+++ b/tests/configlet/util/strip.py
@@ -4,8 +4,8 @@ import json
 import sys
 import xml.etree.ElementTree as ET
 
-from helpers import *
-from common import *
+from tests.configlet.util.common import *
+from tests.configlet.util.helpers import *
 
 from tempfile import mkstemp
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes import issue of test_add_rack.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In nightly test, the following error is seen:
NameError: global name 'base_dir' is not defined

#### How did you do it?
Fix the import issue

#### How did you verify/test it?
Run with physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
