### PR TITLE
Macsec type7 support for CAK keys 

### DIFF
--- a/tests/common/devices/arista.py
+++ b/tests/common/devices/arista.py
@@ -807,13 +807,13 @@ class AristaHost(AnsibleHostBase):
         """
         if key_type == "primary":
             parents = ["mac security", "profile {}".format(profile_name)]
-            commands = ["key {} 7 {} ".format(key, key)]
+            commands = ["key {} 0 {} ".format(key, key)]
             output = self.config(lines=commands, parents=parents)
             test_msg = "Output: {}".format(output)
             return True, test_msg
         elif key_type == "fallback":
             parents = ["mac security", "profile {}".format(profile_name)]
-            commands = ["key {} 7 {} fallback".format(key, key)]
+            commands = ["key {} 0 {} fallback".format(key, key)]
             output = self.config(lines=commands, parents=parents)
             test_msg = "Output: {}".format(output)
             return True, test_msg

--- a/tests/common/devices/arista.py
+++ b/tests/common/devices/arista.py
@@ -807,13 +807,13 @@ class AristaHost(AnsibleHostBase):
         """
         if key_type == "primary":
             parents = ["mac security", "profile {}".format(profile_name)]
-            commands = ["key {} 0 {} ".format(key, key)]
+            commands = ["key {} 7 {} ".format(key, key)]
             output = self.config(lines=commands, parents=parents)
             test_msg = "Output: {}".format(output)
             return True, test_msg
         elif key_type == "fallback":
             parents = ["mac security", "profile {}".format(profile_name)]
-            commands = ["key {} 0 {} fallback".format(key, key)]
+            commands = ["key {} 7 {} fallback".format(key, key)]
             output = self.config(lines=commands, parents=parents)
             test_msg = "Output: {}".format(output)
             return True, test_msg

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -31,7 +31,7 @@ def set_macsec_profile(host, port, profile_name, priority, cipher_suite,
         }
         lines = [
             'cipher {}'.format(eos_cipher_suite[cipher_suite]),
-            'key {} 0 {}'.format(primary_ckn, primary_cak),
+            'key {} 7 {}'.format(primary_ckn, primary_cak),
             'mka key-server priority {}'.format(priority)
             ]
         if send_sci == 'true':

--- a/tests/macsec/profile.json
+++ b/tests/macsec/profile.json
@@ -2,7 +2,7 @@
     "128": {
         "priority": 64,
         "cipher_suite": "GCM-AES-128",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "35045f514b420c0e000b0b7476287f23210806564052510d5c5e56006e6d2d3c23",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
         "send_sci": "false"
@@ -10,7 +10,7 @@
     "256": {
         "priority": 64,
         "cipher_suite": "GCM-AES-256",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "375349440a0c0205050d0d2a7925237d71544254570f5e505879156f2b3a2132345b5d56797f717e646d7b322535272470090901075a564e41010176717171712d",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
         "send_sci": "false"
@@ -18,7 +18,7 @@
     "128_XPN": {
         "priority": 64,
         "cipher_suite": "GCM-AES-XPN-128",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "43030307075f0e5050000e253125207e2d565e731f1a5c4f524f4b2a2e270e0e02",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
         "send_sci": "false"
@@ -26,7 +26,7 @@
     "256_XPN": {
         "priority": 64,
         "cipher_suite": "GCM-AES-XPN-256",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "165b5d56797f717e646d7b322535272470090901075a564e41010176717171712d0b57550b035145515c022a242c05696859485744465e5a537272050a10110735",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
         "send_sci": "false"
@@ -34,7 +34,7 @@
     "128_SCI": {
         "priority": 64,
         "cipher_suite": "GCM-AES-128",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "3106080a00005b554f4e007975707670725b0a54540c0252445e5d7a29252b046a",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
         "send_sci": "true"
@@ -42,7 +42,7 @@
     "256_SCI": {
         "priority": 64,
         "cipher_suite": "GCM-AES-256",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "3946080a0407070303530227257b73213556550958525a771b1650382734362e2a547b79777c6663754b5e372122727c7e03055c504c430f0f0f0a7377772f7e20",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
         "send_sci": "true"
@@ -50,7 +50,7 @@
     "128_XPN_SCI": {
         "priority": 64,
         "cipher_suite": "GCM-AES-XPN-128",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "197a7a767b676074445f4f2223757d7d75045f514b420c0e000b0b7476287f2321",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
         "send_sci": "true"
@@ -58,7 +58,7 @@
     "256_XPN_SCI": {
         "priority": 64,
         "cipher_suite": "GCM-AES-XPN-256",
-        "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        "primary_cak": "207b757a60617745504e5a20747a7c76725e524a450d0d01040a0c75297822227e07554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c033124322627",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
         "send_sci": "true",


### PR DESCRIPTION
### Approach
#### What is the motivation for this PR?
Following this PR : https://github.com/sonic-net/sonic-swss/pull/2892.
MSFT ADO : 25046448

#### How did you do it?
Updated the profile.json files and  macsec config helper eos macsec key configuration to start using type 7 keys

#### How did you verify/test it?
Ran the sonic-mgmt testsuite using azure pipeline : https://dev.azure.com/mssonic/internal/_build/results?buildId=355362&view=results

```

256 cipher suite
---------------------

2023-09-05T21:28:49.8247891Z macsec/test_controlplane.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED [ 25%]
2023-09-05T21:29:40.7325077Z macsec/test_controlplane.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED [ 50%]
2023-09-05T21:30:42.5996584Z macsec/test_controlplane.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED [ 75%]
2023-09-05T21:40:10.1442889Z macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor[256_XPN_SCI] SKIPPED [ 25%]
2023-09-05T21:46:07.3679940Z macsec/test_dataplane.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN_SCI] PASSED [ 75%]
2023-09-05T21:46:40.9046519Z macsec/test_dataplane.py::TestDataPlane::test_counters[256_XPN_SCI] SKIPPED [100%]
2023-09-05T21:56:02.9546015Z macsec/test_deployment.py::TestDeployment::test_config_reload[256_XPN_SCI] PASSED [100%]
2023-09-05T22:02:37.7583207Z macsec/test_fault_handling.py::TestFaultHandling::test_link_flap[256_XPN_SCI] PASSED [ 50%]
2023-09-05T22:05:49.2488586Z macsec/test_fault_handling.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN_SCI] PASSED [100%]
2023-09-05T22:10:11.2433992Z macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel[256_XPN_SCI] PASSED [ 25%]
2023-09-05T22:12:23.9622315Z macsec/test_interop_protocol.py::TestInteropProtocol::test_lldp[256_XPN_SCI] PASSED [ 50%]
2023-09-05T22:12:23.9652391Z macsec/test_interop_protocol.py::TestInteropProtocol::test_bgp[256_XPN_SCI] SKIPPED [ 75%]

macsec/test_controlplane.py::TestControlPlane::test_rekey_by_period[256_XPN_SCI]  and
macsec/test_dataplane.py::TestDataPlane::test_dut_to_neighbor[256_XPN_SCI]  PASSED when ran separately.


128  cipher suite
---------------------


2023-09-06T14:46:57.3394106Z macsec/test_controlplane.py::TestControlPlane::test_wpa_supplicant_processes[128_SCI] PASSED [ 25%]
2023-09-06T14:47:47.4097240Z macsec/test_controlplane.py::TestControlPlane::test_appl_db[128_SCI] PASSED [ 50%]
2023-09-06T14:48:47.9331774Z macsec/test_controlplane.py::TestControlPlane::test_mka_session[128_SCI] PASSED [ 75%]
2023-09-06T14:49:20.4008634Z macsec/test_controlplane.py::TestControlPlane::test_rekey_by_period[128_SCI] SKIPPED [100%]
2023-09-06T14:49:23.8751921Z macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor[128_SCI] SKIPPED [ 25%]
2023-09-06T14:54:18.9892866Z macsec/test_dataplane.py::TestDataPlane::test_dut_to_neighbor[128_SCI] PASSED [ 50%]
2023-09-06T14:55:16.6903328Z macsec/test_dataplane.py::TestDataPlane::test_neighbor_to_neighbor[128_SCI] PASSED [ 75%]
2023-09-06T14:56:26.1174068Z macsec/test_dataplane.py::TestDataPlane::test_counters[128_SCI] PASSED   [100%]
2023-09-06T15:05:52.8857911Z macsec/test_deployment.py::TestDeployment::test_config_reload[128_SCI] PASSED [100%]
2023-09-06T15:12:34.1145445Z macsec/test_fault_handling.py::TestFaultHandling::test_link_flap[128_SCI] PASSED [ 50%]
2023-09-06T15:15:47.0048553Z macsec/test_fault_handling.py::TestFaultHandling::test_mismatch_macsec_configuration[128_SCI] PASSED [100%]
2023-09-06T15:20:08.2761009Z macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel[128_SCI] PASSED      [ 25%]
2023-09-06T15:22:21.9127964Z macsec/test_interop_protocol.py::TestInteropProtocol::test_lldp[128_SCI] PASSED [ 50%]
2023-09-06T15:22:21.9154379Z macsec/test_interop_protocol.py::TestInteropProtocol::test_bgp[128_SCI] SKIPPED [ 75%]
2023-09-06T15:23:00.6891816Z macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp[128_SCI] SKIPPED [100%]




```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
