### PR TITLE
[Nvidia]Fix the issue in check sysfs on sn5600 platform

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -9,7 +9,7 @@ SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS + SPC4_HWSKUS
 
 PSU_CAPABILITIES = [
     ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_in', 'psu{}_volt_out'],
-    ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_out2']
+    ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_in', 'psu{}_volt_out2']
 ]
 SWITCH_MODELS = {
     "x86_64-nvidia_sn5600-r0": {
@@ -26,7 +26,7 @@ SWITCH_MODELS = {
         "psus": {
             "number": 2,
             "hot_swappable": True,
-            "capabilities": PSU_CAPABILITIES[0]
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1


### PR DESCRIPTION
For the psu capability, the psuX_volt_in_capability can be checked on any kind of platform.
For sn5600, need to check the psuX_volt_out2_capability, but not psuX_volt_out_capability.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the issue in check sysfs on sn5600 platform
Fixes # (issue) Fix the issue in check sysfs on sn5600 platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the failure for the test_check_sysfs due to /var/run/hw-management/power/psu1_volt_out_capability not exist on the sn5600 platform
#### How did you do it?

#### How did you verify/test it?
after the change, run the test_check_sysfs , and it could pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
