### PR TITLE
Watchdog reset skip

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -868,7 +868,6 @@ platform_tests/test_reboot.py::test_watchdog_reboot:
     conditions_logical_operator: or
     conditions:
       - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
-      - "'t1' in topo_type and platform in ['x86_64-8102_64h_o-r0']"
 
 #######################################
 #####   test_reload_config.py     #####

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -228,7 +228,7 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                         localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
+                         localhost, conn_graph_facts, xcvr_skip_list, tbinfo):      # noqa F811
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -239,6 +239,13 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
         pytest.skip(
             "Watchdog is not supported on this DUT, skip this test case")
+    if "x86_64-8102_64h_o-r0" in duthost.facts['platform']:
+        output = duthost.shell("dmidecode -s bios-version")["stdout"]
+        bios = output.split('-')
+        bios_version = bios[1]
+        if bios_version < "218" and "t1" in tbinfo["topo"]["type"] :
+            pytest.skip("Skip test if BIOS ver <218 and topo is T1 and platform is M64")
+
 
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
                      xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -243,9 +243,8 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
         output = duthost.shell("dmidecode -s bios-version")["stdout"]
         bios = output.split('-')
         bios_version = bios[1]
-        if bios_version < "218" and "t1" in tbinfo["topo"]["type"] :
+        if bios_version < "218" and "t1" in tbinfo["topo"]["type"]:
             pytest.skip("Skip test if BIOS ver <218 and topo is T1 and platform is M64")
-
 
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
                      xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga. MSFT cannot upgrade from the Ref. point to newer FPD. Upgrading to newer fpd will brick the box for old proto. Hence skipping this only for Cisco Platform x86_64-8102_64h_o-r0


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test watchdog reboot is not supported in Cisco Platform x86_64-8102_64h_o-r0 having old fpga
#### How did you do it?
Added skip in test_reboot.py for watchdog_reboot
#### How did you verify/test it?
============================================================================================= short test summary info =============================================================================================
SKIPPED [1] /data/tests/platform_tests/test_reboot.py:279: Skip test if BIOS ver <218 and topo is T1 and platform is M64
=========================================================================================== 1 skipped in 190.56 seconds ==========================================================================================
#### Any platform specific information?
Cisco platform x86_64-8102_64h_o-r0
#### Supported testbed topology if it's a new test case?
T1 topology
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
