### PR TITLE
[cherry-pick] [PR:8733] Call duthost_console fixture for test_escape_character test case (#8733)

### DIFF
--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -1,12 +1,9 @@
-import pexpect
 import logging
-import time
-import re
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert
 
 TOTAL_PACKETS = 100
+packet_number = 10
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -14,12 +11,8 @@ pytestmark = [
 ]
 
 
-def test_console_escape():
-    child = pexpect.spawn("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS))
-    time.sleep(5)
-    child.sendcontrol('C')
-    child.expect("\^C")
-    match = re.search(r'(\d) packets transmitted', child.read())
-    pytest_assert(int(match.group(1)) < TOTAL_PACKETS, "Escape Character does not work.")
-
-
+def test_console_escape(duthost_console):
+    duthost_console.send_command("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS),
+                                 expect_string=r"icmp_seq={}".format(packet_number))
+    duthost_console.send_command("\x03",
+                                 expect_string=r"{} packets transmitted".format(packet_number), max_loops=300)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Cherry-Pick PR** for 202205 from master https://github.com/sonic-net/sonic-mgmt/pull/8733

Summary:
Fixes # (issue)

- This PR fixes 'test_escape_character' test under dut_console test suite.
- Currently test runs the respective 'ping' command on the test bed server instead of running it on the console of the respective DUT.
- And also pexpect.spawn creates child process for ping under sonic-mgmt docker where the test is running instead of the DUT console.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

- Fix 'test_escape_character' test under dut_console test suite, by calling 'duthost_console' fixture.
- Currently test runs on test bed server and executes 'ping' command which is not the expected behavior.

#### How did you do it?

- Call 'duthost_console' fixture of conftest.py from the test case.
- Send 'ping' command and escape character directly on the DUT console instead of creating child process.

#### How did you verify/test it?

- Ran the dut_console test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/e014697d-f1b5-4c79-9a9a-137d17299d85)
