### PR TITLE
[test_snmp_memory_load] reserver 256M free memory

### DIFF
--- a/tests/snmp/memory.py
+++ b/tests/snmp/memory.py
@@ -3,11 +3,13 @@
 import time
 import subprocess
 
+
 def get_free_memory():
     command = "grep MemFree /proc/meminfo | awk '{print $2}'"
     output = subprocess.check_output(command, shell=True)
     free_memory = int(output.strip())
     return free_memory
+
 
 reserve_free_memory = 256 * 1024 * 1024    # reserve 256M
 free_memory = get_free_memory()            # KB
@@ -25,7 +27,7 @@ else:
     # for small memory device, use chunk size instead of total_chars
     command = "sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
     subprocess.run(command, shell=True)
-    # reserve 256M for system run, 32M for chunk size 
+    # reserve 256M for system run, 32M for chunk size
     free_memory = get_free_memory()
     if (free_memory * 1024) > (reserve_free_memory + chunk_size):
         large_string = ""

--- a/tests/snmp/memory.py
+++ b/tests/snmp/memory.py
@@ -3,36 +3,41 @@
 import time
 import subprocess
 
-
 def get_free_memory():
     command = "grep MemFree /proc/meminfo | awk '{print $2}'"
     output = subprocess.check_output(command, shell=True)
     free_memory = int(output.strip())
     return free_memory
 
-
-free_memory = get_free_memory()
+reserve_free_memory = 256 * 1024 * 1024    # reserve 256M
+free_memory = get_free_memory()            # KB
+chunk_size = 32 * 1024 * 1024              # chunk size 32M
 total_chars = 512000000
 
-if (free_memory * 1024) > int(total_chars * 130 / 100):
+# reserve 256M for system run
+if (free_memory * 1024 - reserve_free_memory) > total_chars:
     load = []
     count = 1000
     for i in range(0, count):
         load.append([' ' * int(total_chars / count)])
         time.sleep(0.01)
 else:
-    chunk_size = int((free_memory * 1024 * 100 / 130) / 2)
-    large_string = ""
-    remaining_chars = total_chars
-    # print("Free Memory: {} total_chars {} chunk_size {}".format(free_memory, total_chars, chunk_size))
+    # for small memory device, use chunk size instead of total_chars
+    command = "sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
+    subprocess.run(command, shell=True)
+    # reserve 256M for system run, 32M for chunk size 
+    free_memory = get_free_memory()
+    if (free_memory * 1024) > (reserve_free_memory + chunk_size):
+        large_string = ""
+        remaining_chars = total_chars
+        print("Free Memory: {} total_chars {} chunk_size {}".format(free_memory, total_chars, chunk_size))
+        try:
+            while remaining_chars > 0:
+                chunk = ' ' * min(chunk_size, remaining_chars)
+                large_string += chunk
+                remaining_chars -= chunk_size
 
-    try:
-        while remaining_chars > 0:
-            chunk = ' ' * min(chunk_size, remaining_chars)
-            large_string += chunk
-            remaining_chars -= chunk_size
-
-        for i in range(0, len(large_string), chunk_size):
-            print(large_string[i:i+chunk_size])
-    except MemoryError:
-        print("Not enough memory to generate and print the large string.")
+            for i in range(0, len(large_string), chunk_size):
+                print(large_string[i:i+chunk_size])
+        except MemoryError:
+            print("Not enough memory to generate and print the large string.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
16303901

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The case failed on 7050qx which is a low memory device

#### How did you do it?
Reserve 256M memory for the system to avoid DUT out of memory

#### How did you verify/test it?
Run original case
snmp/test_snmp_memory.py::test_snmp_memory_load[str2-7050qx-32s-acs-01] PASSED  

#### Any platform specific information?
Low memory device

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
