### PR TITLE
[py3 migration] [202205] fix incompatible py3 usage in populate_fdb.py

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/populate_fdb.py
+++ b/ansible/roles/test/files/ptftests/py3/populate_fdb.py
@@ -2,6 +2,7 @@ import ipaddress
 import json
 import logging
 import ptf
+import six
 
 # Packet Test Framework imports
 import ptf
@@ -126,7 +127,7 @@ class PopulateFdb(BaseTest):
                     numDistinctIp
                 )
             )
-            vmIp[vlan] = ipaddress.ip_address(unicode(config["addr"])) + 1
+            vmIp[vlan] = ipaddress.ip_address(six.text_type(config["addr"])) + 1
 
         return vmIp
 
@@ -163,7 +164,7 @@ class PopulateFdb(BaseTest):
                 mac = self.__convertMacToStr(macInt + i)
                 numMac += 1
             if i % self.macToIpRatio[0] == 0:
-                vmIp[vlan] = ipaddress.ip_address(unicode(vmIp[vlan])) + 1
+                vmIp[vlan] = ipaddress.ip_address(six.text_type(vmIp[vlan])) + 1
                 numIp += 1
 
             packet[scapy.Ether].src = mac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
#9526 introduced this issue.
More fixes are needed in 202205 branch for PTF python3 migration.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Test failed with error:
File \"ptftests/py3/populate_fdb.py\", line 129, in __prepareVmIp", "    vmIp[vlan] = ipaddress.ip_address(unicode(config[\"addr\"])) + 1", "NameError: name 'unicode' is not defined"

#### How did you do it?
In Python3, unicode is not needed.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
