### PR TITLE
Fix permission of /tmp to unblock copp test

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -221,10 +221,11 @@ def _install_nano(dut, creds,  syncd_docker_name):
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
-
+        # Change the permission of /tmp to 777 to workaround issue #16034
         if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
-                    rm -rf /var/lib/apt/lists/* \
+                    chmod 777 /tmp \
+                    && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
                     && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
                     python3-dev python-setuptools wget cmake python-is-python3 \
@@ -239,7 +240,8 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     " '''.format(http_proxy, https_proxy, syncd_docker_name)
         else:
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
-                    rm -rf /var/lib/apt/lists/* \
+                    chmod 777 /tmp \
+                    && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
                     && apt-get install -y python-pip build-essential libssl-dev libffi-dev \
                     python-dev python-setuptools wget cmake \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix the permission of `/tmp` to unblock the copp test.
Because of issue https://github.com/sonic-net/sonic-buildimage/issues/16034 , the `/tmp` directory in syncd docker has incorrect permission.
This PR unblocked the issue by setting the permission to `777` before `apt install`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305 

### Approach
#### What is the motivation for this PR?
This PR is to fix permission for `/tmp` to unblock copp test.

#### How did you do it?
Change the permission of `/tmp` to `777` before `apt get`.

#### How did you verify/test it?
The change is verified on a MSN-2700 device
```
collected 14 items                                                                                                                                                         

copp/test_copp.py::TestCOPP::test_policer[str-msn2700-02-ARP]  ^HPASSED                                                                                                 [  7%]
copp/test_copp.py::TestCOPP::test_policer[str-msn2700-02-IP2ME] PASSED                                                                                               [ 14%]
copp/test_copp.py::TestCOPP::test_policer[str-msn2700-02-SNMP]  ^HPASSED                                                                                                [ 21%]
copp/test_copp.py::TestCOPP::test_policer[str-msn2700-02-SSH] PASSED                                                                                                 [ 28%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-BGP] PASSED                                                                                              [ 35%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-DHCP] PASSED                                                                                             [ 42%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-DHCP6] PASSED                                                                                            [ 50%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-LACP]  ^HPASSED                                                                                             [ 57%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-LLDP] PASSED                                                                                             [ 64%]
copp/test_copp.py::TestCOPP::test_no_policer[str-msn2700-02-UDLD] PASSED                                                                                             [ 71%]
copp/test_copp.py::TestCOPP::test_add_new_trap[str-msn2700-02] PASSED                                                                                                [ 78%] ^H
copp/test_copp.py::TestCOPP::test_remove_trap[str-msn2700-02-delete_feature_entry]  ^HPASSED                                                                            [ 85%] ^H
copp/test_copp.py::TestCOPP::test_remove_trap[str-msn2700-02-disable_feature_status] PASSED                                                                          [ 92%] ^H
copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[str-msn2700-02]  ^HPASSED                                                                               [100%] ^H

================================================================= 14 passed, 3 warnings in 2959.99 seconds =================================================================
```
#### Any platform specific information?
The issue is Mellanox platform specific. But the change is applied to all platforms.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
