### PR TITLE
Reduce time cost of test_fdb on topology dualtor-64

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -56,7 +56,8 @@ def get_dummay_mac_count(tbinfo, duthosts, rand_one_dut_hostname):
         return DUMMY_MAC_COUNT_SLIM
 
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
-    REQUIRED_TOPO = ["t0-116"]
+    # Use DUMMY_MAC_COUNT_SLIM on dualtor-64 to reduce running time
+    REQUIRED_TOPO = ["t0-116", "dualtor-64"]
     if tbinfo["topo"]["name"] in REQUIRED_TOPO:
         # To reduce the case running time
         logger.info("Use dummy mac count {} on topo {}\n".format(DUMMY_MAC_COUNT_SLIM, tbinfo["topo"]["name"]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #9457 
This PR is to reduce the time cost of `test_fdb` on dualtor-64 topology.
Before this change, the `test_fdb` costs over 4 hours.
Now it takes around 20 minutes after we run the test on less dummy MAC addresses. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
### Approach
#### What is the motivation for this PR?
This PR is to fix #9457.

#### How did you do it?
Use less dummy MAC address on dualtor-64 topology.

#### How did you verify/test it?
The change is verified on a dualtor-64 testbed.
```
collected 4 items                                                                                                                                                          

fdb/test_fdb.py::test_fdb[ethernet]  ^HPASSED                                                                                                                           [ 25%]
fdb/test_fdb.py::test_fdb[arp_request]  ^H ^HPASSED                                                                                                                        [ 50%]
fdb/test_fdb.py::test_fdb[arp_reply]  ^HPASSED                                                                                                                          [ 75%]
fdb/test_fdb.py::test_fdb[cleanup] PASSED                                                                                                                            [100%]

================================================================= 4 passed, 3 warnings in 1383.63 seconds =================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
