### PR TITLE
Fix dualtor inventory parse error

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -59,7 +59,7 @@ def mux_server_info(request, tbinfo):
         server = tbinfo['server']
         vmset_name = tbinfo['group-name']
 
-        inv_files = request.config.option.ansible_inventory
+        inv_files = utilities.get_inventory_files(request)
         ip = utilities.get_test_server_vars(inv_files, server).get('ansible_host')
         _port_map = utilities.get_group_visible_vars(inv_files, server).get('mux_simulator_http_port')
         port = _port_map[tbinfo['conf-name']]

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -90,7 +90,7 @@ def nic_simulator_info(request, tbinfo):
 
     server = tbinfo["server"]
     vmset_name = tbinfo["group-name"]
-    inv_files = request.config.option.ansible_inventory
+    inv_files = utilities.get_inventory_files(request)
     ip = tbinfo["netns_mgmt_ip"].split("/")[0]
     _port_map = utilities.get_group_visible_vars(inv_files, server).get('nic_simulator_grpc_port')
     port = _port_map[tbinfo['conf-name']]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix the error:
```
inv_files = request.config.option.ansible_inventory
> ip = utilities.get_test_server_vars(inv_files, server).get('ansible_host')
E AttributeError: 'NoneType' object has no attribute 'get'
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
The reason is that `request.config.option.ansible_inventory` returns a string, which could be a string of multiple inventory files like `"inv_file0,inv_file1"`

But `InventoryManager` takes inventory files as a list(https://github.com/ansible/ansible/blob/ca08261f08a5071cc5f8c73e61342f5a9581b9cd/lib/ansible/inventory/manager.py#L157-L163), so we should split the string if it contains multiple inventory files(from `"inv_file0,inv_file1"` to `["inv_file0", "inv_file1"]`

#### How did you verify/test it?
Run pretests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
