### PR TITLE
[Elastictest] Support to pass deploy minigraph parameter in the night…

### DIFF
--- a/.azure-pipelines/run-test-elastictest-nightly-template.yml
+++ b/.azure-pipelines/run-test-elastictest-nightly-template.yml
@@ -24,6 +24,11 @@ parameters:
     default: ""
     displayName: "Upgrade image parameter"
 
+  - name: DEPLOY_MG_EXTRA_PARAMS
+    type: string
+    default: ""
+    displayName: "Deploy minigraph parameter"
+
   - name: COMMON_EXTRA_PARAMS
     type: string
     default: ""
@@ -81,6 +86,7 @@ steps:
       MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
       IMAGE_URL: ${{ parameters.IMAGE_URL }}
       UPGRADE_IMAGE_PARAM: ${{ parameters.UPGRADE_IMAGE_PARAM }}
+      DEPLOY_MG_EXTRA_PARAMS: ${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}
       REPO_NAME: "sonic-mgmt-int"
       STOP_ON_FAILURE: "False"
       TEST_PLAN_TYPE: "NIGHTLY"


### PR DESCRIPTION
…ly template

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support to pass deploy minigraph parameter in the nightly template

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Support to pass deploy minigraph parameter in the nightly template
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
