### PR TITLE
[202205] test_radv_ipv6_ra is unnecessarily skipped on non-dualtor topo

### DIFF
--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -3,13 +3,12 @@ import logging
 
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_garp_service                                # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr                         # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_common import cable_type                                     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_garp_service                                # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # noqa F401
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr                         # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
@@ -23,16 +22,14 @@ RADV_BACKUP_CONF_FILE = '/tmp/radvd.conf'
 RADV_MIN_RA_INTERVAL_SECS = 3
 RADV_MAX_RA_INTERVAL_SECS = 4
 
-"""
-@summary: This fixture collects the data related to downlink VLAN port(s) and
-the connected PTF port(s) required to setup the RADV tests
-
-"""
-
 
 @pytest.fixture(scope="module", autouse=True)
-def radv_test_setup(request, duthosts, ptfhost, tbinfo):
-    duthost = duthosts[0]
+def radv_test_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    """
+    @summary: This fixture collects the data related to downlink VLAN port(s) and
+    the connected PTF port(s) required to setup the RADV tests
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     logging.info("radv_test_setup() DUT {}".format(duthost.hostname))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -73,27 +70,22 @@ def radv_test_setup(request, duthosts, ptfhost, tbinfo):
     return vlan_interfaces_list
 
 
-"""
-@summary: Updates min/max RA interval in RADVd's config file
-
-"""
-
-
 def dut_update_ra_interval(duthost, ra, interval):
+    """
+    @summary: Updates min/max RA interval in RADVd's config file
+    """
     logging.info("Updating %s to %d in RADVd's config file:%s", ra, int(interval), RADV_CONF_FILE)
     cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)
     duthost.shell("docker exec radv {}".format(cmd))
 
 
-"""
-@summary: A fixture that updates the RADVd's periodic RA update intervals and restores the
-intervals to old values after the test
-
-"""
-
-
 @pytest.fixture
-def dut_update_radv_periodic_ra_interval(duthost):
+def dut_update_radv_periodic_ra_interval(duthosts, rand_one_dut_hostname):
+    """
+    @summary: A fixture that updates the RADVd's periodic RA update intervals and restores the
+    intervals to old values after the test
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     pytest_assert(duthost.is_service_fully_started('radv'), "radv service not running")
 
     cmd = 'docker exec radv [ -f {} ] && echo "1" || echo "0"'.format(RADV_CONF_FILE)
@@ -117,18 +109,16 @@ def dut_update_radv_periodic_ra_interval(duthost):
     logging.info("Successfully restored RADVd's config back to original")
 
 
-"""
-@summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
-
-"""
-
-
 def test_radv_router_advertisement(
-        request, tbinfo,
-        duthost, ptfhost,
-        radv_test_setup,
+        duthosts, rand_one_dut_hostname,
+        ptfhost, radv_test_setup,
         dut_update_radv_periodic_ra_interval,
-        toggle_all_simulator_ports_to_upper_tor):
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+):
+    """
+    @summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -146,13 +136,15 @@ def test_radv_router_advertisement(
                    log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log", is_python3=True)
 
 
-"""
-@summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
-
-"""
-
-
-def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup, toggle_all_simulator_ports_to_upper_tor):
+def test_solicited_router_advertisement(
+        duthosts, rand_one_dut_hostname,
+        ptfhost, radv_test_setup,
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+):
+    """
+    @summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -171,18 +163,15 @@ def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_
                    log_file="/tmp/radv_ipv6_ra_test.RadvSolicitedRATest.log", is_python3=True)
 
 
-"""
-@summary: Test validates the M flag in RADVd's periodic router advertisement sent on each VLAN interface 
-
-"""
-
-
 def test_unsolicited_router_advertisement_with_m_flag(
-    request, tbinfo,
-    duthost, ptfhost,
-    radv_test_setup,
-    toggle_all_simulator_ports_to_upper_tor,
+        duthosts, rand_one_dut_hostname,
+        ptfhost, radv_test_setup,
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
 ):
+    """
+    @summary: Test validates the M flag in RADVd's periodic router advertisement sent on each VLAN interface
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -200,13 +189,15 @@ def test_unsolicited_router_advertisement_with_m_flag(
                    log_file="/tmp/router_adv_mflag_test.RadvUnSolicitedRATest.log", is_python3=True)
 
 
-"""
-@summary: Test validates the M flag in RADVd's solicited router advertisement sent on each VLAN interface
-
-"""
-
-
-def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, duthost, radv_test_setup, toggle_all_simulator_ports_to_upper_tor):
+def test_solicited_router_advertisement_with_m_flag(
+        duthosts, rand_one_dut_hostname,
+        ptfhost, radv_test_setup,
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+):
+    """
+    @summary: Test validates the M flag in RADVd's solicited router advertisement sent on each VLAN interface
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
What is the motivation for this PR?
Cherry-pick #9048

Script test_radv_ipv6_ra.py is unnecessarily skipped on non-dualtor topology. The reason is that this script uses fixture toggle_all_simulator_ports_to_upper_tor which depends on cable_type fixture.

The cable_type fixture requires that the topology must has "dualtor", otherwise skip the test.

How did you do it?
This change updated the test_radv_ipv6_ra.py to use fixture toggle_all_simulator_ports_to_random_side.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
