### PR TITLE
[master][CI/CD] Refine PR test template console log, display Elastictest link more clearly

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -154,8 +154,6 @@ steps:
 
       rm -f new_test_plan_id.txt
 
-      echo "##[group][test_plan.py] create result"
-
       python ./.azure-pipelines/test_plan.py create \
       -t ${{ parameters.TOPOLOGY }} \
       -o new_test_plan_id.txt \
@@ -183,8 +181,6 @@ steps:
       --dump-kvm-if-fail ${{ parameters.DUMP_KVM_IF_FAIL }} \
       --requester "${{ parameters.REQUESTER }}" \
       --max-execute-seconds $((${{ parameters.MAX_RUN_TEST_MINUTES }} * 60))
-
-      echo "##[endgroup]"
 
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -154,6 +154,8 @@ steps:
 
       rm -f new_test_plan_id.txt
 
+      echo "##[group][test_plan.py] create result"
+
       python ./.azure-pipelines/test_plan.py create \
       -t ${{ parameters.TOPOLOGY }} \
       -o new_test_plan_id.txt \
@@ -182,39 +184,64 @@ steps:
       --requester "${{ parameters.REQUESTER }}" \
       --max-execute-seconds $((${{ parameters.MAX_RUN_TEST_MINUTES }} * 60))
 
+      echo "##[endgroup]"
+
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 
       echo "Created test plan $TEST_PLAN_ID"
-      echo "Check $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID for test plan status"
+
+      echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+      echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+      echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+      echo -e "\033[33mfor detailed test plan progress \033[0m"
+
       echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
     displayName: "Trigger test"
 
   - script: |
       set -e
       echo "Lock testbed"
-      echo "SONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com"
-      echo "Runtime detailed progress at $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+
+      echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+      echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+      echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+      echo -e "\033[33mfor detailed test plan progress \033[0m"
+
       # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
+      echo "##[group][test_plan.py] poll LOCK_TESTBED status"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state LOCK_TESTBED
+      echo "##[endgroup]"
     displayName: "Lock testbed"
 
   - script: |
       set -e
       echo "Prepare testbed"
       echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient"
-      echo "SONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com"
-      echo "Runtime detailed progress at $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+
+      echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+      echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+      echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+      echo -e "\033[33mfor detailed test plan progress \033[0m"
+
       # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
+      echo "##[group][test_plan.py] poll PREPARE_TESTBED status"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state PREPARE_TESTBED
+      echo "##[endgroup]"
     displayName: "Prepare testbed"
 
   - script: |
       set -e
       echo "Run test"
-      echo "SONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com"
-      echo "Runtime detailed progress at $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+
+      echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+      echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+      echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+      echo -e "\033[33mfor detailed test plan progress \033[0m"
+
       # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
+      echo "##[group][test_plan.py] poll EXECUTING status"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }}
+      echo "##[endgroup]"
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
 
@@ -222,10 +249,16 @@ steps:
       - script: |
           set -e
           echo "KVM dump"
-          echo "SONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com"
-          echo "Runtime detailed progress at $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+
+          echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+          echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+          echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+          echo -e "\033[33mfor detailed test plan progress \033[0m"
+
           # When "KVMDUMP" finish, it changes into "FAILED", "CANCELLED" or "FINISHED"
+          echo "##[group][test_plan.py] poll KVMDUMP status"
           python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state KVMDUMP
+          echo "##[endgroup]"
         condition: succeededOrFailed()
         displayName: "KVM dump"
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

[CI/CD] Refine PR test template console log, display Elastictest link more clearly.
![image](https://github.com/sonic-net/sonic-mgmt/assets/39114813/c2581581-e99d-4046-a6b9-4d641f419a8a)

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Origin pipeline display console log not very clearly for user to quickly find the Elastictest page to check detailed issue.

#### How did you do it?
Use log group to aggregate the output of calling test_plan.py.
Change text color for Elastictest info and page link.

#### How did you verify/test it?
PR test executing normally and log clearer.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
