### PR TITLE
Recover telemetry settings when error happens in module `telemetry/test_telemetry.py`.

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, wait_tcp_connection
 from telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
 
@@ -47,20 +48,33 @@ def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localh
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    default_client_auth = setup_telemetry_forpyclient(duthost)
+    try:
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        default_client_auth = setup_telemetry_forpyclient(duthost)
 
-    # Wait until telemetry was restarted
-    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started.")
-    logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
+        if default_client_auth == "true":
+            duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"',
+                          module_ignore_errors=False)
+            duthost.shell("systemctl reset-failed telemetry")
+            duthost.service(name="telemetry", state="restarted")
+        else:
+            logger.info('client auth is false. No need to restart telemetry')
 
-    # Wait until the TCP port was opened
-    dut_ip = duthost.mgmt_ip
-    wait_tcp_connection(localhost, dut_ip, TELEMETRY_PORT, timeout_s=60)
+        # Wait until telemetry was restarted
+        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started.")
+        logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
 
-    # pyclient should be available on ptfhost. If it was not available, then fail pytest.
-    file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
-    py_assert(file_exists["stat"]["exists"] is True)
+        # Wait until the TCP port was opened
+        dut_ip = duthost.mgmt_ip
+        wait_tcp_connection(localhost, dut_ip, TELEMETRY_PORT, timeout_s=60)
+
+        # pyclient should be available on ptfhost. If it was not available, then fail pytest.
+        file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
+        py_assert(file_exists["stat"]["exists"] is True)
+    except RunAnsibleModuleFail as e:
+        logger.info("Error happens in the setup period of setup_streaming_telemetry, recover the telemetry.")
+        restore_telemetry_forpyclient(duthost, default_client_auth)
+        raise e
 
     yield
     restore_telemetry_forpyclient(duthost, default_client_auth)

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -58,13 +58,6 @@ def setup_telemetry_forpyclient(duthost):
     client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
                                     module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
-    if client_auth == "true":
-        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"',
-                      module_ignore_errors=False)
-        duthost.shell("systemctl reset-failed telemetry")
-        duthost.service(name="telemetry", state="restarted")
-    else:
-        logger.info('client auth is false. No need to restart telemetry')
     return client_auth
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module telemetry/test_telemetry.py, errors may happen in the setup period of fixture setup_streaming_telemetry, and the the recover function can be not be executed in the teardown period. This will change the running config, and cause unnecessary reload. In this PR, when the errors happen in the setup period, we will recover the telemetry config immediately.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module telemetry/test_telemetry.py, errors may happen in the setup period of fixture setup_streaming_telemetry, and the the recover function can be not be executed in the teardown period. This will change the running config, and cause unnecessary reload. In this PR, when the errors happen in the setup period, we will recover the telemetry config immediately.

#### How did you do it?
When the errors happen in the setup period, we will recover the telemetry config immediately.

#### How did you verify/test it?
```
07:35:09 test_telemetry.setup_streaming_telemetry L0142 INFO   | Error happens in the setup period of setup_streaming_telemetry, recover the telemetry.
07:36:35 conftest.core_dump_and_config_check      L1890 INFO   | Core dump and config check passed for telemetry/test_telemetry.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
