### PR TITLE
Add portstat to debug FDB packet delay issue

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -185,15 +185,15 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                
         # need to use Mask to ignore the priority field.
         exp_pkt = Mask(exp_pkt)
         exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
-    logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}'
-                 .format(source_ports, source_mac, dest_mac, src_vlan, dest_ports))
 
     # fdb test will send lots of pkts between paired ports, it's hard to guarantee there is no congestion
-    # on server side during this period. So tolerant to retry 3 times before complain the assert.
+    # on server side during this period. So tolerant to retry 5 times before complain the assert.
 
-    retry_count = 3
+    retry_count = 5
     pkt_count = 1
-    for _ in range(retry_count):
+    for cnt in range(retry_count):
+        logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}, dst_vlan {}, count {}'
+                     .format(source_ports, source_mac, dest_mac, src_vlan, dest_ports, dst_vlan, pkt_count))
         try:
             ptfadapter.dataplane.flush()
             testutils.send(ptfadapter, source_ports[0], pkt, count=pkt_count)
@@ -207,6 +207,11 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                
         except Exception:
             # Send 10 pkts in retry to make this test case to be more tolerent of congestion on server/ptf
             pkt_count = 10
+            logger.info("Packets not reached destination in first pass, sleep and retry count {}".format(cnt))
+            time.sleep(FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
+            result = duthost.command("portstat", module_ignore_errors=True)
+            logger.info("Port counters: {}".format(result['stdout']))
+            duthost.command("portstat -c", module_ignore_errors=True)
             pass
     else:
         result = duthost.command("show mac", module_ignore_errors=True)

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -192,7 +192,7 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                
     retry_count = 5
     pkt_count = 1
     for cnt in range(retry_count):
-        logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}, dst_vlan {}, count {}'
+        logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {} dst_vlan {} count {}'
                      .format(source_ports, source_mac, dest_mac, src_vlan, dest_ports, dst_vlan, pkt_count))
         try:
             ptfadapter.dataplane.flush()

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -207,7 +207,7 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                
         except Exception:
             # Send 10 pkts in retry to make this test case to be more tolerent of congestion on server/ptf
             pkt_count = 10
-            logger.info("Packets not reached destination in first pass, sleep and retry count {}".format(cnt))
+            logger.info("Packets not reached destination in first pass,sleep and retry count {}".format(cnt))
             time.sleep(FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
             result = duthost.command("portstat", module_ignore_errors=True)
             logger.info("Port counters: {}".format(result['stdout']))


### PR DESCRIPTION
### Description of PR
In some fdb test runs, packets are not received by PTF server. To debug this issue, add DUT's portstat in the test log.

### Type of change
Debug failures

### Back port request
None

### Approach
#### What is the motivation for this PR?
Add DUT portstat to debug any PTF server packet drop issues.

#### How did you do it?
Include DUT's portstat.
