### PR TITLE
[acl][fanout] Optimize skip condition for SONiC fanout in test_acl_outer_vlan

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -626,7 +626,13 @@ def skip_sonic_leaf_fanout(fanouthosts):
     """
     for fanouthost in list(fanouthosts.values()):
         if fanouthost.get_fanout_os() == 'sonic':
-            pytest.skip("Not supporteds on SONiC leaf-fanout")
+            os_version = fanouthost.get_sonic_os_version()
+            asic_type = fanouthost.facts['asic_type']
+            platform = fanouthost.facts["platform"]
+            if "202205" not in os_version:
+                pytest.skip("Not supporteds on SONiC leaf-fanout with os version is not 202205")
+            if not (asic_type in ["broadcom"] or platform in ["armhf-nokia_ixs7215_52x-r0"]):
+                pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
 
 class TestAclVlanOuter_Ingress(AclVlanOuterTest_Base):

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -208,3 +208,8 @@ class FanoutHost(object):
 
     def set_port_fec(self, interface_name, mode):
         self.host.set_port_fec(interface_name, mode)
+
+    def get_sonic_os_version(self):
+        if self.os != 'sonic':
+            return None
+        return self.host.os_version


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Currently some SONiC fanout supports tagged packet test. No need to skip for those devices.

#### How did you do it?
Optimize skip condition for SONiC fanout in test_acl_outer_vlan.

#### How did you verify/test it?
Run tests with Nokia 7215 / Broadcom SONiC fanouts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
