### PR TITLE
[202012] Check if BGP has Loopback0 IP as its router ID (#8576)

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -15,6 +15,7 @@ from tests.common.helpers.sad_path import SadOperation
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import InterruptableThread
+from tests.common.fixtures.duthost_utils import check_bgp_router_id
 
 logger = logging.getLogger(__name__)
 
@@ -488,6 +489,9 @@ class AdvancedReboot:
             try:
                 if self.preboot_setup:
                     self.preboot_setup()
+                if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
+                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
+                                                        self.duthost.hostname)
                 if self.advanceboot_loganalyzer:
                     pre_reboot_analysis, post_reboot_analysis = self.advanceboot_loganalyzer
                     marker = pre_reboot_analysis()

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -514,3 +514,23 @@ def load_dscp_to_queue_map(duthost, port, dut_qos_maps):
     except:
         logger.error("Failed to retrieve dscp to queue map for port {} on {}".format(port, duthost.hostname))
         return {}
+
+
+def check_bgp_router_id(duthost, mgFacts):
+    """
+    Check bgp router ID is same as Loopback0
+    """
+    check_bgp_router_id_cmd = r'vtysh -c "show ip bgp summary json"'
+    bgp_summary = duthost.shell(check_bgp_router_id_cmd, module_ignore_errors=True)
+    try:
+        bgp_summary_json = json.loads(bgp_summary['stdout'])
+        router_id = str(bgp_summary_json['ipv4Unicast']['routerId'])
+        loopback0 = str(mgFacts['minigraph_lo_interfaces'][0]['addr'])
+        if router_id == loopback0:
+            logger.info("BGP router identifier: %s == Loopback0 address %s" % (router_id, loopback0))
+            return True
+        else:
+            logger.info("BGP router identifier %s != Loopback0 address %s" % (router_id, loopback0))
+            return False
+    except Exception as e:
+        logger.error("Error loading BGP routerID - {}".format(e))

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -10,6 +10,7 @@ from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, NIC
 from tests.common.cache import FactsCache
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+from tests.common.fixtures.duthost_utils import check_bgp_router_id
 
 logger = logging.getLogger(__name__)
 SYSTEM_STABILIZE_MAX_TIME = 300
@@ -134,7 +135,7 @@ def check_interfaces(duthosts):
 
 
 @pytest.fixture(scope="module")
-def check_bgp(duthosts):
+def check_bgp(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "bgp"}
     def _check(*args, **kwargs):
         result = parallel_run(_check_bgp_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600, init_result=init_result)
@@ -215,6 +216,11 @@ def check_bgp(duthosts):
                             check_result[a_result]['down_neighbors'], a_result, dut.hostname))
         else:
             logger.info('No BGP neighbors are down on %s' % dut.hostname)
+
+        mgFacts = dut.get_extended_minigraph_facts(tbinfo)
+        if dut.num_asics() == 1 and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
+            check_result['failed'] = True
+            logger.info("Failed to verify BGP router identifier is Loopback0 address on %s" % dut.hostname)
 
         logger.info("Done checking bgp status on %s" % dut.hostname)
         results[dut.hostname] = check_result

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -218,7 +218,8 @@ def check_bgp(duthosts, tbinfo):
             logger.info('No BGP neighbors are down on %s' % dut.hostname)
 
         mgFacts = dut.get_extended_minigraph_facts(tbinfo)
-        if dut.num_asics() == 1 and not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
+        if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' and \
+           not wait_until(timeout, interval, 0, check_bgp_router_id, dut, mgFacts):
             check_result['failed'] = True
             logger.info("Failed to verify BGP router identifier is Loopback0 address on %s" % dut.hostname)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This is a cherry-pick PR for https://github.com/sonic-net/sonic-mgmt/pull/8576 and https://github.com/sonic-net/sonic-mgmt/pull/9090
Summary: Skip check_bgp_router_id on T2 devices
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
An issue was found that T0 did not announce Loopback to T1, this check is to bridge the test gap to ensure bgp router identifier matches Loopback0 IP.

#### How did you do it?
Added in sanity_check to match bgp router id and loopback0 ip

#### How did you verify/test it?
Ran a advanced_reboot manually and checked expected log: BGP router identifier: <loopback0 ip>
https://elastictest.org/scheduler/testplan/649c780c75768730ce0de9f3

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
