### PR TITLE
Fix EVERFLOW egress mirroring test in dualtor setup

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -50,7 +50,7 @@ UP_STREAM = "upstream"
 DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
 
-def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
+def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
     """
     Generate setup information dictionary for T0 and T1/ T2 topologies.
     """
@@ -225,6 +225,13 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scena
     upstream_router_mac = upStreamDutHost.asic_instance(asic_id).get_router_mac()
     asic_id = downStreamDutHost.get_asic_id_from_namespace(downstream_namespace)
     downstream_router_mac = downStreamDutHost.asic_instance(asic_id).get_router_mac()
+    if 'dualtor' in topo:
+        # On dualtor setup, we need to use the MAC of the VLAN interface
+        # as the src MAC of downstream traffic
+        downstream_vlan_mac = dutHost.get_dut_iface_mac('Vlan1000')
+        upstream_vlan_mac = dutHost.asic_instance().get_router_mac()
+    else:
+        downstream_vlan_mac = upstream_vlan_mac = None
 
     setup_information = {
         "test_mirror_v4": test_mirror_v4,
@@ -260,6 +267,7 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scena
                 "everflow_dut": upStreamDutHost,
                 "ingress_router_mac": upstream_router_mac,
                 "egress_router_mac": downstream_router_mac,
+                "vlan_mac": downstream_vlan_mac,
                 "src_port": upstream_ports[0],
                 "src_port_lag_name": upstream_dest_lag_name[0],
                 "src_port_ptf_id": (str(mg_facts_list[1]["minigraph_ptf_indices"][upstream_ports[0]])
@@ -281,6 +289,7 @@ def gen_setup_information(downStreamDutHost, upStreamDutHost, tbinfo, topo_scena
                 "everflow_dut": downStreamDutHost,
                 "ingress_router_mac": downstream_router_mac,
                 "egress_router_mac": upstream_router_mac,
+                "vlan_mac": upstream_vlan_mac,
                 "src_port": downstream_ports[0],
                 # DUT whose downstream are servers doesn't have lag connect to server
                 "src_port_lag_name": "Not Applicable" \
@@ -340,7 +349,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
         pytest_assert(len(duthosts) > 1, "Test must run on whole chassis")
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
 
-    setup_information = gen_setup_information(downstream_duthost, upstream_duthost, tbinfo, topo_scenario)
+    setup_information = gen_setup_information(duthost, downstream_duthost, upstream_duthost, tbinfo, topo_scenario)
 
     # Disable BGP so that we don't keep on bouncing back mirror packets
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
@@ -786,14 +795,10 @@ class BaseEverflowTest(object):
                                                                                  direction,
                                                                                  mirror_packet,
                                                                                  src_port_metadata_map[src_port][1])
-
+            # Avoid changing the original packet
+            mirror_packet_sent = mirror_packet.copy()
             if src_port_metadata_map[src_port][0]:
-
-                mirror_packet_sent = mirror_packet.copy()
-
                 mirror_packet_sent[packet.Ether].dst = src_port_metadata_map[src_port][0]
-            else:
-                mirror_packet_sent = mirror_packet
 
             ptfadapter.dataplane.flush()
             testutils.send(ptfadapter, src_port, mirror_packet_sent)
@@ -825,6 +830,9 @@ class BaseEverflowTest(object):
                     if 't2' in setup['topo']:
                         if duthost.facts['switch_type'] == "voq":
                             mirror_packet_sent[packet.Ether].src = setup[direction]["ingress_router_mac"]
+                    elif direction == 'downstream' and setup.get("dualtor", False):
+                        # On dualtor deployment, the SRC_MAC of the downstream mirror packet is the VLAN MAC
+                        mirror_packet_sent[packet.Ether].src = setup[direction]["vlan_mac"]
                     else:
                         mirror_packet_sent[packet.Ether].src = setup[direction]["egress_router_mac"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The EVERFLOW Egress mirroring test was failing on Mellanox dualtor because the expected mirroring packet doesn't match the sent packet.
```
pytest_assert(inner_packet.pkt_match(mirror_packet_sent), "Mirror payload does not match received packet")
```
It's because for the downstream traffic on dualtor testbed, the src_mac should be the MAC address of `Vlan1000`. The value is different from the router MAC.

This PR addressed the issue by changing the src MAC address of the downstream traffic to VLAN MAC on dualtor testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix EVERFLOW egress mirroring test in dualtor testbed.

#### How did you do it?
This PR addressed the issue by changing the src MAC address of the downstream traffic to VLAN MAC on dualtor testbed.

#### How did you verify/test it?
Verified on a SN4600 dualtor testbed.
```
collected 40 items                                                                                                                                                         

everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream-default]  ^HPASSED                              [  2%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream-default] PASSED                           [  5%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream-default] PASSED                   [  7%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream-default]  ^HPASSED                     [ 10%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream-default] PASSED                             [ 12%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream-default] SKIPPED                              [ 15%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream-default] SKIPPED                           [ 17%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream-default] SKIPPED                   [ 20%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream-default] SKIPPED                     [ 22%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream-default] SKIPPED                             [ 25%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream-default] SKIPPED                              [ 27%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream-default] SKIPPED                           [ 30%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream-default] SKIPPED                   [ 32%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream-default] SKIPPED                     [ 35%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream-default] SKIPPED                             [ 37%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream-default]  ^HPASSED                                [ 40%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream-default] PASSED                             [ 42%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream-default] PASSED                     [ 45%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream-default]  ^HPASSED                       [ 47%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream-default] PASSED                               [ 50%] ^H
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream-default] PASSED                                [ 52%] ^H
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream-default] PASSED                             [ 55%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream-default] PASSED                     [ 57%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream-default] PASSED                       [ 60%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream-default]  ^HPASSED                               [ 62%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream-default] SKIPPED                                [ 65%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream-default] SKIPPED                             [ 67%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream-default] SKIPPED                     [ 70%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream-default] SKIPPED                       [ 72%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream-default] SKIPPED                               [ 75%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream-default] SKIPPED                                [ 77%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream-default] SKIPPED                             [ 80%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream-default] SKIPPED                     [ 82%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream-default] SKIPPED                       [ 85%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream-default] SKIPPED                               [ 87%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream-default]  ^HPASSED                                  [ 90%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream-default] PASSED                               [ 92%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream-default] PASSED                       [ 95%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream-default] PASSED                         [ 97%] ^H
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_witPASSED                                 [100%] ^H

```
#### Any platform specific information?
Mellanox dualtor specific issue.
 
#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
