### PR TITLE
[Fix, 202012] Fix multi-asic flaky lldp not ready issue (#9453)

### DIFF
--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -22,43 +22,43 @@ INFRA_CHECK_ITEMS = [
 # Recover related definitions
 RECOVER_METHODS = {
     "config_reload": {
-        "cmd": "bash -c 'config reload -y &>/dev/null'",
-        "reboot": False,
-        "adaptive": False,
-        'recover_wait': 120
-    },
-    "config_reload_f": {
-        "cmd": "bash -c 'config reload -f -y &>/dev/null'",
+        "cmd": "false",
+        "reload": True,
         "reboot": False,
         "adaptive": False,
         'recover_wait': 120
     },
     "load_minigraph": {
         "cmd": "bash -c 'config load_minigraph -y &>/dev/null'",
+        "reload": False,
         "reboot": False,
         "adaptive": False,
         'recover_wait': 60
     },
     "reboot": {
         "cmd": "reboot",
+        "reload": False,
         "reboot": True,
         "adaptive": False,
         'recover_wait': 120
     },
     "warm_reboot": {
         "cmd": "warm-reboot",
+        "reload": False,
         "reboot": True,
         "adaptive": False,
         'recover_wait': 120
     },
     "fast_reboot": {
         "cmd": "fast_reboot",
+        "reload": False,
         "reboot": True,
         "adaptive": False,
         'recover_wait': 120
     },
     "adaptive": {
         "cmd": None,
+        "reload": False,
         "reboot": False,
         "adaptive": True,
         'recover_wait': 30

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -1,14 +1,13 @@
 import json
 import logging
 
-from . import constants
-
-from tests.common.utilities import wait
-from tests.common.platform.device_utils import fanout_switch_port_lookup
-from tests.common.config_reload import config_force_option_supported
-from tests.common.reboot import reboot
-from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_FAST, REBOOT_TYPE_COLD
+from tests.common import config_reload
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_FAST, REBOOT_TYPE_COLD
+from tests.common.reboot import reboot
+from tests.common.utilities import wait
+from . import constants
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +22,7 @@ def reboot_dut(dut, localhost, cmd):
     else:
         reboot_type = REBOOT_TYPE_COLD
 
-    reboot(dut, localhost, reboot_type=reboot_type)
+    reboot(dut, localhost, reboot_type=reboot_type, safe_reboot=True)
 
 
 def _recover_interfaces(dut, fanouthosts, result, wait_time):
@@ -136,11 +135,11 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
             logging.warning("Restoring {} with proposed action: {}, final action: {}".format(result, action, outstanding_action))
 
     if outstanding_action:
-        if outstanding_action == "config_reload" and config_force_option_supported(dut):
-            outstanding_action = "config_reload_f"
-        method    = constants.RECOVER_METHODS[outstanding_action]
+        method = constants.RECOVER_METHODS[outstanding_action]
         wait_time = method['recover_wait']
-        if method["reboot"]:
+        if method["reload"]:
+            config_reload(dut, safe_reload=True)
+        elif method["reboot"]:
             reboot_dut(dut, localhost, method["cmd"])
         else:
             _recover_with_command(dut, method['cmd'], wait_time)
@@ -148,12 +147,12 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
 
 def recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, recover_method):
     logger.warning("Try to recover %s using method %s" % (dut.hostname, recover_method))
-    if recover_method == "config_reload" and config_force_option_supported(dut):
-        recover_method = "config_reload_f"
-    method    = constants.RECOVER_METHODS[recover_method]
+    method = constants.RECOVER_METHODS[recover_method]
     wait_time = method['recover_wait']
     if method["adaptive"]:
         adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, wait_time)
+    elif method["reload"]:
+        config_reload(dut, safe_reload=True)
     elif method["reboot"]:
         reboot_dut(dut, localhost, method["cmd"])
     else:


### PR DESCRIPTION
cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/9453
Description of PR

In the recover of sanity check, for config_reload, we simply sleep 120s. In some topology, like multi-asic scenario, it's not enough. lldp services get a big chance that not ready after 120s, then sanity failed.

Use config_reload with safe_reload to better handle this flaky issue.

Approach
What is the motivation for this PR?
Fix multi-asic lldp flaky issue.

How did you do it?
Use config_reload with safe_reload to better handle this flaky issue.

co-authorized by: jianquanye@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
