### PR TITLE
Adding dut & dut_asic namespace to getSchedulerParam in qos_sai_base

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -408,7 +408,7 @@ class QosSaiBase(QosBase):
                     schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                         argv=[
                             "redis-cli", "-n", "4", "HGET",
-                            "QUEUE|{0}|asic0|{1}|{2}"
+                            "QUEUE|{0}|Asic0|{1}|{2}"
                             .format(dut_asic.sonichost.hostname, port, queue), "scheduler"
                         ]
                     )[0])

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -370,7 +370,7 @@ class QosSaiBase(QosBase):
 
         return watermarkStatus
 
-    def __getSchedulerParam(self, dut_asic, port, queue):
+    def __getSchedulerParam(self, dut_asic, duthost, dut_nasic, port, queue):
         """
             Get scheduler parameters from Redis db
 
@@ -397,7 +397,7 @@ class QosSaiBase(QosBase):
             schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "HGET",
-                    "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                    "QUEUE|{0}|{1}|{2}|{3}".format(duthost, dut_nasic, port, queue), "scheduler"
                 ]
             )[0])
 
@@ -1679,9 +1679,11 @@ class QosSaiBase(QosBase):
                 losslessSchedProfile (dict): Map of scheduler parameters
         """
         dut_asic = get_src_dst_asic_and_duts['src_asic']
+        duthost = get_src_dst_asic_and_duts['src_dut'].sonichost.hostname
+        dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
 
         yield self.__getSchedulerParam(
-            dut_asic,
+            dut_asic, duthost, dut_nasic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSLESS_QUEUE_SCHED
         )
@@ -1702,8 +1704,10 @@ class QosSaiBase(QosBase):
                 lossySchedProfile (dict): Map of scheduler parameters
         """
         dut_asic = get_src_dst_asic_and_duts['src_asic']
+        duthost = get_src_dst_asic_and_duts['src_dut'].sonichost.hostname
+        dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
         yield self.__getSchedulerParam(
-            dut_asic,
+            dut_asic, duthost, dut_nasic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSY_QUEUE_SCHED
         )

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -370,7 +370,7 @@ class QosSaiBase(QosBase):
 
         return watermarkStatus
 
-    def __getSchedulerParam(self, dut_asic, duthost, dut_nasic, port, queue):
+    def __getSchedulerParam(self, dut_asic, port, queue):
         """
             Get scheduler parameters from Redis db
 
@@ -397,7 +397,7 @@ class QosSaiBase(QosBase):
             schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "HGET",
-                    "QUEUE|{0}|{1}|{2}|{3}".format(duthost, dut_nasic, port, queue), "scheduler"
+                    "QUEUE|{0}|{1}|{2}|{3}".format(dut_asic.sonichost.hostname, dut_asic.namespace, port, queue), "scheduler"
                 ]
             )[0])
 
@@ -1683,7 +1683,7 @@ class QosSaiBase(QosBase):
         dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
 
         yield self.__getSchedulerParam(
-            dut_asic, duthost, dut_nasic,
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSLESS_QUEUE_SCHED
         )
@@ -1707,7 +1707,7 @@ class QosSaiBase(QosBase):
         duthost = get_src_dst_asic_and_duts['src_dut'].sonichost.hostname
         dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
         yield self.__getSchedulerParam(
-            dut_asic, duthost, dut_nasic,
+            dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],
             self.TARGET_LOSSY_QUEUE_SCHED
         )

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -397,7 +397,8 @@ class QosSaiBase(QosBase):
             schedProfile = "SCHEDULER|" + six.text_type(dut_asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "HGET",
-                    "QUEUE|{0}|{1}|{2}|{3}".format(dut_asic.sonichost.hostname, dut_asic.namespace, port, queue), "scheduler"
+                    "QUEUE|{0}|{1}|{2}|{3}"
+                    .format(dut_asic.sonichost.hostname, dut_asic.namespace, port, queue), "scheduler"
                 ]
             )[0])
 
@@ -1679,8 +1680,6 @@ class QosSaiBase(QosBase):
                 losslessSchedProfile (dict): Map of scheduler parameters
         """
         dut_asic = get_src_dst_asic_and_duts['src_asic']
-        duthost = get_src_dst_asic_and_duts['src_dut'].sonichost.hostname
-        dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
 
         yield self.__getSchedulerParam(
             dut_asic,
@@ -1704,8 +1703,7 @@ class QosSaiBase(QosBase):
                 lossySchedProfile (dict): Map of scheduler parameters
         """
         dut_asic = get_src_dst_asic_and_duts['src_asic']
-        duthost = get_src_dst_asic_and_duts['src_dut'].sonichost.hostname
-        dut_nasic = get_src_dst_asic_and_duts['src_asic'].get_asic_namespace()
+
         yield self.__getSchedulerParam(
             dut_asic,
             dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Due to the change in PR(#15914) the search criteria to get scheduler parameters from Redis db needs to be changed

Summary:
The query to redis db was previously searched with only port & queue . Now in addition to it the duthost & asic namespace has to be concatenated  in search

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
Due to the change in PR(#15914) the search criteria to get scheduler parameters from Redis db needs to be changed
Adding the correct duthost details in redis query fetch the appropriate result
#### What is the motivation for this PR?
qos test failed with - IndexError: list index out of range

#### How did you do it?
Adding the correct duthost details in redis query fetch the appropriate result
#### How did you verify/test it?
Re-run the qos test suite
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
