### PR TITLE
Fix KeyError caused by PR #9054. 

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -928,7 +928,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
     # Reduce ACL to one rule (plus default)
     crm_stats_acl_entry_used = 2
     apply_acl_config(duthost, asichost, "test_acl_entry", asic_collector, entry_num=1)
-    if duthost.facts["platform_asic"] == "broadcom-dnx":
+    if duthost.facts.get("platform_asic", None) == "broadcom-dnx":
         # Each ACL rule consumes an acl entry per bind point
         asicAclBindings = set()
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #9054, it will try to get `duthost.facts["platform_asic"]` in test_crm.py, but in file `tests/common/devices/sonic.py`, which define the duthost.facts, platform_asic may not exist in duthost.facts. And this will cause KeyError in test_crm.py. In this PR, if platform_asic doesn't exist in duthost.facts, we set it None. 

Summary:
Fixes #9054 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR #9054, it will try to get `duthost.facts["platform_asic"]` in test_crm.py, but in file `tests/common/devices/sonic.py`, which define the duthost.facts, platform_asic may not exist in duthost.facts. And this will cause KeyError in test_crm.py. In this PR, if platform_asic doesn't exist in duthost.facts, we set it None. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
