### PR TITLE
[HLX] Stop cpu_wdt service before doing watchdog reboot

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -245,15 +245,20 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
         bios_version = bios[1]
         if bios_version < "218" and "t1" in tbinfo["topo"]["type"]:
             pytest.skip("Skip test if BIOS ver <218 and topo is T1 and platform is M64")
-    if "x86_64-cel_e1031-r0" in duthost.facts['platform']:
-        # On Celestica E1031 platform, the cpu_wdt service periodically sends keep alive
-        # message to watchdog via "watchdogutil arm -s <timeout>" command. This may affect
-        # the test result. So, we need to stop the cpu_wdt service before doing watchdog
-        # reboot on the DUT.
-        duthost.shell("sudo systemctl stop cpu_wdt", module_ignore_errors=True)
+    try:
+        if "x86_64-cel_e1031-r0" in duthost.facts['platform']:
+            # On Celestica E1031 platform, the cpu_wdt service periodically sends keep alive
+            # message to watchdog via "watchdogutil arm -s <timeout>" command. This may affect
+            # the test result. So, we need to stop the cpu_wdt service before doing watchdog
+            # reboot on the DUT.
+            duthost.shell("sudo systemctl stop cpu_wdt", module_ignore_errors=True)
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
-                     xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+                         xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)
+    finally:
+        if "x86_64-cel_e1031-r0" in duthost.facts['platform']:
+            # On Celestica E1031 platform, ensure the cpu_wdt service is started once test finished.
+            duthost.shell("sudo systemctl start cpu_wdt", module_ignore_errors=True)
 
 
 def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -245,6 +245,12 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
         bios_version = bios[1]
         if bios_version < "218" and "t1" in tbinfo["topo"]["type"]:
             pytest.skip("Skip test if BIOS ver <218 and topo is T1 and platform is M64")
+    if "x86_64-cel_e1031-r0" in duthost.facts['platform']:
+        # On Celestica E1031 platform, the cpu_wdt service periodically sends keep alive
+        # message to watchdog via "watchdogutil arm -s <timeout>" command. This may affect
+        # the test result. So, we need to stop the cpu_wdt service before doing watchdog
+        # reboot on the DUT.
+        duthost.shell("sudo systemctl stop cpu_wdt", module_ignore_errors=True)
 
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
                      xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR sonic-net/sonic-buildimage#16083 introduced `cpu_wdt` service on Celestica E1031 platform. The `cpu_wdt` service periodically sends keep alive message to watchdog via "watchdogutil arm -s <timeout>" command. This may affect the test result of `test_watchdog_reboot`. This PR add one step to stop the `cpu_wdt` service before doing watchdog reboot on the DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

On Celestica-E1031 platform, stop the `cpu_wdt` service before doing watchdog reboot.

#### How did you do it?

Add one step in `test_watchdog_reboot`.

#### How did you verify/test it?

Verified on Celestica-E1031 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
