### PR TITLE
[Fanout] Enable port counters for Nokia-7215 and Arista-720DT fanout switch

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -99,7 +99,7 @@
             "FLEX_COUNTER_STATUS": "disable"
         },
         "PORT": {
-            "FLEX_COUNTER_STATUS": "disable"
+            "FLEX_COUNTER_STATUS": "enable"
         },
         "PORT_BUFFER_DROP": {
             "FLEX_COUNTER_STATUS": "disable"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable port counters for Nokia-7215 and Arista-720DT fanout switch. Current configuration template cause `portstat` command displays `N/A`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Enable port counters for Nokia-7215 and Arista-720DT fanout switch. Current configuration template cause `portstat` command displays `N/A`.

#### How did you do it?
Updated the configuration jinja template.

#### How did you verify/test it?
Verified on Nokia-7215 fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
