### PR TITLE
[Snappi] RDMA headroom test fix for 7050CX3

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -233,7 +233,7 @@ def collect_dut_pfc_pause_delay_params(dut):
         pfc_pause_delay_test_params[1023] = True
     elif 'arista' and '7050cx3' in platform.lower():
         pfc_pause_delay_test_params[0] = True
-        pfc_pause_delay_test_params[200] = False
+        pfc_pause_delay_test_params[1023] = True
     else:
         pfc_pause_delay_test_params = None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Arista 7050CX3 has an ingress lossless pool size of 32.7MB and pg headroom size of 0.16MB. The params for the headroom response test assumed older values which were drastically smaller to collect packets in the queue. Since there is more space in the buffer now, the 7050CX3 can support longer delays in PFC response times from its peers. 
 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Fixed outdated test information

#### How did you do it?

#### How did you verify/test it?
Test passes on 7050CX3 lab device. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
