### PR TITLE
[Mellanox] Added missed config in headroom calculation for 800G ports

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -3138,7 +3138,7 @@ def mellanox_calculate_headroom_data(duthost, port_to_test):
     head_room_data = {}
 
     # Init pause_quanta_per_speed_dict
-    pause_quanta_per_speed_dict = {400000: 905, 200000: 453, 100000: 394, 50000: 147,
+    pause_quanta_per_speed_dict = {800000: 905, 400000: 905, 200000: 453, 100000: 394, 50000: 147,
                                    40000: 118, 25000: 80, 10000: 67, 1000: 2, 100: 1}
 
     # Get effective speed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added missed configuration in the calculation of headroom.
Related configuration: #2860


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix failed tests on setups with 800G:

- tests/qos/test_buffer.py::test_port_auto_neg
- tests/qos/test_buffer.py::test_lossless_pg[6]
- tests/qos/test_buffer.py::test_lossless_pg[3-4]

#### How did you do it?
Added missed config

#### How did you verify/test it?
Executed failed tests.
Now they are passing


