### PR TITLE
Skip default route and loopback case in BSL testing 

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -9,7 +9,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.bsl
 def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                             localhost, creds_all_duts, tbinfo):
     """compare the snmp facts between observed states and target state"""

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -8,7 +8,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.bsl
 def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                        nbrhosts, tbinfo, localhost, creds_all_duts):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip test_snmp_default_route and test_snmp_loopback in BSL testing, because BSL is layer2 which don't have BGP neighbors and default route.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Skip test_snmp_default_route and test_snmp_loopback in BSL testing, because BSL is layer2 which don't have BGP neighbors and default route.

#### How did you do it?
Remove @pytest.mark.bsl

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
