### PR TITLE
Cisco: Skip Watermark test for multi-DUT cases.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1946,14 +1946,17 @@ class QosSaiBase(QosBase):
         return test_port_ids
 
     @pytest.fixture(scope="function", autouse=False)
-    def _skip_allportQWM_multi_DUT(
+    def _skip_watermark_multi_DUT(
             self,
             get_src_dst_asic_and_duts,
             dutQosConfig):
+        if not is_cisco_device(get_src_dst_asic_and_duts['src_dut']):
+            yield
+            return
         if (get_src_dst_asic_and_duts['src_dut'] !=
                 get_src_dst_asic_and_duts['dst_dut']):
             pytest.skip(
-                "AllportQueueWaterMark is skipped for multiDUT scenarios.")
+                "All WM Tests are skipped for multiDUT for cisco platforms.")
 
         yield
         return

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1945,6 +1945,7 @@ class QosSaiBase(QosBase):
         logger.info(f"Test ports ids is{test_port_ids}")
         return test_port_ids
 
+    @pytest.fixture(scope="function", autouse=False)
     def _skip_allportQWM_multi_DUT(
             self,
             get_src_dst_asic_and_duts,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1944,3 +1944,15 @@ class QosSaiBase(QosBase):
                 max_port_num = len(port_list)
         logger.info(f"Test ports ids is{test_port_ids}")
         return test_port_ids
+
+    def _skip_allportQWM_multi_DUT(
+            self,
+            get_src_dst_asic_and_duts,
+            dutQosConfig):
+        if (get_src_dst_asic_and_duts['src_dut'] !=
+                get_src_dst_asic_and_duts['dst_dut']):
+            pytest.skip(
+                "AllportQueueWaterMark is skipped for multiDUT scenarios.")
+
+        yield
+        return

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -889,7 +889,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(
         self, request, get_src_dst_asic_and_duts, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLossyProfile, resetWatermark,
+        ingressLosslessProfile, egressLossyProfile, resetWatermark, _skip_watermark_multi_DUT
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -1365,7 +1365,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, _skip_watermark_multi_DUT
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic
@@ -1565,7 +1565,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, _skip_watermark_multi_DUT
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -1819,7 +1819,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, _skip_allportQWM_multi_DUT
+        resetWatermark, _skip_watermark_multi_DUT
     ):
         """
             Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1819,7 +1819,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, _skip_allportQWM_multi_DUT
     ):
         """
             Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports


### PR DESCRIPTION
The Watermark tests need the values for destination port, but qos.yaml params are read for the source port only. Until the infra provides a way to get the dst qos parameters, we need to skip the tests.