### PR TITLE
Issue #6657 - 'systemctl restart ferret' failure in test_decap testcase

### DIFF
--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -95,6 +95,7 @@ class RestAPI(object):
     PORT = 448
 
     def __init__(self, obj, db, src_ip):
+        SocketServer.TCPServer.allow_reuse_address = True
         self.httpd = SocketServer.TCPServer(("", self.PORT), obj)
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         self.context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #6657 
Fix "systemctl restart ferret" failure in test_decap testcase.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix "systemctl restart ferret" failure in test_decap testcase. After ferret is stopped, TCP session stuck in TIME_WAIT. Then starting ferret will trigger binding to the same port. This bind() function failed.
Traceback (most recent call last):
  File "/opt/ferret.py", line 350, in <module>
    main()
  File "/opt/ferret.py", line 342, in main
    rest = RestAPI(Ferret, db, src_ip)
  File "/opt/ferret.py", line 99, in __init__
    self.httpd = SocketServer.TCPServer(("", self.PORT), obj)
  File "/usr/lib/python2.7/SocketServer.py", line 420, in __init__
    self.server_bind()
  File "/usr/lib/python2.7/SocketServer.py", line 434, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 98] Address already in use

#### How did you do it?
By using SocketServer.TCPServer.allow_reuse_address = True
SO_REUSEADDR will be set. The bind() function will success.

#### How did you verify/test it?
Test with 7260 dualtor physical testbed in 5 consecutive tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
