### PR TITLE
[advanced-reboot][dualtor] Update Loopback0 ping test: expect same count for sent and rcvd packets

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -2329,11 +2329,6 @@ class ReloadTest(BaseTest):
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(
             self, self.ping_dut_exp_packet, self.vlan_ports, timeout=self.PKT_TOUT)
 
-        if self.is_dualtor:
-            # handle two-for-one icmp reply for dual tor (when vlan and dut mac are diff):
-            # icmp_responder will also generate a response for this ICMP req, ignore that reply
-            total_rcv_pkt_cnt = total_rcv_pkt_cnt - self.ping_dut_pkts
-
         self.log("Send %5d Received %5d ping DUT" %
                  (self.ping_dut_pkts, total_rcv_pkt_cnt), True)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently dual tor warmboot fails w/ control plane not ready for warmboot. This is because the test expects 2 responses for every ping packet sent to Loopback. This expectation is not correct after PR https://github.com/sonic-net/sonic-mgmt/pull/9089 is merged.

Update the testcase to now only expect 1 icmp response for every icmp packet sent to Loopback0.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Dualtor warmboot fails w/ below error:

```
2023-08-17 18:14:39 : Send   100 Received   100 servers->t1
2023-08-17 18:14:41 : Send   500 Received   500 t1->servers
2023-08-17 18:14:41 : Data plane state transition from partial to up (500)
2023-08-17 18:14:42 : Send    10 Received     0 ping DUT

2023-08-17 18:14:45 : --------------------------------------------------
2023-08-17 18:14:45 : Fails:
2023-08-17 18:14:45 : --------------------------------------------------
2023-08-17 18:14:45 : FAILED:dut:IO didn't come up within warm up timeout. Control plane: down, Data plane: up
2023-08-17 18:14:45 : FAILED:dut:DUT is not ready for test
2023-08-17 18:14:45 : ==================================================
```

#### How did you do it?

Updated the test to remove the earlier expectation of removing the packets that were sent by icmp_responder.

This essentially reverts part of older PR: https://github.com/sonic-net/sonic-mgmt/pull/6968

#### How did you verify/test it?

Tested on a physical testbed and this test issue is not seen.
The test is now able to see the responses of ping packets:

```
2023-08-22 22:39:06 : Send   100 Received   100 servers->t1
2023-08-22 22:39:07 : Send   500 Received   500 t1->servers
2023-08-22 22:39:09 : Send    10 Received    10 ping DUT
2023-08-22 22:39:10 : Send     1 Received     1 arp ping
2023-08-22 22:39:12 : Send   100 Received   100 servers->t1
2023-08-22 22:39:13 : Send   500 Received   500 t1->servers
2023-08-22 22:39:15 : Send    10 Received    10 ping DUT
2023-08-22 22:39:15 : Schedule to reboot the remote switch in 10 sec
2023-08-22 22:39:15 : Wait until Control plane is down
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
