### PR TITLE
Skip certain voq tests when ports to T3 VM's are not available in t2 min topology

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -793,6 +793,9 @@ class TestVoqIPFwd(object):
         ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
         logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl,
                                                                                                  size=size))
+        if 'portC' not in ports or 'portD' not in ports:
+            pytest.skip("Did not find ports in the DUTs (linecards) connected to T3 VM's")
+
         # these don't decrement ttl
         check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size, ttl=ttl,
                      ttl_change=0)
@@ -894,6 +897,10 @@ class TestVoqIPFwd(object):
         ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
         logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}"
                     .format(ipv=version, ttl=ttl, size=size))
+
+        if 'portC' not in ports or 'portD' not in ports:
+            pytest.skip("Did not find ports in the DUTs (linecards) connected to T3 VM's")
+
         vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
         check_packet(eos_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_lb', src_ip_fld='nbr_lb', dev=vm_host_to_A,
                      size=size, ttl=ttl)
@@ -922,6 +929,9 @@ def test_ipforwarding_ttl0(duthosts, all_cfg_facts, tbinfo, ptfhost, version, po
     """
 
     ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
+
+    if 'portD' not in ports:
+        pytest.skip("Did not find ports in the DUTs (linecards) connected to T3 VM's")
 
     if 'portB' in ports:
         dst_list = [('portB', ports['portB']['nbr_lb']), ('portD', ports['portD']['nbr_lb'])]
@@ -1028,6 +1038,10 @@ class TestFPLinkFlap(LinkFlap):
         logger.info("Fanouthosts: %s", fanouthosts)
 
         ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
+
+        if 'portC' not in ports or 'portD' not in ports:
+            pytest.skip("Did not find ports in the DUTs (linecards) connected to T3 VM's")
+
         cfg_facts = all_cfg_facts[ports['portA']['dut'].hostname][ports['portA']['asic'].asic_index]['ansible_facts']
 
         if "portchannel" in ports['portA']['port'].lower():
@@ -1150,6 +1164,9 @@ def test_ipforwarding_jumbo_to_dut(duthosts, all_cfg_facts, tbinfo, ptfhost, por
 
     """
     ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
+
+    if 'portD' not in ports:
+        pytest.skip("Did not find ports in the DUTs (linecards) connected to T3 VM's")
 
     dst_ip = ports[port][ip]
 


### PR DESCRIPTION
Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/9363

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
Add skip to tests when ports to T3 VM's are not available in t2 min topology. 

In the T2 min topolgy as there are less ports per asic, skip the test if we don't have enough ports.

#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
```


jujoseph@d01ac6af286b:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -c voq/test_voq_ipfwd.py -i '../ansible/str2,../ansible/veos' -n vms29-t2-xxxx-1  -t 't2,any' -u -e "--skip_sanity --disable_loganalyzer"
=== Running tests in groups ===
Running: python2 -m pytest voq/test_voq_ipfwd.py --inventory ../ansible/str2,../ansible/veos --host-pattern str2-xxxx-lc1-1,str2-xxxx-lc2-1,str2-xxxx-sup-1 --testbed vms29-t2-xxxx-1 --testbed_file /var/src/sonic-mgmt-int/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --skip_sanity --disable_loganalyzer
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================== test session starts ==========================================================================================================
platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, metadata-1.11.0, celery-4.4.7, repeat-0.9.1, forked-1.3.0, ansible-2.2.4, html-1.22.1, xdist-1.28.0
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 127 items                                                                                                                                                                                                                     

voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_local_addr[str2-xxxx-lc2-1-0] PASSED                                                                                                                            [  0%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_inband_addr[str2-xxxx-lc2-1-0] PASSED                                                                                                                           [  1%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_bgp[str2-xxxx-lc2-1-0] PASSED                                                                                                                                   [  2%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_nbr_lb_addr[str2-xxxx-lc2-1] PASSED                                                                                                                             [  3%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_local_addr[str2-xxxx-lc2-1-1] PASSED                                                                                                                            [  3%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_inband_addr[str2-xxxx-lc2-1-1] PASSED                                                                                                                           [  4%]
voq/test_voq_ipfwd.py::TestTableValidation::test_host_route_table_bgp[str2-xxxx-lc2-1-1] PASSED                                                                                                                                   [  5%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-4-2-1500] PASSED                                                                                                                                   [  6%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-4-255-1500] PASSED                                                                                                                                 [  7%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-4-128-64] PASSED                                                                                                                                   [  7%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-4-128-9000] PASSED                                                                                                                                 [  8%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-6-2-1500] PASSED                                                                                                                                   [  9%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-6-255-1500] PASSED                                                                                                                                 [ 10%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-6-128-64] PASSED                                                                                                                                   [ 11%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[portchannel-6-128-9000] PASSED                                                                                                                                 [ 11%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-4-2-1500] PASSED                                                                                                                                      [ 12%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-4-255-1500] PASSED                                                                                                                                    [ 13%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-4-128-64] PASSED                                                                                                                                      [ 14%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-4-128-9000] PASSED                                                                                                                                    [ 14%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-6-2-1500] PASSED                                                                                                                                      [ 15%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-6-255-1500] PASSED                                                                                                                                    [ 16%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-6-128-64] PASSED                                                                                                                                      [ 17%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_interface_ping[ethernet-6-128-9000] PASSED                                                                                                                                    [ 18%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-4-2-64] PASSED                                                                                                                                         [ 18%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-4-128-64] PASSED                                                                                                                                       [ 19%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-4-255-1456] PASSED                                                                                                                                     [ 20%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-4-1-1456] PASSED                                                                                                                                       [ 21%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-6-2-64] PASSED                                                                                                                                         [ 22%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-6-128-64] PASSED                                                                                                                                       [ 22%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-6-255-1456] PASSED                                                                                                                                     [ 23%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[ethernet-6-1-1456] PASSED                                                                                                                                       [ 24%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-4-2-64] PASSED                                                                                                                                      [ 25%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-4-128-64] PASSED                                                                                                                                    [ 25%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-4-255-1456] PASSED                                                                                                                                  [ 26%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-4-1-1456] PASSED                                                                                                                                    [ 27%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-6-2-64] PASSED                                                                                                                                      [ 28%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-6-128-64] PASSED                                                                                                                                    [ 29%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-6-255-1456] PASSED                                                                                                                                  [ 29%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_local_neighbor_ping[portchannel-6-1-1456] PASSED                                                                                                                                    [ 30%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-4-2-64] PASSED                                                                                                                                            [ 31%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-4-128-64] PASSED                                                                                                                                          [ 32%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-4-255-1456] PASSED                                                                                                                                        [ 33%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-4-1-1456] PASSED                                                                                                                                          [ 33%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-6-2-64] PASSED                                                                                                                                            [ 34%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-6-128-64] PASSED                                                                                                                                          [ 35%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-6-255-1456] PASSED                                                                                                                                        [ 36%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[ethernet-6-1-1456] PASSED                                                                                                                                          [ 37%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-4-2-64] PASSED                                                                                                                                         [ 37%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-4-128-64] PASSED                                                                                                                                       [ 38%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-4-255-1456] PASSED                                                                                                                                     [ 39%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-4-1-1456] PASSED                                                                                                                                       [ 40%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-6-2-64] PASSED                                                                                                                                         [ 40%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-6-128-64] PASSED                                                                                                                                       [ 41%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-6-255-1456] PASSED                                                                                                                                     [ 42%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_neighbor_lb_ping[portchannel-6-1-1456] PASSED                                                                                                                                       [ 43%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-4-2-64] PASSED                                                                                                                                                 [ 44%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-4-128-64] PASSED                                                                                                                                               [ 44%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-4-255-1456] PASSED                                                                                                                                             [ 45%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-4-1-1456] PASSED                                                                                                                                               [ 46%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-6-2-64] PASSED                                                                                                                                                 [ 47%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-6-128-64] PASSED                                                                                                                                               [ 48%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-6-255-1456] PASSED                                                                                                                                             [ 48%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[ethernet-6-1-1456] PASSED                                                                                                                                               [ 49%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-4-2-64] PASSED                                                                                                                                              [ 50%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-4-128-64] PASSED                                                                                                                                            [ 51%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-4-255-1456] PASSED                                                                                                                                          [ 51%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-4-1-1456] PASSED                                                                                                                                            [ 52%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-6-2-64] PASSED                                                                                                                                              [ 53%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-6-128-64] PASSED                                                                                                                                            [ 54%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-6-255-1456] PASSED                                                                                                                                          [ 55%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_inband_ping[portchannel-6-1-1456] PASSED                                                                                                                                            [ 55%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-4-2-64] SKIPPED                                                                                                                                                [ 56%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-4-128-64] SKIPPED                                                                                                                                              [ 57%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-4-1-1456] SKIPPED                                                                                                                                              [ 58%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-4-255-1456] SKIPPED                                                                                                                                            [ 59%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-6-2-64] SKIPPED                                                                                                                                                [ 59%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-6-128-64] SKIPPED                                                                                                                                              [ 60%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-6-1-1456] SKIPPED                                                                                                                                              [ 61%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[ethernet-6-255-1456] SKIPPED                                                                                                                                            [ 62%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-4-2-64] SKIPPED                                                                                                                                             [ 62%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-4-128-64] SKIPPED                                                                                                                                           [ 63%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-4-1-1456] SKIPPED                                                                                                                                           [ 64%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-4-255-1456] SKIPPED                                                                                                                                         [ 65%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-6-2-64] SKIPPED                                                                                                                                             [ 66%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-6-128-64] SKIPPED                                                                                                                                           [ 66%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-6-1-1456] SKIPPED                                                                                                                                           [ 67%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_dut_lb_ping[portchannel-6-255-1456] SKIPPED                                                                                                                                         [ 68%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-2-64] SKIPPED                                                                                                                                            [ 69%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-128-64] SKIPPED                                                                                                                                          [ 70%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-4-255-1456] SKIPPED                                                                                                                                        [ 70%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-2-64] SKIPPED                                                                                                                                            [ 71%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-128-64] SKIPPED                                                                                                                                          [ 72%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[ethernet-6-255-1456] SKIPPED                                                                                                                                        [ 73%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-4-2-64] SKIPPED                                                                                                                                         [ 74%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-4-128-64] SKIPPED                                                                                                                                       [ 74%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-4-255-1456] SKIPPED                                                                                                                                     [ 75%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-2-64] SKIPPED                                                                                                                                         [ 76%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-128-64] SKIPPED                                                                                                                                       [ 77%]
voq/test_voq_ipfwd.py::TestVoqIPFwd::test_voq_end_to_end_ping[portchannel-6-255-1456] SKIPPED                                                                                                                                     [ 77%]
voq/test_voq_ipfwd.py::test_ipforwarding_ttl0[ethernet-4] SKIPPED                                                                                                                                                                 [ 78%]
voq/test_voq_ipfwd.py::test_ipforwarding_ttl0[ethernet-6] SKIPPED                                                                                                                                                                 [ 79%]
voq/test_voq_ipfwd.py::test_ipforwarding_ttl0[portchannel-4] PASSED                                                                                                                                                               [ 80%]
voq/test_voq_ipfwd.py::test_ipforwarding_ttl0[portchannel-6] PASSED                                                                                                                                                               [ 81%]
voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[ethernet-4] SKIPPED                                                                                                                                         [ 81%]
voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[ethernet-6] SKIPPED                                                                                                                                         [ 82%]
voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[portchannel-4] SKIPPED                                                                                                                                      [ 83%]
voq/test_voq_ipfwd.py::TestFPLinkFlap::test_front_panel_linkflap_port[portchannel-6] SKIPPED                                                                                                                                      [ 84%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-my_ip] SKIPPED                                                                                                                                             [ 85%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-my_lb_ip] SKIPPED                                                                                                                                          [ 85%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portA-inband] SKIPPED                                                                                                                                            [ 86%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portD-my_lb_ip] SKIPPED                                                                                                                                          [ 87%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-4-portD-inband] SKIPPED                                                                                                                                            [ 88%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-my_ip] SKIPPED                                                                                                                                             [ 88%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-my_lb_ip] SKIPPED                                                                                                                                          [ 89%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portA-inband] SKIPPED                                                                                                                                            [ 90%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portD-my_lb_ip] SKIPPED                                                                                                                                          [ 91%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[ethernet-6-portD-inband] SKIPPED                                                                                                                                            [ 92%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-my_ip] PASSED                                                                                                                                           [ 92%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-my_lb_ip] PASSED                                                                                                                                        [ 93%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portA-inband] PASSED                                                                                                                                          [ 94%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portD-my_lb_ip] PASSED                                                                                                                                        [ 95%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-4-portD-inband] PASSED                                                                                                                                          [ 96%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-my_ip] PASSED                                                                                                                                           [ 96%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-my_lb_ip] PASSED                                                                                                                                        [ 97%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portA-inband] PASSED                                                                                                                                          [ 98%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portD-my_lb_ip] PASSED                                                                                                                                        [ 99%]
voq/test_voq_ipfwd.py::test_ipforwarding_jumbo_to_dut[portchannel-6-portD-inband] PASSED                                                                                                                                          [100%]







=========================================================================================================== warnings summary ============================================================================================================
======================================================================================================== short test summary info ========================================================================================================
SKIPPED [2] /var/src/sonic-mgmt-int/tests/voq/test_voq_ipfwd.py:927: Did not find ports in the DUTs (linecards) connected to T3 VM's
SKIPPED [10] /var/src/sonic-mgmt-int/tests/voq/test_voq_ipfwd.py:1160: Did not find ports in the DUTs (linecards) connected to T3 VM's
SKIPPED [12] /var/src/sonic-mgmt-int/tests/voq/test_voq_ipfwd.py:895: Did not find ports in the DUTs (linecards) connected to T3 VM's
SKIPPED [16] /var/src/sonic-mgmt-int/tests/voq/test_voq_ipfwd.py:791: Did not find ports in the DUTs (linecards) connected to T3 VM's
SKIPPED [4] /var/src/sonic-mgmt-int/tests/voq/test_voq_ipfwd.py:1034: Did not find ports in the DUTs (linecards) connected to T3 VM's
========================================================================================== 83 passed, 44 skipped, 1 warnings in 627.97 seconds =========================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
