### PR TITLE
Added support of Cisco gb asic in T2 role

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -919,7 +919,13 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
+        if dutAsic == "gb" and topo == "t2":
+            if get_src_dst_asic_and_duts['src_asic'] == \
+                    get_src_dst_asic_and_duts['dst_asic']:
+                dutTopo = dutTopo + "any"
+            else:
+                dutTopo = dutTopo + topo
+        elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any


### PR DESCRIPTION

Adding a check for single-asic for cisco-8000 T2 platforms.

For cisco-8000 platforms (currently named as "gb" in qos.yaml), we have to fallback to the qos.yaml parameters listed for topo-any in case of single-ASIC tests(src & dst ASICS are same). For multi-asic and multi-DUT tests, the qos.yaml provides the parameters under topo-t2.

So we add a logic to check if the current test is single-asic and use topo-any for the parameters, and if not, use topo-t2.