### PR TITLE
RCA is When we are deleting the agent-id, hsflowd is referring to eth0

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -474,7 +474,7 @@ class TestAgentId():
         # Verify  whether the samples are received with previously configured agent ip
         partial_ptf_runner(
             polling_int=20,
-            agent_id=var['lo_ip'],
+            agent_id=var['mgmt_ip'],
             active_collectors="['collector0','collector1']")
 
     def testAddAgent(self, duthost, partial_ptf_runner):


### PR DESCRIPTION
Why I did it
For  sflow_bug#13407: After migration of hsflowd version v2.0.51-26, When we are deleting the agent-id, hsflowd is referring for the eth0 interface and expecting samples in that interface. 
(This is with the updated hsflowd , When you start hsflowd with no explicit agent-id configured, it will run an "election" to decide which IP address to adopt.)

How I did it
Modified the script to check for mgmt_ip.

How to verify it
Post upgrade to latest version of hsflowd, run the script and make sure that it passes.


Signed-off-by: Gokulnath-Raja <Gokulnath_R@dell.com>
Co-authored-by: mohanapriya-meganathan <mohanapriya.m1@dell.com>


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

Script Log 
[test_sflow_log.txt](https://github.com/sonic-net/sonic-mgmt/files/12473632/test_sflow_log.txt)
