### PR TITLE
[202205][PTF python3 migration] Modify test_decap PTF script

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -128,9 +128,9 @@ class DecapPacketTest(BaseTest):
 
         # Index of current DSCP and TTL value in allowed DSCP_RANGE and TTL_RANGE
         self.dscp_in_idx = 0  # DSCP of inner layer.
-        self.dscp_out_idx = len(self.DSCP_RANGE) / 2  # DSCP of outer layer. Set different initial dscp_in and dscp_out
+        self.dscp_out_idx = len(self.DSCP_RANGE) // 2  # DSCP of outer layer. Set different initial dscp_in and dscp_out
         self.ttl_in_idx = 0  # TTL of inner layer.
-        self.ttl_out_idx = len(self.TTL_RANGE) / 2  # TTL of outer layer. Set different initial ttl_in and ttl_out
+        self.ttl_out_idx = len(self.TTL_RANGE) // 2  # TTL of outer layer. Set different initial ttl_in and ttl_out
 
         self.summary = {}
 
@@ -577,7 +577,7 @@ class DecapPacketTest(BaseTest):
         self.print_summary()
 
         total = len(outer_pkt_types)*len(inner_pkt_types)
-        passed = len(filter(lambda status: status == 'Passed', self.summary.values()))
+        passed = len(list(filter(lambda status: status == 'Passed', self.summary.values())))
 
         # assert all passed
         assert total == passed, "total tests {}, passed: {}".format(total, passed)

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -224,7 +224,8 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
                                mux_status_from_nic_simulator())
                            },
                    qlen=PTFRUNNER_QLEN,
-                   log_file=log_file)
+                   log_file=log_file,
+                   is_python3=True)
     finally:
         # Remove test decap configuration
         if vxlan != "set_unset":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Manually cherry-pick #9347
Migrate test_decap PTF script to Python3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
