### PR TITLE
Fix _strptime type issue 

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -6,6 +6,7 @@ import re
 import paramiko
 import pickle
 import ast
+import _strptime  # noqa F401 workaround python bug ref: https://stackoverflow.com/a/22476843/2514803
 
 from operator import itemgetter
 from collections import defaultdict


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When runnig warm-reboot or fast-reboot test, sometimes we can encounter the error:[Functional] [fast-reboot] | Exception occured when parsing logs from VM: msg='module' object has no attribute '_strptime' type=<type 'exceptions.AttributeError'>.

This issue is a python2.7 known issue(https://stackoverflow.com/a/22476843/2514803), and it was fixed in sonic-mgmt before. But the relevant fix was removed by mistake by the PR: https://github.com/sonic-net/sonic-mgmt/pull/7968/files.  However, the relevant fix still exists on the branch 202205 and before. So,  add it back.
 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix issue: https://stackoverflow.com/a/22476843/2514803

#### How did you do it?
import _strptime

#### How did you verify/test it?
run warm-reboot or fast-reboot time 

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
T0

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
