### PR TITLE
[202205] Improve pfcwd function to support dualtor testbed

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -24,6 +24,7 @@ class PfcWdTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
+        self.vlan_mac = self.test_params['vlan_mac']
         self.queue_index = int(self.test_params['queue_index'])
         self.pkt_count = int(self.test_params['pkt_count'])
         self.port_src = int(self.test_params['port_src'])
@@ -105,7 +106,7 @@ class PfcWdTest(BaseTest):
             ip_src = "1.1.1.1"
 
             pkt_args = {
-                'eth_dst': self.router_mac,
+                'eth_dst': self.vlan_mac,
                 'eth_src': src_mac,
                 'ip_src': ip_src,
                 'ip_dst': self.ip_dst,

--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -24,7 +24,7 @@ class PfcWdTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
-        self.vlan_mac = self.test_params['vlan_mac']
+        self.vlan_mac = self.test_params.get('vlan_mac', self.router_mac)
         self.queue_index = int(self.test_params['queue_index'])
         self.pkt_count = int(self.test_params['pkt_count'])
         self.port_src = int(self.test_params['port_src'])

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -220,4 +220,3 @@ def pause_icmp_responder(ptfhost):
     yield
 
     ptfhost.shell("supervisorctl restart icmp_responder", module_ignore_errors=True)
-

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -12,7 +12,8 @@ from .files.pfcwd_helper import start_wd_on_ports
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 from tests.common import constants
-from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
+from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -141,20 +142,21 @@ class PfcCmd(object):
         )
 
     @staticmethod
-    def get_mmu_params(dut, port):
+    def get_mmu_params(dut, port, dualtor_ports):
         """
         Retreive the pg profile for a port and the dynamic threshold used
 
         Args:
             dut(AnsibleHost) : dut instance
             port(string) : port name
+            dualtor_ports(set): downlink ports on T1 or uplink ports on T0
 
         Returns:
             pg_profile(string), alpha(string)
         """
         logger.info("Retreiving pg profile and dynamic threshold for port: {}".format(port))
-
-        if is_tunnel_qos_remap_enabled(dut):
+        if port in dualtor_ports:
+            # Queue 2&6 are enabled only on T1 downlink and T0 uplink ports
             queue_range = '2-4'
         else:
             queue_range = '3-4'
@@ -271,8 +273,18 @@ class PfcPktCntrs(object):
             pytest_assert(err_msg)
 
 class SetupPfcwdFunc(object):
+    
+    def parse_test_port_info(self):
+        """
+        Parse the test port information into a dict
+        {port_id: port_type}
+        """
+        self.port_id_to_type_map = dict()
+        for _, v in self.test_ports_info.items():
+            self.port_id_to_type_map[v['test_port_id']] = v['test_port_type']
+
     """ Test setup per port """
-    def setup_test_params(self, port, vlan, init=False, mmu_params=False, detect=True, toggle=False):
+    def setup_test_params(self, port, vlan, init=False, mmu_params=False, detect=True, toggle=False, dualtor_ports=set()):
         """
         Sets up test parameters associated with a DUT port
 
@@ -282,11 +294,12 @@ class SetupPfcwdFunc(object):
             init(bool) : If the fanout needs to be initialized or not
         """
         logger.info("--- Setting up test params for port {} ---".format(port))
+        self.parse_test_port_info()
         self.setup_port_params(port, init=init, detect=detect)
         if toggle:
             self.update_queue(port)
         if mmu_params:
-            self.setup_mmu_params(port)
+            self.setup_mmu_params(port, dualtor_ports)
         self.resolve_arp(vlan, self.is_dualtor)
         if not self.pfc_wd['fake_storm']:
             self.storm_setup(init=init, detect=detect)
@@ -318,6 +331,7 @@ class SetupPfcwdFunc(object):
             self.pfc_wd['test_port_ids'] = self.pfc_wd['test_port_id']
         self.pfc_wd['test_port_vlan_id'] = self.ports[port].get('test_port_vlan_id')
         self.pfc_wd['rx_port_vlan_id'] = self.ports[port].get('rx_port_vlan_id')
+        self.pfc_wd['port_id_to_type_map'] = self.port_id_to_type_map
         self.queue_oid = self.dut.get_queue_oid(port, self.pfc_wd['queue_index'])
         if init and detect:
             self.log_handle = dict()
@@ -336,14 +350,14 @@ class SetupPfcwdFunc(object):
         logger.info("Current queue: {}".format(self.pfc_wd['queue_index']))
         self.queue_oid = self.dut.get_queue_oid(port, self.pfc_wd['queue_index'])
 
-    def setup_mmu_params(self, port):
+    def setup_mmu_params(self, port, dualtor_ports):
         """
         Retrieve the pg profile and alpha values of the port under test
 
         Args:
             port(string) : DUT port
         """
-        self.pg_profile, self.alpha = PfcCmd.get_mmu_params(self.dut, port)
+        self.pg_profile, self.alpha = PfcCmd.get_mmu_params(self.dut, port, dualtor_ports)
 
     def update_mmu_params(self, mmu_action, port):
         """
@@ -425,7 +439,7 @@ class SetupPfcwdFunc(object):
 
 class SendVerifyTraffic():
     """ PTF test """
-    def __init__(self, ptf, router_mac, pfc_params):
+    def __init__(self, ptf, router_mac, pfc_params, is_dualtor):
         """
         Args:
             ptf(AnsibleHost) : ptf instance
@@ -444,7 +458,12 @@ class SendVerifyTraffic():
         self.pfc_wd_rx_neighbor_addr = pfc_params['rx_neighbor_addr']
         self.pfc_wd_test_port_vlan_id = pfc_params['test_port_vlan_id']
         self.pfc_wd_rx_port_vlan_id = pfc_params['rx_port_vlan_id']
+        self.port_id_to_type_map = pfc_params['port_id_to_type_map']
         self.port_type = pfc_params['port_type']
+        if is_dualtor:
+            self.vlan_mac = "00:aa:bb:cc:dd:ee"
+        else:
+            self.vlan_mac = router_mac
 
     def verify_tx_egress(self, action):
         """
@@ -459,12 +478,13 @@ class SendVerifyTraffic():
         if action == "forward" and  type(self.pfc_wd_test_port_ids) == list:
                 dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         ptf_params = {'router_mac': self.router_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
-                      'port_type': self.port_type,
+                      'port_type': self.port_id_to_type_map[self.pfc_wd_rx_port_id[0]],
                       'wd_action': action}
         if self.pfc_wd_rx_port_vlan_id is not None:
             ptf_params['port_src_vlan_id'] = self.pfc_wd_rx_port_vlan_id
@@ -489,12 +509,13 @@ class SendVerifyTraffic():
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
         ptf_params = {'router_mac': self.router_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_rx_neighbor_addr,
-                      'port_type': self.port_type,
+                      'port_type': self.port_id_to_type_map[self.pfc_wd_test_port_id],
                       'wd_action': action}
         if self.pfc_wd_rx_port_vlan_id is not None:
             ptf_params['port_dst_vlan_id'] = self.pfc_wd_rx_port_vlan_id
@@ -521,12 +542,13 @@ class SendVerifyTraffic():
              other_queue = self.pfc_queue_index + 1
 
         ptf_params = {'router_mac': self.router_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': other_queue,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
-                      'port_type': self.port_type,
+                      'port_type': self.port_id_to_type_map[self.pfc_wd_rx_port_id[0]],
                       'wd_action': 'forward'}
         if self.pfc_wd_rx_port_vlan_id is not None:
             ptf_params['port_src_vlan_id'] = self.pfc_wd_rx_port_vlan_id
@@ -553,12 +575,13 @@ class SendVerifyTraffic():
              other_pg = self.pfc_queue_index + 1
 
         ptf_params = {'router_mac': self.router_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': other_pg,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_rx_neighbor_addr,
-                      'port_type': self.port_type,
+                      'port_type': self.port_id_to_type_map[self.pfc_wd_test_port_id],
                       'wd_action': 'forward'}
         if self.pfc_wd_rx_port_vlan_id is not None:
             ptf_params['port_dst_vlan_id'] = self.pfc_wd_rx_port_vlan_id
@@ -575,6 +598,7 @@ class SendVerifyTraffic():
         """
         logger.info("Send packets to {} to fill up the buffer".format(self.pfc_wd_test_port))
         ptf_params = {'router_mac': self.router_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
@@ -717,7 +741,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = action
 
     def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                           ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                           ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, pause_icmp_responder,
+                           toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m):
         """
         PFCwd functional test
 
@@ -739,6 +764,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fanout = fanouthosts
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
+        self.test_ports_info = setup_info['test_ports']
         self.neighbors = setup_info['neighbors']
         self.peer_dev_list = dict()
         self.fake_storm = fake_storm
@@ -754,7 +780,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),
-                self.pfc_wd)
+                self.pfc_wd,
+                self.is_dualtor)
             pfc_wd_restore_time_large = request.config.getoption("--restore-time")
             # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
             self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
@@ -783,7 +810,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                              ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                              ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, pause_icmp_responder,
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m):
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -820,6 +848,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
         self.ports = setup_info['selected_test_ports']
         selected_ports = list(self.ports.keys())[:2]
+        self.test_ports_info = setup_info['test_ports']
         pytest_require(len(selected_ports) == 2, 'Pfcwd multi port test needs at least 2 ports')
         self.neighbors = setup_info['neighbors']
         self.peer_dev_list = dict()
@@ -840,7 +869,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.traffic_inst = SendVerifyTraffic(
                                                           self.ptf,
                                                           duthost.get_dut_iface_mac(port),
-                                                          self.pfc_wd)
+                                                          self.pfc_wd,
+                                                          self.is_dualtor)
                     self.run_test(self.dut, port, "drop", restore=False)
                 for idx, port in enumerate(selected_ports):
                     logger.info("")
@@ -857,7 +887,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
 
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
-                              ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                              ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, dualtor_ports, pause_icmp_responder,
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -889,6 +920,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fanout = fanouthosts
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
+        self.test_ports_info = setup_info['test_ports']
         key, value  = self.ports.items()[0]
         self.ports = {key: value}
         port = key
@@ -898,7 +930,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.storm_hndle = None
         self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         logger.info("---- Testing on port {} ----".format(port))
-        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True)
+        self.setup_test_params(port, setup_info['vlan'], init=True, mmu_params=True, dualtor_ports=dualtor_ports)
         self.rx_action = None
         self.tx_action = None
         self.set_traffic_action(duthost, "drop")
@@ -909,7 +941,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 self.traffic_inst = SendVerifyTraffic(
                     self.ptf,
                     duthost.get_dut_iface_mac(port),
-                    self.pfc_wd)
+                    self.pfc_wd,
+                    self.is_dualtor)
                 pfc_wd_restore_time_large = request.config.getoption("--restore-time")
                 # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
                 self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
@@ -919,7 +952,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 self.traffic_inst = SendVerifyTraffic(
                     self.ptf,
                     duthost.get_dut_iface_mac(port),
-                    self.pfc_wd)
+                    self.pfc_wd,
+                    self.is_dualtor)
                 self.run_test(self.dut, port, "drop", mmu_action=mmu_action)
                 self.dut.command("pfcwd stop")
 
@@ -936,7 +970,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.dut.command("pfcwd stop")
 
     def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-                               tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                               tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, pause_icmp_responder,
+                               toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m):
         """
         Test PfCWD functionality after toggling port
 
@@ -969,6 +1004,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.fanout = fanouthosts
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
+        self.test_ports_info = setup_info['test_ports']
         self.neighbors = setup_info['neighbors']
         self.peer_dev_list = dict()
         self.fake_storm = fake_storm
@@ -986,7 +1022,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.traffic_inst = SendVerifyTraffic(
                 self.ptf,
                 duthost.get_dut_iface_mac(port),
-                self.pfc_wd)
+                self.pfc_wd,
+                self.is_dualtor)
             pfc_wd_restore_time_large = request.config.getoption("--restore-time")
             # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
             self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to backport PR #9158 into `202205` branch.
This PR is to improve test cases in [test_pfcwd_function.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:pfcwd_func_test_dualtor?expand=1#diff-bb4f2b9da0ca66c236beedfb7cc790bf6294f5bb8722ca0038e49d755c8f9c33) to support dualtor testbed.

The improvements include
1. Toggle mux cable to the randomly selected ToR before running test
2. Use vlan MAC (00:aa:bb:cc:dd:ee) if the ingress port is a vlan member on dualtor testbed
3. Pause `icmp_responder` if the test is running on dualtor testbed
4. Update the key name of `BUFFER_PG` table. Only use `2-6` if the port has 4 lossless queues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The PR is to improve test cases in test_pfcwd_function.py to support dualtor testbed.

#### How did you do it?
1. Toggle mux cable to the randomly selected ToR before running test
2. Use vlan MAC (00:aa:bb:cc:dd:ee) if the ingress port is a vlan member on dualtor testbed
3. Pause `icmp_responder` if the test is running on dualtor testbed
4. Update the key name of `BUFFER_PG` table. Only use `2-6` if the port has 4 lossless queues.

#### How did you verify/test it?
The change is verified on a dualtor testbed and T1 testbed.
```
collected 4 items                                                                                                                                                                           

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[str2-7050cx3-acs-07-None]  ^HPASSED                                                                                      [ 25%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[str2-7050cx3-acs-07-None] SKIPPED                                                                                  [ 50%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str2-7050cx3-acs-07-None]  ^H ^HPASSED                                                                                   [ 75%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[str2-7050cx3-acs-07-None]  ^HPASSED                                                                                  [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
