### PR TITLE
[snmp][multi-asic]: Fix test_snmp_queue to support multi-asic platform

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -52,7 +52,7 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
                     for k, v in list(snmp_facts['snmp_interfaces'].items()) if v['name'] in alias_port_name_map]
 
     for intf in q_interfaces:
-        assert intf in snmp_ifnames, "Port %s with QUEUE config is not present in snmp interfaces"
+        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)
 
     for k, v in snmp_facts['snmp_interfaces'].items():
         # v['name'] is  alias for example Ethernet1/1


### PR DESCRIPTION
platform

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>
(cherry picked from commit 38cb1337201d5f2d9f9f1c3fa9f438d907e41be0)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/8934)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
test_snmp_queue was modified to get keys "QUEUE|*" from config_db in https://github.com/sonic-net/sonic-mgmt/pull/6744.
This has to be modified to get keys from all namespace config_db on mulit-asic platform.
Currently, test tries to retrieve from host config_db and skips the test for multi-asic platform.

Test is currently skipped for supervisor node, but should not be skipped for supervisor node of packet chassis.
#### How did you do it?

1. Modified to get interfaces with queue configuration from all namespaces.
2. The test case was not checking the right field in snmp_interfaces SNMP result. Test case was checking for "description" of each interface, from description, interface name was extracted and checked if the interface name is present in QUEUE table.
This check will always be false and pytest fail condition was never hit. The test case was always incorrectly passing.
```
(Pdb) snmp_facts['snmp_interfaces']['117']['description']
u'ARISTA02T1:Ethernet1'

   for k, v in list(snmp_facts['snmp_interfaces'].items()):
        if "Ethernet" in v['description']:
            intf = v['description'].split(':')
            # 'ARISTA*:Ethernet*'
            if len(intf) == 2:
                if intf[1] in q_interfaces and 'queues' not in v: -- intf[1] in q_interfaces will always be false
                    pytest.fail(
                        "port %s does not have queue counters" % v['name'])  -- will never hit this condition
                intf[1] will always be Ethernet1 which is the interface of the neighbor
```
Modified test to use 'name' which gives the interface alias instead of interface name present in 'description'
```
(Pdb) snmp_facts['snmp_interfaces']['117']['name']
u'fortyGigE0/116'
```
3. Remove skip of supervisor node.
4.  On voq chassis LC, QUEUE configuration will include hostname and asic namespace as queue configuration is created on system port. Test is modified to get the interface name for voq chassis.
```
"QUEUE": {
        "<hostname>|asic0|Ethernet0|0": {
            "scheduler": "scheduler.0"
        },
```

#### How did you verify/test it?
Verified on single asic VS testbed.
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_queue.py  -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -u
=== Running tests in groups ===
Running: pytest snmp/test_snmp_queue.py --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --skip_sanity --disable_loganalyzer
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
..                                                                                                                                                                                         

snmp/test_snmp_queue.py::test_snmp_queues[vlab-01] PASSED                                                                                                                                                                                                [100%]

---------------------------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------------------------------
================================================================================================================== 1 passed in 18.02 seconds ===================================================================================================================
INFO:root:Can not get Allure report URL. Please check logs

```
Verified on packet and voq chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
