### PR TITLE
Fix for issue #8666

### DIFF
--- a/ansible/library/switch_capabilities_facts.py
+++ b/ansible/library/switch_capabilities_facts.py
@@ -39,8 +39,8 @@ class SwitchCapabilityModule(object):
         """
         self.facts['switch_capabilities'] = {}
         namespace_list = multi_asic.get_namespace_list()
-
-        SonicDBConfig.load_sonic_global_db_config()
+        if multi_asic.is_multi_asic():
+            SonicDBConfig.load_sonic_global_db_config()
         conn = SonicV2Connector(namespace=namespace_list[0])
         conn.connect(conn.STATE_DB)
         keys = conn.keys(conn.STATE_DB, 'SWITCH_CAPABILITY|*')

--- a/ansible/library/switch_capabilities_facts.py
+++ b/ansible/library/switch_capabilities_facts.py
@@ -2,6 +2,7 @@
 
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import multi_asic
+from ansible.module_utils.multi_asic_utils import load_db_config
 DOCUMENTATION = '''
 module:         switch_capability_facts
 version_added:  "1.0"
@@ -11,9 +12,9 @@ short_description: Retrieve switch capability information
 
 # swsssdk will be deprecate after 202205
 try:
-    from swsssdk import SonicDBConfig, SonicV2Connector
+    from swsssdk import SonicV2Connector
 except ImportError:
-    from swsscommon.swsscommon import SonicDBConfig, SonicV2Connector
+    from swsscommon.swsscommon import SonicV2Connector
 
 EXAMPLES = '''
 - name: Get switch capability facts
@@ -39,8 +40,7 @@ class SwitchCapabilityModule(object):
         """
         self.facts['switch_capabilities'] = {}
         namespace_list = multi_asic.get_namespace_list()
-        if multi_asic.is_multi_asic():
-            SonicDBConfig.load_sonic_global_db_config()
+        load_db_config()
         conn = SonicV2Connector(namespace=namespace_list[0])
         conn.connect(conn.STATE_DB)
         keys = conn.keys(conn.STATE_DB, 'SWITCH_CAPABILITY|*')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is the fix for issue #8666.
In the script ansible/library/switch_capabilities_facts.py, we should only run the method SonicDBConfig.load_sonic_global_db_config() when the dut is multi-asic, otherwise the error in #8666 will be printed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To fix issue #8666.
#### How did you do it?
Don't run SonicDBConfig.load_sonic_global_db_config() on single asic duts.
#### How did you verify/test it?
Run any test on a single asic dut, the error no longer reproduce.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
