### PR TITLE
lag_test: Add check to verify that an initial LACP packet was received

### DIFF
--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -97,6 +97,7 @@ class LacpTimingTest(BaseTest, RouterUtility):
         # Verify two LACP packets.
         (rcv_device, rcv_port, rcv_pkt, last_pkt_time) = self.dataplane.poll(
             port_number=self.exp_iface, timeout=self.timeout, exp_pkt=masked_exp_pkt)
+        self.assertTrue(rcv_pkt is not None, "Failed to receive initial LACP packet\n")
         last_pkt_time = round(float(last_pkt_time), 2)
 
         for i in range(0, self.interval_count):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

If, for some reason, the LAG session is down and there are no LACP PDU packets being sent back and forth, then the `LacpTimingTest` class will fail with a error about an invalid argument to `float`.

#### How did you do it?

In the LacpTimingTest class, when getting the initial LACP packet, first check to see that a packet was captured before trying to convert the timestamp value of the tuple to a `float`.

This doesn't necessarily prevent an error from being thrown, it just makes it a more graceful/expected failure.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
