### PR TITLE
Add config save after TSB to reset device state

### DIFF
--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -133,3 +133,10 @@ class TestTrafficShiftOnSup:
             self.run_cmd_on_sup("sudo TSB")
             # Verify DUT is in normal state.
             self.verify_traffic_shift_state_all_lcs(TS_NORMAL, "normal")
+
+            # Save config and perform config reload on all LCs
+            self.run_cmd_on_sup("rexec all -c 'sudo config save -y'")
+            self.config_reload_all_lcs()
+
+            # Verify DUT is in normal state.
+            self.verify_traffic_shift_state_all_lcs(TS_NORMAL, "normal")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Changes to fix the issue where after running bgp/test_traffic_sup.py and reload, the device came up with TSA enabled, causing subsequent test failures.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To fix the issue where after running bgp/test_traffic_sup.py and reload, the device came up with TSA enabled, causing subsequent test failures.

#### How did you do it?
In test_TSA_TSB_chassis_with_config_reload, config was saved after TSA, but not after subsequent TSB. Due to this, the device returned to isolated state when rebooted in subsequent tests

#### How did you verify/test it?
Manual run of bgp/test_traffic_shift_sup.py and validated config DB and current state on all LCs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
