### PR TITLE
[cacl] stabilize the cacl test

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -37,8 +37,8 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                    version="v2c",
                    community=creds['snmp_rocommunity'],
                    wait=True,
-                   timeout=20,
-                   interval=20)
+                   timeout=30,
+                   interval=5)
 
     # Ensure we can send an NTP request
     if NTPLIB_INSTALLED:


### PR DESCRIPTION
The timeout and the interval in the waituntil function should not be same, when it is same, waituntil could not work as expected, it will always only run the function for one time, if the function we are checking return False, it will not do retry.

Change-Id: Ib6069609a94af9b7e966fb7393247624b247ad56

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Fixes # (issue) the test not stable issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
stabilize the cacl test case
#### How did you do it?
Change the timeout and the interval in the waituntil func
#### How did you verify/test it?
Run the test case few times, and all pass.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
