### PR TITLE
Adding dualtor iptable rules for test_cacl_application_dualtor

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -16,19 +16,6 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-ignored_iptable_rules = []
-
-@pytest.fixture(scope="module", autouse=True)
-def ignore_hardcoded_cacl_rule_on_dualtor(tbinfo):
-    global ignored_iptable_rules
-    # There are some hardcoded cacl rule for dualtot testbed, which should be ignored
-    if "dualtor" in tbinfo['topo']['name']:
-        rules_to_ignore = [
-        "-A INPUT -p udp -m udp --dport 67 -j DHCP",
-        "-A DHCP -j RETURN",
-        "-N DHCP"
-        ]
-        ignored_iptable_rules += rules_to_ignore
 
 @pytest.fixture(scope="function", params=["active_tor", "standby_tor"])
 def duthost_dualtor(request, upper_tor_host, lower_tor_host):
@@ -407,6 +394,15 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     # Allow all incoming IPv6 DHCP packets
     iptables_rules.append("-A INPUT -p udp -m udp --dport 546:547 -j ACCEPT")
     ip6tables_rules.append("-A INPUT -p udp -m udp --dport 546:547 -j ACCEPT")
+	
+    # There are some hardcoded cacl rule for dualtor testbed
+    if "dualtor" in tbinfo['topo']['name']:
+        rules_to_expect_for_dualtor = [
+                                       "-A INPUT -p udp -m udp --dport 67 -j DHCP",
+                                       "-A DHCP -j RETURN",
+                                       "-N DHCP"
+                                      ]
+        iptables_rules.extend(rules_to_expect_for_dualtor)
 
     # On standby tor, it has expected dhcp mark iptables rules.
     if expected_dhcp_rules_for_standby:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The expected rules for dualtor are present in the script as a fixture "ignore_hardcoded_cacl_rule_on_dualtor" but the global variable "ignored_iptable_rules" is not called anywhere. This is causing test_cacl_application_dualtor to fail because the script is not expecting these rules.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205


#### Any platform specific information?
Checked it on DualToR testbed with Cisco devices

