### PR TITLE
[arp_responder] Fix response icmpv6 packet error

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -63,7 +63,7 @@ class ARPResponder(object):
 
         ndp_reply = ARPResponder.generate_neigh_adv(ARPResponder.ip_sets[interface][request_ip],
                                                     remote_mac, request_ip, remote_ip)
-        scapy.sendp(ndp_reply)
+        scapy.sendp(ndp_reply, iface=interface)
 
     @staticmethod
     def generate_arp_reply(local_mac, remote_mac, local_ip, remote_ip, vlan_id):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Introduced this PR: https://github.com/sonic-net/sonic-mgmt/pull/8697. Missing specifying interface would causes that ipv6 reply packet is sent by default interface([sendrecv.py](https://github.com/secdev/scapy/blob/2fe5cee7b2fdca940b1774ee26a4948e88417232/scapy/sendrecv.py#L452)), which is incorrect.

#### How did you do it?
Specify send interface.

#### How did you verify/test it?
* Run this script in ptf and ping ipv6 address from DUT, then run `show ndp` in DUT, address pinged before can be seen in ndp table.
* Run **test_acl.py** in **m0** testbed, all passed. (This test case in m0 would trigger ndp reply)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
