### PR TITLE
Fix Python2/3 compatibility issue in device_connection.py

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -2,8 +2,13 @@ import paramiko
 import logging
 import socket
 import sys
+import six
+
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
-from retrying import retry
+if six.PY2:
+    from pip._vendor.retrying import retry
+else:
+    from retrying import retry
 logger = logging.getLogger(__name__)
 
 DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Possible bad fix introduced by #9475 
Fixes Python2/3 compatibility issue in device_connection.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
There is an import issue which is from Python2/3 compatibility issue.
from pip._vendor.retrying import retry
from retrying import retry

#### How did you do it?
Use six package: six.PY2

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
