### PR TITLE
[202012] Change tool scripts to use Python2 explicitly

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import argparse
 import logging
 import os

--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 """Script for upgrading SONiC image for nightly tests.
 
 Main purpose of this script is to upgrade SONiC image for nightly tests. Based on the arguments passed in, the script

--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 from shutil import copyfile
 import yaml
 import datetime

--- a/ansible/devutils
+++ b/ansible/devutils
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Supress warning
 import warnings

--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import csv
 import sys

--- a/ansible/linkstate/testbed_inv.py
+++ b/ansible/linkstate/testbed_inv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import json

--- a/ansible/recover_server.py
+++ b/ansible/recover_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Script used to recover testbed servers after reboot/upgrade/black-out.
     - Cleanup server

--- a/ansible/restart_nightly_ptf.py
+++ b/ansible/restart_nightly_ptf.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import argparse
 import logging
 import imp

--- a/ansible/upgrade_sonic.py
+++ b/ansible/upgrade_sonic.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import argparse
 import logging
 import sys


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is a part of Python3 migration. The incoming new sonic-mgmt-docker will set Python3 as default. Old branch will use Python2 explicitly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This is a part of Python3 migration. The incoming new sonic-mgmt-docker will set Python3 as default. Old branch will use Python2 explicitly.

#### How did you do it?
In tool scripts, add head: #!/usr/bin/env python2
In any caller of tool scripts, use "./" to call the scripts.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
