### PR TITLE
Added expected error to ignore for bgp suppress TC

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -93,7 +93,7 @@ def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganaly
     if loganalyzer:
         ignoreRegex = [
             ".*ERR swss#supervisor-proc-exit-listener:.*Process \'orchagent\' is stuck in namespace \'host\' "
-            "\\(.* minutes\\)*"
+            "\\(.* minutes\\).*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -81,7 +81,7 @@ TRAFFIC_DATA_DROP = [
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganalyzer):
     """
-       Ignore expected errors during TC execution
+       Ignore expected error during TC execution
 
        Args:
             duthosts: list of DUTs.

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -92,7 +92,8 @@ def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganaly
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:
         ignoreRegex = [
-            ".*ERR swss#supervisor-proc-exit-listener:.*Process \'orchagent\' is stuck in namespace \'host\' \(.* minutes\)*"
+            ".*ERR swss#supervisor-proc-exit-listener:.*Process \'orchagent\' is stuck in namespace \'host\' "
+            "\\(.* minutes\\)*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -78,6 +78,25 @@ TRAFFIC_DATA_DROP = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganalyzer):
+    """
+       Ignore expected errors during TC execution
+
+       Args:
+            duthosts: list of DUTs.
+            rand_one_dut_hostname: Hostname of a random chosen dut
+            loganalyzer: Loganalyzer utility fixture
+    """
+    # When loganalyzer is disabled, the object could be None
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR swss#supervisor-proc-exit-listener:.*Process \'orchagent\' is stuck in namespace \'host\' \(.* minutes\)*"
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+
+
 @pytest.fixture(scope="function")
 def restore_bgp_suppress_fib(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
TC test_credit_loop fails with error log: 
ERR swss#supervisor-proc-exit-listener: Process 'orchagent' is stuck in namespace 'host' (1.0 minutes).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Considering that the test stops orchagent on purpose, messages ignored above should be added to loganalyzer. 
#### How did you do it?
Added ignore regex
#### How did you verify/test it?
Run TC, TC passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
