### PR TITLE
Fix everflow syntax issue on T2 topology

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -356,9 +356,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
 
     if 't2' in topo:
-        for duthost in duthosts.frontend_nodes:
-            duthost.command("sudo config bgp shutdown all")
-            duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
+        for dut_host in duthosts.frontend_nodes:
+            dut_host.command("sudo config bgp shutdown all")
+            dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp shutdown all")
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
@@ -369,9 +369,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
 
     # Enable BGP again
     if 't2' in topo:
-        for duthost in duthosts.frontend_nodes:
-            duthost.command("sudo config bgp startup all")
-            duthost.command("rm -rf {}".format(DUT_RUN_DIR))
+        for dut_host in duthosts.frontend_nodes:
+            dut_host.command("sudo config bgp startup all")
+            dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp startup all")
         duthost.command("rm -rf {}".format(DUT_RUN_DIR))

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -356,9 +356,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
 
     if 't2' in topo:
-        for dut_host in duthosts.frontend_nodes:
-            dut_host.command("sudo config bgp shutdown all")
-            dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
+        for duthost in duthosts.frontend_nodes:
+            duthost.command("sudo config bgp shutdown all")
+            duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp shutdown all")
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -342,6 +342,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
         dict: Required test information
 
     """
+    duthost = None
     topo = tbinfo['topo']['name']
     if 't1' in topo or 't0' in topo or 'm0' in topo or 'mx' in topo or 'dualtor' in topo:
         downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
@@ -355,9 +356,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
 
     if 't2' in topo:
-        for duthost in duthosts.frontend_nodes:
-            duthost.command("sudo config bgp shutdown all")
-            duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
+        for dut_host in duthosts.frontend_nodes:
+            dut_host.command("sudo config bgp shutdown all")
+            dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp shutdown all")
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #9570 

This PR addressed the syntax issue on T2 topology.
```
UnboundLocalError: local variable 'duthost' referenced before assignment
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
This PR is to fix the everflow syntax issue on T2 topology.

#### How did you do it?
Always define `duthost`, and set it to `None` by default.

#### How did you verify/test it?

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
