### PR TITLE
[202012] Fix potential KeyError of fixtures like vmhost, ptfhost, fanouthosts 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,8 @@ def enhance_inventory(request):
     This fixture is automatically applied, you don't need to declare it in your test script.
     """
     inv_opt = request.config.getoption("ansible_inventory")
+    if isinstance(inv_opt, list):
+        return
     inv_files = [inv_file.strip() for inv_file in inv_opt.split(",")]
     try:
         setattr(request.config.option, "ansible_inventory", inv_files)
@@ -369,7 +371,7 @@ def localhost(ansible_adhoc):
 
 
 @pytest.fixture(scope="session")
-def ptfhost(ansible_adhoc, tbinfo, duthost):
+def ptfhost(enhance_inventory, ansible_adhoc, tbinfo, duthost):
     if "ptf_image_name" in tbinfo and "docker-keysight-api-server" in tbinfo["ptf_image_name"]:
         return None
     if "ptf" in tbinfo:
@@ -382,7 +384,7 @@ def ptfhost(ansible_adhoc, tbinfo, duthost):
 
 
 @pytest.fixture(scope="module")
-def k8smasters(ansible_adhoc, request):
+def k8smasters(enhance_inventory, ansible_adhoc, request):
     """
     Shortcut fixture for getting Kubernetes master hosts
     """
@@ -414,7 +416,7 @@ def k8scluster(k8smasters):
 
 
 @pytest.fixture(scope="module")
-def nbrhosts(ansible_adhoc, tbinfo, creds, request):
+def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
     """
     Shortcut fixture for getting VM host
     """
@@ -457,7 +459,7 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
 
 
 @pytest.fixture(scope="module")
-def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
+def fanouthosts(enhance_inventory, ansible_adhoc, conn_graph_facts, creds, duthosts):
     """
     Shortcut fixture for getting Fanout hosts
     """
@@ -543,7 +545,7 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
 
 
 @pytest.fixture(scope="session")
-def vmhost(ansible_adhoc, request, tbinfo):
+def vmhost(enhance_inventory, ansible_adhoc, request, tbinfo):
     server = tbinfo["server"]
     inv_files = get_inventory_files(request)
     vmhost = get_test_server_host(inv_files, server)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry-pick #9259 

The fixtures creating testbed device objects depend on supplied inventory files. When multiple inventory files are supplied to the pytest command, fixture 'enhance_inventory' ensures that a list of inventory files are supplied to ansible's InventoryManager under the hood.

Although fixture `enhance_inventory` is set to "autouse". There is still chance that it is executed after fixtures like vmhost, ptfhost, fanouthots, etc. In this case, multiple inventory files may be supplied to InventoryManager as a string using "," to separate the inventory files. Then InventoryManager may fail to find the correct inventory files and eventually result in "KeyError" while trying to return some hosts defined in the inventory files.

#### How did you do it?
This change fixed the issue by specifying "enhance_inventory" in the argument list of fixtures vmhost, fanouthosts, ptfhost, etc. This can ensure that fixture "enhance_inventory" is always executed before the device objects creating fixtures. The ansible InventoryManager can always get a list of inventory files instead of a string with "," in the middle.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
