### PR TITLE
Stabilize `test_create_vrf`

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -605,7 +605,8 @@ def test_create_vrf(construct_url, cleanup_after_testing):
     r = restapi.patch_config_vrouter_vrf_id_routes(
         construct_url, 'vnet-guid-10', params)
     pytest_assert(r.status_code == 204)
-
+    # Wait 2 seconds for routes to be syncd
+    time.sleep(2)
     # Verify routes
     params = '{}'
     r = restapi.get_config_vrouter_vrf_id_routes(
@@ -642,7 +643,8 @@ def test_create_vrf(construct_url, cleanup_after_testing):
     r = restapi.patch_config_vrouter_vrf_id_routes(
         construct_url, 'vnet-guid-10', params)
     pytest_assert(r.status_code == 204)
-
+    # Wait 2 seconds for routes to be syncd
+    time.sleep(2)
     # Verify routes
     params = '{}'
     r = restapi.get_config_vrouter_vrf_id_routes(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test case `test_create_vrf` was failing at a very low possibility (around 1/10) with below error message.
```
        expected = [{"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.1/32", "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.2/32", "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.3/32", "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.4/32", "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.5/32", "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"}]
        for route in expected:
>           pytest_assert(route in r.json())
E           Failed: <Failed instance>
```
After investigating the syslog, the failure is because it requires some time (less than 1 second) to sync the routes configured from restapi.
So I added a 2 seconds' delay between the set and get request.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The PR is to stabilize `test_create_vrf`.
 
#### How did you do it?
Add 2 seconds' delay between the set and get operation.

#### How did you verify/test it?
The change is verified by running `test_create_vrf` for 3 times. It's consistently passing now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
