### PR TITLE
[ansible] Update shell_cmds.py to print exact failed service

### DIFF
--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -132,11 +132,14 @@ def main():
     startd = datetime.datetime.now()
 
     results = []
+    failed_cmds = []
     for cmd in cmds:
-        result = run_cmd(module, cmd, timeout)
+        result = run_cmd(module, cmd)
         results.append(result)
-        if result['rc'] != 0 and not continue_on_fail:
-            break
+        if result['rc'] != 0:
+            failed_cmds.append(cmd)
+            if not continue_on_fail:
+                break
 
     endd = datetime.datetime.now()
     delta = endd - startd
@@ -152,7 +155,8 @@ def main():
 
     if output['failed']:
         module.fail_json(
-            msg='At least running one of the commands failed', **output)
+            msg='At least running one of the commands failed:{}\nfailed command:{}'
+            .format(**output, failed_cmds))
     module.exit_json(**output)
 
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -155,8 +155,7 @@ def main():
 
     if output['failed']:
         module.fail_json(
-            msg='At least running one of the commands failed:{}\nfailed command:{}'
-            .format(**output, failed_cmds))
+            msg='Running command(s) failed: {}!'.format(failed_cmds))
     module.exit_json(**output)
 
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -154,8 +154,11 @@ def main():
     )
 
     if output['failed']:
+        for idx in len(failed_cmds):
+            print("Running command failed: {}!.format(failed_cmds))
         module.fail_json(
-            msg='Running command(s) failed: {}!'.format(failed_cmds))
+            msg='At least running one of the commands failed', **output)
+
     module.exit_json(**output)
 
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -154,8 +154,8 @@ def main():
     )
 
     if output['failed']:
-        for idx in len(failed_cmds):
-            print("Running command failed: {}!".format(failed_cmds[idx]))
+        for failed_cmd in failed_cmds:
+            print("Running command failed: {}!".format(failed_cmd))
         module.fail_json(
             msg='At least running one of the commands failed', **output)
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -155,7 +155,7 @@ def main():
 
     if output['failed']:
         for idx in len(failed_cmds):
-            print("Running command failed: {}!".format(failed_cmds))
+            print("Running command failed: {}!".format(failed_cmds[idx]))
         module.fail_json(
             msg='At least running one of the commands failed', **output)
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -134,7 +134,7 @@ def main():
     results = []
     failed_cmds = []
     for cmd in cmds:
-        result = run_cmd(module, cmd)
+        result = run_cmd(module, cmd, timeout)
         results.append(result)
         if result['rc'] != 0:
             failed_cmds.append(cmd)

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -155,7 +155,7 @@ def main():
 
     if output['failed']:
         for idx in len(failed_cmds):
-            print("Running command failed: {}!.format(failed_cmds))
+            print("Running command failed: {}!".format(failed_cmds))
         module.fail_json(
             msg='At least running one of the commands failed', **output)
 

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -146,6 +146,7 @@ def main():
 
     output = dict(
         cmds=cmds,
+        failed_cmds=failed_cmds,
         results=results,
         start=str(startd),
         end=str(endd),
@@ -154,8 +155,6 @@ def main():
     )
 
     if output['failed']:
-        for failed_cmd in failed_cmds:
-            print("Running command failed: {}!".format(failed_cmd))
         module.fail_json(
             msg='At least running one of the commands failed', **output)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -650,6 +650,9 @@ class SonicHost(AnsibleHostBase):
         for service in self.critical_services:
             cmd = 'docker exec {} supervisorctl status'.format(service)
             cmds.append(cmd)
+        tmp = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)
+        for key in tmp.keys():
+            logging.info("wenyi: shell commands output keys:{}\n".format(key))
         results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
 
         # Extract service name of each command result, transform results list to a dict keyed by service name

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -650,9 +650,6 @@ class SonicHost(AnsibleHostBase):
         for service in self.critical_services:
             cmd = 'docker exec {} supervisorctl status'.format(service)
             cmds.append(cmd)
-        tmp = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)
-        for key in tmp.keys():
-            logging.info("wenyi: shell commands output keys:{}\n".format(key))
         results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
 
         # Extract service name of each command result, transform results list to a dict keyed by service name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This is an enhancement for sanity check or other places where call `shell_cmds` with batch of commands, in such case currently we only tell `one of these commands` failed. 

This PR helps to print the failed command so user would know which service has issue in `failed_cmds` list

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
current impl:
```
"cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec bgp supervisorctl status", "docker exec database supervisorctl status", "docker exec lldp supervisorctl status", "docker exec swss supervisorctl status", "docker exec syncd supervisorctl status", "docker exec teamd supervisorctl status"]}}, "msg": "At least running one of the commands failed"}
```

new impl have additional failed_cmds in output:
```
"start": "2023-08-17 01:07:54.816662",###  "failed_cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec bgp supervisorctl status", "docker exec database supervisorctl status", "docker exec lldp supervisorctl status", "docker exec swss supervisorctl status", "docker exec syncd supervisorctl status", "docker exec teamd supervisorctl status"]### , "delta": "0:00:02.618702", "invocation": {"module_args": {"continue_on_fail": true, "timeout": 30, "cmds": ["docker exec pmon supervisorctl status", "docker exec snmp supervisorctl status", "docker exec lldp supervisorctl status", "docker exec database supervisorctl status", "docker exec bgp supervisorctl status", "docker exec database supervisorctl status", "docker exec lldp supervisorctl status", "docker exec swss supervisorctl status", "docker exec syncd supervisorctl status", "docker exec teamd supervisorctl status"]}}, "msg": "At least running one of the commands failed"}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
