### PR TITLE
Fix port selection in ptfhost_utils.py

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -518,10 +518,10 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
                 ]
 
     disabled_ptf_ports = set()
+    # Data in ptf_map_disabled is {dut_port_index: ptf_port_index}
     for ptf_map in tbinfo['topo']['ptf_map_disabled'].values():
         # Loop ptf_map of each DUT. Each ptf_map maps from ptf port index to dut port index
-        disabled_ptf_ports = disabled_ptf_ports.union(set(ptf_map.keys()))
-
+        disabled_ptf_ports = disabled_ptf_ports.union(set(ptf_map.values()))
     router_macs = []
     all_dut_names = [duthost.hostname for duthost in duthosts]
     for a_dut_name in tbinfo['duts']:
@@ -534,10 +534,9 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
     logger.info('active_dut_map={}'.format(active_dut_map))
     logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
     logger.info('router_macs={}'.format(router_macs))
-
     ports_map = {}
     for ptf_port, dut_intf_map in list(tbinfo['topo']['ptf_dut_intf_map'].items()):
-        if str(ptf_port) in disabled_ptf_ports:
+        if int(ptf_port) in disabled_ptf_ports:
             # Skip PTF ports that are connected to disabled VLAN interfaces
             continue
         asic_idx = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix the port selection code in `ptfhost_utils.py`.
Because of the issue in port selection, the disabled port can be used in test and that results in test failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix the port selection code in `ptfhost_utils.py`.

#### How did you do it?
This PR addressed the issue by using the correct key-value in dict `disabled_ptf_ports`.

#### How did you verify/test it?
The change is verified by running `test_decap`

```
collected 4 items                                                                                                                                                          

decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable] ^HPASSED                                                                                                                                                               [ 25%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]  ^HPASSED                                                                                      [ 50%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable] SKIPPED                                                                                          [ 75%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset] SKIPPED                                                                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
