### PR TITLE
Modify import path in script `get_dut_version.py`. 

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -15,7 +15,7 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
     sys.path.append(ansible_path)
 
-from devutil.devices import init_localhost, init_testbed_sonichosts  # noqa E402
+from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa E402
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #8917 , it re-organizes files under ansible/devutil, and change the path of function `init_localhost` and `init_testbed_sonichosts`. But it didn't modify the import path in script `get_dut_version.py`, which will cause import error. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR #8917 , it re-organizes files under ansible/devutil, and change the path of function `init_localhost` and `init_testbed_sonichosts`. But it didn't modify the import path in script `get_dut_version.py`, which will cause import error. 

#### How did you do it?
Modify import path in script `get_dut_version.py`. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
