### PR TITLE
[ansible/remove_topo] Add workaround for server temporarily unreachable while remove-topo

### DIFF
--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -69,12 +69,27 @@
     loop_control:
       loop_var: dut_name
 
+  - name: Get running processes in PTF container before stopping it
+    shell: docker exec ptf_{{ vm_set_name }} ps -ef
+    register: debug_ptf_processes
+    become: yes
+    ignore_errors: yes
+
+  - name: Print running processes in PTF container before stopping it
+    debug:
+      msg: "{{ debug_ptf_processes.stdout_lines }}"
+    when: debug_ptf_processes is defined
+
   - name: Stop ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}
       state: stopped
     become: yes
     ignore_errors: yes
+
+  - name: [Workaround] Sleep 180 seconds to avoid server temporarily unreachable
+    pause:
+      seconds: 180
 
   - name: Remove ptf docker container ptf_{{ vm_set_name }}
     docker_container:

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -87,7 +87,7 @@
     become: yes
     ignore_errors: yes
 
-  - name: [Workaround] Sleep 180 seconds to avoid server temporarily unreachable
+  - name: (Workaround) Sleep 180 seconds to avoid server temporarily unreachable
     pause:
       seconds: 180
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the remove-topo process, I observed some server will be temporarily unreachable after stop PTF container. This issue will cause the next step (remove PTF container) fail and the remove-topo process exit unexpected. This issue is still under investigation. To mitigate it, I add a workaround to let the remove-topo process pause 180 seconds after stop PTF container. This interval would be enough for server be back online.
Also added some logs for debugging the server crash issue when stop PTF container.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
1. Add workaround for server temporarily unreachable issue after PTF container is stopped.
2. Add debug logs for server crash issue when stop PTF container.

#### How did you do it?
Updated the `remove_topo.yml` ansible playbook.

#### How did you verify/test it?
Verified on several physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
