### PR TITLE
[ansible] update default ceos image to newer version

### DIFF
--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -3,7 +3,10 @@
 #ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
 #ceos_image_orig: ceosimage:4.23.2F
 #ceos_image: ceosimage:4.23.2F-1
-ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
-ceos_image_orig: ceosimage:4.25.5.1M
-ceos_image: ceosimage:4.25.5.1M-1
+#ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
+#ceos_image_orig: ceosimage:4.25.5.1M
+#ceos_image: ceosimage:4.25.5.1M-1
+ceos_image_filename: cEOS64-lab-4.29.3M.tar
+ceos_image_orig: ceosimage:4.29.3M
+ceos_image: ceosimage:4.29.3M-1
 skip_ceos_image_downloading: false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Newer ceos image can run on Ubuntu 22.04 docker with cgroupv2

#### How did you do it?
Change ceos version in group_vars/all/ceos.yml

#### How did you verify/test it?
Run nightly on ubuntu 20.04 and 22.04 server.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
