### PR TITLE
Add try-finally to recovery DUT in module `acl/test_stress_acl.py`. 

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -135,32 +135,32 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
     verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "forward")
+    try:
+        loops = 0
+        while loops <= loop_times:
+            logger.info("loops: {}".format(loops))
+            if loops == 0:
+                rand_selected_dut.shell(cmd_add_rules)
+            else:
+                readd_id = loops + ACL_RULE_NUMS
+                ip_addr1 = readd_id % 256
+                ip_addr2 = int(readd_id / 256)
+                rand_selected_dut.shell('sonic-db-cli CONFIG_DB hset "ACL_RULE|STRESS_ACL| RULE_{}" \
+                                        "SRC_IP" "20.0.{}.{}/32" "PACKET_ACTION" "DROP" "PRIORITY" "{}"'
+                                        .format(readd_id, ip_addr2, ip_addr1, readd_id))
+                acl_rule_list.append(readd_id)
 
-    loops = 0
-    while loops <= loop_times:
-        logger.info("loops: {}".format(loops))
-        if loops == 0:
-            rand_selected_dut.shell(cmd_add_rules)
-        else:
-            readd_id = loops + ACL_RULE_NUMS
-            ip_addr1 = readd_id % 256
-            ip_addr2 = int(readd_id / 256)
-            rand_selected_dut.shell('sonic-db-cli CONFIG_DB hset "ACL_RULE|STRESS_ACL| RULE_{}" \
-                                    "SRC_IP" "20.0.{}.{}/32" "PACKET_ACTION" "DROP" "PRIORITY" "{}"'
-                                    .format(readd_id, ip_addr2, ip_addr1, readd_id))
-            acl_rule_list.append(readd_id)
+            wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
+            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "drop")
 
-        wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
-        verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "drop")
+            del_rule_id = random.choice(acl_rule_list)
+            rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
+            wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
+            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, del_rule_id, "drop")
+            acl_rule_list.remove(del_rule_id)
 
-        del_rule_id = random.choice(acl_rule_list)
-        rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
-        wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
-        verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, del_rule_id, "drop")
-        acl_rule_list.remove(del_rule_id)
-
-        loops += 1
-
-    rand_selected_dut.shell(cmd_rm_all_rules)
-    rand_selected_dut.shell(cmd_remove_table)
-    logger.info("End")
+            loops += 1
+    finally:
+        rand_selected_dut.shell(cmd_rm_all_rules)
+        rand_selected_dut.shell(cmd_remove_table)
+        logger.info("End")

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -156,7 +156,8 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
             del_rule_id = random.choice(acl_rule_list)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
             wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
-            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, del_rule_id, "drop")
+            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
+                             acl_rule_list, del_rule_id, "drop")
             acl_rule_list.remove(del_rule_id)
 
             loops += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Module `acl/test_stress_acl.py` will add several acl tules in config to test stress, and will delete the stess rules at the end of TC. But if there is something wrong happens, it will go to the end of TC, and will not delete these rules. This will cause unnecessary config reload. In this PR, we add try-finally to ensure the logic of recovering will be exectued. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Module `acl/test_stress_acl.py` will add several acl tules in config to test stress, and will delete the stess rules at the end of TC. But if there is something wrong happens, it will go to the end of TC, and will not delete these rules. This will cause unnecessary config reload. In this PR, we add try-finally to ensure the logic of recovering will be exectued. 

#### How did you do it?
Add try-finally to ensure the logic of recovering will be exectued. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
