### PR TITLE
reduce the burst rate for " test_po_update_io_no_loss"

### DIFF
--- a/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
+++ b/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
+command=/usr/bin/python /opt/ptf_nn_agent.py --set-iface-rcv-buffer 157286400 --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
 
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log

--- a/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
+++ b/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --set-iface-rcv-buffer 157286400 --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
 
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -337,7 +337,7 @@ def test_po_update_io_no_loss(
             testutils.send(ptfadapter, in_ptf_index, pkt)
             send_count += 1
             if send_count > 100:
-                time.sleep(0)
+                time.sleep(0.001)
             member_update_thread_finished = \
                 (not member_update_finished_flag.empty()) and member_update_finished_flag.get()
             reach_max_time = time.time() > t_max


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On our dualtor test, the test_po_update_io_no_loss case failed because of excessive packet loss.  For example:
8:43:25 test_po_update.test_po_update_io_no_loss L0316 INFO   | match_count: 26206, send_count: 32401

After debug and investigation, we found the LACP communication is normal during the process. The cause of excessive packet loss is due to small rcv socket buffer of ptf_nn_agent.  On PTF side, the pytest uses a nn socket to communicate with ptf NN agent.  This socket's rcv buffer could lead to packet loss if the peer side could not handle the traffic asap.  All PTF threads are running on linux user space with common priority, if the server is not powerful enough or it's kinda busy, the ptf rcv thread may not be able to pull the pkts from socket buffer ASAP.

To improve this limitation, there are two options:
1.  use a larger rcv buffer for ptf_nn_agent socket.  for example, set the rcv buffer to 157286400, with this larger rcv buffer, the testcase can always pass in our dualtor test. 
2.  Another option for this kind of issue is to slow down the traffic burst. For example, replace the "sleep(0)" on #8684 with "sleep(0.001)".

Here, we choose the option 2 after discussing with MSFT.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
