### PR TITLE
[dhcp_relay][m0] Add support for in test_dhcp_pkt_fwd for m0-2vlan

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -106,7 +106,7 @@ class DhcpPktFwdBase:
         """
         duthost = duthosts[rand_one_dut_hostname]
         topo_name = tbinfo["topo"]["name"]
-        if "t1" not in topo_name and topo_name != "m0":
+        if "t1" not in topo_name and tbinfo["topo"]["type"] != "m0":
             pytest.skip("Unsupported topology: {}".format(topo_name))
 
         downstreamPorts = []
@@ -115,9 +115,9 @@ class DhcpPktFwdBase:
         mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
 
         for dutPort, neigh in list(mgFacts["minigraph_neighbors"].items()):
-            if "t1" in topo_name and "T0" in neigh["name"] or topo_name == "m0" and "MX" in neigh["name"]:
+            if "t1" in topo_name and "T0" in neigh["name"] or "m0" in topo_name and "MX" in neigh["name"]:
                 downstreamPorts.append(dutPort)
-            elif "t1" in topo_name and "T2" in neigh["name"] or topo_name == "m0" and "M1" in neigh["name"]:
+            elif "t1" in topo_name and "T2" in neigh["name"] or "m0" in topo_name and "M1" in neigh["name"]:
                 upstreamPorts.append(dutPort)
 
         yield {"upstreamPorts": upstreamPorts, "downstreamPorts": downstreamPorts}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Add support for in test_dhcp_pkt_fwd for m0-2vlan

#### How did you do it?
Add support for in test_dhcp_pkt_fwd for m0-2vlan

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
