### PR TITLE
[icmp_responder] Cache replies to reduce response time

### DIFF
--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -68,6 +68,7 @@ class ICMPResponderProtocol(asyncio.Protocol):
         if not self.on_con_lost.cancelled():
             self.on_con_lost.set_result(True)
 
+    @functools.lru_cache(maxsize=None)
     def icmp_reply(self, icmp_request):
         reply = Ether(icmp_request)
         reply[ICMP].type = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
As the probes received from one port are the same basically(except those with TLVs), we could simply cache the replies instead of generating them in each reply cycle.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use `functools.lru_cache` to cache the calls to `icmp_reply`.

#### How did you verify/test it?
With the `lru_cache`, the execution time of 1000 repeated calls to `icmp_reply` is reduced from `0.6184256076812744s` to `0.0006690025329589844s`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
