### PR TITLE
[master][CI/CD] Refine the way to get test repo sonic-mgmt url

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -181,6 +181,7 @@ steps:
       --scripts-exclude "${{ parameters.SCRIPTS_EXCLUDE }}" \
       --features-exclude "${{ parameters.FEATURES_EXCLUDE }}" \
       --repo-name ${{ parameters.REPO_NAME }} \
+      --mgmt-url ${{ parameters.MGMT_URL }} \
       --mgmt-branch ${{ parameters.MGMT_BRANCH }} \
       --stop-on-failure ${{ parameters.STOP_ON_FAILURE }} \
       --retry-times ${{ parameters.RETRY_TIMES }} \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -214,11 +214,6 @@ class TestPlanManager(object):
 
         common_extra_params = common_extra_params + " --completeness_level=confident --allow_recover"
 
-        # If triggered by the internal repos, use internal sonic-mgmt repo as the code base
-        sonic_mgmt_repo_url = GITHUB_SONIC_MGMT_REPO
-        if kwargs.get("source_repo") in INTERNAL_REPO_LIST:
-            sonic_mgmt_repo_url = INTERNAL_SONIC_MGMT_REPO
-
         # If triggered by mgmt repo, use pull request id as the code base
         sonic_mgmt_pull_request_id = ""
         if MGMT_REPO_FLAG in kwargs.get("source_repo"):
@@ -260,7 +255,7 @@ class TestPlanManager(object):
                     "kvm_image_branch": kvm_image_branch
                 },
                 "sonic_mgmt": {
-                    "repo_url": sonic_mgmt_repo_url,
+                    "repo_url": kwargs["mgmt_url"],
                     "branch": kwargs["mgmt_branch"],
                     "pull_request_id": sonic_mgmt_pull_request_id
                 },
@@ -501,6 +496,16 @@ if __name__ == "__main__":
         default="",
         required=False,
         help="KVM build id."
+    )
+    parser_create.add_argument(
+        "--mgmt-url",
+        type=str,
+        dest="mgmt_url",
+        nargs='?',
+        const=GITHUB_SONIC_MGMT_REPO,
+        default=GITHUB_SONIC_MGMT_REPO,
+        required=False,
+        help="URL of sonic-mgmt repo to run the test"
     )
     parser_create.add_argument(
         "--mgmt-branch",
@@ -844,6 +849,7 @@ if __name__ == "__main__":
                 features_exclude=args.features_exclude,
                 output=args.output,
                 source_repo=repo_name,
+                mgmt_url=args.mgmt_url,
                 mgmt_branch=args.mgmt_branch,
                 common_extra_params=args.common_extra_params,
                 num_asic=args.num_asic,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Refine the way to get test repo `sonic-mgmt` url. Currently, all places to run PR test powered by **Elastictest** will pass the param `MGMT_URL`, which indicates the test repo. So, we don't need to judge which test repo is by the source repo triggered the pipelines.

Signed-off-by: Chun'ang Li [chunangli@microsoft.com](mailto:chunangli@microsoft.com)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Refine the way to get test repo `sonic-mgmt` url. Currently, all places to run PR test powered by **Elastictest** will pass the param `MGMT_URL`, which indicates the test repo. So, we don't need to judge which test repo is by the source repo triggered the pipelines.

#### How did you do it?
Modify PR test template and test_plan script.

#### How did you verify/test it?
PR test executing normally in public repo/internal repo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
