### PR TITLE
fix for test_lag_db_status run with dut_lag param as unknown

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -550,7 +550,7 @@ def test_lag_db_status_with_po_update(duthosts, teardown, enum_dut_portchannel_w
             asic_index = int(lag_facts['lags'][lag_name]['po_namespace_id'])
         else:
             asic_index = DEFAULT_ASIC_ID
-        asichost = duthost.asic_instance(asic_index) 
+        asichost = duthost.asic_instance(asic_index)
         for po_intf, port_info in list(lag_facts['lags'][lag_name]['po_stats']['ports'].items()):
             # 1 Remove port member from portchannel
             asichost.config_portchannel_member(lag_name, po_intf, "del")

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -461,12 +461,6 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
     test_lags = []
     try:
         lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']
-        namespace_id = lag_facts['lags'][dut_lag]['po_namespace_id']
-        if namespace_id:
-            asic_index = int(lag_facts['lags'][dut_lag]['po_namespace_id'])
-        else:
-            asic_index = DEFAULT_ASIC_ID
-        asichost = duthost.asic_instance(asic_index)
         # Test for each lag
         if dut_lag == "unknown":
             test_lags = lag_facts['names']
@@ -476,6 +470,12 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
             test_lags = [dut_lag]
         # 1. Check if status of interface is in sync with state_db after bootup.
         for lag_name in test_lags:
+            namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+            if namespace_id:
+                asic_index = int(lag_facts['lags'][lag_name]['po_namespace_id'])
+            else:
+                asic_index = DEFAULT_ASIC_ID
+            asichost = duthost.asic_instance(asic_index)
             for po_intf, port_info in list(lag_facts['lags'][lag_name]['po_stats']['ports'].items()):
                 if not check_status_is_syncd(asichost, po_intf, port_info, lag_name):
                     pytest.fail("{} member {}'s status is not synced with oper_status in state_db."
@@ -483,6 +483,12 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
 
         # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
         for lag_name in test_lags:
+            namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+            if namespace_id:
+                asic_index = int(lag_facts['lags'][lag_name]['po_namespace_id'])
+            else:
+                asic_index = DEFAULT_ASIC_ID
+            asichost = duthost.asic_instance(asic_index)
             for po_intf, port_info in list(lag_facts['lags'][lag_name]['po_stats']['ports'].items()):
                 asichost.shutdown_interface(po_intf)
                 # Retrieve lag_facts after shutdown interface
@@ -501,10 +507,10 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
     finally:
         # Recover interfaces in case of failure
         lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']
-        namespace_id = lag_facts['lags'][dut_lag]['po_namespace_id']
         for lag_name in test_lags:
+            namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
             if namespace_id:
-                asic_index = int(lag_facts['lags'][dut_lag]['po_namespace_id'])
+                asic_index = int(lag_facts['lags'][lag_name]['po_namespace_id'])
             else:
                 asic_index = DEFAULT_ASIC_ID
             asichost = duthost.asic_instance(asic_index)
@@ -529,12 +535,6 @@ def test_lag_db_status_with_po_update(duthosts, teardown, enum_dut_portchannel_w
         pytest.fail("Failed with duthost is not found for dut name {}.".format(dut_name))
 
     lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']
-    namespace_id = lag_facts['lags'][dut_lag]['po_namespace_id']
-    if namespace_id:
-        asic_index = int(lag_facts['lags'][dut_lag]['po_namespace_id'])
-    else:
-        asic_index = DEFAULT_ASIC_ID
-    asichost = duthost.asic_instance(asic_index)
     # Test for each lag
     if dut_lag == "unknown":
         test_lags = lag_facts['names']
@@ -545,6 +545,12 @@ def test_lag_db_status_with_po_update(duthosts, teardown, enum_dut_portchannel_w
 
     # Check if status of interface is in sync with state_db after removing/adding member.
     for lag_name in test_lags:
+        namespace_id = lag_facts['lags'][lag_name]['po_namespace_id']
+        if namespace_id:
+            asic_index = int(lag_facts['lags'][lag_name]['po_namespace_id'])
+        else:
+            asic_index = DEFAULT_ASIC_ID
+        asichost = duthost.asic_instance(asic_index) 
         for po_intf, port_info in list(lag_facts['lags'][lag_name]['po_stats']['ports'].items()):
             # 1 Remove port member from portchannel
             asichost.config_portchannel_member(lag_name, po_intf, "del")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When test_lag_db_status testcase is run with the dut_lag parameter is "unknown" (test_lag_db_status[unknown|unknown]), the testcase fails with the following error: KeyError: 'unknown', at the time it tries to access the namespace_id value from the lag_facts dictionary with the lag name as the key. The testcase checks that if the dut_lag parameter is "unknown", the test should run for all the portchannels. But at this point, this check is after the testcase tries to access the namespace_id value based on the lag name, leading to failure when the dut_lag parameter is "unknown".
Fix: The testcase should first get the list of portchannels if the dut_lag is "unknown", and then fetch the namespace_id for the portchannels.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
