### PR TITLE
Update assert on test_syseepromd.py (#8236)

### DIFF
--- a/tests/platform_tests/daemon/test_syseepromd.py
+++ b/tests/platform_tests/daemon/test_syseepromd.py
@@ -152,8 +152,10 @@ def test_pmon_syseepromd_stop_and_start_status(check_daemon_status, duthosts, ra
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart,
-                  'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'.format(data_after_restart, data_before_restart))
+    pytest_assert(
+        data_after_restart['data'] == data_before_restart['data'],
+        'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'
+        .format(data_after_restart['data'], data_before_restart['data']))
 
 
 def test_pmon_syseepromd_term_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname, data_before_restart):
@@ -179,8 +181,10 @@ def test_pmon_syseepromd_term_and_start_status(check_daemon_status, duthosts, ra
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart,
-                  'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'.format(data_after_restart, data_before_restart))
+    pytest_assert(
+        data_after_restart['data'] == data_before_restart['data'],
+        'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'
+        .format(data_after_restart['data'], data_before_restart['data']))
 
 
 def test_pmon_syseepromd_kill_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname, data_before_restart):
@@ -207,5 +211,7 @@ def test_pmon_syseepromd_kill_and_start_status(check_daemon_status, duthosts, ra
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(duthost)
-    pytest_assert(data_after_restart == data_before_restart,
-                  'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'.format(data_after_restart, data_before_restart))
+    pytest_assert(
+        data_after_restart['data'] == data_before_restart['data'],
+        'DB data present before and after restart does not match, data_after_restart {}, data_before_restart {}'
+        .format(data_after_restart['data'], data_before_restart['data']))


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)
fix assertion on the test_syseepromd.py, tests failed over a comparison of irrelevant values.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
tests cases failed with error:
Failed: DB data present before and after restart does not match, data_after_restart {'keys': [u'EEPROM_INFO|0x22', u'EEPROM_INFO|0x21', u'EEPROM_INFO|Checksum', u'EEPROM_INFO|TlvHeader', u'EEPROM_INFO|0xfd', u'EEPROM_INFO|0x2b', u'EEPROM_INFO|0x29', u'EEPROM_INFO|0x28', u'EEPROM_INFO|State', u'EEPROM_INFO|0x2a', u'EEPROM_INFO|0x26', u'EEPROM_INFO|0x23', u'EEPROM_INFO|0x25', u'EEPROM_INFO|0xfe', u'EEPROM_INFO|0x24'], 'data': {u'EEPROM_INFO|0x29': {'Value': '2022.08-5.3.0010-9600', 'Name': 'ONIE Version', 'Len': '21'}, u'EEPROM_INFO|0x28': {'Value': 'x86_64-mlnx_msn4600C-r0', 'Name': 'Platform Name', 'Len': '64'}, u'EEPROM_INFO|State': {'Initialized': '1'}, u'EEPROM_INFO|0x23': {'Value': 'MT2053X21259', 'Name': 'Serial Number', 'Len': '24'}, u'EEPROM_INFO|0x22': {'Value': 'MSN4600-CS2FO', 'Name': 'Part Number', 'Len': '20'}, u'EEPROM_INFO|0x21': {'Value': 'MSN4600C', 'Name': 'Product Name', 'Len': '64'}, u'EEPROM_INFO|0x26': {'Value': '0', 'Name': 'Device Version', 'Len': '1'}, u'EEPROM_INFO|0x25': {'Value': '01/10/2021 17:35:10', 'Name': 'Manufacture Date', 'Len': '19'}, u'EEPROM_INFO|0x24': {'Value': '1C:34:DA:2C:B3:00', 'Name': 'Base MAC Address', 'Len': '6'}, u'EEPROM_INFO|0xfe': {'Value': '0xD50CE8A4', 'Name': 'CRC-32', 'Len': '4'}, u'EEPROM_INFO|0xfd': {'Name_2': 'Vendor Extension', 'Name_3': 'Vendor Extension', 'Name_0': 'Vendor Extension', 'Name_1': 'Vendor Extension', 'Name_4': 'Vendor Extension', 'Name_5': 'Vendor Extension', 'Value_5': '0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x79 0x00 0x00 0x30 0x00 0x40 0x00 0x00 0x00 0x00 0x00', 'Value_4': '0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_1': '0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0x99 0x00 0x00 0x4D 0x54 0x32 0x30 0x35 0x33 0x58 0x32 0x31 0x32 0x35 0x39 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x2D 0x43 0x53 0x32 0x46 0x4F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x41 0x41 0x00 0x00 0x00 0x3F 0xDE 0xC8 0x54 0x69 0x67 0x6F 0x6E 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x7C 0x00 0x00 0x07 0x04 0xED 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_0': '0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_3': '0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0xAF 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x1C 0x34 0xDA 0x2C 0xB3 0x00 0x00 0xFE 0x1C 0x34 0xDA 0x03 0x00 0x2C 0xB3 0x00', 'Value_2': '0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Num_vendor_ext': '6', 'Len_5': '20', 'Len_4': '36', 'Len_1': '164', 'Len_0': '36', 'Len_3': '36', 'Len_2': '36'}, u'EEPROM_INFO|Checksum': {'Valid': '1'}, u'EEPROM_INFO|TlvHeader': {'Total Length': '595', 'Version': '1', 'Id String': 'TlvInfo'}, u'EEPROM_INFO|0x2b': {'Value': 'Mellanox', 'Name': 'Manufacturer', 'Len': '8'}, u'EEPROM_INFO|0x2a': {'Value': '254', 'Name': 'MAC Addresses', 'Len': '2'}}}, data_before_restart {'keys': [u'EEPROM_INFO|0x2b', u'EEPROM_INFO|0x29', u'EEPROM_INFO|0x28', u'EEPROM_INFO|State', u'EEPROM_INFO|0x22', u'EEPROM_INFO|0x2a', u'EEPROM_INFO|0x26', u'EEPROM_INFO|0x21', u'EEPROM_INFO|0x23', u'EEPROM_INFO|0x25', u'EEPROM_INFO|Checksum', u'EEPROM_INFO|0xfe', u'EEPROM_INFO|0x24', u'EEPROM_INFO|TlvHeader', u'EEPROM_INFO|0xfd'], 'data': {u'EEPROM_INFO|0x29': {'Value': '2022.08-5.3.0010-9600', 'Name': 'ONIE Version', 'Len': '21'}, u'EEPROM_INFO|0x28': {'Value': 'x86_64-mlnx_msn4600C-r0', 'Name': 'Platform Name', 'Len': '64'}, u'EEPROM_INFO|State': {'Initialized': '1'}, u'EEPROM_INFO|0x23': {'Value': 'MT2053X21259', 'Name': 'Serial Number', 'Len': '24'}, u'EEPROM_INFO|0x22': {'Value': 'MSN4600-CS2FO', 'Name': 'Part Number', 'Len': '20'}, u'EEPROM_INFO|0x21': {'Value': 'MSN4600C', 'Name': 'Product Name', 'Len': '64'}, u'EEPROM_INFO|0x26': {'Value': '0', 'Name': 'Device Version', 'Len': '1'}, u'EEPROM_INFO|0x25': {'Value': '01/10/2021 17:35:10', 'Name': 'Manufacture Date', 'Len': '19'}, u'EEPROM_INFO|0x24': {'Value': '1C:34:DA:2C:B3:00', 'Name': 'Base MAC Address', 'Len': '6'}, u'EEPROM_INFO|0xfe': {'Value': '0xD50CE8A4', 'Name': 'CRC-32', 'Len': '4'}, u'EEPROM_INFO|0xfd': {'Name_2': 'Vendor Extension', 'Name_3': 'Vendor Extension', 'Name_0': 'Vendor Extension', 'Name_1': 'Vendor Extension', 'Name_4': 'Vendor Extension', 'Name_5': 'Vendor Extension', 'Value_5': '0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x79 0x00 0x00 0x30 0x00 0x40 0x00 0x00 0x00 0x00 0x00', 'Value_4': '0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_1': '0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0x99 0x00 0x00 0x4D 0x54 0x32 0x30 0x35 0x33 0x58 0x32 0x31 0x32 0x35 0x39 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x2D 0x43 0x53 0x32 0x46 0x4F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x41 0x41 0x00 0x00 0x00 0x3F 0xDE 0xC8 0x54 0x69 0x67 0x6F 0x6E 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x7C 0x00 0x00 0x07 0x04 0xED 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_0': '0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Value_3': '0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0xAF 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x1C 0x34 0xDA 0x2C 0xB3 0x00 0x00 0xFE 0x1C 0x34 0xDA 0x03 0x00 0x2C 0xB3 0x00', 'Value_2': '0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00', 'Num_vendor_ext': '6', 'Len_5': '20', 'Len_4': '36', 'Len_1': '164', 'Len_0': '36', 'Len_3': '36', 'Len_2': '36'}, u'EEPROM_INFO|Checksum': {'Valid': '1'}, u'EEPROM_INFO|TlvHeader': {'Total Length': '595', 'Version': '1', 'Id String': 'TlvInfo'}, u'EEPROM_INFO|0x2b': {'Value': 'Mellanox', 'Name': 'Manufacturer', 'Len': '8'}, u'EEPROM_INFO|0x2a': {'Value': '254', 'Name': 'MAC Addresses', 'Len': '2'}}}

when debugging with these parameters:

(Pdb) data_after_restart['keys'] == data_before_restart['keys']
False
(Pdb) set(data_after_restart['keys']) == set(data_before_restart['keys'])
True
(Pdb) data_after_restart['data'] == data_before_restart['data']
True
the assertion failed because the keys were not in the same order, not because the values weren't equal
I modified the assertion to only compare the 'data'(it already includes the keys)

#### How did you do it?
modified the validation

#### How did you verify/test it?
run the tests

#### Any platform specific information?
no

