### PR TITLE
[202205] Stabilize snmp memory load test

### DIFF
--- a/tests/snmp/memory.py
+++ b/tests/snmp/memory.py
@@ -1,3 +1,7 @@
 #!/usr/bin/python
-load = [' ' * 512000000]
-print(load)
+
+import time
+load = []
+for i in range(0, 1000):
+    load.append([' ' * 512000])
+    time.sleep(0.01)

--- a/tests/snmp/memory.py
+++ b/tests/snmp/memory.py
@@ -1,7 +1,38 @@
 #!/usr/bin/python
 
 import time
-load = []
-for i in range(0, 1000):
-    load.append([' ' * 512000])
-    time.sleep(0.01)
+import subprocess
+
+
+def get_free_memory():
+    command = "grep MemFree /proc/meminfo | awk '{print $2}'"
+    output = subprocess.check_output(command, shell=True)
+    free_memory = int(output.strip())
+    return free_memory
+
+
+free_memory = get_free_memory()
+total_chars = 512000000
+
+if (free_memory * 1024) > int(total_chars * 130 / 100):
+    load = []
+    count = 1000
+    for i in range(0, count):
+        load.append([' ' * int(total_chars / count)])
+        time.sleep(0.01)
+else:
+    chunk_size = int((free_memory * 1024 * 100 / 130) / 2)
+    large_string = ""
+    remaining_chars = total_chars
+    # print("Free Memory: {} total_chars {} chunk_size {}".format(free_memory, total_chars, chunk_size))
+
+    try:
+        while remaining_chars > 0:
+            chunk = ' ' * min(chunk_size, remaining_chars)
+            large_string += chunk
+            remaining_chars -= chunk_size
+
+        for i in range(0, len(large_string), chunk_size):
+            print(large_string[i:i+chunk_size])
+    except MemoryError:
+        print("Not enough memory to generate and print the large string.")

--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -114,7 +114,9 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     sysTotalFreeMemory_OID = "1.3.6.1.4.1.2021.4.11.0"
     cmds = [
         # Command to retrieve free memory from SNMP
-        "snmpget -v 2c -c {} {} {}".format(creds_all_duts[duthost.hostname]["snmp_rocommunity"], host_ip,
+        "docker exec snmp snmpget -v 2c -c {} {} {}".format(
+                                           creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+                                           host_ip,
                                            sysTotalFreeMemory_OID) + "| awk '{print $4}'",
         # Command to read free memory from meminfo
         "grep MemFree /proc/meminfo | awk '{print $2}'",

--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -112,11 +112,19 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     sysTotalFreeMemory_OID = "1.3.6.1.4.1.2021.4.11.0"
-    snmp_command = "snmpget -v 2c -c {} {} {}".format(creds_all_duts[duthost.hostname]["snmp_rocommunity"], host_ip,
-                                                      sysTotalFreeMemory_OID) + "| awk '{print $4}'"
-    snmp_free_memory = localhost.shell(snmp_command)['stdout']
-    mem_free = duthost.shell("grep MemFree /proc/meminfo | awk '{print $2}'")['stdout']
-    mem_total = duthost.shell("grep MemTotal /proc/meminfo | awk '{print $2}'")['stdout']
+    cmds = [
+        # Command to retrieve free memory from SNMP
+        "snmpget -v 2c -c {} {} {}".format(creds_all_duts[duthost.hostname]["snmp_rocommunity"], host_ip,
+                                           sysTotalFreeMemory_OID) + "| awk '{print $4}'",
+        # Command to read free memory from meminfo
+        "grep MemFree /proc/meminfo | awk '{print $2}'",
+        # Command to read total memory from meminfo
+        "grep MemTotal /proc/meminfo | awk '{print $2}'"
+    ]
+    outputs = duthost.shell_cmds(cmds=cmds)
+    snmp_free_memory = int(outputs['results'][0]['stdout'])
+    mem_free = int(outputs['results'][1]['stdout'])
+    mem_total = int(outputs['results'][2]['stdout'])
     percentage = get_percentage_threshold(int(mem_total))
     logger.info("SNMP Free Memory: {}".format(snmp_free_memory))
     logger.info("DUT Free Memory: {}".format(mem_free))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize test case `test_snmp_memory_load`.
The test case run a python script `memory,py` on the DUT to allocate large amount of memory, and then retrieve the free memory by snmp and parsing `/proc/meminfo` correspondingly. And then compare the value retrieved from SNMP and CLI.
It's flaky because
1. The commands are running in 3 separated Ansible calls, which means there is a time gap (around 3 seconds) between each call. There can be memory usage change between each call.
2. The `memory.py` script is running to fast. We need to consume the memory gradually.

This PR addressed the issue with below changes
1. Run the 3 command in a single Ansible call.
2. Improve the `memory.py` script to allocate memory in a relatively slow pace.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to back port PR #9074 into `202205` branch.
The change in PR #9113 and #9716 is also included in this PR.

This PR is to stabilize test case `test_snmp_memory_load`.


#### How did you do it?
This PR addressed the issue with below changes
1. Run the 3 command in a single Ansible call.
2. Improve the `memory.py` script to allocate memory in a relatively slow pace.

#### How did you verify/test it?
The change is verified on a SN4600 testbed. Now it's consistently passing.
```
collected 1 item                                                                                                                                                                            

snmp/test_snmp_memory.py::test_snmp_memory_load[str3-msn4600c-acs-05] PASSED                                                                                                          [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
