### PR TITLE
[cherry-pick 8035] Check existence of inventory files

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -27,6 +27,9 @@ import copy
 import inspect
 import json
 import logging
+import os
+
+import six
 
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.inventory.manager import InventoryManager
@@ -38,6 +41,9 @@ from ansible.plugins.callback import CallbackBase
 from ansible.plugins.loader import module_loader
 from ansible import context
 from ansible.module_utils.common.collections import ImmutableDict
+
+if six.PY2:
+    FileNotFoundError = IOError
 
 logger = logging.getLogger("ansible_hosts")
 
@@ -233,7 +239,7 @@ class AnsibleHostsBase(object):
         self.ans_inv_hosts = self.im.get_hosts(self.host_pattern)
         if len(self.ans_inv_hosts) == 0:
             raise NoAnsibleHostError(
-                "No host '{}' in inventory files '{}'".format(self.hostname, self.inventories)
+                "No host '{}' in inventory files '{}'".format(self.host_pattern, self.inventories)
             )
         self.hostnames = [host.name for host in self.ans_inv_hosts]
         self.hosts_count = len(self.hostnames)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/8035 was missed while backporting the devutils/devices/ansible_hosts.py changes to 202012branch.
This PR is to backport the missed changes.

#### How did you do it?
Added missed importing and some other code missed in backporting.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

