### PR TITLE
[renumber-topo] Add extra mgmt ip to ptf redeploy step

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -137,6 +137,7 @@
       vm_type: "{{ vm_type }}"
       vm_properties: "{{ vm_properties if vm_properties is defined else omit }}"
       ptf_mgmt_ip_addr: "{{ ptf_ip }}"
+      ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
       ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
       ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
       ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary: Follow up PR to https://github.com/sonic-net/sonic-mgmt/pull/8432 which added support for extra mgmt IP in add-topo, but missed to update PTF redeploy,
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

If a testbed supports extra mgmt IP then the PTF gets the extra IP when `add-topo` is run. This change was done as part of  https://github.com/sonic-net/sonic-mgmt/pull/8432

However, if PTF redeploy is done, the extra IP added by add-topo is lost as PTF is recreated.

This issue is fixed in this PR by adding extra mgmt IP support in `renumber_topo` ansible playbook.

#### How did you do it?

#### How did you verify/test it?

Tested on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
