### PR TITLE
Add support of setting docker_inram_size during upgrade image

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -226,7 +226,7 @@ def main(args):
     else:
         logger.info("Use default docker folder size")
 
-    # Set docker folder size
+    # Force reboot the device to apply changes
     if need_shutdown:
         logger.info("Need to shutdown")
         try:

--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -37,6 +37,8 @@ RC_INIT_FAILED = 1
 RC_UPGRADE_PREV_FAILED = 2
 RC_UPGRADE_FAILED = 3
 RC_ENABLE_FIPS_FAILED = 4
+RC_SET_DOCKER_FOLDER_SIZE_FAILED = 5
+RC_SHUTDOWN_FAILED = 6
 
 
 def validate_args(args):
@@ -188,18 +190,50 @@ def main(args):
         sys.exit(RC_UPGRADE_FAILED)
     else:
         logger.info("Upgraded to image {}".format(args.prev_image_url))
+
+    current_build_version = None
     for hostname, version in sonichosts.sonic_version.items():
         logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+        if not current_build_version:
+            current_build_version = version.get("build_version")
 
     # Enable FIPS
+    need_shutdown = False
     if args.enable_fips:
         logger.info("Need to enable FIPS")
         try:
             sonichosts.command("sonic-installer set-fips", module_attrs={"become": True})
-            sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
+            need_shutdown = True
         except Exception as e:
             logger.error("Failed to enable FIPS mode: {}".repr(e))
             sys.exit(RC_ENABLE_FIPS_FAILED)
+
+    # Set docker folder size, required for platforms with small disk
+    if args.docker_folder_size:
+        logger.info("Need to set docker folder size to '{}'".format(args.docker_folder_size))
+        try:
+            sonichosts.lineinfile(
+                line="docker_inram_size={}".format(args.docker_folder_size),
+                path="/host/image-{}/kernel-cmdline-append".format(current_build_version),
+                state="present",
+                create=True,
+                module_attrs={"become": True}
+            )
+            need_shutdown = True
+        except Exception as e:
+            logger.error("Failed to set docker folder size: {}".repr(e))
+            sys.exit(RC_SET_DOCKER_FOLDER_SIZE_FAILED)
+    else:
+        logger.info("Use default docker folder size")
+
+    # Set docker folder size
+    if need_shutdown:
+        logger.info("Need to shutdown")
+        try:
+            sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
+        except Exception as e:
+            logger.error("Failed to shutdown: {}".repr(e))
+            sys.exit(RC_SHUTDOWN_FAILED)
 
     localhost.pause(seconds=180, prompt="Pause after reboot")
     logger.info("===== UPGRADE IMAGE DONE =====")
@@ -290,6 +324,16 @@ if __name__ == "__main__":
         required=False,
         default=False,
         help="Enable FIPS."
+    )
+
+    parser.add_argument(
+        "--docker-folder-size",
+        type=str,
+        dest="docker_folder_size",
+        required=False,
+        default="",
+        help="Docker folder size. Required for devices with small SSD."
+             "If set to 0, docker folder size will not be updated. Example: '3000M'"
     )
 
     parser.add_argument(

--- a/ansible/devutil/devices/sonic.py
+++ b/ansible/devutil/devices/sonic.py
@@ -88,9 +88,9 @@ def patch_rsyslog(sonichosts):
     ]
 
     # Get sonic version, use version of the first host
-    sonic_build_version = sonichosts.shell(
+    sonic_build_version = list(sonichosts.shell(
         "sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version"
-    ).values()[0]["stdout"]
+    ).values())[0]["stdout"]
 
     # Patch rsyslog to stop sending syslog to production and use new template for remote syslog
     for conf_file in rsyslog_conf_files:
@@ -131,9 +131,9 @@ def patch_rsyslog(sonichosts):
     # Workaround for PR https://msazure.visualstudio.com/One/_git/Networking-acs-buildimage/pullrequest/6631568
     # This PR updated the rsyslog.conf to use a new method for sending out syslog. Need to configure the new method
     # to use RemoteSONiCFileFormat too.
-    remote_template = sonichosts.shell(
+    remote_template = list(sonichosts.shell(
         "echo `grep -c 'template=\".*SONiCFileFormat\"' /usr/share/sonic/templates/rsyslog.conf.j2`"
-    ).values()[0]["stdout"]
+    ).values())[0]["stdout"]
     if remote_template == "0":
         for conf_file in rsyslog_conf_files:
             sonichosts.lineinfile(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
For devices with small disk not able to run docker contains due to disk size issue, the workaround is to use ram by increasing "docker_inram_size".

#### How did you do it?
This change enhanced the upgrade_image.py script to support updating "docker_inram_size" via argument "--docker-folder-size".
This change also fixed an issue of getting item from `values()` of a dict in the sonic.py file.

#### How did you verify/test it?
Test run the upgrade_image.py script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
