### PR TITLE
Remove test_decap xfail mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
@@ -28,14 +28,6 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[wa
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6656
 
-decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6657
-
 dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[202205] Remove test_decap xfail mark

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
#9250 has been merged to fix test_decap test failure.
This PR will remove test_decap xfail mark in 202205 branch.

#### How did you do it?
Remove test_decap xfail mark.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
