### PR TITLE
[dualtor] Disable running `icmp_responder` at session-level

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -235,9 +235,9 @@ icmp_responder_session_started = False
 def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
     """Run icmp_responder on ptfhost session-wise on dualtor testbeds with active-active ports."""
     # No vlan is available on non-t0 testbed, so skip this fixture
-    if "dualtor" not in tbinfo["topo"]["name"]:
+    if "dualtor-mixed" not in tbinfo["topo"]["name"] and "dualtor-aa" not in tbinfo["topo"]["name"]:
         logger.info("Skip running icmp_responder at session level, "
-                    "it is only for dualtor testbed.")
+                    "it is only for dualtor testbed with active-active mux ports.")
         yield
         return
 
@@ -269,7 +269,7 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    logger.info("Leave icmp_responder running for dualtor/dualtor-mixed/dualtor-aa topology")
+    logger.info("Leave icmp_responder running for dualtor-mixed/dualtor-aa topology")
     return
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Disable running `icmp_responder` at session level.
The reason is that enabling `icmp_responder` at the session level could cause some T0 testcase failures as the ICMP replies pollute the FDB table.

For example:
Port `Ethernet4`, mux server IP `192.168.0.2`, connected to ptf port `eth1` that has mac `A`.
Port `Ethernet40`, connected to ptf port `eth10` that has mac `B`.

Some T0 testcases configure `192.168.0.2` IP on ptf port `eth10`, DUTs will learn the arp as `192.168.0.2` with mac `B` on port `Ethernet40`. After linkmgrd learns the arp, it will send heartbeats to `192.168.0.2` with dest mac as `B` on `Ethernet4`. As the `icmp_responder` is running, DUT will receive heartbeat replies with source IP `192.168.0.2` and source mac `B` on `Ethernet4`.
So DUT will learn mac `B` on `Ethernet4`, the arp entry of `192.168.0.2` will be: mac `B` on port `Ethernet40`.
In this case, the following I/O verification will fail.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
