### PR TITLE
Fix for GCU Dhcp_Relay issue in KVM test failure 

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -456,7 +456,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
 
 def switch_mode(duthost, port):
     if not port.startswith('"') and not port.endswith('"'):
-        port = '"' + port + '"'
+        port = f'"{port}"'
 
     json_patch = [{
         "PORT": {

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -444,14 +444,18 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             if vlan_port['dev'] not in port_mode_added:
                 cmds.append('config save -y')
                 cmds.append("sudo vi /etc/sonic/config_db.json")
-                cmds.append(":s/port/{}/g".format(vlan_port['dev']))
-                cmds.append(":set mode=trunk")
+                cmds.append(":e /etc/sonic/config_db.json")
+                cmds.append("/\"PORT\"")
+                cmds.append("o")
+                cmds.append('"{}": {{'.format(vlan_port['dev']))
+                cmds.append('"mode": "trunk"')  # Add the "mode" attribute
+                cmds.append('},')
                 cmds.append(":wq")
+                logger.info("Executing vi commands")
                 port_mode_added[vlan_port['dev']] = True
                 cmds.append('echo "trunk mode added to" {port}'.format(port=vlan_port['dev']))
                 cmds.append('config load /etc/sonic/config_db.json -y')
                 cmds.append('cat /etc/sonic/config_db.json')
-
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -442,12 +442,16 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
             if vlan_port['dev'] not in port_mode_added:
+                cmds.append('config save -y')
                 cmds.append("sudo vi /etc/sonic/config_db.json")
                 cmds.append(":s/port/{}/g".format(vlan_port['dev']))
-                cmds.append(":set mode=access")
+                cmds.append(":set mode=trunk")
                 cmds.append(":wq")
                 port_mode_added[vlan_port['dev']] = True
-                duthost.shell("config switch check")
+                cmds.append('echo "trunk mode added to" {port}'.format(port=vlan_port['dev']))
+                cmds.append('config load /etc/sonic/config_db.json -y')
+                cmds.append('cat /etc/sonic/config_db.json')
+
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -455,6 +455,9 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
 
 
 def switch_mode(duthost, port):
+    if not port.startswith('"') and not port.endswith('"'):
+        port = '"' + port + '"'
+
     json_patch = [{
         "PORT": {
             port: {

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -417,7 +417,8 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
     '''
     cmds = []
     port_mode_added = {}    # Keep track of whether switchport mode has been added for each port
-
+    config_switchport = cfg_facts.get('PORT')
+    port_modes = {}
     logger.info("Add vlans, assign IPs")
     for k, v in list(vlan_intfs_dict.items()):
         if v['orig']:
@@ -442,12 +443,19 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-
             if vlan_port['dev'] not in port_mode_added:
-                cmds.append('config switchport mode {smode} {port}'.format(
-                    smode=('access' if vlan_port['pvid'] == permit_vlanid else 'trunk'),
-                    port=vlan_port['dev']))
+                for port in config_switchport:
+                    port_config = config_switchport[port]
+                    if "mode" in port_config:
+                        mode = port_config["mode"]
+                        if mode not in ("trunk"):
+                            duthost.shell("Unsupported port mode: {}")
+                        port_modes[port] = mode
+                    else:
+                        port_modes[port] = "trunk"
+                    duthost.shell("config switchport mode {} {port}")
                 port_mode_added[vlan_port['dev']] = True
+                duthost.shell("config switch check")
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -457,7 +457,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
 def switch_mode(duthost, port):
     json_patch = [{
         "PORT": {
-            "port": {
+            port: {
                 "mode": "trunk"
             }
         }

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -455,12 +455,9 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
 
 
 def switch_mode(duthost, port):
-    if not port.startswith('"') and not port.endswith('"'):
-        port = f'"{port}"'
-
     json_patch = [{
         "PORT": {
-            port: {
+            f'"{port}"': {
                 "mode": "trunk"
             }
         }

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -441,6 +441,10 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
+            if vlan_port['pvid'] == permit_vlanid:
+                cmds.append('config switchport mode access {port}'.format(port=vlan_port['dev']))
+            else:
+                cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -39,17 +39,16 @@ def vlan_intfs_dict(utils_vlan_intfs_dict_orig):        # noqa F811
 def first_avai_vlan_port(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     logger.info("Find a vlan port for new created vlan member")
-    mode = 'trunk'
+
     for v in list(mg_facts['minigraph_vlans'].values()):
         for p in v['members']:
             if p.startswith("Ethernet"):
-                # Set the mode for the interface
-                switchport_mode_cmd = f"config interface {p} switchport {mode}"
-                switchport_mode_result = duthost.shell(switchport_mode_cmd)
                 return p
-    logger.error("No vlan port member ready for test")
 
-    
+    logger.error("No vlan port member ready for test")
+    pytest_assert(False, "No vlan port member ready for test")
+
+
 def ensure_dhcp_relay_running(duthost):
     if not duthost.is_service_fully_started('dhcp_relay'):
         duthost.shell('sudo systemctl start dhcp_relay')
@@ -71,7 +70,6 @@ def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
     |       109 | 192.168.9.1/24   | Ethernet4 | tagged         | disabled    |                       |
     +-----------+------------------+-----------+----------------+-------------+-----------------------+
     """
-    
     logger.info("CREATE TEST VLANS START")
     vlan_ports_list = [{
         'dev': first_avai_vlan_port,

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -70,7 +70,7 @@ def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
     |       109 | 192.168.9.1/24   | Ethernet4 | tagged         | disabled    |                       |
     +-----------+------------------+-----------+----------------+-------------+-----------------------+
     """
-
+    
     logger.info("CREATE TEST VLANS START")
     vlan_ports_list = [{
         'dev': first_avai_vlan_port,
@@ -78,7 +78,18 @@ def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
         'permit_vlanid': [key for key, value in list(vlan_intfs_dict.items())],
         'pvid': 0
     }]
+    
+    mode = "trunk"
 
+    # Set the mode for the interface
+    switchport_mode_cmd = f"config interface {first_avai_vlan_port} switchport {mode}"
+    switchport_mode_result = duthost.shell(switchport_mode_cmd)
+
+    if switchport_mode_result['rc'] != 0:
+    logger.error(f"Failed to set {mode} mode for {first_avai_vlan_port}")
+    else:
+    logger.info(f"Successfully set {mode} mode for {first_avai_vlan_port}")
+    
     utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict, delete_untagged_vlan=False)
     logger.info("CREATE TEST VLANS DONE")
 


### PR DESCRIPTION
**Why I did it**
This PR is created to resolve GCU DHCP_Relay issues in kvm test failure in [Update submodule sonic-utilities to the latest HEAD](https://github.com/sonic-net/sonic-buildimage/pull/16267)

Summary: Fixed PR issues in fixture/duthost_utilites.py to solve vlan addition changes on Port

Signed-off-by: Rida Hanif [rida.hanif@xflowresearch.com](mailto:rida.hanif@xflowresearch.com)



