### PR TITLE
Fix wrong bool argument parsing in upgrade_image.py script

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -16,6 +16,8 @@ import os
 import requests
 import sys
 
+from setuptools import distutils
+
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
@@ -285,17 +287,17 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--always-power-cycle",
-        type=bool,
+        type=distutils.util.strtobool,
         dest="always_power_cycle",
-        default=False,
+        default=0,
         help="Always power cycle DUTs before upgrade."
     )
 
     parser.add_argument(
         "--power-cycle-unreachable",
-        type=bool,
+        type=distutils.util.strtobool,
         dest="power_cycle_unreachable",
-        default=True,
+        default=1,
         help="Only power cycle unreachable DUTs."
     )
 
@@ -319,10 +321,10 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--enable-fips",
-        type=bool,
+        type=distutils.util.strtobool,
         dest="enable_fips",
         required=False,
-        default=False,
+        default=0,
         help="Enable FIPS."
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The upgrade_image.py script defined some bool  type arguments. However, "action" is not specified while defining these arguments.

The result is that if user pass in arguments like below, the argument will be still be evaluated to True as python by default casting string "False" to bool value True.
```
./upgrade_image.py --enable-fips Flase
```
#### How did you do it?
The fix is to take advantage of setuptools.distutils.util.strtobool.

With tool, any values like below passed in to this type of arguments would be evaluated to integer 0:
```
"n", "no", "No", "NO", "False", "false", "FALSE", "FaLsE", ...
```
Any argument value like below would be evaluated to integer 1: 
```
"y", "yes", "Yes", "YES", "True", "true", "TRUE", "TrUe", ...
```

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
