### PR TITLE
Fixed test_get_transceiver_info testcase for ZR SFPs

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -243,6 +243,14 @@ class TestSfpApi(PlatformApiTestBase):
         'rxsigpowerlowwarning'
     ]
 
+    # EXPECTED_QSFPZR COMMON_INFO_KEYS
+    QSFPZR_EXPECTED_XCVR_INFO_KEYS = [
+        'supported_min_laser_freq',
+        'supported_max_laser_freq',
+        'supported_min_tx_power',
+        'supported_max_tx_power'
+    ]
+
     chassis_facts = None
     duthost_vars = None
 
@@ -359,15 +367,18 @@ class TestSfpApi(PlatformApiTestBase):
                     # NOTE: No more releases to be added here. Platform should use SFP-refactor.
                     # 'hardware_rev' is ONLY applicable to QSFP-DD/OSFP modules
                     if duthost.sonic_release in ["201811", "201911", "202012", "202106", "202111"]:
-                        UPDATED_EXPECTED_XCVR_INFO_KEYS = [key if key != 'vendor_rev' else 'hardware_rev' for key in
-                            self.EXPECTED_XCVR_INFO_KEYS]
-                        #self.EXPECTED_XCVR_INFO_KEYS = EXPECTED_XCVR_INFO_KEYS
+                        UPDATED_EXPECTED_XCVR_INFO_KEYS = [
+                            key if key != 'vendor_rev' else 'hardware_rev' for key in self.EXPECTED_XCVR_INFO_KEYS]
                     else:
 
                         if info_dict["type_abbrv_name"] == "QSFP-DD":
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS + \
-                                                           self.EXPECTED_XCVR_NEW_QSFP_DD_INFO_KEYS + \
-                                                           ["active_apsel_hostlane{}".format(i) for i in range(1, info_dict['host_lane_count'] + 1)]
+                                                              self.EXPECTED_XCVR_NEW_QSFP_DD_INFO_KEYS + \
+                                                              ["active_apsel_hostlane{}".format(n)
+                                                               for n in range(1, info_dict['host_lane_count'] + 1)]
+                            if 'ZR' in info_dict['media_interface_code']:
+                                UPDATED_EXPECTED_XCVR_INFO_KEYS = UPDATED_EXPECTED_XCVR_INFO_KEYS + \
+                                                                  self.QSFPZR_EXPECTED_XCVR_INFO_KEYS
                         else:
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS
                     missing_keys = set(UPDATED_EXPECTED_XCVR_INFO_KEYS) - set(actual_keys)


### PR DESCRIPTION
### Description of PR
Fixed test_get_transceiver_info testcase for ZR SFPs
This Pr is the same as PR #7480
cherry picked from master

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

To make test_get_transceiver_info pass if SFP is ZR.
test_get_transceiver_info testcase fails for a ZR SFP with the message:
Failed: Transceiver info contains unexpected field:
'supported_min_laser_freq', 'supported_max_tx_power', 'supported_min_tx_power', 'supported_max_laser_freq'

#### How did you do it?
Added the above keys to tranceiver info keys if SFP is a ZR QSFP-DD

#### How did you verify/test it?
Tested test_get_transceiver_info testcase on a multi cards multi ASICs chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
