### PR TITLE
[advanced-reboot] Use nohup when executing reboot CLI to prevent PIPE errors

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1508,7 +1508,7 @@ class ReloadTest(BaseTest):
             # 1. there is a reader/writer for any bash commands using PIPE
             # 2. the output and error of CLI still gets written to log file
             stdout, stderr, return_code = self.dut_connection.execCommand(
-                "nohup sudo {} -vvv &> {} &".format(
+                "nohup sudo {} -v &> {}".format(
                     reboot_command, reboot_log_file), timeout=10)
 
         elif self.test_params['other_vendor_flag'] is True:

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1493,14 +1493,23 @@ class ReloadTest(BaseTest):
                 "sudo " + self.reboot_type + " -h", timeout=5)
             if "retry count" in stdout:
                 if self.test_params['neighbor_type'] == "sonic":
-                    stdout, stderr, return_code = self.dut_connection.execCommand(
-                        "sudo " + self.reboot_type + " -N", timeout=10)
+                    reboot_command = self.reboot_type + " -N"
                 else:
-                    stdout, stderr, return_code = self.dut_connection.execCommand(
-                        "sudo " + self.reboot_type + " -n", timeout=10)
+                    reboot_command = self.reboot_type + " -n"
             else:
-                stdout, stderr, return_code = self.dut_connection.execCommand(
-                    "sudo " + self.reboot_type, timeout=10)
+                reboot_command = self.reboot_type
+
+            # create an empty log file to capture output of reboot command
+            reboot_log_file = "/host/{}.log".format(reboot_command.replace(' ', ''))
+            self.dut_connection.execCommand("sudo touch {}; sudo chmod 666 {}".format(
+                reboot_log_file, reboot_log_file))
+
+            # execute reboot command w/ nohup so that when the execCommand times-out:
+            # 1. there is a reader/writer for any bash commands using PIPE
+            # 2. the output and error of CLI still gets written to log file
+            stdout, stderr, return_code = self.dut_connection.execCommand(
+                "nohup sudo {} -vvv &> {} &".format(
+                    reboot_command, reboot_log_file), timeout=10)
 
         elif self.test_params['other_vendor_flag'] is True:
             ignore_db_integrity_check = " -d"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix issues where error 141 (no PIPE) causes failure to backup logs needed by log_analyzer
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

In the device where logs are in tmpfs, a backup is made for log_analyzer to work after reboot.

However, there have been many cases when one or more backup files are empty or not created.

Based on current RCA this happens when reboot CLI is executed from test and then SSH command times out.

When command execution ends, but reboot is still in progress in the device, any writes to stdout / etderr fails as there is no reader.
 
#### How did you do it?

To fix no reader issue, run the reboot CLI w/ nohup and redirect the output to a file.

#### How did you verify/test it?

Tested on a physical device in lab.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
