### PR TITLE
Add support for BGPMon over IPv6 for T2 chassis

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -679,7 +679,7 @@ def dut_with_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             if dut_to_T3:
                 break
         if dut_to_T3 is None:
-            pytest.skip("Did not find any DUT in the DUTs (linecards) that are connected to T3 VM's")
+            pytest.fail("Did not find any DUT in the DUTs (linecards) that are connected to T3 VM's")
         return dut_to_T3
     else:
         return duthosts[enum_rand_one_per_hwsku_frontend_hostname]

--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -109,13 +109,10 @@ def build_syn_pkt(local_addr, peer_addr):
 
 
 def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_index,
-                common_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost, tbinfo):
+                common_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """
     Add a bgp monitor on ptf and verify that DUT is attempting to establish connection to it
     """
-    if tbinfo['topo']['type'] == 't2':
-        pytest.skip("Skipping IPv4-based BGPMON test on T2 topology")
-
     duthost = dut_with_default_route
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
@@ -168,13 +165,10 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
 
 
 def test_bgpmon_no_resolve_via_default(dut_with_default_route, enum_rand_one_frontend_asic_index,
-                                       common_setup_teardown, ptfadapter, tbinfo):
+                                       common_setup_teardown, ptfadapter):
     """
     Verify no syn for BGP is sent when 'ip nht resolve-via-default' is disabled.
     """
-    if tbinfo['topo']['type'] == 't2':
-        pytest.skip("Skipping IPv4-based BGPMON test on T2 topology")
-
     duthost = dut_with_default_route
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
     local_addr, peer_addr, peer_ports, asn = common_setup_teardown

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import ipaddress
 from netaddr import IPNetwork
 import ptf.testutils as testutils
 from jinja2 import Template
@@ -8,85 +9,52 @@ from ptf.mask import Mask
 import json
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
-from tests.common.helpers.generators import generate_ip_through_default_route
+from tests.common.helpers.generators import generate_ip_through_default_route, generate_ip_through_default_v6_route
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.utilities import wait_tcp_connection
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
+from test_bgpmon import get_default_route_ports, dut_with_default_route, set_timeout_for_bgpmon
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t2'),
 ]
 
 BGP_PORT = 179
 BGP_CONNECT_TIMEOUT = 121
 MAX_TIME_FOR_BGPMON = 180
 ZERO_ADDR = r'0.0.0.0/0'
+ZERO_V6_ADDR = r'::/0'
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def set_timeout_for_bgpmon(duthost):
-    """
-    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
-    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
-    """
-    global MAX_TIME_FOR_BGPMON
-    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_bgpmon.py', 'cold')
-    if plt_reboot_ctrl:
-        MAX_TIME_FOR_BGPMON = plt_reboot_ctrl.get('timeout', 180)
-
-def get_default_route_ports(host, tbinfo, default_addr=ZERO_ADDR):
-    mg_facts = host.get_extended_minigraph_facts(tbinfo)
-    route_info = json.loads(host.shell("show ip route {} json".format(default_addr))['stdout'])
-    ports = []
-    for route in route_info[default_addr]:
-        if route['protocol'] != 'bgp':
-            continue
-        for itfs in route['nexthops']:
-            if 'interfaceName' in itfs and '-IB' not in itfs['interfaceName']:
-                ports.append(itfs['interfaceName'])
-    port_indices = []
-    for port in ports:
-        if 'PortChannel' in port:
-            for member in mg_facts['minigraph_portchannels'][port]['members']:
-                port_indices.append(mg_facts['minigraph_ptf_indices'][member])
-        else:
-            port_indices.append(mg_facts['minigraph_ptf_indices'][port])
-
-    return port_indices
-
-
-@pytest.fixture(scope="module")
-def dut_with_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
-    if tbinfo['topo']['type'] == 't2':
-        # For T2 setup, default route via eBGP is only advertised from T3 VM's which are connected to one of the
-        # linecards and not the other. So, can't use enum_rand_one_per_hwsku_frontend_hostname for T2.
-        dut_to_T3 = None
-        for a_dut in duthosts.frontend_nodes:
-            minigraph_facts = a_dut.get_extended_minigraph_facts(tbinfo)
-            minigraph_neighbors = minigraph_facts['minigraph_neighbors']
-            for key, value in list(minigraph_neighbors.items()):
-                if 'T3' in value['name']:
-                    dut_to_T3 = a_dut
-                    break
-            if dut_to_T3:
-                break
-        if dut_to_T3 is None:
-            pytest.skip("Did not find any DUT in the DUTs (linecards) that are connected to T3 VM's")
-        return dut_to_T3
-    else:
-        return duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-
-@pytest.fixture
-def common_setup_teardown(dut_with_default_route,  tbinfo):
+def common_v6_setup_teardown(dut_with_default_route, tbinfo, enum_rand_one_frontend_asic_index):
     duthost = dut_with_default_route
-    peer_addr = generate_ip_through_default_route(duthost)
+    peer_addr = generate_ip_through_default_v6_route(duthost)
+    router_id = generate_ip_through_default_route(duthost)
     pytest_assert(peer_addr, "Failed to generate ip address for test")
     peer_addr = str(IPNetwork(peer_addr).ip)
-    peer_ports = get_default_route_ports(duthost, tbinfo)
+    peer_ports = get_default_route_ports(duthost, tbinfo, ZERO_V6_ADDR)
+    
+    # Get loopback4096 address    
+    if enum_rand_one_frontend_asic_index:
+        cfg_facts = duthost.config_facts(source='persistent', asic_index='all')[enum_rand_one_frontend_asic_index]['ansible_facts']
+    else:
+        cfg_facts = duthost.config_facts(source='persistent', asic_index='all')[0]['ansible_facts']
+
+    if 'Loopback4096' in cfg_facts['LOOPBACK_INTERFACE']:
+        lbs4096 = list(cfg_facts['LOOPBACK_INTERFACE']['Loopback4096'].keys())
+        for lb4096 in lbs4096:
+            lb4096intf = ipaddress.ip_interface(lb4096)
+            if lb4096intf.ip.version == 6:
+                if "/" in lb4096:
+                    local_addr = lb4096.split("/")[0] 
+                    break
+                else:
+                    local_addr = lb4096
+
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
-    local_addr = mg_facts['minigraph_lo_interfaces'][0]['addr']
+    #local_addr = mg_facts['minigraph_lo_interfaces'][1]['addr']
     # Assign peer addr to an interface on ptf
     logger.info("Generated peer address {}".format(peer_addr))
     bgpmon_args = {
@@ -99,34 +67,32 @@ def common_setup_teardown(dut_with_default_route,  tbinfo):
     bgpmon_template = Template(open(BGPMON_TEMPLATE_FILE).read())
     duthost.copy(content=bgpmon_template.render(**bgpmon_args),
                  dest=BGPMON_CONFIG_FILE)
-    yield local_addr, peer_addr, peer_ports, mg_facts['minigraph_bgp_asn']
+    yield local_addr, peer_addr, peer_ports, mg_facts['minigraph_bgp_asn'], router_id
     # Cleanup bgp monitor
     duthost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_MONITORS|{}'".format(peer_addr), asic_index='all')
     duthost.file(path=BGPMON_CONFIG_FILE, state='absent')
 
 
-def build_syn_pkt(local_addr, peer_addr):
-    pkt = testutils.simple_tcp_packet(
-        pktlen=54,
-        ip_src=local_addr,
-        ip_dst=peer_addr,
+def build_v6_syn_pkt(local_addr, peer_addr):
+    pkt = testutils.simple_tcpv6_packet(
+        ipv6_src=local_addr,
+        ipv6_dst=peer_addr,
+        pktlen=40,
         tcp_dport=BGP_PORT,
         tcp_flags="S"
     )
+
     exp_packet = Mask(pkt)
+    exp_packet.set_ignore_extra_bytes()
+
     exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
     exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
 
-    exp_packet.set_do_not_care_scapy(scapy.IP, "version")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "ihl")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "tos")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "len")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "flags")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "id")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "frag")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "ttl")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
-    exp_packet.set_do_not_care_scapy(scapy.IP, "options")
+    exp_packet.set_do_not_care_scapy(scapy.IPv6, "version")
+    exp_packet.set_do_not_care_scapy(scapy.IPv6, "tc")
+    exp_packet.set_do_not_care_scapy(scapy.IPv6, "fl")
+    exp_packet.set_do_not_care_scapy(scapy.IPv6, "plen")
+    exp_packet.set_do_not_care_scapy(scapy.IPv6, "hlim")
 
     exp_packet.set_do_not_care_scapy(scapy.TCP, "sport")
     exp_packet.set_do_not_care_scapy(scapy.TCP, "seq")
@@ -137,17 +103,14 @@ def build_syn_pkt(local_addr, peer_addr):
     exp_packet.set_do_not_care_scapy(scapy.TCP, "chksum")
     exp_packet.set_do_not_care_scapy(scapy.TCP, "urgptr")
 
-    exp_packet.set_ignore_extra_bytes()
     return exp_packet
 
 
-def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_index,
-                common_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost, tbinfo):
+def test_bgpmon_v6(dut_with_default_route, localhost, enum_rand_one_frontend_asic_index,
+                common_v6_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """
     Add a bgp monitor on ptf and verify that DUT is attempting to establish connection to it
     """
-    if tbinfo['topo']['type'] == 't2':
-        pytest.skip("Skipping IPv4-based BGPMON test on T2 topology")
 
     duthost = dut_with_default_route
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
@@ -155,18 +118,19 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
     def bgpmon_peer_connected(duthost, bgpmon_peer):
         try:
             bgp_summary = json.loads(asichost.run_vtysh("-c 'show bgp summary json'")['stdout'])
-            return bgp_summary['ipv4Unicast']['peers'][bgpmon_peer]["state"] == "Established"
+            return bgp_summary['ipv6Unicast']['peers'][bgpmon_peer]["state"] == "Established"
         except Exception:
             logger.info('Unable to get bgp status')
             return False
 
-    local_addr, peer_addr, peer_ports, asn = common_setup_teardown
-    exp_packet = build_syn_pkt(local_addr, peer_addr)
+    local_addr, peer_addr, peer_ports, asn, router_id = common_v6_setup_teardown
+    exp_packet = build_v6_syn_pkt(local_addr, peer_addr)
     # Flush dataplane
     ptfadapter.dataplane.flush()
     # Load bgp monitor config
     logger.info("Configured bgpmon and verifying packet on {}".format(peer_ports))
     asichost.write_to_config_db(BGPMON_CONFIG_FILE)
+
     # Verify syn packet on ptf
     (rcvd_port_index, rcvd_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_packet,
                                                                    ports=peer_ports, timeout=BGP_CONNECT_TIMEOUT)
@@ -176,17 +140,17 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
     res = ptfhost.shell('cat /sys/class/net/{}/address'.format(ptf_interface))
     original_mac = res['stdout']
     ptfhost.shell("ifconfig %s hw ether %s" % (ptf_interface, scapy.Ether(rcvd_pkt).dst))
-    ptfhost.shell("ip add add %s dev %s" % (peer_addr + "/24", ptf_interface))
+    ptfhost.shell("ip -6 addr add %s dev %s" % (peer_addr + "/128", ptf_interface))
     ptfhost.exabgp(name=BGP_MONITOR_NAME,
                    state="started",
                    local_ip=peer_addr,
-                   router_id=peer_addr,
+                   router_id=router_id,
                    peer_ip=local_addr,
                    local_asn=asn,
                    peer_asn=asn,
                    port=BGP_MONITOR_PORT, passive=True)
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
-    ptfhost.shell("ip route add %s dev %s" % (local_addr + "/32", ptf_interface))
+    ptfhost.shell("ip -6 route add %s dev %s" % (local_addr + "/128", ptf_interface))
     try:
         pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
                       "Failed to start bgp monitor session on PTF")
@@ -194,30 +158,27 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
                       "BGPMon Peer connection not established")
     finally:
         ptfhost.exabgp(name=BGP_MONITOR_NAME, state="absent")
-        ptfhost.shell("ip route del %s dev %s" % (local_addr + "/32", ptf_interface))
-        ptfhost.shell("ip neigh del %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
-        ptfhost.shell("ip add del %s dev %s" % (peer_addr + "/24", ptf_interface))
+        ptfhost.shell("ip -6 route del %s dev %s" % (local_addr + "/128", ptf_interface))
+        ptfhost.shell("ip -6 neigh del %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
+        ptfhost.shell("ip -6 addr del %s dev %s" % (peer_addr + "/128", ptf_interface))
         ptfhost.shell("ifconfig %s hw ether %s" % (ptf_interface, original_mac))
 
 
-def test_bgpmon_no_resolve_via_default(dut_with_default_route, enum_rand_one_frontend_asic_index,
-                                       common_setup_teardown, ptfadapter, tbinfo):
+def test_bgpmon_no_ipv6_resolve_via_default(dut_with_default_route, enum_rand_one_frontend_asic_index,
+                                       common_v6_setup_teardown, ptfadapter):
     """
     Verify no syn for BGP is sent when 'ip nht resolve-via-default' is disabled.
     """
-    if tbinfo['topo']['type'] == 't2':
-        pytest.skip("Skipping IPv4-based BGPMON test on T2 topology")
-
     duthost = dut_with_default_route
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
-    local_addr, peer_addr, peer_ports, asn = common_setup_teardown
-    exp_packet = build_syn_pkt(local_addr, peer_addr)
+    local_addr, peer_addr, peer_ports, _, _ = common_v6_setup_teardown
+    exp_packet = build_v6_syn_pkt(local_addr, peer_addr)
     # Load bgp monitor config
     logger.info("Configured bgpmon and verifying no packet on {} when resolve-via-default is disabled"
                 .format(peer_ports))
     try:
         # Disable resolve-via-default
-        duthost.run_vtysh(" -c \"configure terminal\" -c \"no ip nht resolve-via-default\"", asic_index='all')
+        duthost.run_vtysh(" -c \"configure terminal\" -c \"no ipv6 nht resolve-via-default\"", asic_index='all')
         # Flush dataplane
         ptfadapter.dataplane.flush()
         asichost.write_to_config_db(BGPMON_CONFIG_FILE)
@@ -228,4 +189,4 @@ def test_bgpmon_no_resolve_via_default(dut_with_default_route, enum_rand_one_fro
                       "Syn packets is captured when resolve-via-default is disabled")
     finally:
         # Re-enable resolve-via-default
-        duthost.run_vtysh("-c \"configure terminal\" -c \"ip nht resolve-via-default\"", asic_index='all')
+        duthost.run_vtysh("-c \"configure terminal\" -c \"ipv6 nht resolve-via-default\"", asic_index='all')

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -167,7 +167,7 @@ def test_bgpmon_v6(dut_with_default_route, localhost, enum_rand_one_frontend_asi
 def test_bgpmon_no_ipv6_resolve_via_default(dut_with_default_route, enum_rand_one_frontend_asic_index,
                                             common_v6_setup_teardown, ptfadapter):
     """
-    Verify no syn for BGP is sent when 'ip nht resolve-via-default' is disabled.
+    Verify no syn for BGP is sent when 'ipv6 nht resolve-via-default' is disabled.
     """
     duthost = dut_with_default_route
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)

--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -2,7 +2,7 @@ from netaddr import IPNetwork
 import json
 
 ZERO_ADDR = r'0.0.0.0/0'
-
+ZERO_V6_ADDR = r'::/0'
 
 def generate_ips(num, prefix, exclude_ips):
     """ Generate random ips within prefix """
@@ -35,7 +35,7 @@ def route_through_default_routes(host, ip_addr):
     ret = True
 
     for prefix in list(routes_info.keys()):
-        if prefix != ZERO_ADDR:
+        if prefix != ZERO_ADDR and prefix != ZERO_V6_ADDR:
             ret = False
             break
     return ret
@@ -51,6 +51,20 @@ def generate_ip_through_default_route(host, exclude_ips=None):
     exclude_ips = exclude_ips if exclude_ips is not None else []
     for leading in range(11, 255):
         ip_addr = generate_ips(1, "{}.0.0.1/24".format(leading), exclude_ips)[0]
+        if route_through_default_routes(host, ip_addr):
+            return ip_addr
+    return None
+
+def generate_ip_through_default_v6_route(host, exclude_ips=None):
+    """
+    @summary: Generate a random IP address routed through default routes
+    @param host: The duthost
+    @param exclude_ips: IPs to exclude, default None
+    @return: A str, on None if non ip is found in given range
+    """
+    exclude_ips = exclude_ips if exclude_ips is not None else []
+    for random_byte in range(0, 9):
+        ip_addr = generate_ips(1, "2603:10b{}::1/120".format(random_byte), exclude_ips)[0]
         if route_through_default_routes(host, ip_addr):
             return ip_addr
     return None

--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -4,6 +4,7 @@ import json
 ZERO_ADDR = r'0.0.0.0/0'
 ZERO_V6_ADDR = r'::/0'
 
+
 def generate_ips(num, prefix, exclude_ips):
     """ Generate random ips within prefix """
     prefix = IPNetwork(prefix)
@@ -54,6 +55,7 @@ def generate_ip_through_default_route(host, exclude_ips=None):
         if route_through_default_routes(host, ip_addr):
             return ip_addr
     return None
+
 
 def generate_ip_through_default_v6_route(host, exclude_ips=None):
     """

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -108,9 +108,9 @@ bgp/test_bgp_speaker.py:
 
 bgp/test_bgpmon.py:
   skip:
-    reason: "Not supported topology backend."
+    reason: "Not supported on T2 topology or topology backend"
     conditions:
-      - "'backend' in topo_name"
+      - "'backend' in topo_name or 't2' in topo_name"
 
 bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Tests for IPv6-based bgpmon for T2 chassis

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add new test cases for IPv6-based bgpmon session

#### How did you do it?
Modified tests to use IPv6 loopback4096 address as source and initiate v6 BGPMon session to exabgp on PTF

#### How did you verify/test it?
Tested on T2 chassis 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
