### PR TITLE
[acl][m0] Test second vlan for m0-2vlan in test_acl

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -552,6 +552,36 @@
                                         "destination-ip-address": "fc02:1000::7/128"
                                     }
                                 }
+                            },
+                            "36": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 36
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::6/128"
+                                    }
+                                }
+                            },
+                            "37": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 37
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -510,6 +510,36 @@
                                         "destination-ip-address": "fc02:1000::7/128"
                                     }
                                 }
+                            },
+                            "36": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 36
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::6/128"
+                                    }
+                                }
+                            },
+                            "37": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 37
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1467,6 +1467,19 @@ def pytest_generate_tests(metafunc):        # noqa E302
         else:
             metafunc.parametrize('topo_scenario', ['default'], scope='module')
 
+    if 'vlan_name' in metafunc.fixturenames:
+        if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
+            if tbinfo['topo']['name'] == 'm0-2vlan':
+                metafunc.parametrize('vlan_name', ['Vlan1000', 'Vlan2000'], scope='module')
+            else:
+                metafunc.parametrize('vlan_name', ['Vlan1000'], scope='module')
+        # Non M0 topo
+        else:
+            if tbinfo['topo']['type'] in ['t0', 'mx']:
+                metafunc.parametrize('vlan_name', ['Vlan1000'], scope='module')
+            else:
+                metafunc.parametrize('vlan_name', ['no_vlan'], scope='module')
+
 
 def get_autoneg_tests_data():
     folder = 'metadata'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Test second vlan for m0-2vlan in test_acl

#### How did you do it?
Add a new fixture `vlan_name` to specify tested vlan.
Belows are IPs tested:
- IPv4:

| Vlan ID | ACL Action | IP |
| ------ | ------- | ----- |
|1000|default|192.168.0.123|
|1000|allow|192.168.0.122|
|1000|block|192.168.0.121|
|2000|default|192.168.0.253|
|2000|allow|192.168.0.252|
|2000|block|192.168.0.251|

- IPv6:

| Vlan ID | ACL Action | IP |
| ------ | ------- | ----- |
|1000|default|fc02:1000::5|
|1000|allow|fc02:1000::6|
|1000|drop|fc02:1000::7|
|2000|default|fc02:1000:0:1::5|
|2000|allow|fc02:1000:0:1::6|
|2000|drop|fc02:1000:0:1::7|

#### How did you verify/test it?
Run tests on t0/t1/m0/m0-2vlan/mx testbeds, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
