### PR TITLE
Add parameter `available-mem-threshold` when adding auto-techsupport-feature in module `show_techsupport/test_auto_techsupport.py`. 

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -606,7 +606,8 @@ def add_delete_auto_techsupport_feature(duthost, feature, action=None, state=DEF
 
     command = base_cmd
     if action == 'add':
-        command = '{}--state {} --rate-limit-interval {}'.format(base_cmd, state, rate_limit)
+        command = '{}--state {} --rate-limit-interval {} ' \
+                  '--available-mem-threshold {}'.format(base_cmd, state, rate_limit, DEFAULT_AVAILABLE_MEM_THRESHOLD)
 
     with allure.step('Doing {} feature {} config: {}'.format(action, feature, command)):
         duthost.shell(command)

--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -129,8 +129,7 @@ class TestAutoTechSupport:
         yield
 
         update_auto_techsupport_feature(self.duthost, self.test_docker,
-                                        rate_limit=DEFAULT_RATE_LIMIT_FEATURE,
-                                        mem_threshold=DEFAULT_AVAILABLE_MEM_THRESHOLD)
+                                        rate_limit=DEFAULT_RATE_LIMIT_FEATURE)
 
     def test_sanity(self, cleanup_list):
         """
@@ -561,7 +560,7 @@ def set_auto_techsupport_global(duthost, state=None, rate_limit=None, techsuppor
             duthost.shell(cmd)
 
 
-def update_auto_techsupport_feature(duthost, feature, state=None, rate_limit=None, mem_threshold=None):
+def update_auto_techsupport_feature(duthost, feature, state=None, rate_limit=None):
     """
     Do configuration using cmd: sudo config auto-techsupport-feature update .....
     :param duthost: duthost object
@@ -577,12 +576,9 @@ def update_auto_techsupport_feature(duthost, feature, state=None, rate_limit=Non
     if rate_limit or rate_limit == 0:
         command = '{} --rate-limit-interval {}'.format(base_cmd, rate_limit)
         commands_list.append(command)
-    if mem_threshold:
-        command = '{} --available-mem-threshold {}'.format(base_cmd, mem_threshold)
-        commands_list.append(command)
 
     if not commands_list:
-        pytest.fail('Provide at least one argument from list: state, rate_limit, mem_threshold')
+        pytest.fail('Provide at least one argument from list: state, rate_limit')
 
     for cmd in commands_list:
         with allure.step('Setting feature {} config: {}'.format(feature, cmd)):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `show_techsupport/test_auto_techsupport.py`, it will delete auto techsupport feature `lldp` and add it again. But when adding, it misses the parameter `available-mem-threshold`. This will cause inconsistent between previous running config and current running config, and cause unnecessary config reload. In this PR, we add the parameter `available-mem-threshold` when adding auto techsupport feature. Meanwhile, PR #9123 is unnecessary when updating auto techsupport feature, so revert part of PR #9123. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module `show_techsupport/test_auto_techsupport.py`, it will delete auto techsupport feature `lldp` and add it again. But when adding, it misses the parameter `available-mem-threshold`. This will cause inconsistent between previous running config and current running config, and cause unnecessary config reload. In this PR, we add the parameter `available-mem-threshold` when adding auto techsupport feature. Meanwhile, PR #9123 is unnecessary when updating auto techsupport feature, so revert part of PR #9123. 

#### How did you do it?
Add the parameter `available-mem-threshold` when adding auto techsupport feature. Meanwhile, PR #9123 is unnecessary when updating auto techsupport feature, so revert part of PR #9123. 

#### How did you verify/test it?
07:08:31 conftest.core_dump_and_config_check      L2092 INFO   | Core dump and config check passed for show_techsupport/test_auto_techsupport.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
