### PR TITLE
Stabilize counterpoll watermark test

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -5,7 +5,7 @@ Tests for the `counterpoll queue/watermark/pg-drop ...` commands in SONiC
 import allure
 import logging
 import random
-
+import time
 import pytest
 
 from tests.common.config_reload import config_reload
@@ -30,6 +30,7 @@ DISABLE = CounterpollConstants.COUNTERPOLL_DISABLE.split(' ')[-1]
 MAPS_LONG_PREFIX = 'COUNTERS_{}_*_MAP'
 
 MAPS = 'maps'
+DELAY = 'delay'
 QUEUE_MAPS = {'prefix': 'QUEUE', MAPS: ['COUNTERS_QUEUE_NAME_MAP', 'COUNTERS_QUEUE_INDEX_MAP',
                                         'COUNTERS_QUEUE_TYPE_MAP', 'COUNTERS_QUEUE_PORT_MAP']}
 
@@ -40,13 +41,14 @@ MAPS_PREFIX_FOR_ALL_COUNTERPOLLS = [QUEUE_MAPS['prefix'], PG_MAPS['prefix']]
 FLEX_COUNTER_PREFIX = 'FLEX_COUNTER_TABLE:'
 RELEVANT_COUNTERPOLLS = [CounterpollConstants.QUEUE, CounterpollConstants.WATERMARK, CounterpollConstants.PG_DROP]
 RELEVANT_MAPS = {CounterpollConstants.QUEUE: {MAPS: [QUEUE_MAPS], CounterpollConstants.TYPE:
-                                                    [CounterpollConstants.QUEUE_STAT_TYPE]},
+                                                    [CounterpollConstants.QUEUE_STAT_TYPE], DELAY: 15},
                  CounterpollConstants.WATERMARK: {MAPS: [QUEUE_MAPS, PG_MAPS],
                                                   CounterpollConstants.TYPE:
                                                       [CounterpollConstants.QUEUE_WATERMARK_STAT_TYPE,
-                                                       CounterpollConstants.PG_WATERMARK_STAT_TYPE]},
+                                                       CounterpollConstants.PG_WATERMARK_STAT_TYPE], DELAY: 65},
                  CounterpollConstants.PG_DROP: {MAPS: [PG_MAPS],
-                                                CounterpollConstants.TYPE: [CounterpollConstants.PG_DROP_STAT_TYPE]}
+                                                CounterpollConstants.TYPE: [CounterpollConstants.PG_DROP_STAT_TYPE],
+                                                DELAY: 15}
                  }
 
 WATERMARK_COUNTERS_DB_STATS_TYPE = ['USER_WATERMARKS', 'PERSISTENT_WATERMARKS', 'PERIODIC_WATERMARKS']
@@ -113,7 +115,9 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
                      .format(duthost.hostname, [tested_counterpoll])):
         ConterpollHelper.enable_counterpoll(duthost, [tested_counterpoll])
         verify_counterpoll_status(duthost, [tested_counterpoll], ENABLE)
-
+    # Delay to allow the counterpoll to generate the maps in COUNTERS_DB
+    with allure.step("waiting {} seconds for counterpoll to generate maps in COUNTERS_DB"):
+        time.sleep(RELEVANT_MAPS[tested_counterpoll][DELAY])
     # verify QUEUE or PG maps are generated into COUNTERS_DB after enabling relevant counterpoll
     with allure.step("Verifying MAPS in COUNTERS_DB on {}...".format(duthost.hostname)):
         maps_dict = RELEVANT_MAPS[tested_counterpoll]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_counterpoll_queue_watermark_pg_drop`.
The error message
```
                msg = "no {} maps found in COUNTERS_DB".format(map_prefix)
>               pytest_assert(map_output, msg)
E               Failed: no PG maps found in COUNTERS_DB

```
It's because there is not enough delay after enabling the counterpoll.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_counterpoll_queue_watermark_pg_drop`.
#### How did you do it?
Add some delay after enabling counterpoll.

#### How did you verify/test it?
Verified on a SN2700 device
```
collected 1 item                                                                                                                                                           

platform_tests/counterpoll/test_counterpoll_watermark.py::test_counterpoll_queue_watermark_pg_drop[str-msn2700-02]  ^HPASSED                                            [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
