### PR TITLE
[VOQ] - Use multi-asic dut's lb4096 IP instead of lb0 IP for ping from nbrs

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -124,7 +124,7 @@ def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo):
 
                 vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
 
-                check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb4096_ip', src_ip_fld='nbr_lb',
                              dev=vm_host_to_A, size=size, ttl=ttl)
 
                 # loopbacks
@@ -143,7 +143,7 @@ def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo):
                              ttl=ttl, ttl_change=0)
 
                 vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
-                check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb4096_ip', src_ip_fld='nbr_lb',
                              dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
 
                 # end to end


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- In case of multi-asic DUTs, for ping from eos peers to DUT's loopback address, use _loopback4096_ IP address which are unique to each line card instead of _loopback0_ IP.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
For VOQ disrupts test cases, for ping from eos peers to DUT's loopback address, it's good to use _loopback4096_ IP address which are unique to each line card instead of _loopback0_ IP.

#### How did you do it?

-  Change 'my_lb_ip' to 'my_lb4096_ip' in check_ip_fwd function in test

#### How did you verify/test it?
- Ran all the VOQ test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/6877c7f8-becb-4c67-b8f6-34f2da5ce45a)
