### PR TITLE
[Dual-Tor][Mellanox]Use GRE type 0x8949 when it is Nvidia platform in the test_encap_with_mirror_session test.

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -247,7 +247,9 @@ def setup_mirror_session(rand_selected_dut, setup_uplink):
     The mirror session is to trigger the issue. No packet is mirrored actually.
     """
     session_name = "dummy_session"
-    cmd = "config mirror_session add {} 25.192.243.243 20.2.214.125 8 100 1234 0".format(session_name)
+    # Nvidia platforms support only the gre_type 0x8949, which is 35145 in decimal.
+    gre_type = 35145 if "mellanox" == rand_selected_dut.facts['asic_type'] else 1234
+    cmd = "config mirror_session add {} 25.192.243.243 20.2.214.125 8 100 {} 0".format(session_name, gre_type)
     rand_selected_dut.shell(cmd=cmd)
     uplink_port_id = setup_uplink
     yield uplink_port_id


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test case test_encap_with_mirror_session in tests/dualtor/test_ipinip.py uses the GRE type 1234(0x04d2) when configuring the mirror session.
But for Nvidia platforms, we only support the GRE type 35145(0x8949) for mirroring and this is already noted in our release notes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the GRE type test issue in test_encap_with_mirror_session test.
#### How did you do it?
Use GRE type 0x8949 when it is Nvidia platform.
#### How did you verify/test it?
Run the test on 4600C dualtor setup, it passed.
#### Any platform specific information?
This change is only for Nvidia platforms.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
