### PR TITLE
[202012] SKIP test thermal control related cases for S6100 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -635,9 +635,10 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_j
   skip:
     # Cisco platforms use different mechanism to generate thermal policy, current method is not applicable
     # Multi ASIC platform running 201911 release doesn't have thermalctld
+    # s6100 has not supported get_thermal_manager yet
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911'])"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json:
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,
@@ -645,9 +646,10 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
   skip:
     # Cisco platforms use different mechanism to generate thermal policy, current method is not applicable
     # Multi ASIC platform running 201911 release doesn't have thermalctld
+    # s6100 has not supported get_thermal_manager yet
     reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911'])"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911']) or ('dell_s6100' in platform) or ('sw_to3200k' in hwsku)"
 
 #######################################
 #####        test_reboot.py       #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Caught exception while initializing thermal manager in case test_thermal_control_load_invalid_value_json on S6100 platform.
thermal control is not supported by Dell for S6000 and S6100 platforms.

#### How did you do it?
SKIP test thermal control related cases for S6100 platform
Cherry pick https://github.com/sonic-net/sonic-mgmt/pull/6051.

#### How did you verify/test it?
run platform_tests/test_platform_info.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
