### PR TITLE
[202205][Snappi] Fix config_reload error

### DIFF
--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -301,7 +301,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,
                          prio_dscp_map=prio_dscp_map,
                          trigger_pfcwd=trigger_pfcwd)
 
-    config_reload(duthost=duthost, config_source='minigraph', safe_reload=True)
+    config_reload(sonic_host=duthost, config_source='minigraph', safe_reload=True)
 
 
 @pytest.mark.disable_loganalyzer
@@ -363,4 +363,4 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,
                          prio_dscp_map=prio_dscp_map,
                          trigger_pfcwd=trigger_pfcwd)
 
-    config_reload(duthost=duthost, config_source='minigraph', safe_reload=True)
+    config_reload(sonic_host=duthost, config_source='minigraph', safe_reload=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: config_reload on 202205 uses "sonic_host" instead of "duthost" as on other branches. This was not caught during cherry-pick, and caused the test to fail on this line.  
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran on 202205 nightly pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
