### PR TITLE
pre check traffic before pfc storm

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -470,6 +470,8 @@ class SendVerifyTraffic():
             self.vlan_mac = "00:aa:bb:cc:dd:ee"
         else:
             self.vlan_mac = router_mac
+        # Verify traffic before pfc storm
+        self.verify_rx_ingress("forward")
 
     def verify_tx_egress(self, action):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Sometimes pfcwd cases failed due to verify_rx_ingress("forward") failure, it is possibly caused by previous scripts or testbed in bad status before pfcwd script running, which is very confusing.
Add pre check traffic before pfc storm, to confirm the traffic issue is caused by pfc storm or not.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
run script test_pfcwd_function.py.
```
-------------------------------------------------------------- generated xml file: /data/tests/logs/tr_2023-08-06-06-36-22.xml --------------------------------------------------------------
---------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------
07:11:16 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================= 4 passed in 2092.53 seconds ==========================
INFO:root:Can not get Allure report URL. Please check logs
root@1d773de39259:/data/tests# cat /data/tests/logs/tr_2023-08-06-06-36-22.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="1d773de39259" name="pytest" skipped="0" tests="4" time="2092.543" timestamp="2023-08-06T06:36:24.015327"><properties><property name="topology" value="t0-64"/><property name="testbed" value="t0-64-2"/><property name="timestamp" value="2023-08-06 06:36:55.493077"/><property name="host" value="mth-t0-64"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-8102_64h_o-r0"/><property name="hwsku" value="Cisco-8102-C64"/><property name="os_version" value="azure_cisco_202205.5599-dirty-20230719.125413"/></properties><testcase classname="pfcwd.test_pfcwd_function.TestPfcwdFunc" file="pfcwd/test_pfcwd_function.py" line="744" name="test_pfcwd_actions[mth-t0-64]" time="555.819"><properties><property name="start" value="2023-08-06 06:36:39.606694"/><property name="end" value="2023-08-06 06:45:55.428143"/></properties></testcase><testcase classname="pfcwd.test_pfcwd_function.TestPfcwdFunc" file="pfcwd/test_pfcwd_function.py" line="814" name="test_pfcwd_multi_port[mth-t0-64]" time="400.505"><properties><property name="start" value="2023-08-06 06:45:55.434580"/><property name="end" value="2023-08-06 06:52:35.942961"/></properties></testcase><testcase classname="pfcwd.test_pfcwd_function.TestPfcwdFunc" file="pfcwd/test_pfcwd_function.py" line="891" name="test_pfcwd_mmu_change[mth-t0-64-None]" time="312.872"><properties><property name="start" value="2023-08-06 06:52:35.946112"/><property name="end" value="2023-08-06 06:57:48.821057"/></properties></testcase><testcase classname="pfcwd.test_pfcwd_function.TestPfcwdFunc" file="pfcwd/test_pfcwd_function.py" line="974" name="test_pfcwd_port_toggle[mth-t0-64]" time="807.726"><properties><property name="start" value="2023-08-06 06:57:48.824372"/><property name="end" value="2023-08-06 07:11:16.553131"/></properties></testcase></testsuite></testsuites>root@1d773de39259:/data/tests# 

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
