### PR TITLE
[202305] Fix creategraph.py python3 compatibility issue

### DIFF
--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -113,21 +113,21 @@ class LabGraph(object):
                 devtype = row['Type'].lower()
                 if 'pdu' in devtype:
                     for key in row:
-                        attrs[key] = row[key].decode('utf-8')
+                        attrs[key] = row[key]
                     etree.SubElement(pdus_root, 'DevicePowerControlInfo', attrs)
                 elif 'consoleserver' in devtype:
                     for key in row:
-                        attrs[key] = row[key].decode('utf-8')
+                        attrs[key] = row[key]
                     etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
                 elif 'mgmttstorrouter' in devtype:
                     for key in row:
-                        attrs[key] = row[key].decode('utf-8')
+                        attrs[key] = row[key]
                     etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
                     etree.SubElement(bmc_root, 'DeviceBmcInfo', attrs)
                 else:
                     for key in row:
                         if key.lower() != 'managementip' and key.lower() != 'protocol':
-                            attrs[key] = row[key].decode('utf-8')
+                            attrs[key] = row[key]
                     etree.SubElement(devices_root, 'Device', attrs)
 
     def read_links(self):
@@ -178,7 +178,7 @@ class LabGraph(object):
             attrs = {}
             for key in link:
                 if key.lower() != 'vlanid' and key.lower() != 'vlanmode':
-                    attrs[key] = link[key].decode('utf-8')
+                    attrs[key] = link[key]
             etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
 
     def read_consolelinks(self):
@@ -190,7 +190,7 @@ class LabGraph(object):
             for cons in csv_cons:
                 attrs = {}
                 for key in cons:
-                    attrs[key] = cons[key].decode('utf-8')
+                    attrs[key] = cons[key]
                 etree.SubElement(conslinks_root, 'ConsoleLinkInfo', attrs)
                 self.consoles.append(cons)
 
@@ -203,7 +203,7 @@ class LabGraph(object):
             for bmc in csv_bmc:
                 attrs = {}
                 for key in bmc:
-                    attrs[key] = bmc[key].decode('utf-8')
+                    attrs[key] = bmc[key]
                 etree.SubElement(bmclinks_root, 'BmcLinkInfo', attrs)
                 self.bmcs.append(bmc)
 
@@ -216,7 +216,7 @@ class LabGraph(object):
             for pdu_link in csv_pdus:
                 attrs = {}
                 for key in pdu_link:
-                    attrs[key] = pdu_link[key].decode('utf-8')
+                    attrs[key] = pdu_link[key]
                 etree.SubElement(pduslinks_root, 'PowerControlLinkInfo', attrs)
                 self.pdus.append(pdu_link)
 
@@ -270,6 +270,10 @@ class LabGraph(object):
         root.append(self.bmcgroot)
         root.append(self.pcgroot)
         result = etree.tostring(root, pretty_print=True)
+        if isinstance(result, bytes):
+            result = result.decode('utf-8')
+        else:
+            result = str(result)
         onexml.write(result)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This fix is only required for 202305 branch.

Branch 202305 is the only branch uses python3 AND "creategraph.py". Older branches are still using python2.
Master branch is also using python3. However, the creategraph.py tool and XML based connection graph files have been deprecated.

#### How did you do it?
The creategraph.py tool has some compatibility issue under python3. This change fixed the issues to make it work under both python2 and python3.

#### How did you verify/test it?
Tested run the tool to generate XML graph under both python2 and python3.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
