### PR TITLE
Revert PR #9256 "Remove pg lossless settings of port speed in module iface_namingmode/test_iface_namingmode.py".

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -3,6 +3,7 @@ import pytest
 import re
 import ipaddress
 
+from tests.common import config_reload
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.utilities import wait, wait_until, delete_running_config
 from netaddr import IPAddress
@@ -820,13 +821,6 @@ class TestConfigInterface():
 
         assert speed == configure_speed
 
-        # Remove interface pg config
-        pg_lossless_key = "pg_lossless_" + str(speed) + "_300m_profile"
-        delete_keys_json = [{"BUFFER_PROFILE": {
-            pg_lossless_key: {}
-        }}]
-        delete_running_config(delete_keys_json, duthost)
-
         out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {}  speed {} {}'.format(
             ifmode, cli_ns_option, test_intf, native_speed))
         if out['rc'] != 0:
@@ -836,6 +830,9 @@ class TestConfigInterface():
         logger.info('speed: {}'.format(speed))
 
         assert speed == native_speed
+
+        # Restore config services
+        config_reload(duthost)
 
 
 def test_show_acl_table(setup, setup_config_mode, tbinfo):

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -831,9 +831,6 @@ class TestConfigInterface():
 
         assert speed == native_speed
 
-        # Restore config services
-        config_reload(duthost)
-
 
 def test_show_acl_table(setup, setup_config_mode, tbinfo):
     """

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -5,7 +5,7 @@ import ipaddress
 
 from tests.common import config_reload
 from tests.common.devices.base import AnsibleHostBase
-from tests.common.utilities import wait, wait_until, delete_running_config
+from tests.common.utilities import wait, wait_until
 from netaddr import IPAddress
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import redis_get_keys

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -3,7 +3,6 @@ import pytest
 import re
 import ipaddress
 
-from tests.common import config_reload
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.utilities import wait, wait_until
 from netaddr import IPAddress


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #9256, we use function `delete_running_config` to delete pg lossless profile in running config, which will cause orchagent coredump. Actually, from SAI side, they don't support such usage. So in module `iface_namingmode/test_iface_namingmode.py`, after case `test_config_interface_speed` running, we use our fixture `core_dump_and_config_check` to do config reload to recover config, thus revert this PR. 

Summary:
Fixes #9256 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In PR #9256, we use function `delete_running_config` to delete pg lossless profile in running config, which will cause orchagent coredump. Actually, from SAI side, they don't support such usage. So in module `iface_namingmode/test_iface_namingmode.py`, after case `test_config_interface_speed` running, we use our fixture `core_dump_and_config_check` to do config reload to recover config, thus revert this PR. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
