### PR TITLE
[202012] Run check_bgp_router_id post reboot

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -489,9 +489,6 @@ class AdvancedReboot:
             try:
                 if self.preboot_setup:
                     self.preboot_setup()
-                if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
-                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
-                                                        self.duthost.hostname)
                 if self.advanceboot_loganalyzer:
                     pre_reboot_analysis, post_reboot_analysis = self.advanceboot_loganalyzer
                     marker = pre_reboot_analysis()
@@ -509,6 +506,9 @@ class AdvancedReboot:
                 # the thread might still be running, and to catch any exceptions after pkill allow 10s to join
                 thread.join(timeout=10)
                 self.__verifyRebootOper(rebootOper)
+                if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
+                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
+                                                        self.duthost.hostname)
                 if self.postboot_setup:
                     self.postboot_setup()
             except Exception:

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -5,7 +5,6 @@ import collections
 import ipaddress
 import time
 import json
-import re
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from jinja2 import Template
@@ -521,19 +520,11 @@ def check_bgp_router_id(duthost, mgFacts):
     """
     Check bgp router ID is same as Loopback0
     """
-    if "201811" in duthost.os_version:
-        check_bgp_router_id_cmd = r"show ip bgp sum"
-    else:
-        check_bgp_router_id_cmd = r'vtysh -c "show ip bgp summary json"'
+    check_bgp_router_id_cmd = r'vtysh -c "show ip bgp summary json"'
     bgp_summary = duthost.shell(check_bgp_router_id_cmd, module_ignore_errors=True)
     try:
-        if "201811" in duthost.os_version:
-            match = re.search(r'BGP router identifier (\d+\.\d+\.\d+\.\d+)', bgp_summary["stdout"])
-            if match:
-                router_id = match.group(1)
-        else:
-            bgp_summary_json = json.loads(bgp_summary['stdout'])
-            router_id = str(bgp_summary_json['ipv4Unicast']['routerId'])
+        bgp_summary_json = json.loads(bgp_summary['stdout'])
+        router_id = str(bgp_summary_json['ipv4Unicast']['routerId'])
         loopback0 = str(mgFacts['minigraph_lo_interfaces'][0]['addr'])
         if router_id == loopback0:
             logger.info("BGP router identifier: %s == Loopback0 address %s" % (router_id, loopback0))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Run check_bgp_router_id post reboot
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Run check_bgp_router_id on target image after reboot

#### How did you do it?
Move check after ptf test

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
