### PR TITLE
[fdb] Address failures on td2 asics for fdb mac move test

### DIFF
--- a/tests/fdb/conftest.py
+++ b/tests/fdb/conftest.py
@@ -36,5 +36,9 @@ def set_polling_interval(duthost):
 
 
 @pytest.fixture(scope='module')
-def get_function_conpleteness_level(pytestconfig):
-    return pytestconfig.getoption("--completeness_level")
+def get_function_conpleteness_level(pytestconfig, duthost):
+    asic_name = duthost.get_asic_name()
+    if asic_name in ['td2']:
+        return None
+    else:
+        return pytestconfig.getoption("--completeness_level")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
On certain platforms with low disk space, failures are seen occassionally on running the test_fdb_mac_move case. This testcase runs in a loop and the number of times the loop is executed is dependent on the completeness_level setting. Lot of syslog messages are generated per loop and for completeness_level settings of 'confident' and above, it can lead to disk full case for certain platforms. This PR resets the completeness_level to basic for td2 platforms so as to reduce the number of iterations of test run.

#### How did you verify/test it?
Ran the testcase multiple times against t0-backend topology and no longer see failures

