### PR TITLE
Add debug info in test_lldp for AssertionError

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -83,6 +83,7 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
         nei_lldp_facts = localhost.lldp_facts(
             host=hostip, version='v2c', community=eos['snmp_rocommunity'])['ansible_facts']
         neighbor_interface = v['port']['ifname']
+        logger.info("lldp facts for interface {}:{}".format(neighbor_interface, nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]))
         # Verify the published DUT system name field is correct
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname
         # Verify the published DUT chassis id field is not empty

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -83,7 +83,8 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
         nei_lldp_facts = localhost.lldp_facts(
             host=hostip, version='v2c', community=eos['snmp_rocommunity'])['ansible_facts']
         neighbor_interface = v['port']['ifname']
-        logger.info("lldp facts for interface {}:{}".format(neighbor_interface, nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]))
+        logger.info("lldp facts for interface {}:{}".format(neighbor_interface,
+                                                            nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]))
         # Verify the published DUT system name field is correct
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname
         # Verify the published DUT chassis id field is not empty


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

test_lldp failed on 4600 platform sometimes. But can't reproduce it locally, add debug info for further investigation.

```
>           assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname
E           AssertionError

collect_techsupport_all_duts = None
config_facts = {'ACL_TABLE': {'DATAACL': {'policy_desc': u'DATAACL', 'ports': [u'PortChannel101', u'PortChannel102', u'PortChannel103...te_limit_interval': u'600', 'state': u'enabled'}, ...}, 'BGP_DEVICE_GLOBAL': {'STATE': {'tsa_enabled': u'false'}}, ...}
dut_system_description = u'SONiC Software Version: SONiC.20220531.37 - HwSku: Mellanox-SN4600C-C64 - Distribution: Debian 11.7 - Kernel: 5.10.0-18-2-amd64'
duthost    = <MultiAsicSonicHost str2-msn4600c-acs-03>
duthosts   = [<MultiAsicSonicHost str2-msn4600c-acs-03>]
enum_frontend_asic_index = None
enum_rand_one_per_hwsku_frontend_hostname = 'str2-msn4600c-acs-03'
eos        = {'bgp_gr_timer': 700, 'ceos_image_mount_dir': '/data/ceos', 'snmp_location': 'str', 'snmp_rocommunity': 'public'}
hostip     = u'172.16.147.63'
k          = 'Ethernet80'
lldpctl_facts = {'lldpctl': {'Ethernet0': {'age': u'0 day, 00:15:13', 'chassis': {'Bridge': {'enabled': u'on'}, 'Router': {'enabled': ...}, 'port': {'aggregation': u'1000001', 'ifname': u'Ethernet2', 'mfs': u'9236', 'ttl': u'120'}, 'rid': u'2', ...}, ...}}
localhost  = <tests.common.devices.local.Localhost object at 0x7f0ca9332810>
loganalyzer = {'str2-msn4600c-acs-03': <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f0c96d2daa0>}
mgmt_alias = u'eth0'
nei_lldp_facts = {'ansible_lldp_facts': {'Ethernet1': {'neighbor_chassis_id': u'0xc655a11c1940', 'neighbor_port_desc': u'VM28031-t0', '..._desc': u'Ubuntu 18.04.6 LTS Linux 4.15.0-208-generic #220-Ubuntu SMP Mon Mar 20 14:27:01 UTC 2023 x86_64', ...}, ...}}
nei_meta   = {'ARISTA01T1': {'hwsku': u'Arista-VM', 'mgmt_addr': u'172.16.147.60', 'type': u'LeafRouter'}, 'ARISTA02T1': {'hwsku': ...', 'type': u'LeafRouter'}, 'ARISTA04T1': {'hwsku': u'Arista-VM', 'mgmt_addr': u'172.16.147.63', 'type': u'LeafRouter'}}
neighbor_interface = u'Ethernet1'
res        = {'stderr_lines': [], u'cmd': u'docker exec -i lldp lldpcli show chassis | grep...C64 - Distribution: Debian 11.7 - Kernel: 5.10.0-18-2-amd64'], 'failed': False}
switch_mac = u'b8:ce:f6:6d:a1:80'
tbinfo     = {'auto_recover': 'True', 'comment': 'v-saidia', 'conf-name': 'vms28-t0-4600c-03', 'duts': ['str2-msn4600c-acs-03'], ...}
v          = {'age': u'0 day, 00:15:10', 'chassis': {'Bridge': {'enabled': u'on'}, 'Router': {'enabled': u'on'}, 'mac': u'0a:9b:d3:...3', ...}, 'port': {'aggregation': u'1000001', 'ifname': u'Ethernet1', 'mfs': u'9236', 'ttl': u'120'}, 'rid': u'5', ...}

lldp/test_lldp.py:78: AssertionError
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_lldp failed on 4600 platform sometimes. But can't reproduce it locally.

#### How did you do it?
Add debug info for further investigation.


#### How did you verify/test it?
Run test_lldp.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
