### PR TITLE
[snmp] Fix snmpget command to run from duthost

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -128,7 +128,9 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     sysTotalFreeMemory_OID = "1.3.6.1.4.1.2021.4.11.0"
     cmds = [
         # Command to retrieve free memory from SNMP
-        "snmpget -v 2c -c {} {} {}".format(creds_all_duts[duthost.hostname]["snmp_rocommunity"], host_ip,
+        "docker exec snmp snmpget -v 2c -c {} {} {}".format(
+                                           creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+                                           host_ip,
                                            sysTotalFreeMemory_OID) + "| awk '{print $4}'",
         # Command to read free memory from meminfo
         "grep MemFree /proc/meminfo | awk '{print $2}'",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/9074 modified test_snmp_memory to make it stable.
This change executes commands to get snmp memory and memory from /proc/meminfo sequentially from duthost.
one of the commands is to use snmpget, which fails because snmpget is available only inside snmp docker.

#### How did you do it?
Modify testcase to run docker exec snmp snmpget instead of snmpget
#### How did you verify/test it?
Verificed on testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
