### PR TITLE
[Elastictest]Support to pass lock_wait_timeout_seconds in the template

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -19,6 +19,10 @@ parameters:
     type: string
     default: ""
 
+  - name: LOCK_WAIT_TIMEOUT_SECONDS
+    type: string
+    default: ""
+
   - name: NUM_ASIC
     type: number
     default: 1
@@ -172,6 +176,7 @@ steps:
       -o new_test_plan_id.txt \
       --min-worker ${{ parameters.MIN_WORKER }} \
       --max-worker ${{ parameters.MAX_WORKER }} \
+      --lock-wait-timeout-seconds ${{ parameters.LOCK_WAIT_TIMEOUT_SECONDS }} \
       --test-set ${{ parameters.TEST_SET }} \
       --kvm-build-id $(KVM_BUILD_ID) \
       --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -233,7 +233,7 @@ class TestPlanManager(object):
             kvm_image_build_id = build_id
             kvm_image_branch = ""
         affinity = json.loads(kwargs.get("affinity", "[]"))
-        payload = json.dumps({
+        payload = {
             "name": test_plan_name,
             "testbed": {
                 "platform": platform,
@@ -243,7 +243,8 @@ class TestPlanManager(object):
                 "min": min_worker,
                 "max": max_worker,
                 "nbr_type": kwargs["vm_type"],
-                "asic_num": kwargs["num_asic"]
+                "asic_num": kwargs["num_asic"],
+                "lock_wait_timeout_seconds": kwargs.get("lock_wait_timeout_seconds", None),
             },
             "test_option": {
                 "stop_on_failure": kwargs.get("stop_on_failure", True),
@@ -282,8 +283,8 @@ class TestPlanManager(object):
             },
             "extra_params": {},
             "priority": 10
-        })
-        print('Creating test plan with payload: {}'.format(payload))
+        }
+        print('Creating test plan with payload:\n{}'.format(json.dumps(payload, indent=4)))
         headers = {
             "Authorization": "Bearer {}".format(self.get_token()),
             "scheduler-site": "PRTest",
@@ -291,7 +292,7 @@ class TestPlanManager(object):
         }
         raw_resp = {}
         try:
-            raw_resp = requests.post(tp_url, headers=headers, data=payload, timeout=10)
+            raw_resp = requests.post(tp_url, headers=headers, data=json.dumps(payload), timeout=10)
             resp = raw_resp.json()
         except Exception as exception:
             raise Exception("HTTP execute failure, url: {}, raw_resp: {}, exception: {}"
@@ -468,6 +469,16 @@ if __name__ == "__main__":
         default=None,
         required=False,
         help="Max worker number for the test plan."
+    )
+    parser_create.add_argument(
+        "--lock-wait-timeout-seconds",
+        type=int,
+        dest="lock_wait_timeout_seconds",
+        nargs='?',
+        const=None,
+        default=None,
+        required=False,
+        help="Max lock testbed wait seconds. None or the values <= 0 means endless."
     )
     parser_create.add_argument(
         "--test-set",
@@ -896,6 +907,7 @@ if __name__ == "__main__":
                 dump_kvm_if_fail=args.dump_kvm_if_fail,
                 requester=args.requester,
                 max_execute_seconds=args.max_execute_seconds,
+                lock_wait_timeout_seconds=args.lock_wait_timeout_seconds,
             )
         elif args.action == "poll":
             tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_state, args.expected_result)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support to pass lock_wait_timeout_seconds in the template

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Support to pass lock_wait_timeout_seconds in the template
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
