### PR TITLE
workaround PFCWD T1 related cases after PR 8859

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -72,7 +72,7 @@ def update_t1_test_ports(duthost, mg_facts, test_ports, tbinfo):
     Find out active IP interfaces and use the list to
     remove inactive ports from test_ports
     """
-    ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index="all")
+    ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index=0)
     port_list = []
     for iface in list(ip_ifaces.keys()):
         if iface.startswith("PortChannel"):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
24767839

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
All pfcwd related cases on T1 failed after the PR https://github.com/sonic-net/sonic-mgmt/pull/8859
the PR would modify the return value of ip_ifaces as a list instead of dict, then caused the issue.
"ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index="all")"

#### How did you do it?
Workaround the issue, use 0 instead of "all" for asic_index, and need the owner of PR 8859 to further analyze.

#### How did you verify/test it?
Run original failure case
pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg[str3-7060-acs-3] PASSED  

#### Any platform specific information?
T1

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
