### PR TITLE
[Mellanox] Fix check fan speed issue

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -224,18 +224,18 @@ def _is_fan_speed_in_range(sysfs_facts):
             fan_speed_set = int(fan_info["speed_set"])
             fan_speed_get = int(fan_info["speed_get"])
 
+            low_threshold = ((float(fan_speed_set) / 255)
+                             * fan_min_speed) * (1 - 0.5)
+            high_threshold = ((float(fan_speed_set) / 255)
+                              * fan_max_speed) * (1 + 0.5)
+
             assert fan_min_speed > 0 and fan_max_speed > 10000, 'Invalid fan min/max speed: {}, {}'.format(
                 fan_min_speed,
                 fan_max_speed)
-            assert fan_min_speed < fan_speed_get < fan_max_speed, 'Fan speed {} not in range: [{}, {}]'.format(
-                fan_speed_get, fan_min_speed, fan_max_speed
+            assert low_threshold < fan_speed_get < high_threshold, 'Fan speed {} not in range: [{}, {}]'.format(
+                fan_speed_get, low_threshold, high_threshold
             )
 
-            low_threshold = ((float(fan_speed_set) / 255)
-                             * fan_max_speed) * (1 - 0.5)
-            high_threshold = ((float(fan_speed_set) / 255)
-                              * fan_max_speed) * (1 + 0.5)
-            return low_threshold < fan_speed_get < high_threshold
         except Exception as e:
             assert False, 'Invalid fan speed: actual speed={}, set speed={}, min={}, max={}, exception={}'.format(
                 fan_info["speed_get"],
@@ -244,6 +244,7 @@ def _is_fan_speed_in_range(sysfs_facts):
                 fan_info["max_speed"],
                 e
             )
+    return True
 
 
 def generate_sysfs_config(platform_data):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The logic of _is_fan_speed_in_range is not correct, we should check low_threshold < fan_speed_get <high_threshold, because there is a tolerance for min speed and max speed. Additionally, the return should be moved to the end, otherwise, it just checks one fan, and the loop will be ended.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix fan speed check issue

#### How did you do it?
Checking low_threshold < fan_speed_get <high_threshold instead of fan_min_speed < fan_speed_get < fan_max_speed

#### How did you verify/test it?
Run test_restart_swss

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
