### PR TITLE
[PTF python3 migration] Modify test_decap PTF script

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -130,10 +130,10 @@ class DecapPacketTest(BaseTest):
         # Index of current DSCP and TTL value in allowed DSCP_RANGE and TTL_RANGE
         self.dscp_in_idx = 0  # DSCP of inner layer.
         # DSCP of outer layer. Set different initial dscp_in and dscp_out
-        self.dscp_out_idx = len(self.DSCP_RANGE) / 2
+        self.dscp_out_idx = len(self.DSCP_RANGE) // 2
         self.ttl_in_idx = 0  # TTL of inner layer.
         # TTL of outer layer. Set different initial ttl_in and ttl_out
-        self.ttl_out_idx = len(self.TTL_RANGE) / 2
+        self.ttl_out_idx = len(self.TTL_RANGE) // 2
 
         self.summary = {}
 
@@ -600,8 +600,8 @@ class DecapPacketTest(BaseTest):
         self.print_summary()
 
         total = len(outer_pkt_types)*len(inner_pkt_types)
-        passed = len(filter(lambda status: status ==
-                     'Passed', self.summary.values()))
+        passed = len(list(filter(lambda status: status ==
+                     'Passed', self.summary.values())))
 
         # assert all passed
         assert total == passed, "total tests {}, passed: {}".format(

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -225,7 +225,8 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
                                mux_status_from_nic_simulator())
                            },
                    qlen=PTFRUNNER_QLEN,
-                   log_file=log_file)
+                   log_file=log_file,
+                   is_python3=True)
     finally:
         # Remove test decap configuration
         if vxlan != "set_unset":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Migrate test_decap PTF script to Python3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This is part of Python3 migration project.
This PR migrate test_decap PTF script to Python3.

#### How did you do it?
2to3 and manually code change.

#### How did you verify/test it?
Run with physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
