### PR TITLE
[platform_tests] fix getting current idle driver error

### DIFF
--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -17,8 +17,8 @@ pytestmark = [
 
 def test_idle_driver(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    idle_driver = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver')['stdout']
-    if idle_driver != "none":
+    idle_driver_result = duthost.shell('cat /sys/devices/system/cpu/cpuidle/current_driver', module_ignore_errors=True)
+    if idle_driver_result['rc'] == 0 and idle_driver_result['stdout'] != "none":
         cstates = duthost.shell('sed -n "s/.*C\\([0-9]*\\).*/\\1/p" '
                                 '/sys/devices/system/cpu/cpu*/cpuidle/state*/name')['stdout'].split()
         max_cstate = max([int(cstate) for cstate in cstates])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In test_idle_driver, the current_driver file, which is where we get the current driver value, could be nonexistent on AMD platform. Not considering that could result in error.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix bug on AMD platform

#### How did you do it?
Fix bug

#### How did you verify/test it?
Run test on previously failed 7215 device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
