### PR TITLE
PFCWD - Test fixes for t2-chassis

### DIFF
--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -23,7 +23,6 @@ from ctypes import (
     cast,
     get_errno,
     pointer,
-    sizeof,
 )
 
 
@@ -217,8 +216,6 @@ def main():
                 packet = packet + binascii.unhexlify(format(options.time, '04x'))
             else:
                 packet = packet + b"\x00\x00"
-
-    packet_bytes = len(packet)
 
     # construct mmsg header to send in bulk for minimal latency
 

--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+
+"""
+Script to generate PFC packets.
+
+"""
+import binascii
+import sys
+import os
+import optparse
+import logging
+import logging.handlers
+from socket import socket, AF_PACKET, SOCK_RAW, SHUT_WR
+import time
+import errno
+from struct import *
+from ctypes import (
+    CDLL,
+    POINTER,
+    Structure,
+    addressof,
+    byref,
+    c_byte,
+    c_int,
+    c_size_t,
+    c_uint,
+    c_uint8,
+    c_uint32,
+    c_ushort,
+    c_void_p,
+    cast,
+    create_string_buffer,
+    get_errno,
+    pointer,
+    sizeof,
+)
+
+
+class struct_iovec(Structure):
+    _fields_ = [
+        ("iov_base", c_void_p),
+        ("iov_len", c_size_t),
+    ]
+
+
+class struct_msghdr(Structure):
+    _fields_ = [
+        ("msg_name", c_void_p),
+        ("msg_namelen", c_uint32),
+        ("msg_iov", POINTER(struct_iovec)),
+        ("msg_iovlen", c_size_t),
+        ("msg_control", c_void_p),
+        ("msg_controllen", c_size_t),
+        ("msg_flags", c_int),
+    ]
+
+
+class struct_mmsghdr(Structure):
+    _fields_ = [
+        ("msg_hdr", struct_msghdr),
+        ("msg_len", c_uint)
+    ]
+
+
+# cdll.LoadLibrary("libc.so.6")
+libc = CDLL("libc.so.6")
+_sendmmsg = libc.sendmmsg
+_sendmmsg.argtypes = [c_int, POINTER(struct_mmsghdr), c_uint, c_int]
+_sendmmsg.restype = c_int
+
+my_logger = logging.getLogger('MyLogger')
+my_logger.setLevel(logging.DEBUG)
+
+fo_logger = logging.getLogger('MyLogger')
+fo_logger.setLevel(logging.DEBUG)
+
+
+def checksum(msg):
+    s = 0
+
+    # loop taking 2 characters at a time
+    for i in range(0, len(msg), 2):
+        w = ord(msg[i]) + (ord(msg[i+1]) << 8)
+        s = s + w
+
+    s = (s >> 16) + (s & 0xffff)
+    s = s + (s >> 16)
+
+    # complement and mask to 4 byte short
+    s = ~s & 0xffff
+
+    return s
+
+
+def sendmmsg(sockfd: int, data: bytes, total_packets: int): # noqa E999
+    """
+    Send multiple messages at once, all constructed from the same pkt data.
+
+    """
+    # msghdr_len = total_packets
+    m_msghdr = (struct_mmsghdr * total_packets)()
+
+    iov = struct_iovec(cast(data, c_void_p), len(data))
+    msg_iov = pointer(iov)
+    msg_iovlen = 1
+    msg_control = 0
+    msg_controllen = 0
+
+    msg_namelen = 0
+    ptr_null = None
+    msg_name = cast(None, c_void_p)
+    i = 0
+    """
+    for destination, packets in data.items():
+        msg_namelen = 0
+        msg_name = 0
+        # no scatter/gather support
+        for pkt in packets:
+            iov = struct_iovec(cast(pkt, c_void_p), len(pkt))
+            msg_iov = pointer(iov)
+
+            msghdr = struct_msghdr(
+                msg_name, msg_namelen, msg_iov, msg_iovlen,
+                msg_control, msg_controllen, 0)
+
+            m_msghdr[i] = struct_mmsghdr(msghdr)
+            i += 1
+    """
+
+    for i in range(0, total_packets):
+        msghdr = struct_msghdr(
+                    msg_name, msg_namelen, msg_iov, msg_iovlen,
+                    msg_control, msg_controllen, 0)
+        m_msghdr[i] = struct_mmsghdr(msghdr)
+        i += 1
+
+    ret = _sendmmsg(sockfd, m_msghdr[0], total_packets, 0)
+    return ret
+
+
+def main():
+    usage = "usage: %prog [options] arg1 arg2"
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option("-i", "--interface", type="string", dest="interface",
+                      help="Interface list to send packets, seperated by ','", metavar="Interface")
+    parser.add_option('-p', "--priority", type="int", dest="priority",
+                      help="PFC class enable bitmap.", metavar="Priority", default=-1)
+    parser.add_option("-t", "--time", type="int", dest="time",
+                      help="Pause time in quanta for global pause or enabled class", metavar="time")
+    parser.add_option("-s", "--sendtime", type="int", dest="sendtime",
+                      help="Total amount of time to send pkts. -n option is ignored if this is set",
+                      metavar="sendtime", default=0)
+    parser.add_option("-n", "--num", type="int", dest="num",
+                      help="Number of packets to be sent", metavar="number", default=1)
+    parser.add_option("-r", "--rsyslog-server", type="string", dest="rsyslog_server",
+                      default="127.0.0.1", help="Rsyslog server IPv4 address", metavar="IPAddress")
+    parser.add_option('-g', "--global", action="store_true", dest="global_pf",
+                      help="Send global pause frames (not PFC)", default=False)
+    (options, args) = parser.parse_args()
+
+    if options.interface is None:
+        print("Need to specify the interface to send PFC/global pause frame packets.")
+        parser.print_help()
+        sys.exit(1)
+
+    if options.time > 65535 or options.time < 0:
+        print("Quanta is not valid. Need to be in range 0-65535.")
+        parser.print_help()
+        sys.exit(1)
+
+    if options.global_pf:
+        # Send global pause frames
+        # -p option should not be set
+        if options.priority != -1:
+            print("'-p' option is not valid when sending global pause frames ('--global' / '-g')")
+            parser.print_help()
+            sys.exit(1)
+    elif options.priority > 255 or options.priority < 0:
+        print("Enable class bitmap is not valid. Need to be in range 0-255.")
+        parser.print_help()
+        sys.exit(1)
+
+    interfaces = options.interface.split(',')
+
+    length_of_list = len(interfaces)
+    sockets = []
+
+    # Only a single socket supported for now
+    try:
+        for i in range(0, length_of_list):
+            mysocket = socket(AF_PACKET, SOCK_RAW)
+            mysocket.setblocking(False)
+            sockets.append(mysocket)
+    except Exception:
+        print("Unable to create socket for i %i. Check your permissions" % i)
+        sys.exit(1)
+
+    # Configure logging
+    handler = logging.handlers.SysLogHandler(address=(options.rsyslog_server, 514))
+    my_logger.addHandler(handler)
+
+    # Configure fanout logging
+    fo_handler = logging.handlers.SysLogHandler()
+    fo_logger.addHandler(fo_handler)
+
+    for s, interface in zip(sockets, interfaces):
+        # todo: check bind return value for possible errors
+        s.bind((interface, 0))
+        s.setsockopt(263, 20, 1)  # QDISC_BYPASS
+        # fo_logger.debug(s.getsockname())
+
+    """
+    Set PFC defined fields and generate the packet
+
+    The Ethernet Frame format for PFC packets is the following:
+
+    Destination MAC |   01:80:C2:00:00:01   |
+                    -------------------------
+    Source MAC      |      Station MAC      |
+                    -------------------------
+    Ethertype       |         0x8808        |
+                    -------------------------
+    OpCode          |         0x0101        |
+                    -------------------------
+    Class Enable V  | 0x00 E7...E0          |
+                    -------------------------
+    Time Class 0    |       0x0000          |
+                    -------------------------
+    Time Class 1    |       0x0000          |
+                    -------------------------
+    ...
+                    -------------------------
+    Time Class 7    |       0x0000          |
+                    -------------------------
+    """
+    """
+    Set pause frame defined fields and generate the packet
+
+    The Ethernet Frame format for pause frames is the following:
+
+    Destination MAC |   01:80:C2:00:00:01   |
+                    -------------------------
+    Source MAC      |      Station MAC      |
+                    -------------------------
+    Ethertype       |        0x8808         |
+                    -------------------------
+    OpCode          |        0x0001         |
+                    -------------------------
+    pause time      |        0x0000         |
+                    -------------------------
+    """
+    src_addr = b"\x00\x01\x02\x03\x04\x05"
+    dst_addr = b"\x01\x80\xc2\x00\x00\x01"
+    if options.global_pf:
+        opcode = b"\x00\x01"
+    else:
+        opcode = b"\x01\x01"
+    ethertype = b"\x88\x08"
+
+    packet = dst_addr + src_addr + ethertype + opcode
+
+    if options.global_pf:
+        packet = packet + binascii.unhexlify(format(options.time, '04x'))
+    else:
+        class_enable = options.priority
+        class_enable_field = binascii.unhexlify(format(class_enable, '04x'))
+
+        packet = packet + class_enable_field
+
+        for p in range(0, 8):
+            if (class_enable & (1 << p)):
+                packet = packet + binascii.unhexlify(format(options.time, '04x'))
+            else:
+                packet = packet + b"\x00\x00"
+
+    packet_bytes = len(packet)
+
+    # construct mmsg header to send in bulk for minimal latency
+
+    total_packets = max(1000, options.num)
+    m_msghdr = (struct_mmsghdr * total_packets)()
+
+    iov = struct_iovec(cast(packet, c_void_p), len(packet))
+
+    msg_iov = pointer(iov)
+    msg_iovlen = 1
+    msg_control = 0
+    msg_controllen = 0
+
+    msg_namelen = 0
+    msg_name = cast(None, c_void_p)
+
+    # construct the vector
+    for i in range(0, 1000):
+        msghdr = struct_msghdr(
+                    msg_name, msg_namelen, msg_iov, msg_iovlen,
+                    msg_control, msg_controllen, 0)
+        m_msghdr[i] = struct_mmsghdr(msghdr)
+        i += 1
+
+    pre_str = 'GLOBAL_PF' if options.global_pf else 'PFC'
+    fo_str = "Fanout"
+
+    total_num_remaining = options.num
+    total_num_sent = 0
+    iters = 0
+    start_time = time.monotonic()
+
+    if options.sendtime > 0:       # send according to requested period of send time
+        num_to_send = 1000
+        print("Generating Packet(s) over period of %f seconds" % options.sendtime)
+        my_logger.debug(pre_str + '_STORM_START')
+        while True:
+            for s in sockets:
+                num_sent = _sendmmsg(s.fileno(), m_msghdr[0], num_to_send, 0)   # direct to c library api
+                if num_sent < 0:
+                    errno = get_errno()
+                    fo_logger.debug(fo_str + ' sendmmsg got errno ' + str(errno) + ' for socket ' + s.getsockname())
+                    break
+                else:
+                    if num_sent != num_to_send:
+                        fo_logger.debug(fo_str + ' sendmmsg iteration ' + str(iters) + ' only sent ' +
+                                        str(num_sent) + ' out of requested ' + str(num_to_send) +
+                                        ' for socket ' + s.getsockname())
+                # Count across all sockets
+                total_num_sent += num_sent
+                iters += 1
+            done_time = time.monotonic()
+            elapsed_time = done_time - start_time
+            if elapsed_time >= options.sendtime:
+                break
+
+        my_logger.debug(pre_str + '_STORM_END')
+        fo_logger.debug(fo_str + '_STORM_END_AFTER_RSYSLOG_CALL : sent ' + str(total_num_sent) + ' pkts in ' + str(
+            iters) + ' iterations and elapsed time of ' + str(elapsed_time) + ' secs')
+    # send according to requested number of pkts
+    else:
+        print("Generating %s Packet(s)" % options.num)
+        my_logger.debug(pre_str + '_STORM_START')
+        num_sockets = len(sockets)
+        total_pkts_sent = [0] * num_sockets
+        total_pkts_remaining = [total_num_remaining] * num_sockets
+        done = [False] * num_sockets
+        keep_sending = True
+        test_failed = False
+        while keep_sending is True:
+            for s in sockets:
+                index = sockets.index(s)
+                if total_pkts_remaining[index] <= 0:
+                    continue
+                num_to_send = min(1000, total_pkts_remaining[index])
+                num_sent = _sendmmsg(s.fileno(), m_msghdr[0], num_to_send, 0)
+                if num_sent < 0:
+                    errno = get_errno()
+                    fo_logger.debug(fo_str + ' sendmmsg got errno ' + str(errno) + ' for socket ' + s.getsockname())
+                    test_failed = True
+                    break
+                else:
+                    if num_sent != num_to_send:
+                        fo_logger.debug(fo_str + ' sendmmsg iteration ' + str(iters) +
+                                        ' only sent ' + str(num_sent) +
+                                        ' out of requested ' + str(num_to_send) + ' for socket ' + s.getsockname())
+                total_pkts_remaining[index] -= num_sent
+                total_pkts_sent[index] += num_sent
+                if total_pkts_remaining[index] <= 0:
+                    done[index] = True
+            if test_failed is True:
+                break
+            iters += 1
+            keep_sending = False
+            for i in range(0, num_sockets):
+                if total_pkts_remaining[i] > 0:
+                    keep_sending = True
+
+        done_time = time.monotonic()
+        elapsed_time = done_time - start_time
+
+        my_logger.debug(pre_str + '_STORM_END')
+        for i in range(0, num_sockets):
+            fo_logger.debug(fo_str + '_STORM_END : socket ' + str(i) + ' sent ' + str(total_pkts_sent[i]) + ' pkts')
+        fo_logger.debug(fo_str + '_STORM_END_AFTER_RSYSLOG_CALL : ' + str(iters) +
+                        ' iterations and elapsed time of ' + str(elapsed_time) + ' secs')
+
+    for s in sockets:
+        s.close()
+        s.detach()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -6,30 +6,21 @@ Script to generate PFC packets.
 """
 import binascii
 import sys
-import os
 import optparse
 import logging
 import logging.handlers
-from socket import socket, AF_PACKET, SOCK_RAW, SHUT_WR
+from socket import socket, AF_PACKET, SOCK_RAW
 import time
-import errno
-from struct import *
 from ctypes import (
     CDLL,
     POINTER,
     Structure,
-    addressof,
-    byref,
-    c_byte,
     c_int,
     c_size_t,
     c_uint,
-    c_uint8,
     c_uint32,
-    c_ushort,
     c_void_p,
     cast,
-    create_string_buffer,
     get_errno,
     pointer,
     sizeof,
@@ -90,52 +81,6 @@ def checksum(msg):
     s = ~s & 0xffff
 
     return s
-
-
-def sendmmsg(sockfd: int, data: bytes, total_packets: int): # noqa E999
-    """
-    Send multiple messages at once, all constructed from the same pkt data.
-
-    """
-    # msghdr_len = total_packets
-    m_msghdr = (struct_mmsghdr * total_packets)()
-
-    iov = struct_iovec(cast(data, c_void_p), len(data))
-    msg_iov = pointer(iov)
-    msg_iovlen = 1
-    msg_control = 0
-    msg_controllen = 0
-
-    msg_namelen = 0
-    ptr_null = None
-    msg_name = cast(None, c_void_p)
-    i = 0
-    """
-    for destination, packets in data.items():
-        msg_namelen = 0
-        msg_name = 0
-        # no scatter/gather support
-        for pkt in packets:
-            iov = struct_iovec(cast(pkt, c_void_p), len(pkt))
-            msg_iov = pointer(iov)
-
-            msghdr = struct_msghdr(
-                msg_name, msg_namelen, msg_iov, msg_iovlen,
-                msg_control, msg_controllen, 0)
-
-            m_msghdr[i] = struct_mmsghdr(msghdr)
-            i += 1
-    """
-
-    for i in range(0, total_packets):
-        msghdr = struct_msghdr(
-                    msg_name, msg_namelen, msg_iov, msg_iovlen,
-                    msg_control, msg_controllen, 0)
-        m_msghdr[i] = struct_mmsghdr(msghdr)
-        i += 1
-
-    ret = _sendmmsg(sockfd, m_msghdr[0], total_packets, 0)
-    return ret
 
 
 def main():

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -42,6 +42,7 @@ class PFCStorm(object):
         self.pfc_queue_idx = kwargs.pop('pfc_queue_index', 3)
         self.pfc_frames_number = kwargs.pop('pfc_frames_number', 100000)
         self.send_pfc_frame_interval = kwargs.pop('send_pfc_frame_interval', 0)
+        self.pfc_send_period = kwargs.pop('pfc_send_period', None)
         self.peer_info = kwargs.pop('peer_info')
         self._validate_params(expected_args=['pfc_fanout_interface', 'peerdevice'])
         if 'hwsku' not in self.peer_info:
@@ -137,7 +138,8 @@ class PFCStorm(object):
             "pfc_fanout_interface": self.peer_info['pfc_fanout_interface'],
             "ansible_eth0_ipv4_addr": self.ip_addr,
             "peer_hwsku": self.peer_info['hwsku'],
-            "send_pfc_frame_interval": self.send_pfc_frame_interval
+            "send_pfc_frame_interval": self.send_pfc_frame_interval,
+            "pfc_send_period": self.pfc_send_period
             }
         if self.peer_device.os in self._PFC_GEN_DIR:
             self.extra_vars['pfc_gen_dir'] = \
@@ -281,13 +283,17 @@ class PFCMultiStorm(object):
                          'pfc_fanout_interface': self.peer_params[peer_dev]['intfs']}
 
             q_idx, frames_cnt, gen_file = self._get_pfc_params(peer_dev)
+            if self.duthost.topo_type == 't2':
+                gen_file = 'pfc_gen_t2.py'
+                pfc_send_time = 60
             # get pfc storm handle
             self.storm_handle[peer_dev] = PFCStorm(self.duthost, self.fanout_graph,
-                                                   self.fanouthosts,
-                                                   pfc_queue_index=q_idx,
-                                                   pfc_frames_number=frames_cnt,
-                                                   pfc_gen_file=gen_file,
-                                                   peer_info=peer_info)
+                                                  self.fanouthosts,
+                                                  pfc_queue_index=q_idx,
+                                                  pfc_frames_number=frames_cnt,
+                                                  pfc_gen_file=gen_file,
+                                                  pfc_send_period=pfc_send_time,
+                                                  peer_info=peer_info)
 
             self.storm_handle[peer_dev].deploy_pfc_gen()
 

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -156,7 +156,7 @@ class PFCStorm(object):
         Populates the pfc storm start template
         """
         self._update_template_args()
-        if self.dut.topo_type == 't2':
+        if self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
         else:
@@ -169,7 +169,7 @@ class PFCStorm(object):
         Populates the pfc storm stop template
         """
         self._update_template_args()
-        if self.dut.topo_type == 't2':
+        if self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
         else:
@@ -283,7 +283,7 @@ class PFCMultiStorm(object):
                          'pfc_fanout_interface': self.peer_params[peer_dev]['intfs']}
 
             q_idx, frames_cnt, gen_file = self._get_pfc_params(peer_dev)
-            if self.duthost.topo_type == 't2':
+            if self.duthost.topo_type == 't2' and self.fanouthosts[peer_dev].os == 'sonic':
                 gen_file = 'pfc_gen_t2.py'
                 pfc_send_time = 60
             else:

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -154,8 +154,12 @@ class PFCStorm(object):
         Populates the pfc storm start template
         """
         self._update_template_args()
-        self.pfc_start_template = os.path.join(
-            TEMPLATES_DIR, "pfc_storm_{}.j2".format(self.peer_device.os))
+        if self.dut.topo_type == 't2':
+            self.pfc_start_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
+        else:
+            self.pfc_start_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_{}.j2".format(self.peer_device.os))
         self.extra_vars.update({"template_path": self.pfc_start_template})
 
     def _prepare_stop_template(self):
@@ -163,8 +167,12 @@ class PFCStorm(object):
         Populates the pfc storm stop template
         """
         self._update_template_args()
-        self.pfc_stop_template = os.path.join(
-            TEMPLATES_DIR, "pfc_storm_stop_{}.j2".format(self.peer_device.os))
+        if self.dut.topo_type == 't2':
+            self.pfc_stop_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
+        else:
+            self.pfc_stop_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_stop_{}.j2".format(self.peer_device.os))
         self.extra_vars.update({"template_path": self.pfc_stop_template})
 
     def _run_pfc_gen_template(self):

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -286,6 +286,9 @@ class PFCMultiStorm(object):
             if self.duthost.topo_type == 't2':
                 gen_file = 'pfc_gen_t2.py'
                 pfc_send_time = 60
+            else:
+                gen_file = 'pfc_gen.py'
+                pfc_send_time = None
             # get pfc storm handle
             self.storm_handle[peer_dev] = PFCStorm(self.duthost, self.fanout_graph,
                                                    self.fanouthosts,

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -288,12 +288,12 @@ class PFCMultiStorm(object):
                 pfc_send_time = 60
             # get pfc storm handle
             self.storm_handle[peer_dev] = PFCStorm(self.duthost, self.fanout_graph,
-                                                  self.fanouthosts,
-                                                  pfc_queue_index=q_idx,
-                                                  pfc_frames_number=frames_cnt,
-                                                  pfc_gen_file=gen_file,
-                                                  pfc_send_period=pfc_send_time,
-                                                  peer_info=peer_info)
+                                                   self.fanouthosts,
+                                                   pfc_queue_index=q_idx,
+                                                   pfc_frames_number=frames_cnt,
+                                                   pfc_gen_file=gen_file,
+                                                   pfc_send_period=pfc_send_time,
+                                                   peer_info=peer_info)
 
             self.storm_handle[peer_dev].deploy_pfc_gen()
 

--- a/tests/common/templates/pfc_storm_sonic_t2.j2
+++ b/tests/common/templates/pfc_storm_sonic_t2.j2
@@ -1,6 +1,6 @@
 cd {{pfc_gen_dir}}
 {% if (pfc_asym is defined) and (pfc_asym == True) %}
-nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}" > /dev/null 2>&1 &
+nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s {{pfc_send_period}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}" > /dev/null 2>&1 &
 {% else %}
-nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1 &
+nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s {{pfc_send_period}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1 &
 {% endif %}

--- a/tests/common/templates/pfc_storm_sonic_t2.j2
+++ b/tests/common/templates/pfc_storm_sonic_t2.j2
@@ -1,0 +1,6 @@
+cd {{pfc_gen_dir}}
+{% if (pfc_asym is defined) and (pfc_asym == True) %}
+nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}" > /dev/null 2>&1 &
+{% else %}
+nohup sh -c "{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo nice --20 python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1 &
+{% endif %}

--- a/tests/common/templates/pfc_storm_stop_sonic_t2.j2
+++ b/tests/common/templates/pfc_storm_stop_sonic_t2.j2
@@ -2,5 +2,5 @@ cd {{pfc_gen_dir}}
 {% if (pfc_asym is defined) and (pfc_asym == True) %}
 nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}'" > /dev/null 2>&1 &
 {% else %}
-nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}'" > /dev/null 2>&1 &
+nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s {{pfc_send_period}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}'" > /dev/null 2>&1 &
 {% endif %}

--- a/tests/common/templates/pfc_storm_stop_sonic_t2.j2
+++ b/tests/common/templates/pfc_storm_stop_sonic_t2.j2
@@ -1,0 +1,6 @@
+cd {{pfc_gen_dir}}
+{% if (pfc_asym is defined) and (pfc_asym == True) %}
+nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}'" > /dev/null 2>&1 &
+{% else %}
+nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}'" > /dev/null 2>&1 &
+{% endif %}

--- a/tests/common/templates/pfc_storm_stop_sonic_t2.j2
+++ b/tests/common/templates/pfc_storm_stop_sonic_t2.j2
@@ -1,6 +1,6 @@
 cd {{pfc_gen_dir}}
 {% if (pfc_asym is defined) and (pfc_asym == True) %}
-nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s 8 -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}'" > /dev/null 2>&1 &
+nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -s {{pfc_send_period}}  -n {{pfc_frames_number}} -i {{pfc_fanout_interface}}'" > /dev/null 2>&1 &
 {% else %}
 nohup sh -c "{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -s {{pfc_send_period}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -r {{ansible_eth0_ipv4_addr}}'" > /dev/null 2>&1 &
 {% endif %}

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -427,6 +427,7 @@ class SetupPfcwdFunc(object):
                 pfc_send_time = 60
             else:
                 gen_file = 'pfc_gen.py'
+                pfc_send_time = None
 
             # get pfc storm handle
             if init and detect:

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -422,11 +422,19 @@ class SetupPfcwdFunc(object):
                          }
             self.peer_dev_list[self.peer_device] = peer_info['hwsku']
 
+            if self.dut.topo_type == 't2':
+                gen_file = 'pfc_gen_t2.py'
+                pfc_send_time = 60
+            else:
+                gen_file = 'pfc_gen.py'
+
             # get pfc storm handle
             if init and detect:
                 self.storm_hndle = PFCStorm(self.dut, self.fanout_info, self.fanout,
                                             pfc_queue_idx=self.pfc_wd['queue_index'],
                                             pfc_frames_number=self.pfc_wd['frames_number'],
+                                            pfc_send_period=pfc_send_time,
+                                            pfc_gen_file=gen_file,
                                             peer_info=peer_info)
             self.storm_hndle.update_queue_index(self.pfc_wd['queue_index'])
             self.storm_hndle.update_peer_info(peer_info)

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -422,7 +422,7 @@ class SetupPfcwdFunc(object):
                          }
             self.peer_dev_list[self.peer_device] = peer_info['hwsku']
 
-            if self.dut.topo_type == 't2':
+            if self.dut.topo_type == 't2' and self.fanout[self.peer_device].os == 'sonic':
                 gen_file = 'pfc_gen_t2.py'
                 pfc_send_time = 60
             else:

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -186,7 +186,7 @@ class TestPfcwdAllTimer(object):
         self.all_dut_detect_restore_time.append(dut_detect_restore_time)
         logger.info(
             "Iteration all_dut_detect_restore_time list {} and length {}".format(
-                self.all_dut_detect_restore_time, len(self.all_dut_detect_restore_time)))
+                ",".join(str(i) for i in self.all_dut_detect_restore_time), len(self.all_dut_detect_restore_time)))
 
     def verify_pfcwd_timers(self):
         """
@@ -232,8 +232,8 @@ class TestPfcwdAllTimer(object):
         dut_config_pfcwd_time = 10000
 
         logger.info(
-            "all_dut_detect_restore_time list {} and length {}".format(
-                self.all_dut_detect_restore_time, len(self.all_dut_detect_restore_time)))
+            "all_dut_detect_restore_time sorted list {} and length {}".format(
+                ",".join(str(i) for i in self.all_dut_detect_restore_time), len(self.all_dut_detect_restore_time)))
 
         logger.info("Verify that real dut detection-restoration time is less than expected value")
         err_msg = ("Real dut detection-restoration time is greater than configured: Real dut detection-restore time: {}"

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -273,12 +273,12 @@ class TestPfcwdAllTimer(object):
         self.all_dut_detect_restore_time = list()
         try:
             if self.dut.topo_type == 't2':
-                for i in xrange(1, 11):
+                for i in range(1, 11):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers_t2()
             else:
-                for i in xrange(1, 20):
+                for i in range(1, 20):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers()

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -277,7 +277,7 @@ class TestPfcwdAllTimer(object):
         self.all_dut_detect_restore_time = list()
         try:
             if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
-                for i in xrange(1, 11):
+                for i in range(1, 11):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers_t2()

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -140,8 +140,12 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     logger.info("Setting up storm params")
     pfc_queue_index = 4
     pfc_frames_count = 1000000
+    if dut.topo_type == 't2':
+        pfc_gen_file = 'pfc_gen_t2.py'
+    else:
+        pfc_gen_file = 'pfc_gen.py'
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
-                            pfc_frames_number=pfc_frames_count, peer_info=peer_params)
+                            pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file, peer_info=peer_params)
     storm_handle.deploy_pfc_gen()
     return storm_handle
 
@@ -159,17 +163,28 @@ class TestPfcwdAllTimer(object):
         self.storm_handle.start_storm()
         logger.info("Wait for queue to recover from PFC storm")
         time.sleep(8)
-
-        storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
-        storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
+        if self.dut.topo_type == 't2':
+            storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
+        else:
+            storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
+            storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         logger.info("Wait for PFC storm end marker to appear in logs")
         time.sleep(8)
-        storm_end_ms = self.retrieve_timestamp("[P]FC_STORM_END")
-        storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
-        real_detect_time = storm_detect_ms - storm_start_ms
-        real_restore_time = storm_restore_ms - storm_end_ms
-        self.all_detect_time.append(real_detect_time)
-        self.all_restore_time.append(real_restore_time)
+        if self.dut.topo_type == 't2':
+            storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
+        else:
+            storm_end_ms = self.retrieve_timestamp("[P]FC_STORM_END")
+            storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
+            real_detect_time = storm_detect_ms - storm_start_ms
+            real_restore_time = storm_restore_ms - storm_end_ms
+            self.all_detect_time.append(real_detect_time)
+            self.all_restore_time.append(real_restore_time)
+
+        dut_detect_restore_time = storm_restore_ms - storm_detect_ms
+        self.all_dut_detect_restore_time.append(dut_detect_restore_time)
+        logger.info(
+            "Iteration all_dut_detect_restore_time list {} and length {}".format(
+                self.all_dut_detect_restore_time, len(self.all_dut_detect_restore_time)))
 
     def verify_pfcwd_timers(self):
         """
@@ -205,6 +220,24 @@ class TestPfcwdAllTimer(object):
                                                                           config_restore_time))
         pytest_assert(self.all_restore_time[9] < config_restore_time, err_msg)
 
+    def verify_pfcwd_timers_t2(self):
+        """
+        Compare the timestamps obtained and verify the timer accuracy for t2 chassis
+        """
+        self.all_dut_detect_restore_time.sort()
+        # Detect to restore elapsed time should always be less than 10 seconds since
+        # storm is sent for 8 seconds
+        dut_config_pfcwd_time = 10000
+
+        logger.info(
+            "all_dut_detect_restore_time list {} and length {}".format(
+                self.all_dut_detect_restore_time, len(self.all_dut_detect_restore_time)))
+
+        logger.info("Verify that real dut detection-restoration time is less than expected value")
+        err_msg = ("Real dut detection-restoration time is greater than configured: Real dut detection-restore time: {}"
+                   " Expected: {}".format(self.all_dut_detect_restore_time[5], dut_config_pfcwd_time))
+        pytest_assert(self.all_dut_detect_restore_time[5] < dut_config_pfcwd_time, err_msg)
+
     def retrieve_timestamp(self, pattern):
         """
         Retreives the syslog timestamp in ms associated with the pattern
@@ -237,11 +270,18 @@ class TestPfcwdAllTimer(object):
         self.dut = duthost
         self.all_detect_time = list()
         self.all_restore_time = list()
+        self.all_dut_detect_restore_time = list()
         try:
-            for i in range(1, 20):
-                logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
-                self.run_test()
-            self.verify_pfcwd_timers()
+            if self.dut.topo_type == 't2':
+                for i in xrange(1, 11):
+                    logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
+                    self.run_test()
+                self.verify_pfcwd_timers_t2()
+            else:
+                for i in xrange(1, 20):
+                    logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
+                    self.run_test()
+                self.verify_pfcwd_timers()
 
         except Exception as e:
             pytest.fail(str(e))

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -142,10 +142,12 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     pfc_frames_count = 1000000
     if dut.topo_type == 't2':
         pfc_gen_file = 'pfc_gen_t2.py'
+        pfc_send_time = 8
     else:
         pfc_gen_file = 'pfc_gen.py'
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
-                            pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file, peer_info=peer_params)
+                            pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file,
+                            pfc_send_period=pfc_send_time, peer_info=peer_params)
     storm_handle.deploy_pfc_gen()
     return storm_handle
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -140,7 +140,8 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     logger.info("Setting up storm params")
     pfc_queue_index = 4
     pfc_frames_count = 1000000
-    if dut.topo_type == 't2':
+    peer_device = peer_params['peerdevice']
+    if dut.topo_type == 't2' and fanout[peer_device].os == 'sonic':
         pfc_gen_file = 'pfc_gen_t2.py'
         pfc_send_time = 8
     else:
@@ -166,14 +167,14 @@ class TestPfcwdAllTimer(object):
         self.storm_handle.start_storm()
         logger.info("Wait for queue to recover from PFC storm")
         time.sleep(8)
-        if self.dut.topo_type == 't2':
+        if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         else:
             storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         logger.info("Wait for PFC storm end marker to appear in logs")
         time.sleep(8)
-        if self.dut.topo_type == 't2':
+        if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
         else:
             storm_end_ms = self.retrieve_timestamp("[P]FC_STORM_END")
@@ -275,8 +276,8 @@ class TestPfcwdAllTimer(object):
         self.all_restore_time = list()
         self.all_dut_detect_restore_time = list()
         try:
-            if self.dut.topo_type == 't2':
-                for i in range(1, 11):
+            if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
+                for i in xrange(1, 11):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers_t2()

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -145,6 +145,7 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
         pfc_send_time = 8
     else:
         pfc_gen_file = 'pfc_gen.py'
+        pfc_send_time = None
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                             pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file,
                             pfc_send_period=pfc_send_time, peer_info=peer_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes '_test_pfcwd_timer_accuracy_' test failures for **t2-chassis**.
- Currently, for '_t2_' chassis, the timer accuracy test fails w.r.t the issues related to PFC storm detection and restoration on the DUT.
- And also, this PR adds a new pfc_gen file specifically for 't2-chassis' w.r.t '_TestPfcwdFunc_' and '_TestPfcwdAllPortStorm_' test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
- PFC storm detection/restoration logic for t2-chassis w.r.t to the existing '_pfc_gen.py_' template is not working as expected.
- Due to this, the '_test_pfcwd_timer_accuracy_' , '_TestPfcwdFunc_' and '_TestPfcwdAllPortStorm_' tests fail for t2 multi-asic dut.

#### How did you do it?
- By introducing a new template file for _t2-chassis_ which does bulk send from leaf fanout instead of sending 1 packet at a time, and also sends for a period of 'n' seconds (_instead of using a specified number of packets_) which gives enough time for the dut to detect storm.  @snider-nokia will provide further details about how t2 fanout script has been modified in a subsequent comment.
- And also, created separate '_storm-start_'/'_storm-stop_' .j2 files for t2-chassis.

#### How did you verify/test it?
- Test verification is done by finding the delta of '_storm-detection_' and '_storm-restoration_' time from the orchagent logs on the dut instead of relying on the DEBUG message logs from the leaf fanout.
- Ran all the '_pfcwd_' test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?
- Changes are only relevant for sonic leaf fanout.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Attaching test run logs for reference.
[pfcwd.log.txt](https://github.com/sonic-net/sonic-mgmt/files/12364225/pfcwd.log.txt)
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/e846426e-c6c6-48f6-8a80-63c1e8992622)

