### PR TITLE
Fix eos implementation of check_intf_link_state()

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -104,8 +104,9 @@ class EosHost(AnsibleHostBase):
 
     def check_intf_link_state(self, interface_name):
         show_int_result = self.eos_command(
-            commands=['show interface %s' % interface_name])
-        return 'Up' in show_int_result['stdout_lines'][0]
+            commands=['show interface %s | json' % interface_name])
+        int_status = show_int_result['stdout'][0]['interfaces'][interface_name]['interfaceStatus']
+        return int_status == 'connected'
 
     def links_status_down(self, ports):
         show_int_result = self.eos_command(commands=['show interface status'])


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

[PR#8468](https://github.com/sonic-net/sonic-mgmt/pull/8468) exposed a latent bug in the eos device implementation of check_intf_link_state() which currently always returns False and caused several VoQ tests to fail. Checking the text output for 'Up' is not a reliable way to determine the state of an interface.

A better way to do this is to directly check the 'interfaceStatus' from the JSON output.