### PR TITLE
update ser timeout ignore memory for th2

### DIFF
--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -263,6 +263,10 @@ SKIP_MEMORY_PER_ASIC = {
             'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE0.mmu_xpe0', 'ING_SNAT.ipipe0',
             'MMU_THDM_MCQE_QUEUE_OFFSET_B_PIPE1.mmu_xpe0', 'MMU_THDU_OFFSET_QGROUP_PIPE3.mmu_xpe0',
             'ING_VP_VLAN_MEMBERSHIP.ipipe0', 'MMU_THDU_CONFIG_PORT_PIPE3.mmu_xpe0', 'FP_GLOBAL_MASK_TCAM.ipipe0',
+            'IS_TDM_CALENDAR0.ipipe0', 'IS_TDM_CALENDAR1.ipipe0', 'IS_TDM_CALENDAR0_PIPE0.ipipe0',
+            'IS_TDM_CALENDAR0_PIPE1.ipipe0', 'IS_TDM_CALENDAR0_PIPE2.ipipe0', 'IS_TDM_CALENDAR0_PIPE3.ipipe0',
+            'IS_TDM_CALENDAR1_PIPE0.ipipe0', 'IS_TDM_CALENDAR1_PIPE1.ipipe0', 'IS_TDM_CALENDAR1_PIPE2.ipipe0',
+            'IS_TDM_CALENDAR1_PIPE3.ipipe0',
         ],
         'timeout_basic': [
         ],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
24688867

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_ser failed due to timeout from new incoming memory for th2

#### How did you do it?
update the failure memory into timeout ignore list

#### How did you verify/test it?
run the original case

#### Any platform specific information?
TH2 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
