### PR TITLE
[SNMP][IPv6]: Skip SNMP IPv6 related tests in 202211 branch.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1002,6 +1002,18 @@ show_techsupport/test_techsupport.py::test_techsupport:
 #######################################
 #####            snmp             #####
 #######################################
+snmp/test_snmp_link_local.py:
+  skip:
+    reason: "SNMP over IPv6 support not present in 202211 branch."
+    conditions:
+      - "branch in ['202211']"
+
+snmp/test_snmp_loopback.py:
+  skip:
+    reason: "SNMP over Loopback IPv6 support not present in 202211 branch."
+    conditions:
+      - "branch in ['202211']"
+
 snmp/test_snmp_pfc_counters.py:
   skip:
     reason: "M0/MX topo does not support test_snmp_pfc_counters"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Issue https://github.com/sonic-net/sonic-buildimage/issues/16165

Changes added in the PR https://github.com/sonic-net/sonic-buildimage/pull/15487 to support SNMP over IPv6 does not handle if mgmt IP address is obtained via DHCP.

#### How did you do it?
Skip the sonic-mgmt SNMP IPv6 related tests in 202211 so that the https://github.com/sonic-net/sonic-buildimage/pull/15487 can be reverted.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
