### PR TITLE
Revert "add overflow_egress for PGDropTest multi-asic (#9464)"

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1535,13 +1535,21 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
-        testParams.update(qosConfig['pg_drop'])
+        pgDropKey = "pg_drop"
         testParams.update({
+            "dscp": qosConfig[pgDropKey]["dscp"],
+            "ecn": qosConfig[pgDropKey]["ecn"],
+            "pg": qosConfig[pgDropKey]["pg"],
+            "queue": qosConfig[pgDropKey]["queue"],
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "pkts_num_trig_pfc": qosConfig[pgDropKey]["pkts_num_trig_pfc"],
+            "pkts_num_trig_ingr_drp": qosConfig[pgDropKey]["pkts_num_trig_ingr_drp"],
+            "pkts_num_margin": qosConfig[pgDropKey]["pkts_num_margin"],
+            "iterations": qosConfig[pgDropKey]["iterations"],
             "hwsku": dutTestParams['hwsku']
         })
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -32,8 +32,7 @@ from switch import (switch_init,
                     sai_thrift_read_pg_shared_watermark,
                     sai_thrift_read_buffer_pool_watermark,
                     sai_thrift_read_headroom_pool_watermark,
-                    sai_thrift_read_queue_occupancy,
-                    sai_thrift_read_pg_occupancy)
+                    sai_thrift_read_queue_occupancy)
 from switch_sai_thrift.ttypes import (sai_thrift_attribute_value_t,
                                       sai_thrift_attribute_t)
 from switch_sai_thrift.sai_headers import (SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID)
@@ -240,37 +239,6 @@ def fill_leakout_plus_one(test_case, src_port_id, dst_port_id, pkt, queue, asic_
                     packet_i + 1, queue_counters_base[queue], queue_counters[queue]), file=sys.stderr)
                 return True
     return False
-
-
-def overflow_egress(test_case, src_port_id, pkt, queue, asic_type):
-    # Attempts to queue 1 packet while compensating for a varying packet
-    # leakout and egress queues. Returns pkts_num_egr_mem: number of packets
-    # short of filling egress memory and leakout.
-    # Returns extra_bytes_occupied:
-    #    extra number of bytes occupied in source port
-    pkts_num_egr_mem = 0
-    extra_bytes_occupied = 0
-    if asic_type not in ['cisco-8000']:
-        return pkts_num_egr_mem, extra_bytes_occupied
-
-    pg_cntrs_base = sai_thrift_read_pg_occupancy(
-        test_case.src_client, port_list['src'][src_port_id])
-    max_cycles = 1000
-    for cycle_i in range(max_cycles):
-        send_packet(test_case, src_port_id, pkt, 1000)
-        pg_cntrs = sai_thrift_read_pg_occupancy(
-            test_case.src_client, port_list['src'][src_port_id])
-        if pg_cntrs[queue] > pg_cntrs_base[queue]:
-            print("get_pkts_num_egr_mem: Success, sent %d packets, "
-                  "SQ occupancy bytes rose from %d to %d" % (
-                      (cycle_i + 1) * 1000, pg_cntrs_base[queue],
-                      pg_cntrs[queue]), file=sys.stderr)
-            pkts_num_egr_mem = cycle_i * 1000
-            extra_bytes_occupied = pg_cntrs[queue] - pg_cntrs_base[queue]
-            print("overflow_egress:pkts_num_egr_mem:{}, extra_bytes_occupied:{}".format(
-                pkts_num_egr_mem, extra_bytes_occupied))
-            return pkts_num_egr_mem, extra_bytes_occupied
-    raise RuntimeError("Couldn't overflow the egress memory after 1000 iterations.")
 
 
 def get_peer_addresses(data):
@@ -3955,8 +3923,6 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
             self.test_params['pkts_num_trig_ingr_drp'])
         iterations = int(self.test_params['iterations'])
         margin = int(self.test_params['pkts_num_margin'])
-        cell_size = int(self.test_params.get('cell_size', 0))
-        is_multi_asic = (self.src_client != self.dst_client)
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         dst_port_id = get_rx_port(
@@ -3988,21 +3954,14 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 pg_dropped_cntrs_base = sai_thrift_read_pg_drop_counters(
                     self.src_client, port_list['src'][src_port_id])
-                pkt_num = pkts_num_trig_pfc
-
-                # Fill egress memory and leakout
-                if 'cisco-8000' in asic_type and is_multi_asic:
-                    pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(
-                        self, src_port_id, pkt, pg, asic_type)
-                    pkt_num -= extra_bytes_occupied // cell_size
 
                 # Send packets to trigger PFC
                 print("Iteration {}/{}, sending {} packets to trigger PFC".format(
                     test_i + 1, iterations, pkts_num_trig_pfc), file=sys.stderr)
-                send_packet(self, src_port_id, pkt, pkt_num)
+                send_packet(self, src_port_id, pkt, pkts_num_trig_pfc)
 
                 # Account for leakout
-                if 'cisco-8000' in asic_type and not is_multi_asic:
+                if 'cisco-8000' in asic_type:
                     queue_counters = sai_thrift_read_queue_occupancy(
                         self.dst_client, "dst", dst_port_id)
                     occ_pkts = queue_counters[queue] // (packet_length + 24)


### PR DESCRIPTION
This reverts commit 9dd33d792b533ac49f836e4566c9c34dbce0ecc3.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

most of qos sai case failed because :
```
    "  File \"saitests/py3/sai_qos_tests.py\", line 24, in <module>",
    "    from switch import (switch_init,",
    "ImportError: cannot import name 'sai_thrift_read_pg_occupancy' from 'switch' (saitests/py3/switch.py)"
```

RCA:

#8546 and #9464 have dependency, should double commit PR https://github.com/sonic-net/sonic-mgmt/pull/8664 first.


#### How did you do it?

revert #9464, and request Raghav cherry pick #8664 asap.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
