### PR TITLE
[202012] Fix import issue of scripts under tests/snappi_tests

### DIFF
--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -32,7 +32,7 @@ steps:
 - script: |
     set -x
     sudo docker exec -t -w /var/src/sonic-mgmt/tests sonic-mgmt-collect \
-      pytest --inventory ../ansible/veos_vtb --host-pattern all \
+      python2 -m pytest --inventory ../ansible/veos_vtb --host-pattern all \
       --testbed_file vtestbed.yaml --testbed vms-kvm-t0 \
       --ignore saitests --ignore ptftests --ignore acstests \
       --ignore scripts --ignore k8s --ignore sai_qualify --ignore common \

--- a/tests/snappi_tests/ecn/conftest.py
+++ b/tests/snappi_tests/ecn/conftest.py
@@ -1,4 +1,4 @@
-from ecn_args.ecn_args import add_ecn_args
+from tests.snappi_tests.ecn.ecn_args.ecn_args import add_ecn_args
 
 
 def pytest_addoption(parser):

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked
+from tests.snappi_tests.ecn.files.helper import run_ecn_test, is_ecn_marked
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
@@ -8,7 +8,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked
+from tests.snappi_tests.ecn.files.helper import run_ecn_test, is_ecn_marked
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
@@ -8,7 +8,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts

--- a/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts
@@ -42,14 +42,14 @@ def test_pfc_single_lossless_headroom(snappi_api,
         enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
         all_prio_list (pytest fixture): list of all the priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        enum_pfc_pause_delay_test_params (str): pfc delay value to test, 
+        enum_pfc_pause_delay_test_params (str): pfc delay value to test,
                                                   and delay responses e.g. "200|False"
 
     Returns:
         N/A
     """
 
-    pytest_require(enum_pfc_pause_delay_test_params is not None, 
+    pytest_require(enum_pfc_pause_delay_test_params is not None,
                     "Skip this testcase since pfc pause delay values have not been configured yet")
     dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
     dut_hostname2, lossless_prio = enum_dut_lossless_prio.split('|')
@@ -112,14 +112,14 @@ def test_pfc_pause_multi_lossless_headroom(snappi_api,
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        enum_pfc_pause_delay_test_params (str): pfc delay value to test, 
+        enum_pfc_pause_delay_test_params (str): pfc delay value to test,
                                                   and delay responses e.g. "200|False"
 
     Returns:
         N/A
     """
 
-    pytest_require(enum_pfc_pause_delay_test_params is not None, 
+    pytest_require(enum_pfc_pause_delay_test_params is not None,
                     "Skip this testcase since pfc pause delay values have not been configured yet")
     dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
     pytest_require(rand_one_dut_hostname == dut_hostname,

--- a/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401

--- a/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.helper import run_pfc_test
+from tests.snappi_tests.pfc.files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401

--- a/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
-from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
+from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
@@ -9,7 +10,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
-from files.pfcwd_basic_helper import run_pfcwd_basic_test
+from tests.snappi_tests.pfcwd.files.pfcwd_basic_helper import run_pfcwd_basic_test
 from tests.snappi_tests.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map
-from files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
+from tests.snappi_tests.pfcwd.files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list
-from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
+from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_testbed_config
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list
 
-from files.pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
+from tests.snappi_tests.pfcwd.files.pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
+++ b/tests/snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from files.packet_reorder_helper import run_ipip_packet_reorder_test
+from tests.snappi_tests.qos.files.packet_reorder_helper import run_ipip_packet_reorder_test
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
To support smooth python3 migration, we need to explicitly specify the python version to be used in each branch. For 202012 branch, default python should be python2. Need to use python2 to run the collect-only check as well.

To avoid potential import issue, updated the relative importing in scripts under tests/snappi_tests to absolute importing.

#### How did you do it?
* Use "python2 -m pytest" instead of directly run "pytest" command to do collect-only check.
* Updated the relative importing in scripts under tests/snappi_tests to absolute importing.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
