### PR TITLE
Fix test_retry_count.py PR test failure - 'dict_keys' object is not subscriptable

### DIFF
--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -78,7 +78,7 @@ def higher_retry_count_on_peers(request, duthost, nbrhosts):
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Only supported with SONiC neighbor")
 
-    featureCheckResult = nbrhosts[nbrhosts.keys()[0]]['host'].shell(
+    featureCheckResult = nbrhosts[list(nbrhosts.keys())[0]]['host'].shell(
             "sudo config portchannel retry-count get PortChannel1", module_ignore_errors=True)
     if featureCheckResult["rc"] != 0:
         pytest.skip("SONiC neighbor isn't running supported version of SONiC")
@@ -108,7 +108,7 @@ def higher_retry_count_on_dut(request, duthost, nbrhosts):
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
 
     featureCheckResult = duthost.shell("sudo config portchannel retry-count get {}".format(
-        cfg_facts["PORTCHANNEL"].keys()[0]), module_ignore_errors=True)
+        list(cfg_facts["PORTCHANNEL"].keys())[0]), module_ignore_errors=True)
     if featureCheckResult["rc"] != 0:
         pytest.skip("SONiC DUT isn't running supported version of SONiC")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_retry_count.py PR test failure

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_retry_count.py PR test failure with following error:
  File "/var/src/sonic-mgmt/tests/pc/test_retry_count.py", line 81, in higher_retry_count_on_peers
    featureCheckResult = nbrhosts[nbrhosts.keys()[0]]['host'].shell(
TypeError: 'dict_keys' object is not subscriptable

In Python3, dict cannot be used with [] anymore.

#### How did you do it?
Wrap with list like: list(nbrhosts.keys())[0]

#### How did you verify/test it?
Run with physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
