### PR TITLE
[TACACS] Retry reboot in ro-disk UT when DUT not reachable.

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 
+from ansible.errors import AnsibleConnectionFailure
 from tests.common.devices.base import RunAnsibleModuleFail
 from tests.common.utilities import wait_until
 from tests.common.utilities import skip_release
@@ -67,6 +68,10 @@ def do_reboot(duthost, localhost, duthosts):
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="stopped", delay=5, timeout=60)
             rebooted = True
             break
+        except AnsibleConnectionFailure as e:
+            logger.error("DUT not reachable, exception: {} attempt:{}/{}".
+                         format(repr(e), i, retries))
+            wait(wait_time, msg="Wait {} seconds before retry.".format(wait_time))
         except RunAnsibleModuleFail as e:
             logger.error("DUT did not go down, exception: {} attempt:{}/{}".
                          format(repr(e), i, retries))


### PR DESCRIPTION
Retry reboot in ro-disk UT when DUT not reachable.

### Description of PR
Retry reboot in ro-disk UT when DUT not reachable.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Device unreachable after TACACS ro-disk UT failed.

#### How did you do it?
Add retry when ro-disk DUT not reachable.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
