### PR TITLE
[drop_packets]: Fix to support testbed with different hwsku with different asic count

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -119,13 +119,13 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
                              GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
         for duthost in duthosts.frontend_nodes:
-            ensure_no_l3_drops(duthost, asic_index, packets_count=PKT_NUMBER)
+            ensure_no_l3_drops(duthost, packets_count=PKT_NUMBER)
     elif discard_group == "L3":
         if COMBINED_L2L3_DROP_COUNTER:
             verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
                                  GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
             for duthost in duthosts.frontend_nodes:
-                ensure_no_l3_drops(duthost, asic_index, packets_count=PKT_NUMBER)
+                ensure_no_l3_drops(duthost, packets_count=PKT_NUMBER)
         else:
             if not tx_dut_ports:
                 pytest.fail("No L3 interface specified")
@@ -133,7 +133,7 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
             verify_drop_counters(duthosts, asic_index, tx_dut_ports[ports_info["dut_iface"]],
                                  GET_L3_COUNTERS, L3_COL_KEY, packets_count=PKT_NUMBER)
             for duthost in duthosts.frontend_nodes:
-                ensure_no_l2_drops(duthost, asic_index, packets_count=PKT_NUMBER)
+                ensure_no_l2_drops(duthost, packets_count=PKT_NUMBER)
     elif discard_group == "ACL":
         if not tx_dut_ports:
             pytest.fail("No L3 interface specified")
@@ -154,12 +154,12 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
             pytest.fail(fail_msg)
         if not COMBINED_ACL_DROP_COUNTER:
             for duthost in duthosts.frontend_nodes:
-                ensure_no_l3_drops(duthost, asic_index, packets_count=PKT_NUMBER)
-                ensure_no_l2_drops(duthost, asic_index, packets_count=PKT_NUMBER)
+                ensure_no_l3_drops(duthost, packets_count=PKT_NUMBER)
+                ensure_no_l2_drops(duthost, packets_count=PKT_NUMBER)
     elif discard_group == "NO_DROPS":
         for duthost in duthosts.frontend_nodes:
-            ensure_no_l2_drops(duthost, asic_index, packets_count=PKT_NUMBER)
-            ensure_no_l3_drops(duthost, asic_index, packets_count=PKT_NUMBER)
+            ensure_no_l2_drops(duthost, packets_count=PKT_NUMBER)
+            ensure_no_l3_drops(duthost, packets_count=PKT_NUMBER)
     else:
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2', 'L3', 'ACL' or 'NO_DROPS'")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Seeing failures on testbed with different hwsku's with different asic count.
In Chassis testbed, with different LC hwSKU , if one of the selected LCs have 3 asics and another LC has 2 asics, we see the below failure:
```
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members] 
-------------------------------- live log call ---------------------------------
02:08:08 utilities.wait_until                     L0118 ERROR  | Exception caught while checking <lambda>:Traceback (most recent call last):
  File "/./tests/common/utilities.py", line 112, in wait_until
    check_result = condition(*args, **kwargs)
  File "/./tests/common/helpers/drop_counters/drop_counters.py", line 101, in <lambda>
    check_drops_on_dut = lambda: packets_count in get_drops_across_all_duthosts()
  File "/./tests/common/helpers/drop_counters/drop_counters.py", line 94, in get_drops_across_all_duthosts
    pkt_drops = get_pkt_drops(duthost, get_cnt_cli_cmd, asic_index)
  File "/./tests/common/helpers/drop_counters/drop_counters.py", line 34, in get_pkt_drops
    namespace = duthost.get_namespace_from_asic_id(asic_index)
  File "/./tests/common/devices/multi_asic.py", line 230, in get_namespace_from_asic_id
    raise ValueError("Invalid asic_id '{}' passed as input".format(asic_id))
ValueError: Invalid asic_id '2' passed as input
, error:Invalid asic_id '2' passed as input
```

Issue is because the get_pkt_drop function takes the asic_index of the selected HwSKU or selected LC.
If the random asic_index selected is 2, and if get_pkt_drops() is called with asic_index 2 for a different LC in the testbed with 2 asics, the test fails as asic_index 2 is not present in the different LC.

#### How did you do it?
Fixed get_pkt_drops to go through all asic namespaces and get drop count.
This way get_pkt_drops will return packet drops for all interfaces from all namespaces.
#### How did you verify/test it?
Verified on packet chassis, voq chassis and single asic DUT testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
