### PR TITLE
[master][CI/CD] Priority use args.scripts to get test modules

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -823,9 +823,10 @@ if __name__ == "__main__":
 
             scripts = args.scripts
             specific_param = []
-            # For kvm platform, if args.features or args.scripts is not None, get test modules form it.
+            # For PR test, if specify test modules explicitly, use them to run PR test.
             # Otherwise, get test modules from pr_test_scripts.yaml.
-            if args.platform == "kvm" and (not args.features and not args.scripts):
+            explicitly_specify_test_module = args.features or args.scripts
+            if args.test_plan_type == "PR" and (not explicitly_specify_test_module):
                 args.test_set = args.test_set if args.test_set else args.topology
                 scripts, specific_param = get_test_scripts(args.test_set)
                 scripts = ",".join(scripts)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -823,8 +823,9 @@ if __name__ == "__main__":
 
             scripts = args.scripts
             specific_param = []
-            # For KVM PR test, get test modules from pr_test_scripts.yaml, otherwise use args.scripts
-            if args.platform == "kvm":
+            # If args.scripts is not None, get test modules form it.
+            # Otherwise, get test modules from pr_test_scripts.yaml.
+            if not args.scripts:
                 args.test_set = args.test_set if args.test_set else args.topology
                 scripts, specific_param = get_test_scripts(args.test_set)
                 scripts = ",".join(scripts)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -823,9 +823,9 @@ if __name__ == "__main__":
 
             scripts = args.scripts
             specific_param = []
-            # If args.scripts is not None, get test modules form it.
+            # For kvm platform, if args.features or args.scripts is not None, get test modules form it.
             # Otherwise, get test modules from pr_test_scripts.yaml.
-            if not args.scripts:
+            if args.platform == "kvm" and (not args.features and not args.scripts):
                 args.test_set = args.test_set if args.test_set else args.topology
                 scripts, specific_param = get_test_scripts(args.test_set)
                 scripts = ",".join(scripts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Priority use `args.scripts` to get test modules if this param is not None for KVM platform. Because `pr_test_scripts.yaml` is the default file to get test modules, If we don't pass `args.scripts`, it will get test module from `pr_test_scripts.yaml`.

Signed-off-by: Chun'ang Li [chunangli@microsoft.com](mailto:chunangli@microsoft.com)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Priority use `args.scripts` to get test modules if this param is not None for KVM platform. Because `pr_test_scripts.yaml` is the default file to get test modules, If we don't pass `args.scripts`, it will get test module from `pr_test_scripts.yaml`.

#### How did you do it?
Modify test_plan.py.

#### How did you verify/test it?
Manually trigger two test plans, one pass `args.scrips`, it will get test module from it, another don't pass `args.scripts`, it will get test module from `pr_test_scripts.yaml`. All as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
