### PR TITLE
Decrease the PFC frame counter in PFC watchdog warmboot test

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -133,7 +133,7 @@ class SetupPfcwdFunc(object):
             # Will send traffic for (queues 4 and 3) per each port
             self.pfc_wd['queue_indices'].append(3)
         self.pfc_wd['test_pkt_count'] = 100
-        self.pfc_wd['frames_number'] = 10000000000000
+        self.pfc_wd['frames_number'] = 1000000000
         self.peer_device = self.ports[port]['peer_device']
         self.pfc_wd['test_port'] = port
         self.pfc_wd['rx_port'] = self.ports[port]['rx_port']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to decrease the PFC frame counter in PFC watchdog warmboot test.

The change is required because the `pfc_gen.py` is left running on leaf fanout if the PFCStorm handler failed to kill the script for some reason. The script keeps running on leaf fanout for a few days and affects the nightly test.
The number is changed to  `1000000000` from `10000000000000`.

In my test, it costs around 1 hour for leaf-fanout to generate and send `1000000000` PFC pause frames on a `Intel(R) Pentium(R) CPU D1508 @ 2.20GHz` CPU. The test costs around 20 minutes to finish. So the number should be enough for the test.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to decrease the PFC frame counter in PFC watchdog warmboot test. 

#### How did you do it?
Decrease the number to  `1000000000` from `10000000000000`.

#### How did you verify/test it?
The change is verified by running `pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb`.
```
collected 3 items                                                                                                                                                          

pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm-str-msn2700-22]  ^H ^H ^HPASSED                                                                          [ 33%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm-str-msn2700-22]  ^H ^HPASSED                                                                             [ 66%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm-str-msn2700-22]  ^HPASSED                                                                       [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
