### PR TITLE
fix tcpdump issue in bgp update timer testing

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -73,7 +73,7 @@ def log_bgp_updates(duthost, iface, save_path, ns):
     # wait until tcpdump process created
     if not wait_until(WAIT_TIMEOUT, 5, 1, lambda: is_tcpdump_running(duthost, start_pcap),):
         pytest.fail("Could not start tcpdump")
-    # sleep and waiting for tcpdump start to work (schedualed)
+    # sleep and wait for tcpdump ready to sniff packets
     time.sleep(TCPDUMP_WAIT_TIMEOUT)
 
     try:

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -42,11 +42,13 @@ NEIGHBOR_PORT0 = 11000
 NEIGHBOR_PORT1 = 11001
 WAIT_TIMEOUT = 120
 
+
 def is_tcpdump_running(duthost, cmd):
     check_cmd = "ps u -C tcpdump | grep '%s'" % cmd
     if cmd in duthost.shell(check_cmd)['stdout']:
         return True
     return False
+
 
 @contextlib.contextmanager
 def log_bgp_updates(duthost, iface, save_path, ns):

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -41,6 +41,7 @@ NEIGHBOR_ASN1 = 61001
 NEIGHBOR_PORT0 = 11000
 NEIGHBOR_PORT1 = 11001
 WAIT_TIMEOUT = 120
+TCPDUMP_WAIT_TIMEOUT = 20
 
 
 def is_tcpdump_running(duthost, cmd):
@@ -69,8 +70,11 @@ def log_bgp_updates(duthost, iface, save_path, ns):
         duthost.asic_instance_from_namespace(ns).ns_arg, start_pcap
     )
     duthost.shell(start_pcap_cmd)
-    if not wait_until(WAIT_TIMEOUT, 5, 20, lambda: is_tcpdump_running(duthost, start_pcap),):
+    # wait until tcpdump process created
+    if not wait_until(WAIT_TIMEOUT, 5, 1, lambda: is_tcpdump_running(duthost, start_pcap),):
         pytest.fail("Could not start tcpdump")
+    # sleep and waiting for tcpdump start to work (schedualed)
+    time.sleep(TCPDUMP_WAIT_TIMEOUT)
 
     try:
         yield

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -42,6 +42,11 @@ NEIGHBOR_PORT0 = 11000
 NEIGHBOR_PORT1 = 11001
 WAIT_TIMEOUT = 120
 
+def is_tcpdump_running(duthost, cmd):
+    check_cmd = "ps u -C tcpdump | grep '%s'" % cmd
+    if cmd in duthost.shell(check_cmd)['stdout']:
+        return True
+    return False
 
 @contextlib.contextmanager
 def log_bgp_updates(duthost, iface, save_path, ns):
@@ -58,10 +63,13 @@ def log_bgp_updates(duthost, iface, save_path, ns):
         duthost.asic_instance_from_namespace(ns).ns_arg,
         start_pcap,
     )
-    start_pcap = "nohup {}{} &".format(
+    start_pcap_cmd = "nohup {}{} &".format(
         duthost.asic_instance_from_namespace(ns).ns_arg, start_pcap
     )
-    duthost.shell(start_pcap)
+    duthost.shell(start_pcap_cmd)
+    if not wait_until(WAIT_TIMEOUT, 5, 20, lambda: is_tcpdump_running(duthost, start_pcap),):
+        pytest.fail("Could not start tcpdump")
+
     try:
         yield
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix test_bgp_update_timer.py issue on T0 and T1, which caused by background running tcpdump issue.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_bgp_update_timer.py issue on T0 and T1, which caused by background running tcpdump.
In script using "nohup <> &" running without waiting for tcpdump tool real running on DUT.
So in some failure case, bgp update sendout but tcpdump still not ready to capture packets and cause failure with saying bgp update not found.

#### How did you do it?
Wait until tcpdump tool running on DUT before continue testing

#### How did you verify/test it?
Keep running 10 times on KVM environment without failure. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
