### PR TITLE
[202205][memory-checker] Refactor the test_memory_checker test

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -1,16 +1,12 @@
 """
-The 'stress' utility is leveraged to increase the memory usage of a container continuously, then
-1) Test whether that container can be restarted by the script ran by Monit.
-2) Test whether that container can be restarted by the script ran by Monit; If that container
-   was restarted, then test the script ran by Monit was unable to restart the container anymore
-   due to Monit failed to reset its internal counter.
-3) Test whether that container can be restarted by the script ran by Monit; If that container
-   was restarted, then test the script ran by Monit was able to restart the container with the
-   help of new Monit syntax although Monit failed to reset its internal counter.
+This test file uses python and validates various test cases that Monit is able
+to correctly handle the recovery actions when a container exceeds the memory
+threshold.
 """
+import dateutil.parser
 import logging
-from multiprocessing.pool import ThreadPool
-
+import re
+import time
 import pytest
 
 from pkg_resources import parse_version
@@ -33,7 +29,8 @@ CONTAINER_RESTART_THRESHOLD_SECS = 180
 CONTAINER_CHECK_INTERVAL_SECS = 1
 MONIT_RESTART_THRESHOLD_SECS = 320
 MONIT_CHECK_INTERVAL_SECS = 5
-WAITING_SYSLOG_MSG_SECS = 130
+WAITING_SYSLOG_MSG_SECS = 30
+MONIT_MEMORY_CHECK_TIMEOUT = 700
 
 
 def remove_container(duthost, container_name):
@@ -90,27 +87,30 @@ def backup_monit_config_files(duthost):
         None.
     """
     logger.info("Backing up Monit configuration files on DuT '{}' ...".format(duthost.hostname))
-    duthost.shell("cp -f /etc/monit/monitrc /tmp/")
-    duthost.shell("mv -f /etc/monit/conf.d/monit_* /tmp/")
-    duthost.shell("cp -f /tmp/monit_telemetry /etc/monit/conf.d/")
+    duthost.shell("cp -rf /etc/monit /tmp/")
     logger.info("Monit configuration files on DuT '{}' is backed up.".format(duthost.hostname))
 
 
-def customize_monit_config_files(duthost, temp_config_line):
+def customize_monit_config_files(duthost, container, daemon_cycle_interval, start_delay, fail_cycles):
     """Customizes the Monit configuration file on DuT.
 
     Args:
         duthost: The AnsibleHost object of DuT.
-        temp_config_line: A stirng to replace the initial Monit configuration.
+        daemon_cycle_interval: Interval between two cycles of monit check
+        start_delay: Delay used by monit before running checks
 
     Returns:
         None.
     """
-    logger.info("Modifying Monit config to eliminate start delay and decrease interval ...")
-    duthost.shell("sed -i '$s/^./#/' /etc/monit/conf.d/monit_telemetry")
-    duthost.shell("echo '{}' | tee -a /etc/monit/conf.d/monit_telemetry".format(temp_config_line))
-    duthost.shell("sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc")
-    logger.info("Modifying Monit config to eliminate start delay and decrease interval are done.")
+    logger.info("Modifying Monit config to change interval and start delay ...")
+    duthost.shell(r"sed -Ei 's/(set daemon) [0-9]+/\1 {}/' /etc/monit/monitrc".format(daemon_cycle_interval))
+    duthost.shell(r"sed -Ei 's/(with start delay) [0-9]+/\1 {}/' /etc/monit/monitrc".format(start_delay))
+    logger.info("Modifying Monit config to change interval and start delay done.")
+    if fail_cycles is not None:
+        config_path = '/etc/monit/conf.d/monit_{}'.format(container.name)
+        logger.info("Modifying monit container specific config %s", config_path)
+        duthost.shell(r"sed -Ei 's/for [0-9]+ times/for {} times/' {}".format(fail_cycles, config_path))
+        logger.info("Modifying monit container specific config done.")
 
 
 def restore_monit_config_files(duthost):
@@ -123,8 +123,8 @@ def restore_monit_config_files(duthost):
         None.
     """
     logger.info("Restoring original Monit configuration files on DuT '{}' ...".format(duthost.hostname))
-    duthost.shell("mv -f /tmp/monitrc /etc/monit/")
-    duthost.shell("mv -f /tmp/monit_* /etc/monit/conf.d/")
+    duthost.shell("rm -rf /etc/monit")
+    duthost.shell("mv /tmp/monit /etc/monit")
     logger.info("Original Monit configuration files on DuT '{}' are restored.".format(duthost.hostname))
 
 
@@ -142,6 +142,41 @@ def check_monit_running(duthost):
         return False
 
     return True
+
+
+def parse_monit_output(lines):
+    data = {}
+    service = None
+    for line in lines:
+        if line.startswith("Program '"):
+            prog = line[len("Program '"):].rstrip("'")
+            service = {}
+            data[prog] = service
+            continue
+        if service is None:
+            continue
+        if line.startswith('  '):
+            key, value = line.lstrip().split('  ', 1)
+            service[key.replace(' ', '_')] = value.lstrip()
+    return data
+
+
+def get_monit_service_status(duthost, service):
+    """Returns the current status of a given monit service.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        service: Name of the monit service
+
+    Returns:
+        Status string for the monit service
+    """
+    result = duthost.shell("sudo monit status -B", module_ignore_errors=True, verbose=False)
+    if result["rc"] != 0:
+        return {}
+
+    services = parse_monit_output(result["stdout_lines"])
+    return services[service]
 
 
 def restart_monit_service(duthost):
@@ -167,151 +202,116 @@ def restart_monit_service(duthost):
     logger.info("Monit is running!")
 
 
-def install_stress_utility(duthost, creds, container_name):
-    """Installs 'stress' utility in the container on DuT.
-
-    Args:
-        duthost: The AnsibleHost object of DuT.
-        container_name: A string represents name of the container.
-
-    Returns:
-        None.
-    """
-    logger.info("Installing 'stress' utility in '{}' container ...".format(container_name))
-
-    # Get proxy settings from creds
-    http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
-    https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
-    exit_code = 0
-
-    # Shutdown bgp for having ability to install stress tool
-    logger.info("Shutting down all BGP sessions ...")
-    duthost.shell("config bgp shutdown all")
-    logger.info("All BGP sessions are shut down!...")
-    output = duthost.shell("docker exec {} bash -c 'which stress'".format(container_name), module_ignore_errors=True)
-    if output["rc"] != 0:
-        install_cmd_result = duthost.shell("docker exec {} bash -c 'export http_proxy={} \
-                                        && export https_proxy={} \
-                                        && apt-get update -y \
-                                        && apt-get install stress -y'".format(container_name, http_proxy, https_proxy))
-
-        exit_code = install_cmd_result["rc"]
-
-    pytest_assert(exit_code == 0, "Failed to install 'stress' utility!")
-    logger.info("'stress' utility was installed.")
-
-
-def remove_stress_utility(duthost, container_name):
-    """Removes the 'stress' utility from container and brings up BGP sessions
-    on DuT.
-
-    Args:
-        duthost: The AnsibleHost object of DuT.
-        container_name: A string represents the name of container.
-
-    Returns:
-        None.
-    """
-    logger.info("Removing 'stress' utility from '{}' container ...".format(container_name))
-    remove_cmd_result = duthost.shell("docker exec {} apt-get purge stress -y".format(container_name))
-    exit_code = remove_cmd_result["rc"]
-    pytest_assert(exit_code == 0, "Failed to remove 'stress' utility!")
-    logger.info("'stress' utility was removed.")
-
-    logger.info("Bringing up all BGP sessions ...")
-    duthost.shell("config bgp startup all")
-    logger.info("BGP sessions are started up.")
-
-
 @pytest.fixture
-def test_setup_and_cleanup(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostname,
-                           enum_rand_one_asic_index, enum_dut_feature, request):
+def test_setup_and_cleanup(memory_checker_dut_and_container, request):
     """Backups Monit configuration files, customizes Monit configuration files and
     restarts Monit service before testing. Restores original Monit configuration files
     and restart Monit service after testing.
 
     Args:
         duthost: Hostname of DuT.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
 
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    install_stress_utility(duthost, creds, container_name)
+    duthost, container = memory_checker_dut_and_container
 
     backup_monit_config_files(duthost)
-    customize_monit_config_files(duthost, request.param)
+    customize_monit_config_files(duthost, container, *request.param)
     restart_monit_service(duthost)
 
     yield
 
-    try:
-        restore_monit_config_files(duthost)
-    finally:
-        restart_monit_service(duthost)
+    restore_monit_config_files(duthost)
+    restart_monit_service(duthost)
 
-        restart_container(duthost, container_name)
-        remove_stress_utility(duthost, container_name)
-        postcheck_critical_processes(duthost, container_name)
+    if not container.is_running():
+        container.restart()
+    container.post_check()
 
 
 @pytest.fixture
-def remove_and_restart_container(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostname,
-                                 enum_rand_one_asic_index, enum_dut_feature):
+def remove_and_restart_container(memory_checker_dut_and_container):
     """Removes and restarts 'telemetry' container from DuT.
 
     Args:
-        duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
-
+        memory_checker_dut_and_container: Fixture providing the duthost and container to test
 
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    remove_container(duthost, container_name)
+    duthost, container = memory_checker_dut_and_container
+    container.remove()
 
     yield
 
-    restart_container(duthost, container_name)
-    postcheck_critical_processes(duthost, container_name)
+    if not container.is_running():
+        container.restart()
+    container.post_check()
 
 
-def consume_memory(duthost, container_name, vm_workers):
+@pytest.fixture(params=['telemetry'])
+def enum_memory_checker_container(request):
+    return request.param
+
+
+@pytest.fixture
+def memory_checker_dut_and_container(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                     enum_memory_checker_container):
+    """Perform some checks and return applicable duthost and container name
+
+    Args:
+        duthosts: The fixture returns list of DuTs.
+        enum_memory_checker_container: Fixture returning the name of the container to test
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+          a frontend DuT from testbed.
+
+    Returns:
+        (duthost, container)
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    container_name = enum_memory_checker_container
+    container = MemoryCheckerContainer(container_name, duthost)
+
+    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
+                   and (("20191130" in duthost.os_version and
+                         parse_version(duthost.os_version) > parse_version("20191130.72"))
+                   or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
+                   "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
+
+    return duthost, container
+
+
+def start_consume_memory(duthost, container):
     """Consumes memory more than the threshold value of specified container.
 
     Args:
         duthost: The AnsibleHost object of DuT.
-        container_name: Name of container.
-        vm_workers: Number of workers which does the spinning on malloc()/free()
-          to consume memory.
+        container: Container object to test
 
     Returns:
         None.
     """
-    logger.info("Executing command 'stress -m {}' in '{}' container ...".format(vm_workers, container_name))
-    duthost.shell("docker exec {} stress -m {}".format(container_name, vm_workers), module_ignore_errors=True)
+    mem_size = container.mem_size_to_allocate()
+    cmd = """python3 -c 'import ctypes, time; arr = (ctypes.c_uint8 * {})(); time.sleep(1000)'""".format(mem_size)
+    logger.info("Executing python command to consume %s in %s container", mem_size, container.name)
+    docker_cmd = 'docker exec {} {} &'.format(container.name, cmd)
+    duthost.shell(docker_cmd, module_ignore_errors=True)
+
+
+def stop_consume_memory(duthost, container):
+    """Stop the excessive memory allocation if running
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container: Container object to test
+
+    Returns:
+        None.
+    """
+    logger.info("Stopping python command that consumes memory in %s container", container.name)
+    docker_cmd = 'docker exec {} pkill -f time.sleep'.format(container.name)
+    duthost.shell(docker_cmd, module_ignore_errors=True)
 
 
 def check_critical_processes(duthost, container_name):
@@ -351,51 +351,6 @@ def postcheck_critical_processes(duthost, container_name):
     logger.info("All critical processes in '{}' container are running.".format(container_name))
 
 
-def consumes_memory_and_checks_container_restart(duthost, container_name, vm_workers):
-    """Invokes the 'stress' utility to consume memory more than the threshold asynchronously
-    and checks whether the container can be stopped and restarted. Loganalyzer is leveraged
-    to check whether the log messages related to container stopped were generated.
-
-    Args:
-        duthost: The AnsibleHost object of DuT.
-        container_name: A string represents the name of container.
-        vm_workers: Number of workers which does the spinning on malloc()/free()
-          to consume memory.
-
-    Returns:
-        None.
-    """
-    expected_alerting_messages = []
-    expected_alerting_messages.append(".*restart_service.*Restarting service 'telemetry'.*")
-    expected_alerting_messages.append(".*Stopping Telemetry container.*")
-    expected_alerting_messages.append(".*Stopped Telemetry container.*")
-    expected_alerting_messages.append(".*Starting Telemetry container.*")
-    expected_alerting_messages.append(".*Started Telemetry container.*")
-
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_restart_due_to_memory")
-    loganalyzer.expect_regex = []
-    loganalyzer.expect_regex.extend(expected_alerting_messages)
-    marker = loganalyzer.init()
-
-    thread_pool = ThreadPool()
-    thread_pool.apply_async(consume_memory, (duthost, container_name, vm_workers))
-
-    logger.info("Sleep '{}' seconds to wait for the alerting messages from syslog ...".format(WAITING_SYSLOG_MSG_SECS))
-    time.sleep(WAITING_SYSLOG_MSG_SECS)
-
-    logger.info("Checking the alerting messages related to container stopped ...")
-    loganalyzer.analyze(marker)
-    logger.info("Found all the expected alerting messages from syslog!")
-
-    logger.info("Waiting for '{}' container to be restarted ...".format(container_name))
-    restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
-                           CONTAINER_CHECK_INTERVAL_SECS,
-                           0,
-                           check_container_state, duthost, container_name, True)
-    pytest_assert(restarted, "Failed to restart '{}' container!".format(container_name))
-    logger.info("'{}' container is restarted.".format(container_name))
-
-
 def get_container_mem_usage(duthost, container_name):
     """Gets the memory usage of a container.
 
@@ -406,7 +361,7 @@ def get_container_mem_usage(duthost, container_name):
     Returns:
         mem_usage: A string represents memory usage.
     """
-    get_mem_usage_cmd = "docker stats --no-stream --format \{{\{{.MemUsage\}}\}} {}".format(container_name)
+    get_mem_usage_cmd = r"docker stats --no-stream --format \{{\{{.MemUsage\}}\}} {}".format(container_name)
     cmd_result = duthost.shell(get_mem_usage_cmd)
 
     exit_code = cmd_result["rc"]
@@ -418,226 +373,289 @@ def get_container_mem_usage(duthost, container_name):
     return mem_usage
 
 
-def consumes_memory_and_checks_monit(duthost, container_name, vm_workers, new_syntax_enabled):
-    """Invokes the 'stress' utility to consume memory more than the threshold asynchronously
-    and checks whether the container can be stopped and restarted. After container was restarted,
-    'stress' utility will be invoked again to consume memory and checks whether Monit was able to
-    restart this container with or without help of new syntax.
+def mem_size_str_to_int(size_str):
+    size, unit = re.match(r'([0-9\.]+)(.*)', size_str).groups()
+    factor = {
+        'B': 1,
+        'KB': 1000,
+        'KiB': 1024,
+        'MB': 1000 ** 2,
+        'MiB': 1024 ** 2,
+        'GB': 1000 ** 3,
+        'GiB': 1024 ** 3,
+    }[unit]
+    return int(float(size) * factor)
+
+
+class MemoryCheckerContainer(object):
+
+    EXTRA_MEMORY_TO_ALLOCATE = 20 * 1024 * 1024
+    # NOTE: these limits could be computed by reading the monit_$container config
+    MEMORY_LIMITS = {
+        'telemetry': 400 * 1024 * 1024,
+    }
+
+    def __init__(self, name, duthost):
+        self.name = name
+        self.duthost = duthost
+        self._last_start_date = None
+
+    @property
+    def memory_limit(self):
+        return self.MEMORY_LIMITS[self.name]
+
+    def current_memory_used(self):
+        value = get_container_mem_usage(self.duthost, self.name)
+        return mem_size_str_to_int(value)
+
+    def mem_size_to_allocate(self):
+        return self.memory_limit - self.current_memory_used() + self.EXTRA_MEMORY_TO_ALLOCATE
+
+    @property
+    def memory_service_name(self):
+        return 'container_memory_{}'.format(self.name)
+
+    def is_running(self):
+        return is_container_running(self.duthost, self.name)
+
+    def get_monit_mem_status(self):
+        return get_monit_service_status(self.duthost, self.memory_service_name)
+
+    def is_monit_mem_ok(self):
+        status = self.get_monit_mem_status()
+        return status['status'] == 'Status ok'
+
+    def is_monit_mem_failed(self):
+        status = self.get_monit_mem_status()
+        return status['status'] == 'Status failed'
+
+    def is_monit_mem_last_ok(self):
+        status = self.get_monit_mem_status()
+        return status['status'] == 'Status ok' and status['last_exit_value'] == '0'
+
+    def is_monit_mem_last_failed(self):
+        status = self.get_monit_mem_status()
+        return status['status'] == 'Status ok' and status['last_exit_value'] != '0'
+
+    def remove(self):
+        remove_container(self.duthost, self.name)
+
+    def restart(self):
+        restart_container(self.duthost, self.name)
+
+    def post_check(self):
+        postcheck_critical_processes(self.duthost, self.name)
+
+    def start_consume_memory(self):
+        start_consume_memory(self.duthost, self)
+
+    def stop_consume_memory(self):
+        stop_consume_memory(self.duthost, self)
+
+    def get_restart_expected_logre(self):
+        cap_name = self.name.capitalize()
+        return [
+            r".*restart_service.*Restarting service '{}'.*".format(self.name),
+            r".*Stopping {} container.*".format(cap_name),
+            r".*Stopped {} container.*".format(cap_name),
+            r".*Starting {} container.*".format(cap_name),
+            r".*Started {} container.*".format(cap_name),
+        ]
+
+    def get_last_start_date(self):
+        rc = self.duthost.shell(r"docker inspect --format \{{\{{.State.StartedAt\}}\}} {}".format(self.name))
+        date_str = rc['stdout_lines'][0].strip()
+        return dateutil.parser.isoparse(date_str)
+
+    def has_container_restarted(self):
+        start_date = self.get_last_start_date()
+        return start_date > self._last_start_date
+
+    def wait_restarted(self, start_date=None):
+        self._last_start_date = start_date or self.get_last_start_date()
+        restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS, 1, 0,
+                               self.has_container_restarted)
+        pytest_assert(restarted, "Failed to restart '{}' container!".format(self.name))
+        self._last_start_date = None
+
+    def wait_monit_mem_ok(self, timeout=MONIT_MEMORY_CHECK_TIMEOUT):
+        logger.info("Waiting for monit status ok for %s", self.name)
+        res = wait_until(timeout, 1, 0, self.is_monit_mem_ok)
+        pytest_assert(res, "Failed to wait for one monit cycle to be ok for {}".format(self.name))
+
+    def wait_monit_mem_failed(self, timeout=MONIT_MEMORY_CHECK_TIMEOUT):
+        logger.info("Waiting for monit status failed for %s", self.name)
+        res = wait_until(timeout, 1, 0, self.is_monit_mem_failed)
+        pytest_assert(res, "Failed to wait for one monit cycle to fail for {}".format(self.name))
+
+    def wait_monit_mem_last_ok(self, timeout=MONIT_MEMORY_CHECK_TIMEOUT):
+        logger.info("Waiting for last monit status ok for %s", self.name)
+        res = wait_until(timeout, 1, 0, self.is_monit_mem_last_ok)
+        pytest_assert(res, "Failed to wait for one monit cycle to be ok for {}".format(self.name))
+
+    def wait_monit_mem_last_failed(self, timeout=MONIT_MEMORY_CHECK_TIMEOUT):
+        logger.info("Waiting for last monit status failed for %s", self.name)
+        res = wait_until(timeout, 1, 0, self.is_monit_mem_last_failed)
+        pytest_assert(res, "Failed to wait for one monit cycle to fail for {}".format(self.name))
+
+    def wait_ready(self):
+        if not self.is_running():
+            pytest.fail("'{}' is not running!".format(self.name))
+        self.post_check()
+        self.wait_monit_mem_ok()
+
+
+def consumes_memory_and_checks_container_restart(duthost, container):
+    """Allocates memory in the container and checks whether the container can be
+    stopped and restarted. Loganalyzer is leveraged to check whether the log messages
+    related to container stopped were generated.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container: Container object to test
+
+    Returns:
+        None.
+    """
+    marker_prefix = "container_restart_due_to_memory"
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
+    loganalyzer.expect_regex = container.get_restart_expected_logre()
+    with loganalyzer:
+        timeout_monit_fail = 60  # fails happens after 10 cycles of 1 second
+        container.start_consume_memory()
+        container.wait_monit_mem_failed(timeout_monit_fail)
+        logger.info("Container %s should now be restarting", container.name)
+        container.wait_monit_mem_ok(CONTAINER_RESTART_THRESHOLD_SECS)
+
+    logger.info("Container %s restarted.", container.name)
+
+
+def consumes_memory_and_checks_monit(duthost, container):
+    """Invokes a command consuming memory in the background and checks whether the container can
+    be stopped and restarted.
+    After container was restarted, the command will be invoked again to consume memory and checks
+    whether Monit was able to restart this container.
     Loganalyzer is leveraged to check whether the log messages related to container stopped
     and started were generated.
 
     Args:
         duthost: The AnsibleHost object of DuT.
-        container_name: Name of container.
-        vm_workers: Number of workers which does the spinning on malloc()/free()
-          to consume memory.
-        new_syntax_enabled: Checks to make sure container will be restarted if it is set to be
-          `True`.
+        container: Container object being tested
 
     Returns:
         None.
     """
-    expected_alerting_messages = []
-    expected_alerting_messages.append(".*restart_service.*Restarting service 'telemetry'.*")
-    expected_alerting_messages.append(".*Stopping Telemetry container.*")
-    expected_alerting_messages.append(".*Stopped Telemetry container.*")
-    expected_alerting_messages.append(".*Starting Telemetry container.*")
-    expected_alerting_messages.append(".*Started Telemetry container.*")
 
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_memory_checker")
-    loganalyzer.expect_regex = []
-    loganalyzer.expect_regex.extend(expected_alerting_messages)
+    marker_prefix = "test_memory_checker"
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
+    loganalyzer.expect_regex = container.get_restart_expected_logre()
     marker = loganalyzer.init()
 
-    thread_pool = ThreadPool()
-    thread_pool.apply_async(consume_memory, (duthost, container_name, vm_workers))
+    start_date = container.get_last_start_date()
 
-    logger.info("Sleep '{}' seconds to wait for the alerting messages from syslog ...".format(WAITING_SYSLOG_MSG_SECS))
-    time.sleep(WAITING_SYSLOG_MSG_SECS)
+    container.start_consume_memory()
+    container.wait_monit_mem_last_failed(200)
+
+    logger.info("Waiting for container to restart")
+    container.wait_restarted(start_date)
+
+    # Monit container memory check should still be failed at this point
+    container.wait_monit_mem_failed(10)
+
+    # Start consuming memory early and then check the logs so we hit the memory
+    # limit before monit first cycle
+    container.start_consume_memory()
 
     logger.info("Checking the alerting messages related to container restart ...")
     loganalyzer.analyze(marker)
     logger.info("Found all the expected alerting messages from syslog!")
 
-    logger.info("Waiting for '{}' container to be restarted ...".format(container_name))
-    restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
-                           CONTAINER_CHECK_INTERVAL_SECS,
-                           0,
-                           check_container_state, duthost, container_name, True)
-    pytest_assert(restarted, "Failed to restart '{}' container!".format(container_name))
-    logger.info("'{}' container is restarted.".format(container_name))
-
-    logger.info("Running 'stress' utility again in '{}' ...".format(container_name))
-    thread_pool.apply_async(consume_memory, (duthost, container_name, vm_workers))
-
-    check_counter = 0
     marker = loganalyzer.update_marker_prefix("test_monit_counter")
-    logger.info("Checking memory usage of '{}' every 30 seconds for 6 times ...".format(container_name))
-    while check_counter < 6:
-        check_counter += 1
-        mem_usage = get_container_mem_usage(duthost, container_name)
-        logger.info("Memory usage of '{}' is '{}'".format(container_name, mem_usage))
-        time.sleep(30)
 
-    logger.info("Analyzing syslog messages to verify whether '{}' is restarted ...".format(container_name))
-    analyzing_result = loganalyzer.analyze(marker, fail=False)
-    if not new_syntax_enabled:
-        pytest_assert(analyzing_result["total"]["expected_match"] == 0,
-                      "Monit can reset counter and restart '{}'!".format(container_name))
-        logger.info("Monit was unable to reset its counter and '{}' can not be restarted!".format(container_name))
-    else:
-        pytest_assert(analyzing_result["total"]["expected_match"] == len(expected_alerting_messages),
-                      "Monit still can not restart '{}' with the help of new syntax!".format(container_name))
-        logger.info("Monit was able to restart '{}' with the help of new syntax!".format(container_name))
+    logger.info("Waiting for container %s to restart after monit initial delay", container.name)
+    container.wait_restarted()
+    container.wait_ready()
+
+    logger.info("Analyzing syslog messages to verify whether '%s' is restarted ...", container.name)
+    loganalyzer.analyze(marker)
+
+    logger.info("Monit was able to restart '%s'", container.name)
 
 
-@pytest.mark.parametrize("test_setup_and_cleanup",
-                         ['    if status == 3 for 1 times within 2 cycles then exec "/usr/bin/restart_service telemetry"'],
-                         indirect=["test_setup_and_cleanup"])
-def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                        enum_rand_one_asic_index, enum_dut_feature, test_setup_and_cleanup):
+@pytest.mark.parametrize("test_setup_and_cleanup", [(1, 0, None)], indirect=True, ids=[''])
+def test_memory_checker(memory_checker_dut_and_container, test_setup_and_cleanup):
     """Checks whether the container can be restarted or not if the memory
     usage of it is beyond its threshold for specfic times within a sliding window.
-    The `stress` utility is leveraged as the memory stressing tool.
+    A command is used to generate memory allocations beyond the limits.
 
     Args:
-        duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
+        memory_checker_dut_and_container: Fixture providing a duthost and container to test
+        test_setup_and_cleanup: Fixture setting up the test environment
 
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
-    # and number of vm_workers is hard coded. We will extend this testing on all containers after
-    # the feature 'memory_checker' is fully implemented.
-    container_name = "telemetry"
-    vm_workers = 6
-
-    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
-                   and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
-                   or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
-                   "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
-
-    if not is_container_running(duthost, container_name):
-        pytest.fail("'{}' is nor running!".format(container_name))
-
-    consumes_memory_and_checks_container_restart(duthost, container_name, vm_workers)
+    duthost, container = memory_checker_dut_and_container
+    container.wait_ready()
+    consumes_memory_and_checks_container_restart(duthost, container)
 
 
-@pytest.mark.parametrize("test_setup_and_cleanup",
-                         ['    if status == 3 for 1 times within 2 cycles then exec "/usr/bin/restart_service telemetry"'],
-                         indirect=["test_setup_and_cleanup"])
-def test_monit_reset_counter_failure(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                     enum_rand_one_asic_index, enum_dut_feature, test_setup_and_cleanup):
+@pytest.mark.parametrize("test_setup_and_cleanup", [(5, 0, None)], indirect=True, ids=[''])
+def test_memory_checker_recover(memory_checker_dut_and_container, test_setup_and_cleanup):
+    """Checks whether the container can be restarted or not if the memory
+    usage of it is beyond its threshold for specfic times within a sliding window.
+    A command is used to generate memory allocations beyond the limits.
+
+    Args:
+        memory_checker_dut_and_container: Fixture providing a duthost and container to test
+        test_setup_and_cleanup: Fixture setting up the test environment
+
+    Returns:
+        None.
+    """
+    duthost, container = memory_checker_dut_and_container
+
+    container.wait_ready()
+
+    marker_prefix = "container_memory_checker_recover"
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
+    loganalyzer.expect_regex = container.get_restart_expected_logre()
+    marker = loganalyzer.init()
+
+    timeout_status_change = 30  # monit has a 5s cycle interval per test parameters
+
+    container.start_consume_memory()
+    container.wait_monit_mem_last_failed(timeout_status_change)
+
+    container.stop_consume_memory()
+    container.wait_monit_mem_last_ok(timeout_status_change)
+
+    analysis = loganalyzer.analyze(marker, fail=False)
+    pytest_assert(not analysis['total']['expected_match'],
+                  "Container {} restarted during the test which was not expected".format(container.name))
+
+
+@pytest.mark.parametrize("test_setup_and_cleanup", [(60, 0, 2)], indirect=True, ids=[''])
+def test_monit_reset_counter_failure(memory_checker_dut_and_container, test_setup_and_cleanup):
     """Checks that Monit was unable to reset its counter. Specifically Monit will restart
-    the contanier if memory usage of it is larger than the threshold for specific times within
+    the container if memory usage of it is larger than the threshold for specific times within
     a sliding window. However, Monit was unable to restart the container anymore if memory usage is
     still larger than the threshold continuoulsy since Monit failed to reset its internal counter.
-    The `stress` utility is leveraged as the memory stressing tool.
+    A command is used to generate memory allocations beyond the limits.
 
     Args:
-        duthosts: The fixture returns list of DuTs.
-        test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
+        memory_checker_dut_and_container: Fixture providing a duthost and container to test
+        test_setup_and_cleanup: Fixture setting up the test environment
 
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
-    # and number of vm_workers is hard coded. We will extend this testing on all containers after
-    # the feature 'memory_checker' is fully implemented.
-    container_name = "telemetry"
-    vm_workers = 6
-
-    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
-                   and ("20201231" in duthost.os_version or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
-                   "Test is not supported for platform Celestica E1031, 20191130 and older image versions!")
-
-    logger.info("Checks whether '{}' is running ...".format(container_name))
-    is_running = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
-                            CONTAINER_CHECK_INTERVAL_SECS,
-                            0,
-                            check_container_state, duthost, container_name, True)
-    pytest_assert(is_running, "'{}' is not running on DuT!".format(container_name))
-    logger.info("'{}' is running on DuT!".format(container_name))
-
-    consumes_memory_and_checks_monit(duthost, container_name, vm_workers, False)
+    duthost, container = memory_checker_dut_and_container
+    container.wait_ready()
+    consumes_memory_and_checks_monit(duthost, container)
 
 
-@pytest.mark.parametrize("test_setup_and_cleanup",
-                         ['    if status == 3 for 1 times within 2 cycles then exec "/usr/bin/restart_service telemetry" repeat every 2 cycles'],
-                         indirect=["test_setup_and_cleanup"])
-def test_monit_new_syntax(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                          enum_rand_one_asic_index, enum_dut_feature, test_setup_and_cleanup):
-    """Checks that new syntax of Monit can mitigate the issue which shows Monit was unable
-    to restart container due to failing reset its internal counter. With the help of this syntax,
-    the culprit container can be restarted by Monit if memory usage of it is larger than the threshold
-    for specific times continuously.
-
-    Args:
-        duthosts: The fixture returns list of DuTs.
-        test_setup_and_cleanup: Fixture to setup prerequisites before and after testing.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
-
-    Returns:
-        None.
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
-    # and number of vm_workers is hard coded. We will extend this testing on all containers after
-    # the feature 'memory_checker' is fully implemented.
-    container_name = "telemetry"
-    vm_workers = 6
-
-    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
-                   and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
-                   or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
-                   "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
-
-    logger.info("Checks whether '{}' is running ...".format(container_name))
-    is_running = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
-                            CONTAINER_CHECK_INTERVAL_SECS,
-                            0,
-                            check_container_state, duthost, container_name, True)
-    pytest_assert(is_running, "'{}' is not running on DuT!".format(container_name))
-    logger.info("'{}' is running on DuT!".format(container_name))
-
-    consumes_memory_and_checks_monit(duthost, container_name, vm_workers, True)
-
-
-def check_log_message(duthost, container_name):
+def check_log_message(duthost, container, wait_time):
     """Leverages LogAanlyzer to check whether `memory_checker` can log the specific message
     into syslog or not.
 
@@ -648,24 +666,18 @@ def check_log_message(duthost, container_name):
     Returns:
         None.
     """
-    expected_alerting_messages = []
-    expected_alerting_messages.append(".*\[memory_checker\] Exits without checking memory usage.*'telemetry'.*")
-
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="memory_checker_skip_removed_container")
-    loganalyzer.expect_regex = []
-    loganalyzer.expect_regex.extend(expected_alerting_messages)
-    marker = loganalyzer.init()
-
-    logger.info("Sleep '{}' seconds to wait for the message from syslog ...".format(WAITING_SYSLOG_MSG_SECS))
-    time.sleep(WAITING_SYSLOG_MSG_SECS)
-
-    logger.info("Checking the syslog message written by 'memory_checker' ...")
-    loganalyzer.analyze(marker)
-    logger.info("Found the expected message from syslog!")
+    loganalyzer.expect_regex = [
+        r".*\[memory_checker\] Exits without checking memory usage.*'{}'.*".format(container.name),
+    ]
+    with loganalyzer:
+        logger.info("Sleep '{}' seconds to wait for the message from syslog ...".format(wait_time))
+        time.sleep(wait_time)
 
 
-def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                                  enum_rand_one_asic_index, enum_dut_feature,
+@pytest.mark.parametrize("test_setup_and_cleanup", [(1, 0, None)], indirect=True, ids=[''])
+def test_memory_checker_without_container_created(memory_checker_dut_and_container,
+                                                  test_setup_and_cleanup,
                                                   remove_and_restart_container):
     """Checks whether 'memory_checker' script can log an message into syslog if
     one container is not created during device is booted/reooted. This test case will
@@ -673,32 +685,14 @@ def test_memory_checker_without_container_created(duthosts, enum_rand_one_per_hw
     successfully.
 
     Args:
-        duthosts: The fixture returns list of DuTs.
-        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
-        a frontend DuT per hwsku from testbed.
-        enum_dut_feature: This fixture will choose a random feature on
-        the enum_rand_one_per_hwsku_frontend_hostname
-
+        memory_checker_dut_and_container: Fixture providing a duthost and container to test
+        test_setup_and_cleanup: Fixture setting up the test environment
+        remove_and_restart_container: Fixture removing the container before the test
+                                      and restarting it after
 
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asic_instance(enum_rand_one_asic_index)
-    container_name = asic.get_docker_name(enum_dut_feature)
-
-    pytest_require(container_name == "telemetry",
-                   "Skips testing memory_checker of container '{}' since memory monitoring is only enabled for 'telemetry'."
-                   .format(container_name))
-
-    # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
-    # and number of vm_workers is hard coded. We will extend this testing on all containers after
-    # the feature 'memory_checker' is fully implemented.
-    container_name = "telemetry"
-
-    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
-                   and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
-                   or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
-                   "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
-
-    check_log_message(duthost, container_name)
+    duthost, container = memory_checker_dut_and_container
+    wait_time_monit_complaints = 20
+    check_log_message(duthost, container, wait_time_monit_complaints)


### PR DESCRIPTION
### Description of PR

Cherry-pick of #9193

This refactor introduces many changes:
 - Better reliability on systems with small RAM capacity
 - Better control over the amount of memory consumed by the test
 - Remove the external dependency on the `stress` utility
 - Faster overall runtime for the test
 - A new testcase making sure that monit recovers if memory was above threshold for only a single cycle
 - Remove check of new/old syntax. It makes no sense to change the product code and then test that, that's not shipping code.

Summary: Refactor the test_memory_checker test
Fixes # (issue)
