### PR TITLE
Adding SSH config generation support.

### DIFF
--- a/ansible/devutil/inv_helpers.py
+++ b/ansible/devutil/inv_helpers.py
@@ -136,9 +136,28 @@ class HostManager():
                         res['password'] = [vars['secret_group_vars']
                                            [cred['alias']][p] for p in cred['password']]
                         break
-        else:
-            res['username'] = jinja2.Template(vars['ansible_ssh_user']).render(**vars)
-            res['password'] = jinja2.Template(vars['ansible_ssh_pass']).render(**vars)
+
+        if 'username' not in vars:
+            ssh_user = ''
+            if 'ansible_ssh_user' in vars:
+                ssh_user = vars['ansible_ssh_user']
+            elif 'ansible_user' in vars:
+                ssh_user = vars['ansible_user']
+            else:
+                ssh_user = ''
+
+            res['username'] = jinja2.Template(ssh_user).render(**vars)
+
+        if 'password' not in vars:
+            ssh_pass = ''
+            if 'ansible_ssh_pass' in vars:
+                ssh_pass = vars['ansible_ssh_pass']
+            elif 'ansible_password' in vars:
+                ssh_pass = vars['ansible_password']
+            else:
+                ssh_pass = ''
+
+            res['password'] = [jinja2.Template(ssh_pass).render(**vars)]
 
         # console username and password
         console_login_creds = vars.get("console_login", {})

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -6,7 +6,7 @@ import argparse
 import os
 from devutil.testbed import TestBed
 from devutil.inv_helpers import HostManager
-from devutil.ssh_session_repo import SecureCRTSshSessionRepoGenerator
+from devutil.ssh_session_repo import SecureCRTSshSessionRepoGenerator, SshConfigSshSessionRepoGenerator
 
 
 class TestBedSshSessionRepoGenerator(object):
@@ -26,6 +26,8 @@ class TestBedSshSessionRepoGenerator(object):
         """Generate SSH session repo."""
         for testbed in self.testbeds.values():
             self._generate_ssh_sessions_for_testbed(testbed)
+
+        self.repo_generator.finish()
 
     def _generate_ssh_sessions_for_testbed(self, testbed):
         """Generate SSH sessions for a testbed.
@@ -109,13 +111,27 @@ def main(args):
         print("{} testbeds loaded.\n".format(len(testbeds)))
 
     print(
-        "Starting SSH session repo generation with config: OutputDir = {}, Template = {}".format(
-            args.target, args.template_file_path
+        "Starting SSH session repo generation with config: Target = {}, Format = {}, Template = {}".format(
+            args.target, args.format, args.template_file_path
         )
     )
-    repo_generator = SecureCRTSshSessionRepoGenerator(
-        args.target, args.template_file_path
-    )
+    if args.format == "securecrt":
+        repo_generator = SecureCRTSshSessionRepoGenerator(
+            args.target, args.template_file_path
+        )
+    elif args.format == "ssh":
+        ssh_config_params = {}
+        for param in args.ssh_config_params:
+            key, value = param.split("=")
+            ssh_config_params[key] = value
+
+        repo_generator = SshConfigSshSessionRepoGenerator(
+            args.target, ssh_config_params
+        )
+    else:
+        print("Unsupported output format: {}".format(args.format))
+        return
+
     testbed_repo_generator = TestBedSshSessionRepoGenerator(testbeds, repo_generator)
     testbed_repo_generator.generate()
 
@@ -124,7 +140,7 @@ if __name__ == "__main__":
     # Parse arguments
     example_text = """Examples:
 - python3 ssh_session_gen.py -i inventory -o /data/sessions/testbeds -p some_securecrt_session.ini
-- python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds -p some_securecrt_session.ini
+- python3 ssh_session_gen.py -i lab t2_lab -n vms-.* -o /data/sessions/testbeds --format ssh
 - python3 ssh_session_gen.py -i your_own_inv -t your_own_testbed.yaml -n .*some_tests.* -o /data/sessions/testbeds \
     -p some_securecrt_session.ini
 
@@ -181,11 +197,30 @@ the `secrets.json` file and use the alternative credentials.
     )
 
     parser.add_argument(
+        "--format",
+        type=str,
+        dest="format",
+        choices=["securecrt", "ssh"],
+        default="securecrt",
+        help="Output target format, currently supports securecrt or ssh.",
+    )
+
+    parser.add_argument(
+        "--ssh-config-params",
+        type=str,
+        dest="ssh_config_params",
+        nargs="+",
+        default="",
+        help="Extra SSH config parameters, only used when --format=ssh. E.g. ProxyJump=jumpbox",
+    )
+
+    parser.add_argument(
         "-p",
         "--template",
         type=str,
         dest="template_file_path",
-        help="Session file template path. Used for clone your current session settings.",
+        help="Session file template path. Used for clone your current session settings. "
+             "Only used when --format=securecrt.",
     )
 
     args = parser.parse_args()

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -79,6 +79,9 @@ class TestBedSshSessionRepoGenerator(object):
             )
         )
 
+        if testbed_node.ssh_user == '':
+            print("WARNING: SSH user is empty for testbed node: {}".format(testbed_node.name))
+
         session_path = os.path.join(
             testbed.inv_name,
             testbed.conf_name,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Add SSH config generation support for test bed. To execute it, we can specify the output format as ssh. 

And here is an example of generate the ssh config file to "/data/sessions/ssh_config" with jumpbox set to "devvm".

```bash
~/env-python3/bin/python3 ssh_session_gen.py -i inventory -o /data/sessions/ssh_config --format ssh --ssh-config-params "PROXYJUMP=devvm"
```

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

This change is supposed to help developers accessing the testbed in daily work.

#### How did you do it?

This change improves the current SecureCRT testbed generation script by addin the SSH config generator as a new backend.

#### How did you verify/test it?

Generate all sessions and check the result:

![image](https://github.com/sonic-net/sonic-mgmt/assets/1533278/11a0a5d0-402a-4e0e-b9e0-1145e4f57bcc)

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
