### PR TITLE
[chassis] test_memory_checker.py use same random dut for fixtures and functions 

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -18,7 +18,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_utils import check_container_state
-from tests.common.helpers.dut_utils import decode_dut_and_container_name
 from tests.common.helpers.dut_utils import is_container_running
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
@@ -266,7 +265,7 @@ def test_setup_and_cleanup(duthosts, creds, enum_rand_one_per_hwsku_frontend_hos
 
 @pytest.fixture
 def remove_and_restart_container(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostname,
-                           enum_rand_one_asic_index, enum_dut_feature, enum_dut_feature):
+                                 enum_rand_one_asic_index, enum_dut_feature):
     """Removes and restarts 'telemetry' container from DuT.
 
     Args:
@@ -665,7 +664,8 @@ def check_log_message(duthost, container_name):
 
 
 def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                  enum_rand_one_asic_index, enum_dut_feature, remove_and_restart_container):
+                                                  enum_rand_one_asic_index, enum_dut_feature,
+                                                  remove_and_restart_container):
     """Checks whether 'memory_checker' script can log an message into syslog if
     one container is not created during device is booted/reooted. This test case will
     remove a container explicitly to simulate the scenario in which the container was not created

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -223,10 +223,13 @@ def remove_stress_utility(duthost, container_name):
     duthost.shell("config bgp startup all")
     logger.info("BGP sessions are started up.")
 
+@pytest.fixture(autouse=True)
+def rand_dut_for_all_functions(enum_rand_one_per_hwsku_frontend_hostname):
+   return enum_rand_one_per_hwsku_frontend_hostname
 
 @pytest.fixture
 def test_setup_and_cleanup(duthosts, creds, enum_dut_feature_container,
-                           enum_rand_one_per_hwsku_frontend_hostname, request):
+                           rand_dut_for_all_functions, request):
     """Backups Monit configuration files, customizes Monit configuration files and
     restarts Monit service before testing. Restores original Monit configuration files
     and restart Monit service after testing.
@@ -238,9 +241,9 @@ def test_setup_and_cleanup(duthosts, creds, enum_dut_feature_container,
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "
@@ -269,12 +272,12 @@ def test_setup_and_cleanup(duthosts, creds, enum_dut_feature_container,
 
 @pytest.fixture
 def remove_and_restart_container(duthosts, creds, enum_dut_feature_container,
-                                 enum_rand_one_per_hwsku_frontend_hostname):
+                                 rand_dut_for_all_functions):
     """Removes and restarts 'telemetry' container from DuT.
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        rand_dut_for_all_functions: The fixture randomly pick up
         a frontend DuT from testbed.
 
 
@@ -282,9 +285,9 @@ def remove_and_restart_container(duthosts, creds, enum_dut_feature_container,
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "
@@ -498,23 +501,23 @@ def consumes_memory_and_checks_monit(duthost, container_name, vm_workers, new_sy
                           'then exec "/usr/bin/restart_service telemetry"'],
                          indirect=["test_setup_and_cleanup"])
 def test_memory_checker(duthosts, enum_dut_feature_container, test_setup_and_cleanup,
-                        enum_rand_one_per_hwsku_frontend_hostname):
+                        rand_dut_for_all_functions):
     """Checks whether the container can be restarted or not if the memory
     usage of it is beyond its threshold for specfic times within a sliding window.
     The `stress` utility is leveraged as the memory stressing tool.
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        rand_dut_for_all_functions: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "
@@ -546,7 +549,7 @@ def test_memory_checker(duthosts, enum_dut_feature_container, test_setup_and_cle
                           'then exec "/usr/bin/restart_service telemetry"'],
                          indirect=["test_setup_and_cleanup"])
 def test_monit_reset_counter_failure(duthosts, enum_dut_feature_container, test_setup_and_cleanup,
-                                     enum_rand_one_per_hwsku_frontend_hostname):
+                                     rand_dut_for_all_functions):
     """Checks that Monit was unable to reset its counter. Specifically Monit will restart
     the contanier if memory usage of it is larger than the threshold for specific times within
     a sliding window. However, Monit was unable to restart the container anymore if memory usage is
@@ -556,16 +559,16 @@ def test_monit_reset_counter_failure(duthosts, enum_dut_feature_container, test_
     Args:
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        rand_dut_for_all_functions: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "
@@ -601,7 +604,7 @@ def test_monit_reset_counter_failure(duthosts, enum_dut_feature_container, test_
                           '"/usr/bin/restart_service telemetry" repeat every 2 cycles'],
                          indirect=["test_setup_and_cleanup"])
 def test_monit_new_syntax(duthosts, enum_dut_feature_container, test_setup_and_cleanup,
-                          enum_rand_one_per_hwsku_frontend_hostname):
+                          rand_dut_for_all_functions):
     """Checks that new syntax of Monit can mitigate the issue which shows Monit was unable
     to restart container due to failing reset its internal counter. With the help of this syntax,
     the culprit container can be restarted by Monit if memory usage of it is larger than the threshold
@@ -610,16 +613,16 @@ def test_monit_new_syntax(duthosts, enum_dut_feature_container, test_setup_and_c
     Args:
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        rand_dut_for_all_functions: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "
@@ -679,7 +682,7 @@ def check_log_message(duthost, container_name):
 
 
 def test_memory_checker_without_container_created(duthosts, enum_dut_feature_container, remove_and_restart_container,
-                                                  enum_rand_one_per_hwsku_frontend_hostname):
+                                                  rand_dut_for_all_functions):
     """Checks whether 'memory_checker' script can log an message into syslog if
     one container is not created during device is booted/reooted. This test case will
     remove a container explicitly to simulate the scenario in which the container was not created
@@ -687,16 +690,16 @@ def test_memory_checker_without_container_created(duthosts, enum_dut_feature_con
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        rand_dut_for_all_functions: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
         None.
     """
     dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname,
+    pytest_require(dut_name == rand_dut_for_all_functions,
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_dut_for_all_functions))
 
     pytest_require(container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' "

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -232,6 +232,10 @@ def test_setup_and_cleanup(duthosts, creds, enum_rand_one_per_hwsku_frontend_hos
 
     Args:
         duthost: Hostname of DuT.
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
         None.
@@ -271,7 +275,9 @@ def remove_and_restart_container(duthosts, creds, enum_rand_one_per_hwsku_fronte
     Args:
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT from testbed.
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
 
 
     Returns:
@@ -500,7 +506,9 @@ def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     Args:
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-          a frontend DuT from testbed.
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
         None.
@@ -548,7 +556,9 @@ def test_monit_reset_counter_failure(duthosts, enum_rand_one_per_hwsku_frontend_
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-          a frontend DuT from testbed.
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
         None.
@@ -599,7 +609,9 @@ def test_monit_new_syntax(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-          a frontend DuT from testbed.
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
         None.
@@ -674,7 +686,10 @@ def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hw
     Args:
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-          a frontend DuT from testbed.
+        a frontend DuT per hwsku from testbed.
+        enum_dut_feature: This fixture will choose a random feature on 
+        the enum_rand_one_per_hwsku_frontend_hostname
+
 
     Returns:
         None.

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -223,9 +223,11 @@ def remove_stress_utility(duthost, container_name):
     duthost.shell("config bgp startup all")
     logger.info("BGP sessions are started up.")
 
+
 @pytest.fixture(autouse=True)
 def rand_dut_for_all_functions(enum_rand_one_per_hwsku_frontend_hostname):
    return enum_rand_one_per_hwsku_frontend_hostname
+
 
 @pytest.fixture
 def test_setup_and_cleanup(duthosts, creds, enum_dut_feature_container,

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -270,7 +270,7 @@ def remove_and_restart_container(duthosts, creds, enum_rand_one_per_hwsku_fronte
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        rand_dut_for_all_functions: The fixture randomly pick up
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT from testbed.
 
 
@@ -499,7 +499,7 @@ def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        rand_dut_for_all_functions: The fixture randomly pick up
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
@@ -547,7 +547,7 @@ def test_monit_reset_counter_failure(duthosts, enum_rand_one_per_hwsku_frontend_
     Args:
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        rand_dut_for_all_functions: The fixture randomly pick up
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
@@ -598,7 +598,7 @@ def test_monit_new_syntax(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     Args:
         duthosts: The fixture returns list of DuTs.
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        rand_dut_for_all_functions: The fixture randomly pick up
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:
@@ -673,7 +673,7 @@ def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hw
 
     Args:
         duthosts: The fixture returns list of DuTs.
-        rand_dut_for_all_functions: The fixture randomly pick up
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
           a frontend DuT from testbed.
 
     Returns:

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -234,7 +234,7 @@ def test_setup_and_cleanup(duthosts, creds, enum_rand_one_per_hwsku_frontend_hos
         duthost: Hostname of DuT.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
@@ -276,7 +276,7 @@ def remove_and_restart_container(duthosts, creds, enum_rand_one_per_hwsku_fronte
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
 
@@ -507,7 +507,7 @@ def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
@@ -557,7 +557,7 @@ def test_monit_reset_counter_failure(duthosts, enum_rand_one_per_hwsku_frontend_
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
@@ -610,7 +610,7 @@ def test_monit_new_syntax(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
@@ -687,7 +687,7 @@ def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hw
         duthosts: The fixture returns list of DuTs.
         enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
         a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on 
+        enum_dut_feature: This fixture will choose a random feature on
         the enum_rand_one_per_hwsku_frontend_hostname
 
 

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -226,7 +226,7 @@ def remove_stress_utility(duthost, container_name):
 
 @pytest.fixture(autouse=True)
 def rand_dut_for_all_functions(enum_rand_one_per_hwsku_frontend_hostname):
-   return enum_rand_one_per_hwsku_frontend_hostname
+    return enum_rand_one_per_hwsku_frontend_hostname
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This is testcase enhancement, it'll save number of `skipped` testcases in this test file.
call combination of `enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_asic_index, enum_dut_feature` to let random feature choosing same dut as enum_rand_one_per_hwsku_frontend_hostname. 
original way of `enum_dut_feature_container, enum_rand_one_per_hwsku_frontend_hostname` will generate combination of 
`test_memory_checker[lc7-1-lc5-1|lldp1` which `lc5-1|lldp1` is generated by `enum_dut_feature_container` and `enum_rand_one_per_hwsku_frontend_hostname` is `lc7`. This combination then gets skipped when decoding enum_dut_feature_container. This PR intends to avoid those combinations, instead of skip.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before lots of skips due to:
```
SKIPPED [4] /azp/_work/35/s/tests/common/helpers/assertions.py:13: Skips testing memory_checker of container 'teamd' on the DuT 'lc7-1' since another DuT 'lc5-1' was chosen.
============== 1 failed, 7 passed, 312 skipped in 4599.02 seconds ==============
```

After, only skipped when container is not telemetry:
```
=========================== short test summary info ============================
SKIPPED [1] /var/src/private/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skips testing memory_checker of container 'teamd0' since memory monitoring is only enabled for 'telemetry'.
...
==================== 2 passed, 26 skipped in 986.11 seconds ====================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
