### PR TITLE
Get core dump files from dut if new core dump generates.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2039,6 +2039,10 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             if new_core_dumps[duthost.hostname]:
                 core_dump_check_pass = False
 
+                base_dir = os.path.dirname(os.path.realpath(__file__))
+                for new_core_dump in new_core_dumps[duthost.hostname]:
+                    duthost.fetch(src="/var/core/{}".format(new_core_dump), dest=os.path.join(base_dir, "logs"))
+
             logger.info("Collecting running config after test on {}".format(duthost.hostname))
             # get running config after running
             duts_data[duthost.hostname]["cur_running_config"] = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We want to get core dump files for debugging if new core dump generates. In this PR, we use function `duthost.fetch` to copy core dump files from DUT to test server and Elastictest supports downloading files under `tests/logs` folder. So we can get these core dump files. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
We want to get core dump files for debugging if new core dump generates. In this PR, we use function `duthost.fetch` to copy core dump files from DUT to test server and Elastictest supports downloading files under `tests/logs` folder. So we can get these core dump files. 

#### How did you do it?
We use function `duthost.fetch` to copy core dump files from DUT to test server and Elastictest supports downloading files under `tests/logs` folder.

#### How did you verify/test it?
```
yutongzhang@yutongzhang-sonic-mgmt:/var/src/sonic-mgmt-int-202012/tests/logs/str-s6000-on-4/var/core$ ls
testcoredump1.txt  testcoredump2.txt  testcoredump3.txt
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
