### PR TITLE
Ignore 'Failed to get port by bridge port ID' in test_vlan.py

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -25,6 +25,24 @@ pytestmark = [
 PTF_PORT_MAPPING_MODE = "use_orig_interface"
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    """
+       Ignore expected errors in logs during test execution
+
+       Args:
+           loganalyzer: Loganalyzer utility fixture
+           duthost: DUT host object
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:
+        loganalyzer_ignore_regex = [
+            ".*ERR swss#orchagent: :- update: Failed to get port by bridge port ID.*",
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
+
+    yield
+
 def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                       src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
 

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -43,6 +43,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
 
     yield
 
+
 def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                       src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
test_vlan case failed at teardown phase, in which it found 'Failed to get port by bridge port ID' error syslog.
ADO 24807870


#### How did you do it?
Bridge port was removed and as part of the removal all FDB entries are removed. As part of this notification, Broadcom sends 'SAI_FDB_EVENT_AGED'. When Sonic orchagent code checks for bridge_port, it was already removed. 
Ignore 'Failed to get port by bridge port ID' in test_vlan.py

#### How did you verify/test it?
run test_vlan.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
