### PR TITLE
Specific field CustomMsg to distinguish config reload or core dump. 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2199,7 +2199,10 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
         items = request.session.items
         for item in items:
             if item.module.__name__ + ".py" == module_name.split("/")[-1]:
-                item.user_properties.append(('CustomMsg', json.dumps({'DutChekResult': False})))
+                item.user_properties.append(('CustomMsg', json.dumps({'DutChekResult': {
+                    'core_dump_check_pass': core_dump_check_pass,
+                    'config_db_check_pass': config_db_check_pass
+                }})))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We have a field `CustomMsg` to record the result of fixture `core_dump_and_config_check` in DB. But previously, we record the result of core dump check and config check combinationly, either core dump check fails or config check fails, we will record false in this filed. In this PR, we will specific this filed, and record this two type of results respectively. And the format of this filed in DB is 
```
{
    'DutChekResult': {
        'core_dump_check_pass': core_dump_check_pass,
        'config_db_check_pass': config_db_check_pass
    }
}
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
We have a field `CustomMsg` to record the result of fixture `core_dump_and_config_check` in DB. But previously, we record the result of core dump check and config check combinationly, either core dump check fails or config check fails, we will record false in this filed. In this PR, we will specific this filed, and record this two type of results respectively. And the format of this filed in DB is 
```
{
    'DutChekResult': {
        'core_dump_check_pass': core_dump_check_pass,
        'config_db_check_pass': config_db_check_pass
    }
}
```

#### How did you do it?
Add more information into field `CustomMsg`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
