### PR TITLE
Improve pfcwd function test to support dualtor testbed

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -20,6 +20,7 @@ class PfcWdTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
+        self.vlan_mac = self.test_params['vlan_mac']
         self.queue_index = int(self.test_params['queue_index'])
         self.pkt_count = int(self.test_params['pkt_count'])
         self.port_src = int(self.test_params['port_src'])
@@ -106,7 +107,7 @@ class PfcWdTest(BaseTest):
             ip_src = "1.1.1.1"
 
             pkt_args = {
-                'eth_dst': self.router_mac,
+                'eth_dst': self.vlan_mac,
                 'eth_src': src_mac,
                 'ip_src': ip_src,
                 'ip_dst': self.ip_dst,

--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -20,7 +20,7 @@ class PfcWdTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
-        self.vlan_mac = self.test_params['vlan_mac']
+        self.vlan_mac = self.test_params.get('vlan_mac', self.router_mac)
         self.queue_index = int(self.test_params['queue_index'])
         self.pkt_count = int(self.test_params['pkt_count'])
         self.port_src = int(self.test_params['port_src'])

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -146,7 +146,6 @@ def setup_pfc_test(
         test_ports = update_t1_test_ports(
             duthost, mg_facts, test_ports, tbinfo
         )
-
     # select a subset of ports from the generated port list
     selected_ports = select_test_ports(test_ports)
 
@@ -206,3 +205,18 @@ def setup_dut_test_params(
 
     logger.info("dut_test_params : {}".format(dut_test_params))
     yield dut_test_params
+
+
+# icmp_responder need to be paused during the test because the test case
+# configures static IP address on ptf host and sends ICMP reply to DUT.
+@pytest.fixture(scope="module")
+def pause_icmp_responder(ptfhost):
+    icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
+    if "RUNNING" not in icmp_responder_status:
+        yield
+        return
+    ptfhost.shell("supervisorctl stop icmp_responder", module_ignore_errors=True)
+
+    yield
+
+    ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve test cases in [test_pfcwd_function.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:pfcwd_func_test_dualtor?expand=1#diff-bb4f2b9da0ca66c236beedfb7cc790bf6294f5bb8722ca0038e49d755c8f9c33) to support dualtor testbed.

The improvements include
1. Toggle mux cable to the randomly selected ToR before running test
2. Use vlan MAC (00:aa:bb:cc:dd:ee) if the ingress port is a vlan member on dualtor testbed
3. Pause `icmp_responder` if the test is running on dualtor testbed
4. Update the key name of `BUFFER_PG` table. Only use `2-6` if the port has 4 lossless queues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The PR is to improve test cases in test_pfcwd_function.py to support dualtor testbed.

#### How did you do it?
1. Toggle mux cable to the randomly selected ToR before running test
2. Use vlan MAC (00:aa:bb:cc:dd:ee) if the ingress port is a vlan member on dualtor testbed
3. Pause `icmp_responder` if the test is running on dualtor testbed
4. Update the key name of `BUFFER_PG` table. Only use `2-6` if the port has 4 lossless queues.

#### How did you verify/test it?
The change is verified on a dualtor testbed and T1 testbed.
```
collected 4 items                                                                                                                                                                           

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[str2-7050cx3-acs-07-None]  ^HPASSED                                                                                      [ 25%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[str2-7050cx3-acs-07-None] SKIPPED                                                                                  [ 50%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str2-7050cx3-acs-07-None]  ^H ^HPASSED                                                                                   [ 75%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[str2-7050cx3-acs-07-None]  ^HPASSED                                                                                  [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
