### PR TITLE
Stop overriding all ansible connection variables with 'use_own_value'

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -34,13 +34,19 @@
   gather_facts: no
   pre_tasks:
   - set_fact: ansible_user="{{ vm_host_user }}"
-    when: vm_host_user is defined
+    when:
+      - vm_host_user is defined
+      - vm_host_user != 'use_own_value'
 
   - set_fact: ansible_password="{{ vm_host_password }}"
-    when: vm_host_password is defined
+    when:
+      - vm_host_password is defined
+      - vm_host_password != 'use_own_value'
 
   - set_fact: ansible_become_password="{{ vm_host_become_password }}"
-    when: vm_host_become_password is defined
+    when:
+      - vm_host_become_password is defined
+      - vm_host_become_password != 'use_own_value'
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -20,13 +20,19 @@
     - vars/docker_registry.yml
   pre_tasks:
   - set_fact: ansible_user="{{ vm_host_user }}"
-    when: vm_host_user is defined
+    when:
+      - vm_host_user is defined
+      - vm_host_user != 'use_own_value'
 
   - set_fact: ansible_password="{{ vm_host_password }}"
-    when: vm_host_password is defined
+    when:
+      - vm_host_password is defined
+      - vm_host_password != 'use_own_value'
 
   - set_fact: ansible_become_password="{{ vm_host_become_password }}"
-    when: vm_host_become_password is defined
+    when:
+      - vm_host_become_password is defined
+      - vm_host_become_password != 'use_own_value'
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -19,13 +19,19 @@
     - vars/docker_registry.yml
   pre_tasks:
   - set_fact: ansible_user="{{ vm_host_user }}"
-    when: vm_host_user is defined
+    when:
+      - vm_host_user is defined
+      - vm_host_user != 'use_own_value'
 
   - set_fact: ansible_password="{{ vm_host_password }}"
-    when: vm_host_password is defined
+    when:
+      - vm_host_password is defined
+      - vm_host_password != 'use_own_value'
 
   - set_fact: ansible_become_password="{{ vm_host_become_password }}"
-    when: vm_host_become_password is defined
+    when:
+      - vm_host_become_password is defined
+      - vm_host_become_password != 'use_own_value'
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/6303 asked to replace use_own_value to vm_host_xxx which override all ansible connection variables.
see the following lines in ansible/group_vars/all/creds.yml and ansible/group_vars/vm_host/creds.yml

vm_host_user: use_own_value
vm_host_password: use_own_value
vm_host_become_password: use_own_value

and a related task in ansible/testbed_add_vm_topology.yml

  - set_fact: ansible_user="{{ vm_host_user }}"
    when: vm_host_user is defined

These variables are now compared to default before changing all ansible connection values.
This could make the KVM Testbed configuration simpler (docs/testbed/README.testbed.VsSetup.md) as the configuration could now only ask to set ansible_user for STR-ACS-VSERV-01 (and even this could even been done automatically when setting the public keys).

Please note that this will defacto fix the documentation which forgets modifying vm_host_* vars in ansible/group_vars/all/creds.yml,

fix: #9790