### PR TITLE
[Snappi] Validate PFC frame bug fix

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -850,13 +850,13 @@ class packet_capture(Enum):
     IP_CAPTURE = "IP_Capture"
 
 
-def config_capture_pkt(testbed_config, port_id, capture_type, capture_name=None):
+def config_capture_pkt(testbed_config, port_names, capture_type, capture_name=None):
     """
     Generate the configuration to capture packets on a port for a specific type of packet
 
     Args:
         testbed_config (obj): L2/L3 snappi config of a testbed
-        port_id (int): ID of DUT port to capture packets
+        port_names (list of string): names of ixia ports to capture packets on
         capture_type (Enum): Type of packet to capture
         capture_name (str): Name of the capture
 
@@ -865,7 +865,9 @@ def config_capture_pkt(testbed_config, port_id, capture_type, capture_name=None)
     """
 
     cap = testbed_config.captures.capture(name=capture_name if capture_name else "PacketCapture")[-1]
-    cap.port_names = [testbed_config.ports[port_id].name]
+    cap.port_names = []
+    for p_name in port_names:
+        cap.port_names.append(p_name)
     cap.format = cap.PCAP
 
     if capture_type == packet_capture.IP_CAPTURE:

--- a/tests/common/snappi_tests/pfc_packet.py
+++ b/tests/common/snappi_tests/pfc_packet.py
@@ -82,7 +82,7 @@ class PFCPacket():
             if val not in valid_options:
                 return False
 
-        return False
+        return True
 
     def _check_class_pause_times(self):
         """

--- a/tests/common/snappi_tests/read_pcap.py
+++ b/tests/common/snappi_tests/read_pcap.py
@@ -10,7 +10,7 @@ PFC_MAC_CONTROL_CODE = 0x8808
 PFC_DEST_MAC = "01:80:c2:00:00:01"
 
 
-def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=100000, UTIL_THRESHOLD=0.8):
+def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
     """
     Validate PFC frame by checking the CBFC opcode, class enable vector and class pause times.
 

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -14,6 +14,7 @@ from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 logger = logging.getLogger(__name__)
 
 SNAPPI_POLL_DELAY_SEC = 2
+CONTINUOUS_MODE = -5
 
 
 def setup_base_traffic_config(testbed_config,
@@ -201,7 +202,7 @@ def generate_pause_flows(testbed_config,
                          global_pause,
                          snappi_extra_params,
                          pause_flow_delay_sec=0,
-                         pause_flow_dur_sec='continuous'):
+                         pause_flow_dur_sec=CONTINUOUS_MODE):
     """
     Generate configurations of pause flows.
 
@@ -257,7 +258,7 @@ def generate_pause_flows(testbed_config,
 
     pause_flow.rate.pps = pps
     pause_flow.size.fixed = 64
-    if pause_flow_dur_sec != 'continuous':
+    if pause_flow_dur_sec != CONTINUOUS_MODE:
         pause_flow.duration.fixed_seconds.seconds = pause_flow_dur_sec
         pause_flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec(pause_flow_delay_sec))
     else:

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -199,7 +199,9 @@ def generate_pause_flows(testbed_config,
                          pause_flow_name,
                          pause_prio_list,
                          global_pause,
-                         snappi_extra_params):
+                         snappi_extra_params,
+                         pause_flow_delay_sec=0,
+                         pause_flow_dur_sec='continuous'):
     """
     Generate configurations of pause flows.
 
@@ -209,6 +211,8 @@ def generate_pause_flows(testbed_config,
         pause_prio_list (list): list of pause priorities
         global_pause (bool): global pause or per priority pause
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+        pause_flow_delay_sec (int): delay of pause flows in seconds
+        pause_flow_dur_sec (int): duration of pause flows in seconds except when set to continuous
     """
     base_flow_config = snappi_extra_params.base_flow_config
     pytest_assert(base_flow_config is not None, "Cannot find base flow configuration")
@@ -253,8 +257,12 @@ def generate_pause_flows(testbed_config,
 
     pause_flow.rate.pps = pps
     pause_flow.size.fixed = 64
-    pause_flow.duration.choice = pause_flow.duration.CONTINUOUS
-    pause_flow.duration.continuous.delay.nanoseconds = 0
+    if pause_flow_dur_sec != 'continuous':
+        pause_flow.duration.fixed_seconds.seconds = pause_flow_dur_sec
+        pause_flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec(pause_flow_delay_sec))
+    else:
+        pause_flow.duration.choice = pause_flow.duration.CONTINUOUS
+        pause_flow.duration.continuous.delay.nanoseconds = int(sec_to_nanosec(pause_flow_delay_sec))
 
     pause_flow.metrics.enable = True
     pause_flow.metrics.loss = True

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -129,9 +129,9 @@ def run_pfc_test(api,
     else:
         # PFC pause frame capture is not requested
         valid_pfc_frame_test = False
-    
+
     pause_flow_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + \
-                     PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
+        PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -32,6 +32,7 @@ data_flow_delay_sec = 1
 SNAPPI_POLL_DELAY_SEC = 2
 PAUSE_FLOW_DUR_BASE_SEC = 3
 TOLERANCE_THRESHOLD = 0.05
+CONTINUOUS_MODE = -5
 
 
 def run_pfc_test(api,
@@ -131,7 +132,7 @@ def run_pfc_test(api,
         valid_pfc_frame_test = False
 
     pause_flow_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + \
-        PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
+        PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else CONTINUOUS_MODE
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -130,7 +130,8 @@ def run_pfc_test(api,
         # PFC pause frame capture is not requested
         valid_pfc_frame_test = False
     
-    pause_flow_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
+    pause_flow_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + \
+                     PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -30,6 +30,7 @@ data_flow_pkt_size = 1024
 DATA_FLOW_DURATION_SEC = 2
 data_flow_delay_sec = 1
 SNAPPI_POLL_DELAY_SEC = 2
+PAUSE_FLOW_DUR_BASE_SEC = 3
 TOLERANCE_THRESHOLD = 0.05
 
 
@@ -128,6 +129,8 @@ def run_pfc_test(api,
     else:
         # PFC pause frame capture is not requested
         valid_pfc_frame_test = False
+    
+    pause_flow_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC if valid_pfc_frame_test else 'continuous'
 
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,
@@ -156,7 +159,9 @@ def run_pfc_test(api,
                          pause_flow_name=PAUSE_FLOW_NAME,
                          pause_prio_list=pause_prio_list,
                          global_pause=global_pause,
-                         snappi_extra_params=snappi_extra_params)
+                         snappi_extra_params=snappi_extra_params,
+                         pause_flow_delay_sec=0,
+                         pause_flow_dur_sec=pause_flow_dur_sec)
 
     flows = testbed_config.flows
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The validate PFC frame PR introduced a bug with a `TypeError` since the default parameters of the `config_capture_pkt` were not set correctly. This PR also fixes a frame checker bug where the result was always set to False. Both bugs have been fixed in this PR.  There is also a duration limit of pause flow frames added compared to the continuous flow of pause frames previously - this will improve the reliability of the snappi capture module since the capture module is heavily unreliable when traffic flows continuously. 

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
bug fix

#### How did you do it?

#### How did you verify/test it?
tested on lab device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
