### PR TITLE
Removed XFAIL for test_continuous_reboot which is passing on dx010 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -836,13 +836,6 @@ platform_tests/test_reboot.py::test_cold_reboot:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6767
 
-platform_tests/test_reboot.py::test_continuous_reboot:
-  xfail:
-    reason: "case failed and waiting for fix"
-    conditions:
-      - "hwsku in ['Celestica-DX010-C32']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6767
-
 platform_tests/test_reboot.py::test_fast_reboot:
   skip:
     reason: "Skip test_fast_reboot for m0/mx"


### PR DESCRIPTION
### Description of PR
I noticed that XFAIL conditional mark was set for this test. I disabled it and then re-ran tests on 20201231.110 and 202205.36 images on dx010 and they both passed:

Summary:
Fixes: [SONiC_Nightly][Failed_Case][platform_tests.test_reboot][test_continuous_reboot][20220531][DX010] - [20201231]
(The GitHub issue in the conditional mark file does not correspond to this issue, hence not linking here )

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach

#### What is the motivation for this PR?
XFAIL conditional mark was set for this test that was giving the impression that the test was failing.

#### How did you do it?
I modified the conditional_mark YAML file to remove the XFAIL for that particular test and platform combination

#### How did you verify/test it?
re-ran tests on 20201231.110 and 202205.36 images on dx010 and they both passed
