### PR TITLE
[Cherry-pick #9125] Adding dut & dut_asic namespace to getSchedulerParam in qos_sai_base

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -395,7 +395,7 @@ class QosSaiBase(QosBase):
                     schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
                         argv=[
                             "redis-cli", "-n", "4", "HGET",
-                            "QUEUE|{0}|asic0|{1}|{2}"
+                            "QUEUE|{0}|Asic0|{1}|{2}"
                             .format(dut_asic.sonichost.hostname, port, queue), "scheduler"
                         ]
                     )[0].encode("utf-8")

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -395,7 +395,7 @@ class QosSaiBase(QosBase):
                     schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
                         argv=[
                             "redis-cli", "-n", "4", "HGET",
-                            "QUEUE|{0}|asic0|{2}|{3}"
+                            "QUEUE|{0}|asic0|{1}|{2}"
                             .format(dut_asic.sonichost.hostname, port, queue), "scheduler"
                         ]
                     )[0].encode("utf-8")

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -381,12 +381,31 @@ class QosSaiBase(QosBase):
                 ]
             )[0].encode("utf-8").translate(None, "[]")
         else:
-            schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
-                argv = [
-                    "redis-cli", "-n", "4", "HGET",
-                    "QUEUE|{0}|{1}".format(port, queue), "scheduler"
-                ]
-            )[0].encode("utf-8")
+            if dut_asic.sonichost.facts['switch_type'] == 'voq':
+                # For VoQ chassis, the scheduler queues config is based on system port
+                if dut_asic.sonichost.is_multi_asic:
+                    schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
+                        argv=[
+                            "redis-cli", "-n", "4", "HGET",
+                            "QUEUE|{0}|{1}|{2}|{3}"
+                            .format(dut_asic.sonichost.hostname, dut_asic.namespace, port, queue), "scheduler"
+                        ]
+                    )[0].encode("utf-8")
+                else:
+                    schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
+                        argv=[
+                            "redis-cli", "-n", "4", "HGET",
+                            "QUEUE|{0}|asic0|{2}|{3}"
+                            .format(dut_asic.sonichost.hostname, port, queue), "scheduler"
+                        ]
+                    )[0].encode("utf-8")
+            else:
+                schedProfile = "SCHEDULER|" + dut_asic.run_redis_cmd(
+                    argv=[
+                        "redis-cli", "-n", "4", "HGET",
+                        "QUEUE|{0}|{1}".format(port, queue), "scheduler"
+                    ]
+                )[0].encode("utf-8")
 
         schedWeight = dut_asic.run_redis_cmd(
             argv = ["redis-cli", "-n", "4", "HGET", schedProfile, "weight"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Due to the change in PR(#15914) the search criteria to get scheduler parameters from Redis db needs to be changed
PR# https://github.com/sonic-net/sonic-mgmt/pull/9125 raised for master branch

Summary:
The query to redis db was previously searched with only port & queue . Now in addition to it the duthost & asic namespace has to be concatenated in search
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The code base is different from master branch, hence raising separate PR for 202205
#### How did you do it?

#### How did you verify/test it?
Re-run the qos test suite
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
