### PR TITLE
Workaound for ansible module executed twice issue of pytest-ansible

### DIFF
--- a/tests/common/plugins/ansible_fixtures.py
+++ b/tests/common/plugins/ansible_fixtures.py
@@ -1,6 +1,6 @@
 """ This module provides few pytest-ansible fixtures overridden """
-
 import pytest
+from pytest_ansible.host_manager import get_host_manager
 
 
 # Here we override ansible_adhoc fixture from pytest-ansible plugin to overcome
@@ -12,6 +12,35 @@ import pytest
 def ansible_adhoc(request):
     """Return an inventory initialization method."""
     plugin = request.config.pluginmanager.getplugin("ansible")
+
+    # HACK: This is to workaround pytest-ansible plugin issue:
+    #     Even no extra-inventory is specified, extra_inventory_manager will still be initialized.
+    #     https://github.com/ansible-community/pytest-ansible/issues/135
+    # As of today, pytest-ansible supports host manager and module dispatcher v29, v212, v213.
+    # While initializing the pytest-ansible plugin, it tries to collect default ansible configurations and
+    # command line options. These options are used for creating host manager. When no extra_inventory is specified,
+    # the options passed to host manager will include extra_inventory=None. However, the host manager will still
+    # try to create extra_inventory_manager with None as the inventory source. This will cause the module dispatcher
+    # to run the module on hosts matching host pattern in both inventory and extra inventory. This would cause an
+    # ansible module executed twice on the same host. In case we wish to use the shell module to run command like
+    # "rm <some_file>" to delete a file. The second run would fail because the file has been deleted in the first run.
+    # For more details, please refer to the Github issue mentioned above.
+    def _initialize(self, config=None, request=None, **kwargs):
+        """Return an initialized Ansible Host Manager instance."""
+        ansible_cfg = {}
+        # merge command-line configuration options
+        if config is not None:
+            ansible_cfg.update(self._load_ansible_config(config))
+            if "extra_inventory" in ansible_cfg and not ansible_cfg["extra_inventory"]:
+                del ansible_cfg["extra_inventory"]
+        # merge pytest request configuration options
+        if request is not None:
+            ansible_cfg.update(self._load_request_config(request))
+        # merge in provided kwargs
+        ansible_cfg.update(kwargs)
+
+        return get_host_manager(**ansible_cfg)
+    plugin.initialize = _initialize.__get__(plugin)
 
     def init_host_mgr(**kwargs):
         return plugin.initialize(request.config, request, **kwargs)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This is to workaround pytest-ansible plugin issue:
    Even no extra-inventory is specified, extra_inventory_manager will still be initialized.
    https://github.com/ansible-community/pytest-ansible/issues/135

As of today, pytest-ansible supports host manager and module dispatcher v29, v212, v213. While initializing the pytest-ansible plugin, it tries to collect default ansible configurations and command line options. These options are used for creating host manager. When no extra_inventory is specified, the options passed to host manager will include extra_inventory=None. However, the host manager will still try to create extra_inventory_manager with None as the inventory source. This will cause the module dispatcher to run the module on hosts matching host pattern in both inventory and extra inventory. This would cause an ansible module executed twice on the same host. In case we wish to use the shell module to run command like "rm <some_file>" to delete a file. The second run would fail because the file has been deleted in the first run. For more details, please refer to the Github issue mentioned above.

This change is only required for python3. Currently master and 202305 branch are using python3. For older branches, they are still using python2 and an older version of pytest-ansible which does not have the bug.

#### How did you do it?
The fix is to overwrite the pytest-ansible plugin's initialize method and remove the extra_inventory option if it is None. This will prevent the host manager from creating extra_inventory_manager with None as the inventory source.

#### How did you verify/test it?
Tried run a few tests with pytest-ansible 3.2.1 and 4.0.0.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
