### PR TITLE
Support docker.io as offered by the latest Ubuntu or Debian versions

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -118,6 +118,46 @@
   when:
     - not 'docker.io' in ansible_facts.packages
 
+- name: Install python-docker
+  apt: pkg=python-docker
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  register: apt_py_docker
+  when:
+    - ansible_python.version.major==2
+    - not (ansible_distribution == 'Ubuntu' and (
+        ansible_distribution_major_version|int < 16 or
+        ansible_distribution_major_version|int >= 20))
+    - not (ansible_distribution == 'Debian' and
+        ansible_distribution_major_version|int != 10)
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+  when:
+    - ansible_python.version.major==2
+    - apt_py_docker.changed
+
+- name: Install python3-docker
+  apt: pkg=python3-docker
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  register: apt_py_docker
+  when:
+    - ansible_python.version.major==3
+    - not (ansible_distribution == 'Ubuntu' and
+        ansible_distribution_major_version|int < 16)
+    - not (ansible_distribution == 'Debian' and
+        ansible_distribution_major_version|int > 0 and
+        ansible_distribution_major_version|int < 10)
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+  when:
+    - ansible_python.version.major==3
+    - apt_py_docker.changed
+
 - name: Update python2 packages
   block:
   - name: remove old python packages
@@ -129,7 +169,9 @@
     pip: name=docker version=4.1.0 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
-  when: pip_executable=="pip"
+  when:
+    - not 'python-docker' in ansible_facts.packages
+    - ansible_python.version.major==2
 
 - name: Update python3 packages
   block:
@@ -142,4 +184,6 @@
     pip: name=docker version=6.1.0 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
-  when: pip_executable=="pip3"
+  when:
+    - not 'python3-docker' in ansible_facts.packages
+    - ansible_python.version.major==3

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -1,58 +1,102 @@
+- name: Gather facts
+  setup:
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Install docker.io
+  apt:
+    name: docker.io
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  register: apt_docker
+  when:
+    - not 'docker-ce' in ansible_facts.packages
+    - not (ansible_distribution == 'Ubuntu' and
+        ansible_distribution_major_version|int < 16)
+    - not (ansible_distribution == 'Debian' and
+        ansible_distribution_major_version|int > 0 and
+        ansible_distribution_major_version|int < 10)
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+  when: apt_docker.changed
+
 - name: Add docker official GPG key
   apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
   become: yes
   environment: "{{ proxy_env | default({}) }}"
+  when:
+    - not 'docker.io' in ansible_facts.packages
 
 - name: Check docker repository
   find:
     paths: /etc/apt/sources.list.d/
     patterns: "*docker*"
   register: docker_repo
+  when:
+    - not 'docker.io' in ansible_facts.packages
 
 - name: Report docker repository exists
   debug:
     msg: "Docker repository already exists"
-  when: docker_repo.matched > 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - docker_repo.matched > 0
 
 - name: Report docker repository not exists
   debug:
     msg: "Docker repository does not exist"
-  when: docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - docker_repo.matched == 0
 
 - name: Add docker repository for 16.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "16.04" and docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - host_distribution_version.stdout == "16.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 17.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
     state: present
   become: yes
-  when: host_distribution_version == "17.04" and docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - host_distribution_version == "17.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 18.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "18.04" and docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - host_distribution_version.stdout == "18.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 20.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "20.04" and docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - host_distribution_version.stdout == "20.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 22.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "22.04" and docker_repo.matched == 0
+  when:
+    - not 'docker.io' in ansible_facts.packages
+    - host_distribution_version.stdout == "22.04" and docker_repo.matched == 0
 
 # In ansible 2.8, there isn't update_cache_retries option in apt module, we can manually run update as a seperate and retryable step
 - name: Run the "apt-get update" as a separate and retryable step
@@ -64,11 +108,15 @@
   until: apt_update_res.cache_updated is defined and apt_update_res.cache_updated
   retries: 5
   delay: 10
+  when:
+    - not 'docker.io' in ansible_facts.packages
 
 - name: Install docker-ce
   apt: pkg=docker-ce
   become: yes
   environment: "{{ proxy_env | default({}) }}"
+  when:
+    - not 'docker.io' in ansible_facts.packages
 
 - name: Update python2 packages
   block:


### PR DESCRIPTION
**Why I did it?**
Latest Debian and Ubuntu distributions provide docker packages which can be reused by the playbook instead of docker-ce. Forcing the use of docker-ce breaks existing servers leveraging docker.io
- https://packages.ubuntu.com/search?keywords=docker.io
- https://packages.debian.org/fr/trixie/docker.io

**How I fix it?**
It installs docker.io if docker is integrated by the distribution and if docker-ce hasn't been installed yet.
Then all the docker-ce tasks are skipped.
Please note that the sonic-mgmt code verification is unchanged as docker-ce is already installed and then all docker.io tasks are skipped. 

**How I verified it?**
The KVM Testbed (docs/testbed/README.testbed.VsSetup.md) was successfully deployed against the latest stable Debian and Ubuntu distribution. No specific failure was detected when running the full test suites vs T0 (as in code verification).