### PR TITLE
sdfs

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -183,7 +183,7 @@ class OVSGroup(StrObj):
 class OVSFlow(StrObj):
     """Object to represent an OVS flow."""
 
-    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix")
+    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix", "packet_filter", "drop")
 
     def __init__(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
         self.in_port = in_port

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -240,8 +240,8 @@ class ShowInterfaceModule(object):
 
     def collect_interface_counter(self, namespace=None, include_internal_intfs=False):
         regex_int = re.compile(
-            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
-            r'([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
+            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
+            r'([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
         self.int_counter = {}
         cli_options = " -n {}".format(
             namespace) if namespace is not None else ""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When the ansible command "interf_counters = duthost.show_interface(command="counter")" is run, the TX_BPS, and RX_BPS are sometimes in KB/s format but the current regex only accounts for values with B/s as the suffix https://github.com/sonic-net/sonic-mgmt/blob/52211bac3650f76786cf34c3f896dba4ab956ff8/docs/api_wiki/ansible_methods/show_interface.md?plain=1#L17

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

