### PR TITLE
Skip test_module for non T2 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -314,6 +314,11 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
 #######################################
 ##### api/test_module.py #####
 #######################################
+platform_tests/api/test_module.py:
+  skip:
+    reason: "Only support T2"
+    conditions:
+      - "topo_type not in ['t2']"
 
 platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info:
   xfail:
@@ -324,10 +329,10 @@ platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info:
 
 
 platform_tests/api/test_module.py::TestModuleApi::test_reboot:
-   skip:
-     reason: "Reboot commands currently not supported from inside pmon container for Cisco 8000 platform"
-     conditions:
-       - "asic_type in ['cisco-8000']"
+  skip:
+    reason: "Reboot commands currently not supported from inside pmon container for Cisco 8000 platform"
+    conditions:
+      - "asic_type in ['cisco-8000']"
 
 #######################################
 #####        api/test_psu.py      #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_module related cases would get the value of “`get_num_modules`”, if the value is equal to zero, then the case would be skipped due to “No modules found on device”.
The value of “`get_num_modules`” on T0/T1 is zero, so the cases would be skipped.
But if there is something wrong with API or unhealthy testbed issue, `get_num_modules` will not return 0 for T0/T1.

Thanks

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip `test_module` for non T2 topology.

#### How did you do it?
Run test_module on T0 or T1 testbed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
