### PR TITLE
[Elastictest] Remove default min max worker definition

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -13,11 +13,11 @@ parameters:
 
   - name: MIN_WORKER
     type: string
-    default: 1
+    default: ""
 
   - name: MAX_WORKER
     type: string
-    default: 1
+    default: ""
 
   - name: NUM_ASIC
     type: number

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -194,7 +194,7 @@ class TestPlanManager(object):
             raise Exception("Get token failed with exception: {}".format(repr(exception)))
 
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
-               min_worker=1, max_worker=2, pr_id="unknown", output=None,
+               min_worker=None, max_worker=None, pr_id="unknown", output=None,
                common_extra_params="", **kwargs):
         tp_url = "{}/test_plan".format(self.url)
         testbed_name = parse_list_from_str(kwargs.get("testbed_name", None))
@@ -450,7 +450,9 @@ if __name__ == "__main__":
         "--min-worker",
         type=int,
         dest="min_worker",
-        default=1,
+        nargs='?',
+        const=None,
+        default=None,
         required=False,
         help="Min worker number for the test plan."
     )
@@ -458,7 +460,9 @@ if __name__ == "__main__":
         "--max-worker",
         type=int,
         dest="max_worker",
-        default=2,
+        nargs='?',
+        const=None,
+        default=None,
         required=False,
         help="Max worker number for the test plan."
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove the default min max worker definition, 
The Scheduler will auto compute min max by testbed name list.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Remove the default min max worker definition, 
The Scheduler will auto compute min max by testbed name list.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
