### PR TITLE
qos-sai: Limit infinite loop for traffic streams to 200 iterations.

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -107,6 +107,9 @@ def get_ip_addr():
     while val < 200:
         val = max(val, (val+1)%250)
         yield "192.0.0.{}".format(val)
+    raise RuntimeError(
+        "The program has run out of IP addresses. "
+        "Please check if the dst port is even used.")
 
 
 def get_tcp_port():

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -104,7 +104,7 @@ def check_leackout_compensation_support(asic, hwsku):
 
 def get_ip_addr():
     val = 1
-    while True:
+    while val < 200:
         val = max(val, (val+1)%250)
         yield "192.0.0.{}".format(val)
 


### PR DESCRIPTION
In qos-sai, the get_multiple_flows() function creates a different traffic stream per dest port, but can run into infinite loop if the dst_port is not used(that happens in case of T0). This PR limits the loop to 200 iterations.