### PR TITLE
Fix RFC 3339 time parsing for Python 2

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -5,7 +5,7 @@ import os
 import re
 import logging
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from tests.platform_tests.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS,\
     SAIREDIS_PATTERNS, OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
@@ -21,6 +21,7 @@ TEMPLATES_DIR = os.path.join(os.path.dirname(
 FMT = "%b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
 FMT_ALT = "%Y-%m-%dT%H:%M:%S.%f%z"
+FMT_ALT_PY2 = "%Y-%m-%dT%H:%M:%S.%f"
 SMALL_DISK_SKUS = [
     "Arista-7060CX-32S-C32",
     "Arista-7060CX-32S-Q32",
@@ -35,7 +36,14 @@ def _parse_timestamp(timestamp):
         try:
             time = datetime.strptime(timestamp, FMT_SHORT)
         except ValueError:
-            time = datetime.strptime(timestamp, FMT_ALT)
+            if sys.version_info.major >= 3:
+                time = datetime.strptime(timestamp, FMT_ALT)
+            else:
+                time = datetime.strptime(timestamp[:-6], FMT_ALT_PY2)
+                if timestamp[26] == "+":
+                    time += timedelta(hours=int(timestamp[27:29]), minutes=int(timestamp[30:]))
+                else:
+                    time -= timedelta(hours=int(timestamp[27:29]), minutes=int(timestamp[30:]))
     return time
 
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import os
 import re
+import sys
 import logging
 from collections import OrderedDict
 from datetime import datetime, timedelta
@@ -39,7 +40,7 @@ def _parse_timestamp(timestamp):
             if sys.version_info.major >= 3:
                 time = datetime.strptime(timestamp, FMT_ALT)
             else:
-                time = datetime.strptime(timestamp[:-6], FMT_ALT_PY2)
+                time = datetime.strptime(timestamp[:26], FMT_ALT_PY2)
                 if timestamp[26] == "+":
                     time += timedelta(hours=int(timestamp[27:29]), minutes=int(timestamp[30:]))
                 else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Microsoft ADO: 24642043

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

The AdvancedReboot class (which is run under Python 2) parses syslogs after completing the warm-reboot/fast-reboot. Some syslog entries may be using the RFC 3339 time format in the log messages. This is before SONiC's log format gets applied here.

PR #8458 added support for parsing these timestamps under Python 3. However, since AdvancedReboot is still using Python 2, it will error out here.

#### How did you do it?

Add support for parsing RFC 3339 timestamps under Python 2.

#### How did you verify/test it?

Tested by doing a fast boot on a physical device, and verified that there were no timestamp parsing errors.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
