### PR TITLE
Update nic_simulator.py to avoid errors when retrieving packet_filter variable

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -183,7 +183,7 @@ class OVSGroup(StrObj):
 class OVSFlow(StrObj):
     """Object to represent an OVS flow."""
 
-    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix")
+    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix", "packet_filter", "drop")
 
     def __init__(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
         self.in_port = in_port

--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -183,7 +183,7 @@ class OVSGroup(StrObj):
 class OVSFlow(StrObj):
     """Object to represent an OVS flow."""
 
-    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix", "packet_filter", "drop")
+    __slots__ = ("in_port", "output_ports", "group", "priority", "_str_prefix")
 
     def __init__(self, in_port, packet_filter=None, output_ports=[], group=None, priority=None):
         self.in_port = in_port

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -240,8 +240,8 @@ class ShowInterfaceModule(object):
 
     def collect_interface_counter(self, namespace=None, include_internal_intfs=False):
         regex_int = re.compile(
-            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
-            r'([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
+            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
+            r'([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
         self.int_counter = {}
         cli_options = " -n {}".format(
             namespace) if namespace is not None else ""

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -240,8 +240,8 @@ class ShowInterfaceModule(object):
 
     def collect_interface_counter(self, namespace=None, include_internal_intfs=False):
         regex_int = re.compile(
-            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
-            r'([,\d]+)\s+(N\/A|[.0-9]+ [K|M|G]B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
+            r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+'
+            r'([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
         self.int_counter = {}
         cli_options = " -n {}".format(
             namespace) if namespace is not None else ""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Class variable __slots__ does not include packet_filter and drop instances which are accessed later. This causes the nic-simulator to not run successfully and add-topo on Active-Active topology does not work
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
