### PR TITLE
[Snappi] PFCWD Tolerance Fixes

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -21,7 +21,7 @@ DATA_FLOW2_NAME = "Data Flow 2"
 WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
-DEVIATION = 0.25
+DEVIATION = 0.3
 
 
 def run_pfcwd_basic_test(api,
@@ -58,6 +58,9 @@ def run_pfcwd_basic_test(api,
 
     start_pfcwd(duthost)
     enable_packet_aging(duthost)
+
+    # Set appropriate pfcwd loss deviation - these values are based on empirical testing
+    DEVIATION = 0.35 if duthost.facts['asic_type'] in ["broadcom"] else 0.3
 
     """ Get the ID of the port to test """
     port_id = get_dut_port_id(dut_hostname=duthost.hostname,

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -131,6 +131,7 @@ def run_pfcwd_multi_node_test(api,
 
     """ Retrieve ASIC information for DUT """
     asic_type = duthost.facts['asic_type']
+    rx_tx_tol_thrhlds = [0.01, 0.02]  # Maintain a 1% and 2% deviation between tx and rx frames
 
     __verify_results(rows=flow_stats,
                      speed_gbps=speed_gbps,
@@ -143,7 +144,8 @@ def run_pfcwd_multi_node_test(api,
                      data_pkt_size=DATA_PKT_SIZE,
                      trigger_pfcwd=trigger_pfcwd,
                      pause_port_id=port_id,
-                     tolerance=TOLERANCE_THRESHOLD,
+                     rx_deviation=TOLERANCE_THRESHOLD,
+                     rx_tx_deviations=rx_tx_tol_thrhlds,
                      asic_type=asic_type)
 
 
@@ -562,7 +564,8 @@ def __verify_results(rows,
                      data_pkt_size,
                      trigger_pfcwd,
                      pause_port_id,
-                     tolerance,
+                     rx_deviation,
+                     rx_tx_deviations,
                      asic_type):
     """
     Verify if we get expected experiment results
@@ -579,7 +582,8 @@ def __verify_results(rows,
         test_flow_pause (bool): if test flows are expected to be paused
         trigger_pfcwd (bool): if PFC watchdog is expected to be triggered
         pause_port_id (int): ID of the port to send PFC pause frames
-        tolerance (float): maximum allowable deviation
+        rx_deviation (float): maximum allowable deviation for rx_frames relative to theoretical value
+        rx_tx_deviations (list of floats): maximum allowable % deviation for rx_frames relative to tx_frames
         asic_type (str): asic_type information for DUT
 
     Returns:
@@ -606,9 +610,8 @@ def __verify_results(rows,
 
             exp_bg_flow_rx_pkts = bg_flow_rate_percent / 100.0 * speed_gbps \
                 * 1e9 * data_flow_dur_sec / 8.0 / data_pkt_size
-            deviation = (rx_frames - exp_bg_flow_rx_pkts) / \
-                float(exp_bg_flow_rx_pkts)
-            pytest_assert(abs(deviation) < tolerance,
+            deviation = (rx_frames - exp_bg_flow_rx_pkts) / float(exp_bg_flow_rx_pkts)
+            pytest_assert(abs(deviation) < rx_deviation,
                           '{} should receive {} packets (actual {})'.
                           format(flow_name, exp_bg_flow_rx_pkts, rx_frames))
 
@@ -640,12 +643,12 @@ def __verify_results(rows,
                               format(flow_name, exp_test_flow_rx_pkts, rx_frames))
 
             else:
-                """ Otherwise, the test flow is not impacted by PFC storm """
-                pytest_assert(tx_frames == rx_frames,
-                              '{} should not have any dropped packet'.format(flow_name))
+                for dev_pct in rx_tx_deviations:
+                    """ Otherwise, the test flow is not impacted by PFC storm """
+                    pytest_assert(abs(tx_frames - rx_frames)/float(tx_frames) < dev_pct,
+                                  '{} should be within {} percent deviation'.format(flow_name, dev_pct*100))
 
-                deviation = (rx_frames - exp_test_flow_rx_pkts) / \
-                    float(exp_test_flow_rx_pkts)
-                pytest_assert(abs(deviation) < tolerance,
+                deviation = (rx_frames - exp_test_flow_rx_pkts) / float(exp_test_flow_rx_pkts)
+                pytest_assert(abs(deviation) < rx_deviation,
                               '{} should receive {} packets (actual {})'.
                               format(flow_name, exp_test_flow_rx_pkts, rx_frames))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: PFCWD tests deviations for certain basic and multi node tests did not exist since there was no source of empirical data available for devices until recently. These tests require empirical tuning for the specific device the test runs on. This PR introduces certain allowable deviations based on device type for basic and multi node PFCWD tests.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Fix PFCWD snappi tests running on nightly

#### How did you do it?
Introduce new acceptable tolerances

#### How did you verify/test it?
Ran on lab device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
