### PR TITLE
Skip test_everflow_per_interface.py for ipv6 variant on broadcom-dnx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -408,7 +408,7 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-defaul
   skip:
     reason: "Skip everflow per interface IPv6 test on unsupported platforms"
     conditions:
-      - "asic_type in ['cisco-8000', 'marvell', 'mellanox']"
+      - "asic_type in ['cisco-8000', 'marvell', 'mellanox'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_l3_scenario]:
   skip:


### PR DESCRIPTION
The fix for https://github.com/sonic-net/sonic-swss/issues/2204 was reverted due to a Mellanox issue.
This has caused the ipv6 variant of test_everflow_per_interface.py to continue to fail.
Skipping that variant until the bug is fixed again.

### Type of change
- [x] Test case(new/improvement)


### Back port request
- [x] 202205
- [x] 202305
