### PR TITLE
[202205][autorestart][mx] Fix test_container_autorestart failed in mx (#8968)

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -25,6 +25,7 @@ CONTAINER_RESTART_THRESHOLD_SECS = 300
 CONTAINER_NAME_REGEX = (r"([a-zA-Z_-]+)(\d*)$")
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
+PROGRAM_STATUS = "RUNNING"
 
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
@@ -314,20 +315,17 @@ def clear_failed_flag_and_restart(duthost, service_name, container_name):
 
 
 def verify_autorestart_with_critical_process(duthost, container_name, service_name, program_name,
-                                             program_status, program_pid):
+                                             program_pid):
     """
     @summary: Kill a critical process in a container to verify whether the container
               is stopped and restarted correctly
     """
-    if program_status == "RUNNING":
-        kill_process_by_pid(duthost, container_name, program_name, program_pid)
-    elif program_status in ["EXITED", "STOPPED", "STARTING"]:
-        pytest.fail("Program '{}' in container '{}' is in the '{}' state, expected 'RUNNING'"
-                    .format(program_name, container_name, program_status))
-    else:
-        pytest.fail("Failed to find program '{}' in container '{}'"
-                    .format(program_name, container_name))
+    global PROGRAM_STATUS
+    pytest_assert(wait_until(40, 3, 0, is_process_running, duthost, container_name, program_name),
+                  "Program '{}' in container '{}' is in the '{}' state, expected 'RUNNING'"
+                  .format(program_name, container_name, PROGRAM_STATUS))
 
+    kill_process_by_pid(duthost, container_name, program_name, program_pid)
     logger.info("Waiting until container '{}' is stopped...".format(container_name))
     stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
                          CONTAINER_CHECK_INTERVAL_SECS,
@@ -445,6 +443,19 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     return critical_proceses, bgp_check
 
 
+def is_process_running(duthost, container_name, program_name):
+    global PROGRAM_STATUS
+    program_status, _ = get_program_info(duthost, container_name, program_name)
+    PROGRAM_STATUS = program_status
+    if program_status == "RUNNING":
+        return True
+    elif program_status in ["EXITED", "STOPPED", "STARTING"]:
+        return False
+    else:
+        pytest.fail("Failed to find program '{}' in container '{}'"
+                    .format(program_name, container_name))
+
+
 def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     feature_autorestart_states = duthost.get_container_autorestart_states()
     disabled_containers = get_disabled_container_list(duthost)
@@ -484,10 +495,9 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
         # TODO: Should remove the following two lines once the issue was solved in the image.
         if feature_name == "syncd" and critical_process == "dsserve":
             continue
-
-        program_status, program_pid = get_program_info(duthost, container_name, critical_process)
+        _, program_pid = get_program_info(duthost, container_name, critical_process)
         verify_autorestart_with_critical_process(duthost, container_name, service_name, critical_process,
-                                                 program_status, program_pid)
+                                                 program_pid)
         # Sleep 20 seconds in order to let the processes come into live after container is restarted.
         # We will uncomment the following line once the "extended" mode is added
         # time.sleep(20)
@@ -499,7 +509,6 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
         group_program_info = get_group_program_info(duthost, container_name, critical_group)
         for program_name in group_program_info:
             verify_autorestart_with_critical_process(duthost, container_name, service_name, program_name,
-                                                     group_program_info[program_name][0],
                                                      group_program_info[program_name][1])
             # We are currently only testing one critical program for each critical group, which is
             # why we use 'break' statement. Once we add the "extended" mode, we will remove this


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick of this PR: https://github.com/sonic-net/sonic-mgmt/pull/8968

Fix test_container_autorestart failed for mx in dhcp_relay container. In mx topo, dhcp_relay container has two critical process group: dhcp-server with dnsmasq and dhcp-relay with dhcp6relay. In this test, we will kill process in critical group to see whether the container can restart successfully. In mx scenario, it will kill dhcp6relay and cause dhcp_relay container restart. And then the dhcp_relay container restarts but the dnsmasq service is too late to start, which cause failed at check dhcp-server critical group.

#### How did you do it?
Add wait_until before check, to ensure required process can start.

#### How did you verify/test it?
Run test in M0/MX/T0/T1 topos, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
