### PR TITLE
[sonic-mgmt 202205] Remove 'unicode()' calls for py3 conversion in decap test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -271,7 +271,7 @@ class DecapPacketTest(BaseTest):
             print("ERROR: unexpected ttl_mode is configured")
             exit()
 
-        if ipaddress.ip_address(unicode(dst_ip)).version == 6:
+        if ipaddress.ip_address(dst_ip).version == 6:
             inner_src_ip = self.DEFAULT_INNER_V6_PKT_SRC_IP
             # build inner packet, if triple_encap is True inner_pkt would be double encapsulated
             inner_pkt = self.create_ipv6_inner_pkt_only(inner_src_ip, dst_ip, tos_in, triple_encap, hlim=inner_ttl)
@@ -339,13 +339,13 @@ class DecapPacketTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
         if self.ignore_ttl:
-            if ipaddress.ip_address(unicode(dst_ip)).version == 4:
+            if ipaddress.ip_address(dst_ip).version == 4:
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             else:
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
 
-        inner_pkt_type = 'ipv4' if ipaddress.ip_address(unicode(dst_ip)).version == 4 else 'ipv6'
+        inner_pkt_type = 'ipv4' if ipaddress.ip_address(dst_ip).version == 4 else 'ipv6'
 
         if outer_pkt_type == 'ipv4':
             outer_src_ip = pkt['IP'].src


### PR DESCRIPTION
Summary:
Fixes #9595

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205 - change is only applicable to 202205, this issue is not present in master

### Approach
#### What is the motivation for this PR?
Remove the unneeded calls to `unicode()` to fix #9595

#### How did you do it?

#### How did you verify/test it?
ran test_decap.py on 202205 with this change and confirmed it works

