### PR TITLE
Refactor fixture `recover_acl_rule` and and use it in module `cacl/test_cacl_function.py`.

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -19,7 +19,7 @@ SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
 
 
-def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds):
+def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds, recover_acl_rule):
     """Test control plane ACL functionality on a SONiC device"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/common/templates/default_acl_rules.json
+++ b/tests/common/templates/default_acl_rules.json
@@ -1,0 +1,38 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "dataacl": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "l2": {
+                                    "config": {
+                                        "ethertype": "2048",
+                                        "vlan_id": "1000"
+                                    }
+                                },
+                                "input_interface": {
+                                    "interface_ref":
+                                    {
+                                        "config": {
+                                            "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2244,6 +2244,7 @@ testutils.verify_packets_any = verify_packets_any_fixed
 if not hasattr(Mask, "set_do_not_care_scapy"):
     Mask.set_do_not_care_scapy = Mask.set_do_not_care_packet
 
+
 @pytest.fixture(scope="module")
 def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """ Fixture for sharing variables beatween test cases """
@@ -2253,6 +2254,7 @@ def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         data[asic.asic_index] = {}
 
     yield data
+
 
 @pytest.fixture(scope="module")
 def recover_acl_rule(duthosts, enum_rand_one_per_hwsku_frontend_hostname, collector):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2247,7 +2247,7 @@ if not hasattr(Mask, "set_do_not_care_scapy"):
 
 @pytest.fixture(scope="module")
 def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """ Fixture for sharing variables beatween test cases """
+    """ Fixture for sharing variables between test cases """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     data = {}
     for asic in duthost.asics:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2246,19 +2246,8 @@ if not hasattr(Mask, "set_do_not_care_scapy"):
 
 
 @pytest.fixture(scope="module")
-def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """ Fixture for sharing variables between test cases """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    data = {}
-    for asic in duthost.asics:
-        data[asic.asic_index] = {}
-
-    yield data
-
-
-@pytest.fixture(scope="module")
-def recover_acl_rule(duthosts, enum_rand_one_per_hwsku_frontend_hostname, collector):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+def recover_acl_rule(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     base_dir = os.path.dirname(os.path.realpath(__file__))
     template_dir = os.path.join(base_dir, "common/templates")

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -155,14 +155,3 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("crm config polling interval {}".format(original_crm_polling_interval))["stdout"]
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
-
-
-@pytest.fixture(scope="module")
-def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """ Fixture for sharing variables beatween test cases """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    data = {}
-    for asic in duthost.asics:
-        data[asic.asic_index] = {}
-
-    yield data

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -155,3 +155,14 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("crm config polling interval {}".format(original_crm_polling_interval))["stdout"]
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
+
+
+@pytest.fixture(scope="module")
+def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """ Fixture for sharing variables between test cases """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    data = {}
+    for asic in duthost.asics:
+        data[asic.asic_index] = {}
+
+    yield data


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `cacl/test_cacl_function.py`, it will use command `acl-loader delete` to delete all acl rules, no matter if the testbed has DATAACL rules before test or not. If this testbed has DATAACL rules before, this deletion will cause inconsistent between previous running config and current running config, and will cause unnecessary config reload. In PR #9199 , we have a fixture `recover_acl_rule` to recovery acl rules. So in this PR, I refactor this fixture and use this fixture to recover acl rules in module `cacl/test_cacl_function.py`.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module `cacl/test_cacl_function.py`, it will use command `acl-loader delete` to delete all acl rules, no matter if the testbed has DATAACL rules before test or not. If this testbed has DATAACL rules before, this deletion will cause inconsistent between previous running config and current running config, and will cause unnecessary config reload. In PR #9199 , we have a fixture `recover_acl_rule` to recovery acl rules. So in this PR, I refactor this fixture and use this fixture to recover acl rules in module `cacl/test_cacl_function.py`.

#### How did you do it?
Move fixture `recover_acl_rule` to tests/conftest.py and use this fixture to recover acl rules in module `cacl/test_cacl_function.py`.

#### How did you verify/test it?
```
07:34:42 conftest.core_dump_and_config_check      L1893 INFO   | Core dump and config check passed for cacl/test_cacl_function.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
