### PR TITLE
[telemetry/test_telemetry]: Fix telemetry testcases test_osbuild_version and test_virtualdb_table_streaming

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -99,7 +99,8 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
 
-def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost,
+                         setup_streaming_telemetry, gnxi_path):
     """ Test osbuild/version query.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -163,7 +164,8 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhos
         pytest.fail("The value of system uptime was not updated correctly.")
 
 
-def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost,
+                                   setup_streaming_telemetry, gnxi_path):
     """Run pyclient from ptfdocker to stream a virtual-db query multiple times.
     """
     logger.info('start virtual db sample streaming testing')


### PR DESCRIPTION

Summary:

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In 202305, telemetry test cases like test_osbuild_version and test_virtualdb_table_streaming fail due to PTF docker failing to establish an SSL connection with the DUT. The function generate_client_cli() tries to run a py_gnmicli.py command on the PTF docker which first authenticates using certificates and then establishes an SSL connection with the DUT. The authentication fails due to bad certificates and hence the testcases fail.
#### How did you do it?
The fix here is to include a fixture setup_streaming_telemetry, which disables authentication using certificates. 
#### How did you verify/test it?
Ran both the testcases (test_osbuild_version and test_virtualdb_table_streaming) and verified that they both pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?


