### PR TITLE
[Mellanox][Dual-Tor][DSCP remapping]Fix a test issue for the dualtor tunnel monitor for Nvidia platforms

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1672,6 +1672,9 @@ Totals               6450                 6449
 
         return asic
 
+    def is_nvidia_platform(self):
+        return 'mellanox' == self.facts['asic_type']
+
     def _get_platform_asic(self, platform):
         platform_asic = os.path.join(
             "/usr/share/sonic/device", platform, "platform_asic"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/9624)
On Nvidia platforms, when the inner/outer DSCPs are 2/2 or 6/6, the tunnel packet is not mapped based on the mapping configuration to queue 1 (they will be mapped to queue 2 and 6).
And we have confirmed with MSFT that such packets are not expected in production.
So, skip the queue check for them.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305 

### Approach
#### What is the motivation for this PR?
Fix test issue (https://github.com/sonic-net/sonic-mgmt/issues/9624)
#### How did you do it?
Skip the queue check in tunnel monitor on Nvidia platforms when dscp is 2/2 or 6/6
#### How did you verify/test it?
Run test on 4600C dualtor setup, passed.
#### Any platform specific information?
Only for Nvidia platforms.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
