### PR TITLE
[advanced-reboot] Update fast-reboot test IO to depend on finalizer status

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1058,7 +1058,7 @@ class ReloadTest(BaseTest):
         # TODO: add timestamp
         self.log("Service has restarted")
 
-    def handle_warm_reboot_health_check(self):
+    def handle_advanced_reboot_health_check(self):
         self.log("Check that device is still forwarding data plane traffic")
         self.fails['dut'].add(
             "Data plane has a forwarding problem after CPU went down")
@@ -1356,7 +1356,7 @@ class ReloadTest(BaseTest):
                 self.handle_advanced_reboot_health_check_kvm()
                 self.handle_post_reboot_health_check_kvm()
             else:
-                self.handle_warm_reboot_health_check()
+                self.handle_advanced_reboot_health_check()
                 self.handle_post_reboot_health_check()
 
             if 'warm-reboot' in self.reboot_type or 'fast-reboot' in self.reboot_type:

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1058,41 +1058,13 @@ class ReloadTest(BaseTest):
         # TODO: add timestamp
         self.log("Service has restarted")
 
-    def handle_fast_reboot_health_check(self):
+    def handle_warm_reboot_health_check(self):
         self.log("Check that device is still forwarding data plane traffic")
         self.fails['dut'].add(
             "Data plane has a forwarding problem after CPU went down")
         self.check_alive()
         self.fails['dut'].clear()
 
-        self.sniff_thr.join()
-        self.sender_thr.join()
-
-        # Stop watching DUT
-        self.watching = False
-        self.log("Stopping reachability state watch thread.")
-        # Wait for the Watcher stopped.
-        self.watcher_is_stopped.wait(timeout=10)
-
-        examine_start = datetime.datetime.now()
-        self.log("Packet flow examine started %s after the reboot" %
-                 str(examine_start - self.reboot_start))
-        self.examine_flow()
-        self.log("Packet flow examine finished after %s" %
-                 str(datetime.datetime.now() - examine_start))
-
-        if self.lost_packets:
-            self.no_routing_stop, self.no_routing_start = datetime.datetime.fromtimestamp(
-                self.no_routing_stop), datetime.datetime.fromtimestamp(self.no_routing_start)
-            self.log("Dataplane disruption lasted %.3f seconds. %d packet(s) lost." % (
-                self.max_disrupt_time, self.max_lost_id))
-            self.log("Total disruptions count is %d. All disruptions lasted %.3f seconds. Total %d packet(s) lost" %
-                     (self.disrupts_count, self.total_disrupt_time, self.total_disrupt_packets))
-        else:
-            self.no_routing_start = self.reboot_start
-            self.no_routing_stop = self.reboot_start
-
-    def handle_warm_reboot_health_check(self):
         # wait until sniffer and sender threads have started
         while not (self.sniff_thr.isAlive() and self.sender_thr.isAlive()):
             time.sleep(1)
@@ -1371,7 +1343,7 @@ class ReloadTest(BaseTest):
             else:
                 self.wait_until_service_restart()
 
-            if 'warm-reboot' in self.reboot_type:
+            if 'warm-reboot' in self.reboot_type or 'fast-reboot' in self.reboot_type:
                 finalizer_timeout = 60 + \
                     self.test_params['reboot_limit_in_seconds']
                 thr = threading.Thread(target=self.check_warmboot_finalizer,
@@ -1384,18 +1356,10 @@ class ReloadTest(BaseTest):
                 self.handle_advanced_reboot_health_check_kvm()
                 self.handle_post_reboot_health_check_kvm()
             else:
-                if self.reboot_type == 'fast-reboot':
-                    thr = threading.Thread(
-                        target=self.wait_until_control_plane_up)
-                    thr.setDaemon(True)
-                    thr.start()
-                    self.handle_fast_reboot_health_check()
-                    thr.join()
-                if 'warm-reboot' in self.reboot_type or 'service-warm-restart' == self.reboot_type:
-                    self.handle_warm_reboot_health_check()
+                self.handle_warm_reboot_health_check()
                 self.handle_post_reboot_health_check()
 
-            if 'warm-reboot' in self.reboot_type:
+            if 'warm-reboot' in self.reboot_type or 'fast-reboot' in self.reboot_type:
                 total_timeout = finalizer_timeout + \
                     self.test_params['warm_up_timeout_secs']
                 start_time = datetime.datetime.now()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fast-reboot is now using same infra for reconciliation and finalization as warm-reboot. Update test also to reuse common methods to measure IO drops.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

A recent PR (https://github.com/sonic-net/sonic-mgmt/pull/8993) made changes to IO calculation for warm-reboot.
IO started w/ teamd going down, and ended when finalizer completed.

This PR updates fast-reload IO calculation to also use the same logic. This is now possible for fast-reboot due to recent chances in newer branches where fast-reload is using warm-reboot reconciliation and finalizer infrastructure. 


#### How did you do it?

Utilize common functions for health check in fast and warm reboot cases.

#### How did you verify/test it?

Tested on physical device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
