### PR TITLE
Add container stopped and container down events test

### DIFF
--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -5,6 +5,7 @@ import logging
 from run_events_test import run_test
 from event_utils import backup_monit_config, customize_monit_config, restore_monit_config
 from telemetry_utils import trigger_logger
+from tests.common.helpers.dut_utils import is_container_running
 
 logger = logging.getLogger(__name__)
 tag = "sonic-events-host"
@@ -54,12 +55,12 @@ def trigger_kernel_event(duthost):
 def get_container(duthost):
     logger.info("Check if acms or snmp container is running")
     container = "acms"
-    container_running = duthost.is_container_running(container)
+    container_running = is_container_running(duthost, container)
     if not container_running:
         container = "snmp"
     else:
         return container
-    container_running = duthost.is_container_running(container)
+    container_running = is_container_running(duthost, container)
     if not container_running:
         return ""
     return container
@@ -70,8 +71,7 @@ def stop_container(duthost):
     container = get_container(duthost)
     assert container != "", "No available container for testing"
 
-    duthost.shell("docker stop {}".format(container))
-    duthost.shell("docker start {}".format(container))
+    duthost.shell("systemctl restart {}".format(container))
 
 
 def mask_container(duthost):

--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 import logging
-
+import time
 from run_events_test import run_test
 from event_utils import backup_monit_config, customize_monit_config, restore_monit_config
 from telemetry_utils import trigger_logger

--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -15,7 +15,7 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
     logger.info("Beginning to test host events")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_kernel_event,
              "event_kernel.json", "sonic-events-host:event-kernel", tag, False)
-    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, stop_container,
+    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, restart_container,
              "event_stopped_ctr.json", "sonic-events-host:event-stopped-ctr", tag, False)
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, mask_container,
              "event_down_ctr.json", "sonic-events-host:event-down-ctr", tag, False)
@@ -52,7 +52,7 @@ def trigger_kernel_event(duthost):
     trigger_logger(duthost, "zlib decompression failed, data probably corrupt", "kernel")
 
 
-def get_container(duthost):
+def get_running_container(duthost):
     logger.info("Check if acms or snmp container is running")
     container = "acms"
     container_running = is_container_running(duthost, container)
@@ -66,9 +66,9 @@ def get_container(duthost):
     return container
 
 
-def stop_container(duthost):
+def restart_container(duthost):
     logger.info("Stopping container for event stopped event")
-    container = get_container(duthost)
+    container = get_running_container(duthost)
     assert container != "", "No available container for testing"
 
     duthost.shell("systemctl restart {}".format(container))
@@ -76,7 +76,7 @@ def stop_container(duthost):
 
 def mask_container(duthost):
     logger.info("Masking container for event down event")
-    container = get_container(duthost)
+    container = get_running_container(duthost)
     assert container != "", "No available container for testing"
 
     duthost.shell("systemctl mask {}".format(container))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Add tests for events when container is stopped (sent when container is initially stopped) and when container is down (container has been down for some time)

#### How did you do it?

Add tests

#### How did you verify/test it?

Manual/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
