### PR TITLE
Skipping PGDrop test for highspeed Long links

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1511,7 +1511,8 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPGDrop(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        _skip_pgdrop_for_hbm_longlink_high_speeds
     ):
         """
             Test QoS SAI PG drop counter


### PR DESCRIPTION
We need to skip PGDrop testcase when
1. We detect HBM
2. and src Port Speed is greater than the backplane port speed.

The rationale:
At higher speeds, the HBM needs a much larger number of 64-byte packets to fill, and the large SMS memory 96MB is never filled, so the Xoff is never triggered.