### PR TITLE
fix infinite loop for pfc_pause_test

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -327,14 +327,13 @@ def pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, dut, port, queue,
         testutils.verify_no_packet_any(ptfadapter, exp_pkt, dst_ports)
         # Check the queue counter didn't increase
         queue_count = get_queue_counter(dut, port, queue, False)
-        assert base_queue_count == queue_count
-        return True
-    except AssertionError:
-        logger.info('assert {}'.format(sys.exc_info()))
-        return False
-    except Exception:
-        logger.info('exception {}'.format(sys.exc_info()))
-        return False
+        if base_queue_count == queue_count:
+            return True
+        else:
+            return False
+    except (AssertionError, Exception) as e:
+        logger.info('{}'.format(sys.exc_info()))
+        raise(e)
     finally:
         stop_pfc_storm(storm_handler)
 
@@ -401,17 +400,14 @@ def test_pfc_pause_extra_lossless_standby(ptfhost, fanouthosts, rand_selected_du
                 if pfc_pause_test(storm_handler, peer_info, prio, ptfadapter, rand_selected_dut, actual_port_name,
                                   queue, pkt, src_port, exp_pkt, dst_ports):
                     break
-            except AssertionError:
+                else:
+                    retry += 1
+            except (AssertionError, Exception):
                 retry += 1
-                if retry == PFC_PAUSE_TEST_RETRY_MAX:
-                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
-                        queue, actual_port_name))
-            except Exception:
-                retry += 1
-                if retry == PFC_PAUSE_TEST_RETRY_MAX:
-                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
-                        queue, actual_port_name))
             time.sleep(5)
+        if retry == PFC_PAUSE_TEST_RETRY_MAX:
+            pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                queue, actual_port_name))
 
 
 def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
@@ -475,17 +471,14 @@ def test_pfc_pause_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut
                                   dualtor_meta['selected_port'], queue, tunnel_pkt.exp_pkt, src_port, exp_pkt,
                                   dst_ports):
                     break
-            except AssertionError:
+                else:
+                    retry += 1
+            except (AssertionError, Exception):
                 retry += 1
-                if retry == PFC_PAUSE_TEST_RETRY_MAX:
-                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
-                        queue, dualtor_meta['selected_port']))
-            except Exception:
-                retry += 1
-                if retry == PFC_PAUSE_TEST_RETRY_MAX:
-                    pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
-                        queue, dualtor_meta['selected_port']))
             time.sleep(5)
+        if retry == PFC_PAUSE_TEST_RETRY_MAX:
+            pytest_assert(False, "The queue {} for port {} counter increased unexpectedly".format(
+                queue, dualtor_meta['selected_port']))
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Issue https://github.com/sonic-net/sonic-mgmt/issues/8720

Observed infinite loop for test_pfc_pause_extra_lossless_standby and test_pfc_pause_extra_lossless_active test.

#### How did you do it?

run test 25 times, all pass

```
$ grep -E "seconds ====|(PASSED|FAILED|SKIPPED|ERROR)\s+\[\s*\d+%\]|FAILED\s+\S+\[\S+\]|ERROR\s+\S+\[\S+\]|\S+\] _" vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_*.FixInfiniteLoop2nd*.console.log
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.15-28-46.FixInfiniteLoop2nd-1.console.log:==================== 1 passed, 1 warnings in 427.34 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.15-44-09.FixInfiniteLoop2nd-2.console.log:==================== 1 passed, 1 warnings in 410.47 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.15-58-01.FixInfiniteLoop2nd-3.console.log:==================== 1 passed, 1 warnings in 421.07 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.16-16-11.FixInfiniteLoop2nd-4.console.log:==================== 1 passed, 1 warnings in 432.45 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.16-31-18.FixInfiniteLoop2nd-5.console.log:==================== 1 passed, 1 warnings in 427.27 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.16-45-46.FixInfiniteLoop2nd-6.console.log:==================== 1 passed, 1 warnings in 427.46 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.16-59-56.FixInfiniteLoop2nd-7.console.log:==================== 1 passed, 1 warnings in 412.71 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.17-13-52.FixInfiniteLoop2nd-8.console.log:==================== 1 passed, 1 warnings in 412.28 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.17-28-41.FixInfiniteLoop2nd-9.console.log:==================== 1 passed, 1 warnings in 412.83 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.17-42-38.FixInfiniteLoop2nd-10.console.log:==================== 1 passed, 1 warnings in 416.00 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.17-57-25.FixInfiniteLoop2nd-11.console.log:==================== 1 passed, 1 warnings in 415.38 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.18-12-15.FixInfiniteLoop2nd-12.console.log:==================== 1 passed, 1 warnings in 409.40 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.18-26-52.FixInfiniteLoop2nd-13.console.log:==================== 1 passed, 1 warnings in 411.38 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.18-40-45.FixInfiniteLoop2nd-14.console.log:==================== 1 passed, 1 warnings in 414.20 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.18-54-39.FixInfiniteLoop2nd-15.console.log:==================== 1 passed, 1 warnings in 405.34 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.19-09-12.FixInfiniteLoop2nd-16.console.log:==================== 1 passed, 1 warnings in 403.16 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.19-22-49.FixInfiniteLoop2nd-17.console.log:==================== 1 passed, 1 warnings in 407.74 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.19-36-32.FixInfiniteLoop2nd-18.console.log:==================== 1 passed, 1 warnings in 403.63 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.19-51-46.FixInfiniteLoop2nd-19.console.log:==================== 1 passed, 1 warnings in 406.75 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.20-05-26.FixInfiniteLoop2nd-20.console.log:==================== 1 passed, 1 warnings in 405.66 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.20-19-03.FixInfiniteLoop2nd-21.console.log:==================== 1 passed, 1 warnings in 404.17 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.20-32-42.FixInfiniteLoop2nd-22.console.log:==================== 1 passed, 1 warnings in 408.80 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.20-47-52.FixInfiniteLoop2nd-23.console.log:==================== 1 passed, 1 warnings in 406.01 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.21-03-17.FixInfiniteLoop2nd-24.console.log:==================== 1 passed, 1 warnings in 405.52 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_active.2023-08-24.21-17-01.FixInfiniteLoop2nd-25.console.log:==================== 1 passed, 1 warnings in 408.16 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.15-21-39.FixInfiniteLoop2nd-1.console.log:==================== 1 passed, 1 warnings in 424.59 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.15-36-00.FixInfiniteLoop2nd-2.console.log:==================== 1 passed, 1 warnings in 487.30 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.15-51-07.FixInfiniteLoop2nd-3.console.log:==================== 1 passed, 1 warnings in 412.54 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.16-05-09.FixInfiniteLoop2nd-4.console.log:==================== 1 passed, 1 warnings in 660.42 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.16-23-31.FixInfiniteLoop2nd-5.console.log:==================== 1 passed, 1 warnings in 465.49 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.16-38-32.FixInfiniteLoop2nd-6.console.log:==================== 1 passed, 1 warnings in 431.88 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.16-53-00.FixInfiniteLoop2nd-7.console.log:==================== 1 passed, 1 warnings in 413.80 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.17-06-56.FixInfiniteLoop2nd-8.console.log:==================== 1 passed, 1 warnings in 414.73 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.17-20-52.FixInfiniteLoop2nd-9.console.log:==================== 1 passed, 1 warnings in 467.36 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.17-35-41.FixInfiniteLoop2nd-10.console.log:==================== 1 passed, 1 warnings in 415.69 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.17-49-41.FixInfiniteLoop2nd-11.console.log:==================== 1 passed, 1 warnings in 461.76 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.18-04-27.FixInfiniteLoop2nd-12.console.log:==================== 1 passed, 1 warnings in 466.38 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.18-19-12.FixInfiniteLoop2nd-13.console.log:==================== 1 passed, 1 warnings in 458.19 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.18-33-50.FixInfiniteLoop2nd-14.console.log:==================== 1 passed, 1 warnings in 413.06 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.18-47-46.FixInfiniteLoop2nd-15.console.log:==================== 1 passed, 1 warnings in 410.70 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.19-01-31.FixInfiniteLoop2nd-16.console.log:==================== 1 passed, 1 warnings in 459.69 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.19-16-02.FixInfiniteLoop2nd-17.console.log:==================== 1 passed, 1 warnings in 404.48 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.19-29-43.FixInfiniteLoop2nd-18.console.log:==================== 1 passed, 1 warnings in 406.80 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.19-43-22.FixInfiniteLoop2nd-19.console.log:==================== 1 passed, 1 warnings in 502.59 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.19-58-40.FixInfiniteLoop2nd-20.console.log:==================== 1 passed, 1 warnings in 404.66 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.20-12-19.FixInfiniteLoop2nd-21.console.log:==================== 1 passed, 1 warnings in 402.16 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.20-25-54.FixInfiniteLoop2nd-22.console.log:==================== 1 passed, 1 warnings in 406.15 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.20-39-37.FixInfiniteLoop2nd-23.console.log:==================== 1 passed, 1 warnings in 492.47 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.20-54-44.FixInfiniteLoop2nd-24.console.log:==================== 1 passed, 1 warnings in 510.84 seconds ====================
vms24-dual-t0-*.qos-test_tunnel_qos_remap_py--test_pfc_pause_extra_lossless_standby.2023-08-24.21-10-09.FixInfiniteLoop2nd-25.console.log:==================== 1 passed, 1 warnings in 409.83 seconds ====================
```


handle false case, resolve infinite loop

#### How did you verify/test it?



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
