### PR TITLE
Remove pg lossless settings of port speed in module `iface_namingmode/test_iface_namingmode.py`.

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -4,7 +4,7 @@ import re
 import ipaddress
 
 from tests.common.devices.base import AnsibleHostBase
-from tests.common.utilities import wait, wait_until
+from tests.common.utilities import wait, wait_until, delete_running_config
 from netaddr import IPAddress
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import redis_get_keys
@@ -819,6 +819,13 @@ class TestConfigInterface():
         logger.info('speed: {}'.format(speed))
 
         assert speed == configure_speed
+
+        # Remove interface pg config
+        pg_lossless_key = "pg_lossless_" + str(speed) + "_300m_profile"
+        delete_keys_json = [{"BUFFER_PROFILE": {
+            pg_lossless_key: {}
+        }}]
+        delete_running_config(delete_keys_json, duthost)
 
         out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {}  speed {} {}'.format(
             ifmode, cli_ns_option, test_intf, native_speed))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `iface_namingmode/test_iface_namingmode.py`, in function `test_config_interface_speed`, it will change interface speed and recover the native speed. But once changing the speed, it will add an entry like `pg_lossless_10000_300m_profile` in running config, which wil cause inconsistent between previous running config and current running config. And will cause config reload in the teardown period of module. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module `iface_namingmode/test_iface_namingmode.py`, in function `test_config_interface_speed`, it will change interface speed and recover the native speed. But once changing the speed, it will add an entry like `pg_lossless_10000_300m_profile` in running config, which wil cause inconsistent between previous running config and current running config. And will cause config reload in the teardown period of module. 

#### How did you do it?
Remove pg lossless settings of port speed after changing port speed. 

#### How did you verify/test it?
```
07:15:08 conftest.core_dump_and_config_check      L2073 INFO   | Core dump and config check passed for iface_namingmode/test_iface_namingmode.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
