### PR TITLE
[master] Add testbed health check scripts for testbed automatic monitor and recover

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -34,7 +34,7 @@ class ElastictestCommonResponse:
         self.errmsg = errmsg
 
 
-class TestbedMonitorResult(ElastictestCommonResponse):
+class TestbedCheckResult(ElastictestCommonResponse):
     pass
 
 
@@ -73,16 +73,16 @@ def check_bgp_session_state(sonichosts, state="established"):
     return True, None, None
 
 
-def monitor(sonichosts, output=None):
+def check(sonichosts, output=None):
     """
-    Perform essential monitoring checks on the given SONiC hosts.
+    Perform essential health checks on the given SONiC hosts.
 
     Args:
-        sonichosts (list): List of SONiC hosts to monitor.
-        output (str, optional): Path to the output file where the monitoring results will be written. Defaults to None.
+        sonichosts (list): List of SONiC hosts to check.
+        output (str, optional): Path to the output file where the checking results will be written. Defaults to None.
 
     Raises:
-        Exception: If an error occurs during the monitoring process.
+        Exception: If an error occurs during the checking process.
 
     """
     try:
@@ -104,16 +104,16 @@ def monitor(sonichosts, output=None):
         else:
             logger.info("Testbed is healthy.")
 
-        testbedMonitorResult = TestbedMonitorResult(code=code, data=data, errmsg=errmsg)
+        testbedCheckResult = TestbedCheckResult(code=code, data=data, errmsg=errmsg)
 
         # If output file is specified, write result to it.
         if output:
             with open(output, "w") as f:
-                f.write(json.dumps(testbedMonitorResult.__dict__))
+                f.write(json.dumps(testbedCheckResult.__dict__, separators=(",", ":"))
                 f.close()
 
     except Exception as e:
-        logger.error("Failed to monitor. {}".format(e))
+        logger.error("Failed to check. {}".format(e))
         sys.exit(1)
 
 
@@ -145,14 +145,14 @@ def main(args):
     if not localhost or not sonichosts:
         sys.exit(1)
 
-    logger.info("Monitoring")
+    logger.info("Checking")
     monitor(sonichosts, args.output)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="Tool for monitoring testbed.")
+        description="Tool for checking testbed health.")
 
     parser.add_argument(
         "-i", "--inventory",

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+"""Script for checking testbed health.
+
+    Example:
+        ./testbed_health_check.py -t vms2-4-t0-2700 -i ../ansible/str --tbfile ../ansible/testbed.yaml -o testbed_health_check_result_vms2-4-t0-2700 --log-level info
+
+    It will print the basic testbed health check result to the console, if you specify an output file, it will write to it as well.
+
+"""
+import argparse
+import logging
+import os
+import sys
+import json
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+base_path = os.path.realpath(os.path.join(_self_dir, ".."))
+if base_path not in sys.path:
+    sys.path.append(base_path)
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
+if ansible_path not in sys.path:
+    sys.path.append(ansible_path)
+
+from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa E402
+
+logger = logging.getLogger(__name__)
+
+
+class ElastictestCommonResponse:
+    def __init__(self, code: int, data: object, errmsg: str):
+        self.code = code
+        self.data = data
+        self.errmsg = errmsg
+
+
+class TestbedMonitorResult(ElastictestCommonResponse):
+    pass
+
+
+def check_bgp_session_state(sonichosts, state="established"):
+    """
+    Check if the current BGP session state equals the target state.
+
+    Args:
+        sonichosts (list): List of SonicHost objects representing the hosts to check.
+        state (str, optional): The target state to compare the BGP session state against. Defaults to "established".
+
+    Returns:
+        tuple: A tuple containing the following:
+            - bool: True if all BGP sessions are in the target state, False otherwise.
+            - dict or None: The BGP facts dictionary if there are sessions not in the target state, None otherwise.
+            - str or None: An error log message if there are sessions not in the target state, None otherwise.
+
+    """
+
+    bgp_facts = sonichosts[0].bgp_facts()['ansible_facts']
+
+    print(json.dumps(bgp_facts, indent=4))
+
+    neigh_not_ok = []
+    for k, v in list(bgp_facts['bgp_neighbors'].items()):
+        if v['state'] != state:
+            neigh_not_ok.append(f"{k}, {v['state']}")
+
+    errlog = "bgp neighbors that not established: {}".format(neigh_not_ok)
+
+    print(errlog)
+
+    if len(neigh_not_ok) > 0:
+        return False, bgp_facts, errlog
+
+    return True, None, None
+
+
+def monitor(sonichosts, output=None):
+    """
+    Perform essential monitoring checks on the given SONiC hosts.
+
+    Args:
+        sonichosts (list): List of SONiC hosts to monitor.
+        output (str, optional): Path to the output file where the monitoring results will be written. Defaults to None.
+
+    Raises:
+        Exception: If an error occurs during the monitoring process.
+
+    """
+    try:
+        # Define variable to record result
+        code = 0
+        data = None
+        errmsg = ""
+
+        # Testbed health check
+        # todo: currently, simply check bgp session state
+        bgp_session_state, bgp_facts, errlog = check_bgp_session_state(sonichosts)
+
+        # If testbed is unhealthy
+        if not bgp_session_state:
+            code = 1
+            data = bgp_facts
+            errmsg = errlog
+            logger.info("Testbed is unhealthy. {}".format(errmsg))
+        else:
+            logger.info("Testbed is healthy.")
+
+        testbedMonitorResult = TestbedMonitorResult(code=code, data=data, errmsg=errmsg)
+
+        # If output file is specified, write result to it.
+        if output:
+            with open(output, "w") as f:
+                f.write(json.dumps(testbedMonitorResult.__dict__))
+                f.close()
+
+    except Exception as e:
+        logger.error("Failed to monitor. {}".format(e))
+        sys.exit(1)
+
+
+def validate_args(args):
+    _log_level_map = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL
+    }
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=_log_level_map[args.log_level],
+        format="%(asctime)s %(filename)s#%(lineno)d %(levelname)s - %(message)s"
+    )
+
+
+def main(args):
+    logger.info("Validating arguments")
+    validate_args(args)
+
+    logger.info("Initializing hosts")
+    localhost = init_localhost(args.inventory, options={"verbosity": args.verbosity})
+    sonichosts = init_testbed_sonichosts(
+        args.inventory, args.testbed_name, testbed_file=args.tbfile, options={"verbosity": args.verbosity}
+    )
+
+    if not localhost or not sonichosts:
+        sys.exit(1)
+
+    logger.info("Monitoring")
+    monitor(sonichosts, args.output)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Tool for monitoring testbed.")
+
+    parser.add_argument(
+        "-i", "--inventory",
+        dest="inventory",
+        nargs="+",
+        help="Ansible inventory file")
+
+    parser.add_argument(
+        "-t", "--testbed-name",
+        type=str,
+        required=True,
+        dest="testbed_name",
+        help="Testbed name."
+    )
+
+    parser.add_argument(
+        "--tbfile",
+        type=str,
+        dest="tbfile",
+        default="testbed.yaml",
+        help="Testbed definition file."
+    )
+
+    parser.add_argument(
+        "-v", "--verbosity",
+        type=int,
+        dest="verbosity",
+        default=2,
+        help="Log verbosity (0-3)."
+    )
+
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        dest="log_level",
+        choices=["debug", "info", "warning", "error", "critical"],
+        default="debug",
+        help="Loglevel"
+    )
+
+    parser.add_argument(
+        "-o", "--output",
+        type=str,
+        dest="output",
+        required=False,
+        help="Output to the specified file."
+    )
+
+    args = parser.parse_args()
+    main(args)
+

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -146,7 +146,7 @@ def main(args):
         sys.exit(1)
 
     logger.info("Checking")
-    monitor(sonichosts, args.output)
+    check(sonichosts, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add testbed health check scripts for testbed automatic monitor and recover.
SONiC Elastictest is onboarding to support testbed health automatic monitor and recover. It needs to do some health checks on testbeds.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

SONiC Elastictest is onboarding to support testbed health automatic monitor and recover. It needs to do some health checks on testbeds.

#### How did you do it?

Add a new script `testbed_health_check.py`.

#### How did you verify/test it?

Verify locally.

Example:

 ` ./testbed_health_check.py -t vms2-4-t0-2700 -i ../ansible/str --tbfile ../ansible/testbed.yaml -o testbed_health_check_result_vms2-4-t0-2700 --log-level info`

It will print the basic testbed check result to the console, if you specify an output file, it will write to it as well.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
