### PR TITLE
[cherry-pick][202205][advanced-reboot] Use nohup when executing reboot CLI to prevent PIPE errors

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1370,8 +1370,6 @@ class ReloadTest(BaseTest):
     def reboot_dut(self):
         time.sleep(self.reboot_delay)
 
-        self.log("Rebooting remote side")
-
         if not self.kvm_test and\
                 (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
                  self.reboot_type or 'service-warm-restart' in self.reboot_type):

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1370,6 +1370,8 @@ class ReloadTest(BaseTest):
     def reboot_dut(self):
         time.sleep(self.reboot_delay)
 
+        self.log("Rebooting remote side")
+
         if not self.kvm_test and\
                 (self.reboot_type == 'fast-reboot' or 'warm-reboot' in
                  self.reboot_type or 'service-warm-restart' in self.reboot_type):
@@ -1380,7 +1382,18 @@ class ReloadTest(BaseTest):
 
         self.log("Rebooting remote side")
         if self.reboot_type != 'service-warm-restart':
-            stdout, stderr, return_code = self.dut_connection.execCommand("sudo " + self.reboot_type, timeout=30)
+            reboot_command = self.reboot_type
+            # create an empty log file to capture output of reboot command
+            reboot_log_file = "/host/{}.log".format(reboot_command.replace(' ', ''))
+            self.dut_connection.execCommand("sudo touch {}; sudo chmod 666 {}".format(
+                reboot_log_file, reboot_log_file))
+
+            # execute reboot command w/ nohup so that when the execCommand times-out:
+            # 1. there is a reader/writer for any bash commands using PIPE
+            # 2. the output and error of CLI still gets written to log file
+            stdout, stderr, return_code = self.dut_connection.execCommand(
+                "nohup sudo {} -v &> {}".format(
+                    reboot_command, reboot_log_file), timeout=10)
         else:
             self.restart_service()
             return


### PR DESCRIPTION
What is the motivation for this PR?
In the device where logs are in tmpfs, a backup is made for log_analyzer to work after reboot. However, there have been many cases when one or more backup files are empty or not created. Based on current RCA this happens when reboot CLI is executed from test and then SSH command times out.

When command execution ends, but reboot is still in progress in the device, any writes to stdout / etderr fails as there is no reader.

How did you do it?
To fix no reader issue, run the reboot CLI w/ nohup and redirect the output to a file.

Tested on physical device

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
