### PR TITLE
Skip checking expected core dump in module `bgp/test_traffic_shift.py`.

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -422,12 +422,13 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
 
 
 def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                   bgpmon_setup_teardown, nbrhosts):
+                                   bgpmon_setup_teardown, nbrhosts, core_dump_and_config_check):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bgp_neighbors = {}
+    duts_data = core_dump_and_config_check
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
@@ -457,6 +458,15 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
         # Wait until bgp sessions are established on DUT
         pytest_assert(wait_until(100, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                       "Not all BGP sessions are established on DUT")
+
+        # If expected core dump files exist, add it into duts_data
+        if "20191130" in duthost.os_version:
+            existing_core_dumps = duthost.shell('ls /var/core/ | grep -v python || true')['stdout'].split()
+        else:
+            existing_core_dumps = duthost.shell('ls /var/core/')['stdout'].split()
+        for core_dump in existing_core_dumps:
+            if re.match("dplane_fpm_nl", core_dump):
+                duts_data[duthost.hostname]["pre_core_dumps"].append(core_dump)
 
         # Wait until all routes are announced to neighbors
         cur_v4_routes = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2038,7 +2038,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
                         json.loads(duthost.shell("cat /etc/sonic/running_golden_config{}.json".format(asic_index),
                                                  verbose=False)['stdout'])
 
-    yield
+    yield duts_data
 
     if check_flag:
         for duthost in duthosts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In module `bgp/test_traffic_shift.py`, test case `test_TSA_B_C_with_no_neighbors` will stop bgp container, which may generate expected core dump files. But in fixture `core_dump_and_config_check`, when new core dump files generates, no matter if they are expected or unexpected. In order to avoid config reload caused by expected core dump files, we will add expected core dump files into dict `duts_data[duthost.hostname]["pre_core_dumps"]` of fixture `core_dump_and_config_check`. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
In module `bgp/test_traffic_shift.py`, test case `test_TSA_B_C_with_no_neighbors` will stop bgp container, which may generate expected core dump files. But in fixture `core_dump_and_config_check`, when new core dump files generates, no matter if they are expected or unexpected. In order to avoid config reload caused by expected core dump files, we will add expected core dump files into dict `duts_data[duthost.hostname]["pre_core_dumps"]` of fixture `core_dump_and_config_check`. 

#### How did you do it?
Yield the variable `duts_data` in fixture `core_dump_and_config_check` and add expected core dump files into `duts_data[duthost.hostname]["pre_core_dumps"]`

#### How did you verify/test it?
Manually add core dump files when TC running, and there is no config reload in teardown period. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
