### PR TITLE
update memory threshold in case test_cpu_memory_usage  for 7050qx

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -36,7 +36,7 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     memory_threshold = 60
     high_cpu_consume_procs = {}
     is_asan = is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname)
-    if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0',
+    if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
19998021

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_cpu_memory_usage case failure on 7050qx platform
system memory usage 85% exceeds 60%: {u'used_percent': 85.2, u'total': 4003824.0, u'used': 3121812.0, u'free': 593944.0}

#### How did you do it?
Update the memory threshold for 7050qx, since it's an expect behavior after docker_inram enabled on 7050qx

#### How did you verify/test it?
Run test_cpu_memory_usage case on 7050qx
platform_tests/test_cpu_memory_usage.py::test_cpu_memory_usage[str2-7050qx-32s-acs-01] PASSED    

#### Any platform specific information?
7050qx

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
