### PR TITLE
Use list to fix wrong population type error

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -88,7 +88,7 @@ def get_sup_node_or_random_node(duthosts):
             return dut
     # if not chassis, it's dualtor or single-dut, return random node or itself
     if len(duthosts) > 1:
-        duthosts = random.sample(duthosts, 1)
+        duthosts = random.sample(list(duthosts), 1)
     logger.info("Randomly select dut {} for testing".format(duthosts[0]))
     return duthosts[0]
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -89,7 +89,7 @@ def get_sup_node_or_random_node(duthosts):
     # if not chassis, it's dualtor or single-dut, return random node or itself
     if len(duthosts) > 1:
         duthosts = random.sample(list(duthosts), 1)
-    logger.info("Randomly select dut {} for testing".format(duthosts[0]))
+    logger.info("Randomly select dut {} for testing".format(list(duthosts)[0]))
     return duthosts[0]
 
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -89,7 +89,7 @@ def get_sup_node_or_random_node(duthosts):
     # if not chassis, it's dualtor or single-dut, return random node or itself
     if len(duthosts) > 1:
         duthosts = random.sample(list(duthosts), 1)
-    logger.info("Randomly select dut {} for testing".format(list(duthosts)[0]))
+    logger.info("Randomly select dut {} for testing".format(duthosts[0]))
     return duthosts[0]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Testcase test_memory_exhaustion failed on dualtor due to:
```
        if isinstance(population, _Set):
            population = tuple(population)
        if not isinstance(population, _Sequence):
>           raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
E           TypeError: Population must be a sequence or set.  For dicts, use list(d).
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix the testcase issue on dualtor when it need to select one host to run test.
#### How did you do it?
Pass list type parameters in random.sample().
#### How did you verify/test it?
Run test case locally with the change and it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
