### PR TITLE
[QoS] DSCP to PG mapping for IP-IP traffic

### DIFF
--- a/tests/common/helpers/base_helper.py
+++ b/tests/common/helpers/base_helper.py
@@ -1,0 +1,24 @@
+"""
+A helper module for all test types. Helper functions here are run on the sonic management docker.
+"""
+def read_logs(log_file_path):
+    """
+    Read logs from the sonic-mgmt docker.
+    Args:
+        duthost: DUT fixture
+        log_file_path: Path of the log file to read
+        
+    Returns:
+        log (List): Contents of the log file line by line as a list
+    """
+    try:
+        with open(log_file_path, "r") as f:
+            lines = f.readlines()
+    except Exception as e:
+        return None
+    logs = []
+    for line in lines:
+        res = line.split(",")
+        logs.append(res)
+    
+    return logs

--- a/tests/common/helpers/base_helper.py
+++ b/tests/common/helpers/base_helper.py
@@ -1,24 +1,26 @@
 """
 A helper module for all test types. Helper functions here are run on the sonic management docker.
 """
+
+
 def read_logs(log_file_path):
     """
     Read logs from the sonic-mgmt docker.
     Args:
         duthost: DUT fixture
         log_file_path: Path of the log file to read
-        
+
     Returns:
         log (List): Contents of the log file line by line as a list
     """
     try:
         with open(log_file_path, "r") as f:
             lines = f.readlines()
-    except Exception as e:
+    except Exception:
         return None
     logs = []
     for line in lines:
         res = line.split(",")
         logs.append(res)
-    
+
     return logs

--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -4,6 +4,7 @@ A helper module for PTF tests.
 
 import pytest
 import random
+import os
 
 from ipaddress import ip_address, IPv4Address
 from tests.common.config_reload import config_reload
@@ -114,14 +115,13 @@ def apply_dscp_cfg_teardown(duthost):
     for asic_id in duthost.get_frontend_asic_ids():
         swss = 'swss{}'.format(asic_id if asic_id is not None else '')
         try:
-            file_out = duthost.shell("docker exec {} ls /usr/share/sonic/templates/ipinip.json.j2.tmp"
-                                    .format(swss))
+            file_out = duthost.shell("docker exec {} ls /usr/share/sonic/templates/ipinip.json.j2.tmp".format(swss))
         except Exception:
             continue
         if file_out["rc"] == 0:
             cmds = [
-                'docker exec {} cp /usr/share/sonic/templates/ipinip.json.j2.tmp /usr/share/sonic/templates/ipinip.json.j2'
-                .format(swss)
+                'docker exec {} cp /usr/share/sonic/templates/ipinip.json.j2.tmp '.format(swss) +
+                '/usr/share/sonic/templates/ipinip.json.j2'
             ]
             reload_required = True
             duthost.shell_cmds(cmds=cmds)
@@ -188,5 +188,5 @@ def fetch_test_logs_ptf(ptfhost, ptf_location, dest_dir):
     curr_dir = os.getcwd()
     logFiles = {'src': log_dir, 'dest': curr_dir + dest_dir, 'flat': True, 'fail_on_missing': False}
     ptfhost.fetch(**logFiles)
-    
+
     return logFiles['dest']

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -102,7 +102,7 @@ class QosBase:
 
         yield dut_test_params_qos
 
-    def runPtfTest(self, ptfhost, testCase='', testParams={}):
+    def runPtfTest(self, ptfhost, testCase='', testParams={}, relax=False):
         """
             Runs QoS SAI test case on PTF host
 
@@ -110,6 +110,7 @@ class QosBase:
                 ptfhost (AnsibleHost): Packet Test Framework (PTF)
                 testCase (str): SAI tests test case name
                 testParams (dict): Map of test params required by testCase
+                relax (bool): Relax ptf verify packet requirements (default: False)
 
             Returns:
                 None
@@ -128,7 +129,7 @@ class QosBase:
             log_file="/tmp/{0}.log".format(testCase),
             qlen=10000,
             is_python3=True,
-            relax=False,
+            relax=relax,
             timeout=1200,
             custom_options=custom_options
         )

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1752,15 +1752,11 @@ class TestQosSai(QosSaiBase):
             "decap_mode": decap_mode
         })
 
-        import pdb; pdb.set_trace()
-
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpToPgMappingIPIP",
             testParams=testParams,
             relax=True
         )
-
-        import pdb; pdb.set_trace()
 
         output_table_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip.txt", 
                             dest_dir="/logs/dscp_to_pg_mapping_ipip.txt")

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -25,6 +25,7 @@ import pytest
 import time
 import json
 import re
+from tabulate import tabulate
 
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts     # noqa F401
 from tests.common.fixtures.duthost_utils import dut_qos_maps, \
@@ -39,6 +40,10 @@ from tests.common.helpers.pfc_storm import PFCStorm
 from tests.pfcwd.files.pfcwd_helper import set_pfc_timers, start_wd_on_ports
 from .qos_sai_base import QosSaiBase
 from tests.common.cisco_data import get_markings_dut, setup_markings_dut
+from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
+    get_stream_ptf_ports, apply_dscp_cfg_setup, apply_dscp_cfg_teardown, fetch_test_logs_ptf   # noqa F401
+from tests.common.utilities import get_ipv4_loopback_ip
+from tests.common.helpers.base_helper import read_logs
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +52,11 @@ pytestmark = [
 ]
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
+
+# Constants for DSP to PG mapping test
+DUMMY_OUTER_SRC_IP = '8.8.8.8'
+DUMMY_INNER_SRC_IP = '9.9.9.9'
+DUMMY_INNER_DST_IP = '10.10.10.10'
 
 
 @pytest.fixture(autouse=True)
@@ -1692,6 +1702,78 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.DscpToPgMapping",
             testParams=testParams
         )
+
+    @pytest.mark.parametrize("decap_mode", ["uniform", "pipe"])
+    def testIPIPQosSaiDscpToPgMapping(
+        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode
+    ):
+        """
+            Test QoS SAI DSCP to PG mapping ptf test
+            Args:
+                duthost (AnsibleHost): The DUT host
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                downstream_links (Fixture): Dict containing DUT host downstream links
+                upstream_links (Fixture): Dict containing DUT host upstream links
+                dut_qos_maps(Fixture): A fixture, return qos maps on DUT host
+                decap_mode (str): decap mode for DSCP
+            Returns:
+                None
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        
+        if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
+            pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is applied")
+
+        # Setup DSCP decap config on DUT
+        apply_dscp_cfg_setup(duthost, decap_mode)
+
+        loopback_ip = get_ipv4_loopback_ip(duthost)
+        downlink = select_random_link(downstream_links)
+        uplink_ptf_ports = get_stream_ptf_ports(upstream_links)
+        router_mac = duthost.facts["router_mac"]
+
+        pytest_assert(downlink is not None, "No downlink found")
+        pytest_assert(uplink_ptf_ports is not None, "No uplink found")
+        pytest_assert(loopback_ip is not None, "No loopback IP found")
+        pytest_assert(router_mac is not None, "No router MAC found")
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "router_mac": router_mac,
+            "src_port_id": downlink.get("ptf_port_id"),
+            "upstream_ptf_ports": uplink_ptf_ports,
+            "inner_dst_port_ip": DUMMY_INNER_DST_IP,
+            "inner_src_port_ip": DUMMY_INNER_SRC_IP,
+            "outer_dst_port_ip": loopback_ip,
+            "outer_src_port_ip": DUMMY_OUTER_SRC_IP,
+            "decap_mode": decap_mode
+        })
+
+        import pdb; pdb.set_trace()
+
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.DscpToPgMappingIPIP",
+            testParams=testParams,
+            relax=True
+        )
+
+        import pdb; pdb.set_trace()
+
+        output_table_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip.txt", 
+                            dest_dir="/logs/dscp_to_pg_mapping_ipip.txt")
+        fail_logs_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip_failures.txt",
+                            dest_dir="/logs/dscp_to_pg_mapping_ipip_failures.txt")
+        local_logs = read_logs(output_table_path)
+        local_fail_logs = read_logs(fail_logs_path)
+        headers = local_logs[0]
+        data = local_logs[1:]
+        logger.info(tabulate(data, headers=headers))
+
+        # Teardown DSCP decap config on DUT
+        apply_dscp_cfg_teardown(duthost)
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
     def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost,

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -53,7 +53,7 @@ pytestmark = [
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
-# Constants for DSP to PG mapping test
+# Constants for DSCP to PG mapping test
 DUMMY_OUTER_SRC_IP = '8.8.8.8'
 DUMMY_INNER_SRC_IP = '9.9.9.9'
 DUMMY_INNER_DST_IP = '10.10.10.10'

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1705,7 +1705,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("decap_mode", ["uniform", "pipe"])
     def testIPIPQosSaiDscpToPgMapping(
-        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode
+        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode  # noqa F811
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -1722,7 +1722,6 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        
         if separated_dscp_to_tc_map_on_uplink(duthost, dut_qos_maps):
             pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is applied")
 
@@ -1758,10 +1757,10 @@ class TestQosSai(QosSaiBase):
             relax=True
         )
 
-        output_table_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip.txt", 
-                            dest_dir="/logs/dscp_to_pg_mapping_ipip.txt")
+        output_table_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip.txt",
+                                                dest_dir="/logs/dscp_to_pg_mapping_ipip.txt")
         fail_logs_path = fetch_test_logs_ptf(ptfhost, ptf_location="./dscp_to_pg_mapping_ipip_failures.txt",
-                            dest_dir="/logs/dscp_to_pg_mapping_ipip_failures.txt")
+                                             dest_dir="/logs/dscp_to_pg_mapping_ipip_failures.txt")
         local_logs = read_logs(output_table_path)
         local_fail_logs = read_logs(fail_logs_path)
         headers = local_logs[0]
@@ -1770,6 +1769,9 @@ class TestQosSai(QosSaiBase):
 
         # Teardown DSCP decap config on DUT
         apply_dscp_cfg_teardown(duthost)
+
+        if local_fail_logs:
+            pytest.fail("Test Failed: {}".format(local_fail_logs))
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
     def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost,

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -886,10 +886,9 @@ class DscpToPgMappingIPIP(sai_base_test.ThriftInterfaceDataPlane):
                     exp_pkt.set_do_not_care_scapy(IP, 'chksum')
 
                     send_packet(self, src_port_id, outer_pkt, DEFAULT_PKT_COUNT)
-                    
+
                     try:
                         port_index, _ = verify_packet_any_port(self, exp_pkt, ports=upstream_ptf_ports, timeout=3)
-                        dst_port_id = upstream_ptf_ports[port_index]
                     except AssertionError:
                         cause_for_failure[0] = True
                         cause_for_failure[1].append("Expected packet with DSCP {} was not received ".format(dscp) +
@@ -902,11 +901,11 @@ class DscpToPgMappingIPIP(sai_base_test.ThriftInterfaceDataPlane):
                     for i in range(0, PG_NUM):
                         try:
                             if i == pg:
-                                assert(pg_cntrs[pg] == pg_cntrs_base[pg] + DEFAULT_PKT_COUNT)
+                                assert (pg_cntrs[pg] == pg_cntrs_base[pg] + DEFAULT_PKT_COUNT)
                                 output_table.append("{}, {}, {}, PASS".format(pg, dscp, pg_cntrs))
                             else:
-                                assert(pg_cntrs[i] == pg_cntrs_base[i])
-                        except:
+                                assert (pg_cntrs[i] == pg_cntrs_base[i])
+                        except Exception:
                             cause_for_failure[0] = True
                             cause_for_failure[1].append("PG counters are not incremented correctly for " +
                                                         "priority group {} and dscp value {}".format(i, dscp))

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -100,7 +100,8 @@ COUNTER_MARGIN = 2  # Margin for counter check
 DEFAULT_DSCP = 4
 DEFAULT_TTL = 64
 DEFAULT_ECN = 1
-DEFAULT_PKT_COUNT = 5
+DEFAULT_PKT_COUNT = 10
+PG_TOLERANCE = 2
 
 
 def check_leackout_compensation_support(asic, hwsku):
@@ -901,10 +902,12 @@ class DscpToPgMappingIPIP(sai_base_test.ThriftInterfaceDataPlane):
                     for i in range(0, PG_NUM):
                         try:
                             if i == pg:
-                                assert (pg_cntrs[pg] == pg_cntrs_base[pg] + DEFAULT_PKT_COUNT)
+                                assert ((pg_cntrs[pg] >= pg_cntrs_base[pg] + DEFAULT_PKT_COUNT - PG_TOLERANCE) and
+                                        (pg_cntrs[pg] <= pg_cntrs_base[pg] + DEFAULT_PKT_COUNT + PG_TOLERANCE))
                                 output_table.append("{}, {}, {}, PASS".format(pg, dscp, pg_cntrs))
                             else:
-                                assert (pg_cntrs[i] == pg_cntrs_base[i])
+                                assert ((pg_cntrs[i] >= pg_cntrs_base[i] - PG_TOLERANCE) and
+                                        (pg_cntrs[i] <= pg_cntrs_base[i] + PG_TOLERANCE))
                         except Exception:
                             cause_for_failure[0] = True
                             cause_for_failure[1].append("PG counters are not incremented correctly for " +

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4,12 +4,14 @@ SONiC Dataplane Qos tests
 import time
 import logging
 import ptf.packet as scapy
+from scapy.all import Ether, IP
 import socket
 import sai_base_test
 import operator
 import sys
 import texttable
 import math
+import os
 from ptf.testutils import (ptf_ports,
                            dp_poll,
                            simple_arp_packet,
@@ -19,7 +21,8 @@ from ptf.testutils import (ptf_ports,
                            simple_qinq_tcp_packet,
                            simple_ip_packet,
                            simple_ipv4ip_packet,
-                           hex_dump_buffer)
+                           hex_dump_buffer,
+                           verify_packet_any_port)
 from ptf.mask import Mask
 from switch import (switch_init,
                     sai_thrift_create_scheduler_profile,
@@ -92,6 +95,12 @@ RELEASE_PORT_MAX_RATE = 0
 ECN_INDEX_IN_HEADER = 53  # Fits the ptf hex_dump_buffer() parse function
 DSCP_INDEX_IN_HEADER = 52  # Fits the ptf hex_dump_buffer() parse function
 COUNTER_MARGIN = 2  # Margin for counter check
+
+# Constants for the IP IP DSCP to PG mapping test
+DEFAULT_DSCP = 4
+DEFAULT_TTL = 64
+DEFAULT_ECN = 1
+DEFAULT_PKT_COUNT = 5
 
 
 def check_leackout_compensation_support(asic, hwsku):
@@ -785,6 +794,136 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             print("END OF TEST", file=sys.stderr)
+
+
+# DSCP to PG mapping for IP-IP packets
+class DscpToPgMappingIPIP(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        switch_init(self.clients)
+        output_table = []
+
+        # Parse input parameters
+        router_mac = self.test_params['router_mac']
+        upstream_ptf_ports = self.test_params['upstream_ptf_ports']
+        outer_src_port_ip = self.test_params['outer_src_port_ip']
+        outer_dst_port_ip = self.test_params['outer_dst_port_ip']
+        src_port_id = int(self.test_params['src_port_id'])
+        inner_src_port_ip = self.test_params['inner_src_port_ip']
+        inner_dst_port_ip = self.test_params['inner_dst_port_ip']
+        src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        dscp_to_pg_map = self.test_params.get('dscp_to_pg_map', None)
+        pkt_dst_mac = router_mac
+        decap_mode = self.test_params['decap_mode']
+
+        if not dscp_to_pg_map:
+            # According to SONiC configuration all dscps are classified to pg 0 except:
+            # dscp  3 -> pg 3
+            # dscp  4 -> pg 4
+            # So for the 64 pkts sent the mapping should be -> 62 pg 0, 1 for pg 3, and 1 for pg 4
+            lossy_dscps = list(range(0, 64))
+            lossy_dscps.remove(3)
+            lossy_dscps.remove(4)
+            pg_dscp_map = {
+                3: [3],
+                4: [4],
+                0: lossy_dscps
+            }
+        else:
+            pg_dscp_map = {}
+            for dscp, pg in dscp_to_pg_map.items():
+                if pg in pg_dscp_map:
+                    pg_dscp_map[int(pg)].append(int(dscp))
+                else:
+                    pg_dscp_map[int(pg)] = [int(dscp)]
+
+        cause_for_failure = [False, []]
+
+        try:
+            for pg, dscps in list(pg_dscp_map.items()):
+
+                # send pkts with dscps that map to the same pg
+                for dscp in dscps:
+                    pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+
+                    if decap_mode == "uniform":
+                        outer_dscp = dscp
+                        inner_dscp = DEFAULT_DSCP
+                        exp_dscp = outer_dscp
+                    elif decap_mode == "pipe":
+                        outer_dscp = DEFAULT_DSCP
+                        inner_dscp = dscp
+                        exp_dscp = inner_dscp
+
+                    inner_pkt = simple_tcp_packet(ip_src=inner_src_port_ip,
+                                                  ip_dst=inner_dst_port_ip,
+                                                  ip_dscp=inner_dscp,
+                                                  ip_ecn=DEFAULT_ECN,
+                                                  ip_ttl=DEFAULT_TTL)
+
+                    inner_pkt.ttl -= 1
+
+                    outer_pkt = simple_ipv4ip_packet(eth_src=src_port_mac,
+                                                     eth_dst=pkt_dst_mac,
+                                                     ip_src=outer_src_port_ip,
+                                                     ip_dst=outer_dst_port_ip,
+                                                     ip_dscp=outer_dscp,
+                                                     ip_ecn=DEFAULT_ECN,
+                                                     inner_frame=inner_pkt[scapy.IP])
+
+                    inner_pkt.ttl += 1
+
+                    exp_pkt = simple_tcp_packet(ip_src=inner_src_port_ip,
+                                                ip_dst=inner_dst_port_ip,
+                                                ip_dscp=exp_dscp,
+                                                ip_ecn=DEFAULT_ECN,
+                                                ip_ttl=DEFAULT_TTL)
+
+                    exp_pkt = Mask(exp_pkt)
+                    exp_pkt.set_do_not_care_scapy(Ether, 'src')
+                    exp_pkt.set_do_not_care_scapy(Ether, 'dst')
+                    exp_pkt.set_do_not_care_scapy(IP, 'id')
+                    exp_pkt.set_do_not_care_scapy(IP, 'ttl')
+                    exp_pkt.set_do_not_care_scapy(IP, 'chksum')
+
+                    send_packet(self, src_port_id, outer_pkt, DEFAULT_PKT_COUNT)
+                    
+                    try:
+                        port_index, _ = verify_packet_any_port(self, exp_pkt, ports=upstream_ptf_ports, timeout=3)
+                        dst_port_id = upstream_ptf_ports[port_index]
+                    except AssertionError:
+                        cause_for_failure[0] = True
+                        cause_for_failure[1].append("Expected packet with DSCP {} was not received ".format(dscp) +
+                                                    "on any of the ports: {}".format(upstream_ptf_ports))
+
+                    # validate pg counters increment by the correct pkt num
+                    time.sleep(1)
+                    pg_cntrs = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
+
+                    for i in range(0, PG_NUM):
+                        try:
+                            if i == pg:
+                                assert(pg_cntrs[pg] == pg_cntrs_base[pg] + DEFAULT_PKT_COUNT)
+                                output_table.append("{}, {}, {}, PASS".format(pg, dscp, pg_cntrs))
+                            else:
+                                assert(pg_cntrs[i] == pg_cntrs_base[i])
+                        except:
+                            cause_for_failure[0] = True
+                            cause_for_failure[1].append("PG counters are not incremented correctly for " +
+                                                        "priority group {} and dscp value {}".format(i, dscp))
+                            output_table.append("{}, {}, {}, FAIL".format(i, dscp, pg_cntrs))
+
+        finally:
+            #import pdb; pdb.set_trace()
+            headers = "Priority Group, DSCP, pg counters, Result"
+            curr_dir = os.getcwd()
+            with open(curr_dir + "/dscp_to_pg_mapping_ipip.txt", "w") as f:
+                f.write(headers+"\n")
+                f.write("\n".join(output_table))
+            if cause_for_failure[0]:
+                with open(curr_dir + "/dscp_to_pg_mapping_ipip_failures.txt", "w") as f:
+                    f.write("\n".join(cause_for_failure[1]))
+
+            print("END OF TEST")
 
 
 # Tunnel DSCP to PG mapping test

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -913,7 +913,6 @@ class DscpToPgMappingIPIP(sai_base_test.ThriftInterfaceDataPlane):
                             output_table.append("{}, {}, {}, FAIL".format(i, dscp, pg_cntrs))
 
         finally:
-            #import pdb; pdb.set_trace()
             headers = "Priority Group, DSCP, pg counters, Result"
             curr_dir = os.getcwd()
             with open(curr_dir + "/dscp_to_pg_mapping_ipip.txt", "w") as f:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently, the test case testQosSaiDscpPGMapping only verify the DSCP to PG mapping for regular traffic. The mapping of IPinIP traffic (decapsulated in IPinIP tunnel) is not tested. Hence a new test case is being added to verify the mapping for IPinIP traffic. This PR adds two tests to test IP-IP packet forwarding in both "uniform" and "pipe" decap mode on the DUT.

Fixes  (issue) #9576 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
See summary.

#### How did you do it?
1. Generate IPinIP traffic from ptf using ptfadapter. The destination IP in the outer layer of the packets should be the loopback (10.1.0.32) of DUT.
2. Ingress the packets to DUT, verify the packets are decapsulated.
3. Check the PG counter within the DUT (using saithrift api), ensure the mapping is as expected.

#### How did you verify/test it?
Tested on lab device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
