### PR TITLE
Define dualtor-64 topology

### DIFF
--- a/ansible/roles/eos/templates/dualtor-64-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-64-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-leaf.j2

--- a/ansible/vars/topo_dualtor-64.yml
+++ b/ansible/vars/topo_dualtor-64.yml
@@ -1,0 +1,362 @@
+topology:
+  dut_num: 2
+  host_interfaces:
+    - 0.2@2,1.2@2
+    - 0.3@3,1.3@3
+    - 0.6@6,1.6@6
+    - 0.7@7,1.7@7
+    - 0.8@8,1.8@8
+    - 0.9@9,1.9@9
+    - 0.10@10,1.10@10
+    - 0.11@11,1.11@11
+    - 0.12@12,1.12@12
+    - 0.13@13,1.13@13
+    - 0.14@14,1.14@14
+    - 0.15@15,1.15@15
+    - 0.18@18,1.18@18
+    - 0.19@19,1.19@19
+    - 0.22@22,1.22@22
+    - 0.23@23,1.23@23
+    - 0.24@24,1.24@24
+    - 0.25@25,1.25@25
+    - 0.26@26,1.26@26
+    - 0.27@27,1.27@27
+    - 0.28@28,1.28@28
+    - 0.29@29,1.29@29
+    - 0.30@30,1.30@30
+    - 0.31@31,1.31@31
+    - 0.32@32,1.32@32
+    - 0.33@33,1.33@33
+    - 0.34@34,1.34@34
+    - 0.35@35,1.35@35
+    - 0.36@36,1.36@36
+    - 0.37@37,1.37@37
+    - 0.38@38,1.38@38
+    - 0.39@39,1.39@39
+    - 0.40@40,1.40@40
+    - 0.41@41,1.41@41
+    - 0.42@42,1.42@42
+    - 0.43@43,1.43@43
+    - 0.44@44,1.44@44
+    - 0.45@45,1.45@45
+    - 0.46@46,1.46@46
+    - 0.47@47,1.47@47
+    - 0.48@48,1.48@48
+    - 0.49@49,1.49@49
+    - 0.50@50,1.50@50
+    - 0.51@51,1.51@51
+    - 0.52@52,1.52@52
+    - 0.53@53,1.53@53
+    - 0.54@54,1.54@54
+    - 0.55@55,1.55@55
+    - 0.56@56,1.56@56
+    - 0.57@57,1.57@57
+    - 0.58@58,1.58@58
+    - 0.59@59,1.59@59
+    - 0.60@60,1.60@60
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  disabled_host_interfaces:
+    - 0.2@2,1.2@2
+    - 0.3@3,1.3@3
+    - 0.18@18,1.18@18
+    - 0.19@19,1.19@19
+    - 0.33@33,1.33@33
+    - 0.34@34,1.34@34
+    - 0.35@35,1.35@35
+    - 0.43@43,1.43@43
+    - 0.44@44,1.44@44
+    - 0.45@45,1.45@45
+    - 0.46@46,1.46@46
+    - 0.47@47,1.47@47
+    - 0.49@49,1.49@49
+    - 0.50@50,1.50@50
+    - 0.51@51,1.51@51
+    - 0.59@59,1.59@59
+    - 0.60@60,1.60@60
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - "0.0@64"
+        - "0.1@65"
+        - "1.0@66"
+        - "1.1@67"
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - "0.4@68"
+        - "0.5@69"
+        - "1.4@70"
+        - "1.5@71"
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - "0.16@72"
+        - "0.17@73"
+        - "1.16@74"
+        - "1.17@75"
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - "0.20@76"
+        - "0.21@77"
+        - "1.20@78"
+        - "1.21@79"
+      vm_offset: 3
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+        - 10.1.0.33/32
+      ipv6:
+        - FC00:1::32/128
+        - FC00:1::33/128
+    loopback1:
+      ipv4:
+        - 10.1.0.34/32
+        - 10.1.0.35/32
+      ipv6:
+        - FC00:1::34/128
+        - FC00:1::35/128
+    loopback2:
+      ipv4:
+        - 10.1.0.36/32
+        - 10.1.0.36/32
+      ipv6:
+        - FC00:1::36/128
+        - FC00:1::36/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1::38/128
+        - FC00:1::39/128
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 36, 37, 38, 39, 40, 41, 42, 48, 52, 53, 54, 55, 56, 57, 58]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26, 27, 28, 29]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200:
+          id: 200
+          intfs: [30, 31, 32, 36, 37, 38, 39, 40, 41, 42, 48, 52, 53, 54, 55, 56, 57, 58]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:200::1/64
+          tag: 200
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [6, 7, 8, 9, 10, 11, 12, 13, 14]
+          prefix: 192.168.0.1/23
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan2000:
+          id: 2000
+          intfs: [15, 22, 23, 24, 25, 26, 27, 28, 29]
+          prefix: 192.168.2.1/23
+          prefix_v6: fc02:401::1/64
+          tag: 2000
+        Vlan3000:
+          id: 3000
+          intfs: [30, 31, 32, 36, 37, 38, 39, 40, 41]
+          prefix: 192.168.4.1/23
+          prefix_v6: fc02:402::1/64
+          tag: 3000
+        Vlan4000:
+          id: 4000
+          intfs: [42, 48, 52, 53, 54, 55, 56, 57, 58]
+          prefix: 192.168.6.1/23
+          prefix_v6: fc02:403::1/64
+          tag: 4000
+    tunnel_configs:
+      default_tunnel_config: tunnel_ipinip
+      tunnel_ipinip:
+        MuxTunnel0:
+          type: IPInIP
+          attach_to: Loopback0
+          dscp: uniform
+          ecn_encap: standard
+          ecn_decap: copy_from_outer
+          ttl_mode: pipe
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+        - 10.0.1.56
+        - FC00::1:71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Port-Channel2:
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::1:72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+        - 10.0.1.58
+        - FC00::1:75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Port-Channel2:
+        ipv4: 10.0.1.59/31
+        ipv6: fc00::1:76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+        - 10.0.1.60
+        - FC00::1:79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Port-Channel2:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::1:7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+        - 10.0.1.62
+        - FC00::1:7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Port-Channel2:
+        ipv4: 10.0.1.63/31
+        ipv6: fc00::1:7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to define dualtor-64 topology.
The dualtor topology is based on `T0-64` topology, which has 64 x 100G ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The PR is to define a new dualtor topology `dualtor-64`.

#### How did you do it?
Add the topology definition file and leaf definition file.

#### How did you verify/test it?
The topology is verified by deploying it on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
