### PR TITLE
[post-test] Add a param to specify show tech since in post-test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,14 @@ def pytest_addoption(parser):
                      help="Specify the url of the saithrift package to be installed on the ptf "
                           "(should be http://<serverip>/path/python-saithrift_0.9.4_amd64.deb")
 
+    #########################
+    #   post-test options   #
+    #########################
+    parser.addoption("--posttest_show_tech_since", action="store", default="yesterday",
+                     help="collect show techsupport since <date>. <date> should be a string which can "
+                          "be parsed by bash command 'date --d <date>'. Default value is yesterday. "
+                          "To collect all time spans, please use '@0' as the value.")
+
     ############################
     #  keysight ixanvl options #
     ############################

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -16,6 +16,8 @@ pytestmark = [
 
 def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     since = request.config.getoption("--posttest_show_tech_since")
+    if since == '':
+        since = 'yesterday'
     duthost = duthosts[enum_dut_hostname]
     """
     A util for collecting techsupport after tests.

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -14,7 +14,8 @@ pytestmark = [
 ]
 
 
-def test_collect_techsupport(duthosts, enum_dut_hostname):
+def test_collect_techsupport(request, duthosts, enum_dut_hostname):
+    since = request.config.getoption("--posttest_show_tech_since")
     duthost = duthosts[enum_dut_hostname]
     """
     A util for collecting techsupport after tests.
@@ -22,12 +23,12 @@ def test_collect_techsupport(duthosts, enum_dut_hostname):
     Since nightly test on Jenkins will do a cleanup at the beginning of tests,
     we need a method to save history logs and dumps. This util does the job.
     """
-    logger.info("Collecting techsupport since yesterday")
+    logger.info("Collecting techsupport since {}".format(since))
     # Because Jenkins is configured to save artifacts from tests/logs,
     # and this util is mainly designed for running on Jenkins,
     # save path is fixed to logs for now.
     TECHSUPPORT_SAVE_PATH = 'logs/'
-    out = duthost.command("generate_dump -s yesterday", module_ignore_errors=True)
+    out = duthost.command("show techsupport --since {}".format(since), module_ignore_errors=True)
     if out['rc'] == 0:
         tar_file = out['stdout_lines'][-1]
         duthost.fetch(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a parameter to specify show tech since in post-test. The default value is `yesterday`, which keeps the same behavior as current code.
To collect show tech result of all time spans, please specify `--posttest_show_tech_since='-1hour'`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Add a parameter to specify show tech since in post-test.

#### How did you do it?
Add parameter `--posttest_show_tech_since` in `conftest.py` and use it in `test_collect_techsupport`.

#### How did you verify/test it?

Verified on physical DUT with below parameters:
* Do not specify `--posttest_show_tech_since`
* Empty string: `--posttest_show_tech_since=`
* Collect all time span: `--posttest_show_tech_since='@0'`
* Collect since 1 hour ago: `--posttest_show_tech_since='-1hour'`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
