### PR TITLE
cisco change for ecn-config-update

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -54,13 +54,27 @@ def ensure_application_of_updated_config(duthost, configdb_field, values):
         values: expected value(s) of configdb_field
     """
     def _confirm_value_in_asic_db():
-        table_name = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
-        wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(table_name))["stdout"]
-        wred_data = ast.literal_eval(wred_data)
-        for field, value in zip(configdb_field.split(','), values.split(',')):
-            if value != wred_data[WRED_MAPPING[field]]:
-                return False
-        return True
+        if(duthost.facts['asic_type'] == 'cisco-8000'):
+            wred_objects = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
+            wred_objects = wred_objects.split("\n")
+            for wred_object in wred_objects:
+                wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(wred_object))["stdout"]
+                if('NULL' in wred_data):
+                    continue
+                wred_data = ast.literal_eval(wred_data)
+                for field, value in zip(configdb_field.split(','), values.split(',')):
+                    if value != wred_data[WRED_MAPPING[field]]:
+                        return False
+                return True
+            return False
+        else:
+            table_name = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
+            wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(table_name))["stdout"]
+            wred_data = ast.literal_eval(wred_data)
+            for field, value in zip(configdb_field.split(','), values.split(',')):
+                if value != wred_data[WRED_MAPPING[field]]:
+                    return False
+            return True
 
     logger.info("Validating fields in ASIC DB...")
     pytest_assert(


### PR DESCRIPTION
**Description of PR**
For Cisco platforms, the command "sonic-db-cli ASIC_DB keys *WRED*” used in this testcase return 2 WRED object instead of 1 that the script expects. This is because one is the "default” WRED profile that SAI/SDK creates with default setting, while other is the user configured WRED profile that sonic creates.

Summary: This can be fixed by checking which WRED object corresponds to default WRED profile and which one corresponds to user configured WRED profile; then ignoring the default profile and using the user configured profile for the testcase

**Type of change**

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

**Back port request**
- [ ] 201911
- [ ] 202012
- [x] 202205

**Approach**

**What is the motivation for this PR?**
All 4 testcases in test_ecn_config_update.py fail on all testbeds

**How did you do it?**
Check which one is the default profile and which one is the user configured profile created by sonic using cli 'sonic-db-cli ASIC_DB hgetall <wred-obj-name>'. (Default profile will have 'NULL' output for this CLI)
Then ignoring the default profile and using the other one for the testcase.
This is done only for 'Cisco' platforms so that testcase logic does not change for other vendors.

**How did you verify/test it?**
Tested it on Cisco-8000 DualToR and T0 testbeds
