### PR TITLE
[202305][mx][acl] Fix test_acl_outer_vlan failed at mx (#9310)

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -18,6 +18,8 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from abc import abstractmethod
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.utilities import get_neighbor_ptf_port_list
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -736,16 +738,15 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
         self._teardown_arp_responder(ptfhost)
 
     def setup_cfg(self, duthost, tbinfo, vlan_setup, tagged_mode, ip_version):
-        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         cfg = {}
         cfg['stage'] = EGRESS
         cfg['vlan_id'] = 10     # Dummy inner vlan id
         cfg['dst_mac'] = duthost.facts['router_mac']    # MAC address should be router_mac rather than ptf mac
         # We will inject packet with vlan from portchannel. The packet will egress from the
         # interface we setup
-        minigraph_portchannels = mg_facts['minigraph_portchannels']
-        member = list(minigraph_portchannels.values())[-1]['members'][-1]
-        cfg['src_port'] = mg_facts['minigraph_ptf_indices'][member]
+        upstream_neightbor_name = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]]
+        ptf_src_ports = get_neighbor_ptf_port_list(duthost, upstream_neightbor_name, tbinfo)
+        cfg['src_port'] = ptf_src_ports[-1]
         if TYPE_TAGGED == tagged_mode:
             cfg['dst_port'] = vlan_setup[100]['tagged_ports'][1]
             cfg['outer_vlan_id'] = 100


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflict of this PR: https://github.com/sonic-net/sonic-mgmt/pull/9310
MX doesn't have portchannel, which would cause failure in this case. This PR is to fix this problem.

#### How did you do it?
How did you do it?
Modify the method of getting upstream neighbor port.

#### How did you verify/test it?
Run tests in m0/mx/t0 physical testbeds, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
