### PR TITLE
[202205][acl][m0] Test second vlan for m0-2vlan in test_acl (#9334)

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -552,6 +552,36 @@
                                         "destination-ip-address": "fc02:1000::7/128"
                                     }
                                 }
+                            },
+                            "36": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 36
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::6/128"
+                                    }
+                                }
+                            },
+                            "37": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 37
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -510,6 +510,36 @@
                                         "destination-ip-address": "fc02:1000::7/128"
                                     }
                                 }
+                            },
+                            "36": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 36
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::6/128"
+                                    }
+                                }
+                            },
+                            "37": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 37
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "fc02:1000:0:1::7/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -14,7 +14,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from tests.common import reboot, port_toggle
-from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.config_reload import config_reload
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa F401
@@ -101,6 +101,19 @@ DOWNSTREAM_IP_TO_ALLOW_VLAN = {
 DOWNSTREAM_IP_TO_BLOCK_VLAN = {
     "ipv4": "192.168.0.121",
     "ipv6": "fc02:1000::7"
+}
+
+DOWNSTREAM_DST_IP_VLAN2000 = {
+    "ipv4": "192.168.0.253",
+    "ipv6": "fc02:1000:0:1::5"
+}
+DOWNSTREAM_IP_TO_ALLOW_VLAN2000 = {
+    "ipv4": "192.168.0.252",
+    "ipv6": "fc02:1000:0:1::6"
+}
+DOWNSTREAM_IP_TO_BLOCK_VLAN2000 = {
+    "ipv4": "192.168.0.251",
+    "ipv6": "fc02:1000:0:1::7"
 }
 
 DOWNSTREAM_IP_PORT_MAP = {}
@@ -238,7 +251,7 @@ def get_t2_info(duthosts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario):
+def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario, vlan_name):
     """Gather all required test information from DUT and tbinfo.
 
     Args:
@@ -251,6 +264,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
 
     """
 
+    pytest_assert(vlan_name in ["Vlan1000", "Vlan2000", "no_vlan"], "Invalid vlan name.")
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
 
@@ -266,9 +280,16 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     # Announce routes for m0 is something different from t1/t0
     if topo_scenario == "m0_vlan_scenario":
         topo = "m0_vlan"
-        DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN
-        DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN
-        DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN
+        if tbinfo["topo"]["name"] == "m0-2vlan":
+            DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN2000 if vlan_name == "Vlan2000" else DOWNSTREAM_DST_IP_VLAN
+            DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN2000 if vlan_name == "Vlan2000" \
+                else DOWNSTREAM_IP_TO_ALLOW_VLAN
+            DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN2000 if vlan_name == "Vlan2000" \
+                else DOWNSTREAM_IP_TO_BLOCK_VLAN
+        else:
+            DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN
+            DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN
+            DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN
     elif topo_scenario == "m0_l3_scenario":
         topo = "m0_l3"
         DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_L3
@@ -276,11 +297,10 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_L3
     if topo in ["t0", "mx", "m0_vlan"]:
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
-                      for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
+                      for ifname in mg_facts["minigraph_vlans"][vlan_name]["members"]]
 
         config_facts = rand_selected_dut.get_running_config_facts()
         vlan_table = config_facts["VLAN"]
-        vlan_name = list(vlan_table.keys())[0]
         if "mac" in vlan_table[vlan_name]:
             vlan_mac = vlan_table[vlan_name]["mac"]
 
@@ -307,9 +327,14 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         downstream_neigh_type = get_downstream_neigh_type(topo)
         pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
+        mg_vlans = mg_facts["minigraph_vlans"]
         for interface, neighbor in mg_facts["minigraph_neighbors"].items():
             port_id = mg_facts["minigraph_ptf_indices"][interface]
             if downstream_neigh_type in neighbor["name"].upper():
+                if topo in ["t0", "mx", "m0_vlan"]:
+                    if interface not in mg_vlans[vlan_name]["members"]:
+                        continue
+
                 downstream_ports[neighbor['namespace']].append(interface)
                 downstream_port_ids.append(port_id)
                 downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
@@ -935,7 +960,7 @@ class BaseAclTest(object):
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(7)
 
-    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version, vlan_name):
         """Verify that we can match and forward a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
@@ -951,16 +976,16 @@ class BaseAclTest(object):
                     rule_id = 30
             elif setup["topo"] in ["m0_vlan", "mx"]:
                 if ip_version == "ipv6":
-                    rule_id = 34
+                    rule_id = 34 if vlan_name == "Vlan1000" else 36
                 else:
-                    rule_id = 33
+                    rule_id = 33 if vlan_name == "Vlan1000" else 2
             else:
                 rule_id = 2
         else:
             rule_id = 3
         counters_sanity_check.append(rule_id)
 
-    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version, vlan_name):
         """Verify that we can match and drop a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
@@ -976,9 +1001,9 @@ class BaseAclTest(object):
                     rule_id = 31
             elif setup["topo"] in ["m0_vlan", "mx"]:
                 if ip_version == "ipv6":
-                    rule_id = 35
+                    rule_id = 35 if vlan_name == "Vlan1000" else 37
                 else:
-                    rule_id = 32
+                    rule_id = 32 if vlan_name == "Vlan1000" else 15
             else:
                 rule_id = 15
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1381,6 +1381,19 @@ def pytest_generate_tests(metafunc):
         else:
             metafunc.parametrize('topo_scenario', ['default'], scope='module')
 
+    if 'vlan_name' in metafunc.fixturenames:
+        if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
+            if tbinfo['topo']['name'] == 'm0-2vlan':
+                metafunc.parametrize('vlan_name', ['Vlan1000', 'Vlan2000'], scope='module')
+            else:
+                metafunc.parametrize('vlan_name', ['Vlan1000'], scope='module')
+        # Non M0 topo
+        else:
+            if tbinfo['topo']['type'] in ['t0', 'mx']:
+                metafunc.parametrize('vlan_name', ['Vlan1000'], scope='module')
+            else:
+                metafunc.parametrize('vlan_name', ['no_vlan'], scope='module')
+
 
 def parametrise_autoneg_tests():
     folder = 'metadata'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflict of this PR: https://github.com/sonic-net/sonic-mgmt/pull/9334
Test second vlan for m0-2vlan in test_acl

#### How did you do it?
Add a new fixture vlan_name to specify tested vlan.

#### How did you verify/test it?
Run tests on t0/t1/m0/m0-2vlan/mx testbeds, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
