### PR TITLE
Revert "[202205][PTF python3 migration] Modify test_pfcwd PTF script …

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -47,20 +47,20 @@ class PfcWdTest(BaseTest):
         for match in matches:
             for port in match.split():
                 dst_port_list.append(int(port))
-        src_mac = self.dataplane.get_mac(*random.choice(list(self.dataplane.ports.keys())))
+        src_mac = self.dataplane.get_mac(*random.choice(self.dataplane.ports.keys()))
 
         if self.port_type == "portchannel":
             for x in range(0, self.pkt_count):
                 sport = random.randint(0, 65535)
                 dport = random.randint(0, 65535)
                 ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
-                ip_src =ipaddress.IPv4Address(ip_src)
+                ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
                 if not isinstance(self.ip_dst, unicode):
                     self.ip_dst = unicode(self.ip_dst, 'utf-8')
                 ip_dst = ipaddress.IPv4Address(self.ip_dst)
                 while ip_src == ip_dst or ip_src.is_multicast or ip_src.is_private or ip_src.is_global or ip_src.is_reserved:
                     ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
-                    ip_src =ipaddress.IPv4Address(ip_src)
+                    ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
 
                 ip_src = str(ip_src)
                 pkt_args = {

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -495,7 +495,7 @@ class SendVerifyTraffic():
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_rx_ingress(self, action):
         """
@@ -526,7 +526,7 @@ class SendVerifyTraffic():
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_other_pfc_queue(self):
         """
@@ -559,7 +559,7 @@ class SendVerifyTraffic():
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_other_pfc_pg(self):
         """
@@ -592,7 +592,7 @@ class SendVerifyTraffic():
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def fill_buffer(self):
         """
@@ -615,7 +615,7 @@ class SendVerifyTraffic():
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_wd_func(self, action, rx_action, tx_action):
         """

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -248,7 +248,7 @@ class SendVerifyTraffic(object):
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_rx_ingress(self, wd_action):
         """
@@ -274,7 +274,7 @@ class SendVerifyTraffic(object):
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
-                   log_file=log_file, is_python3=True)
+                   log_file=log_file)
 
     def verify_wd_func(self, dut, detect=True):
         """


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#9525 because it caused regression in `test_pfcwd_function.py`.

```
======================================================================
ERROR: pfc_wd.PfcWdTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptftests/py3/pfc_wd.py", line 58, in runTest
    if not isinstance(self.ip_dst, unicode):
NameError: name 'unicode' is not defined

----------------------------------------------------------------------
Ran 1 test in 0.001s
```