### PR TITLE
[PTF python3 migration] Modify populate_fdb PTF script

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/populate_fdb.py
+++ b/ansible/roles/test/files/ptftests/py3/populate_fdb.py
@@ -91,7 +91,10 @@ class PopulateFdb(BaseTest):
             Returns:
                 mac (int): integer representation of MAC address
         """
-        return int(mac.translate(None, ":.- "), 16)
+        translation_table = str.maketrans('', '', ":.- ")
+        mac_without_delimiters = mac.translate(translation_table)
+        mac_as_int = int(mac_without_delimiters, 16)
+        return mac_as_int
 
     def __convertMacToStr(self, mac):
         """
@@ -117,7 +120,7 @@ class PopulateFdb(BaseTest):
                 vmIp (dict): Map containing vlan to VM IP address
         """
         vmIp = {}
-        for vlan, vlan_config in self.configData["vlan_interfaces"].items():
+        for vlan, vlan_config in list(self.configData["vlan_interfaces"].items()):
             prefixLen = self.configData["vlan_interfaces"][vlan]["prefixlen"]
             ipCount = 2**(32 - prefixLen) - 3
             numDistinctIp = self.packetCount * \

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -110,7 +110,8 @@ class PopulateFdb:
                 "packet_count": self.packetCount,
                 "mac_to_ip_ratio": self.macToIpRatio,
             },
-            log_file="/tmp/populate_fdb.PopulateFdb.log"
+            log_file="/tmp/populate_fdb.PopulateFdb.log",
+            is_python3=True
         )
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Migrate populate_fdb PTF script to Python3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This is part of Python3 migration project.
This PR migrate populate_fdb PTF script to Python3.

#### How did you do it?
2to3 and manually change code

#### How did you verify/test it?
Test with physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
