### PR TITLE
Cisco-8000 psu led support

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -32,7 +32,7 @@ def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
 def get_dut_psu_line_pattern(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
-    elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0" or dut.facts['asic_type'] == "cisco-8000":
+    elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0":
         psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(N/A)")
     else:
         """

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -253,7 +253,7 @@ def test_show_platform_psustatus_json(duthosts, enum_supervisor_dut_hostname):
     psu_info_list = json.loads(psu_status_output)
 
     # TODO: Compare against expected platform-specific output
-    if duthost.facts["platform"] == "x86_64-dellemc_z9332f_d1508-r0" or duthost.facts['asic_type'] == "cisco-8000":
+    if duthost.facts["platform"] == "x86_64-dellemc_z9332f_d1508-r0":
         led_status_list = ["N/A"]
     else:
         led_status_list = ["green", "amber", "red", "off"]


### PR DESCRIPTION
### Description of PR
Cisco-8000 platforms added support to display the PSU led colors. This has caused test failures since scripts are hard-coded to expect 'N/A' as the led color for these platforms.

### Summary:
Fixes 8/1 PSU related failures from https://migsonic.atlassian.net/browse/MIGSMSFT-246

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PSU tests cases fail due to expecting `N/A` PSU led state, when actual colors are now displayed.

#### How did you do it?
Remove the `cisco-8000` led color filter from psu test scripts in order for tests to pass using the default logic.
