### PR TITLE
Delete config `suppress-fib-pending` after module `bgp/test_bgp_update_timer.py` running. 

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -15,7 +15,7 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
     sys.path.append(ansible_path)
 
-from devutil.devices import init_localhost, init_testbed_sonichosts  # noqa E402
+from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa E402
 
 logger = logging.getLogger(__name__)
 

--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -15,7 +15,7 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
     sys.path.append(ansible_path)
 
-from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa E402
+from devutil.devices import init_localhost, init_testbed_sonichosts  # noqa E402
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -10,7 +10,7 @@ import six
 from scapy.all import sniff, IP
 from scapy.contrib import bgp
 from tests.common.helpers.bgp import BGPNeighbor
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, delete_running_config
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_common import active_active_ports                    # noqa F401
@@ -181,7 +181,17 @@ def common_setup_teardown(
         ),
     )
 
-    return bgp_neighbors
+    yield bgp_neighbors
+
+    # Cleanup suppress-fib-pending config
+    delete_tacacs_json = [{
+        "DEVICE_METADATA": {
+            "localhost": {
+                "suppress-fib-pending": "disabled"
+            }
+        }
+    }]
+    delete_running_config(delete_tacacs_json, duthost)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR #7907 import a fixture `has_suppress_feature` to get `bgp suppress-fib-pending` on DUT, which may add a config `suppress-fib-pending` in running config. And this will cause inconsiscient  between previous running config and current running config, and will cause unnecessary config reload after whole module running. In this PR, I delete this config in the teardown period of this module. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PR #7907 import a fixture `has_suppress_feature` to get `bgp suppress-fib-pending` on DUT, which may add a config `suppress-fib-pending` in running config. And this will cause inconsiscient  between previous running config and current running config, and will cause unnecessary config reload after whole module running. In this PR, I delete this config in the teardown period of this module. 

#### How did you do it?
I delete this config in the teardown period of this module. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
