### PR TITLE
Fix dual-tor dhcpv6 relay test cases failure in latest image

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -84,6 +84,8 @@ class DHCPCounterTest(DataplaneBaseTest):
         self.dut_mac = self.test_params['dut_mac']
         self.vlan_ip = self.test_params['vlan_ip']
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
+        self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
         self.reference = 0
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
@@ -131,7 +133,10 @@ class DHCPCounterTest(DataplaneBaseTest):
 
     def create_server_packet(self, message):
         packet = ptf.packet.Ether(dst=self.dut_mac)
-        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT,
                                  dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,
@@ -147,7 +152,10 @@ class DHCPCounterTest(DataplaneBaseTest):
 
     def create_unknown_server_packet(self):
         packet = ptf.packet.Ether(dst=self.dut_mac)
-        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT,
                                  dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -64,7 +64,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
     """
     duthost = duthosts[rand_one_dut_hostname]
     dhcp_relay_data_list = []
-    uplink_interface_link_local = ""
+    down_interface_link_local = ""
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -127,19 +127,24 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
                     if not iface_is_portchannel_member:
                         uplink_interfaces.append(iface_name)
                     uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
-        if uplink_interface_link_local == "":
+        if down_interface_link_local == "":
             command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1"\
-                      .format(uplink_interfaces[0])
+                      .format(downlink_vlan_iface['name'])
             res = duthost.shell(command)
             if res['stdout'] != "":
-                uplink_interface_link_local = res['stdout']
+                down_interface_link_local = res['stdout']
 
         dhcp_relay_data = {}
         dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
         dhcp_relay_data['client_iface'] = client_iface
         dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
-        dhcp_relay_data['uplink_interface_link_local'] = uplink_interface_link_local
+        dhcp_relay_data['down_interface_link_local'] = down_interface_link_local
+        dhcp_relay_data['loopback_ipv6'] = mg_facts['minigraph_lo_interfaces'][1]['addr']
+        if 'dualtor' in tbinfo['topo']['name']:
+            dhcp_relay_data['is_dualtor'] = True
+        else:
+            dhcp_relay_data['is_dualtor'] = False
 
         res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
         dhcp_relay_data['uplink_mac'] = res['stdout']
@@ -212,25 +217,34 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
                            "dut_mac": str(dhcp_relay['uplink_mac']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
+                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log", is_python3=True)
 
         for message in messages:
-            get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'\
-                          .format(dhcp_relay['downlink_vlan_iface']['name'], message)
-            message_count = duthost.shell(get_message)['stdout']
-            assert int(message_count) > 0, "Missing {} count".format(message)
+            if message == "Relay-Reply" and dhcp_relay['is_dualtor']:
+                get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|Loopback0" {}'.format(message)
+                message_count = duthost.shell(get_message)['stdout']
+                assert int(message_count) > 0, "Missing {} count".format(message)
+            else:
+                get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'\
+                              .format(dhcp_relay['downlink_vlan_iface']['name'], message)
+                message_count = duthost.shell(get_message)['stdout']
+                assert int(message_count) > 0, "Missing {} count".format(message)
 
 
-def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
+def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                            toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     _, duthost = testing_config
     skip_release(duthost, ["201811", "201911", "202106"])  # TO-DO: delete skip release on 201811 and 201911
 
+    # Please note: relay interface always means vlan interface
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,
@@ -244,9 +258,11 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -288,9 +304,11 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -343,7 +361,9 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)


### PR DESCRIPTION

### Description of PR
Fix test_dhcpv6_relay.py case test_dhcp_relay_default and test_dhcpv6_relay_counter failure on dualtor.
The issue is test gap after code commit of https://github.com/sonic-net/sonic-dhcp-relay/pull/42 in master 
and https://github.com/sonic-net/sonic-dhcp-relay/pull/40 in 202012. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test_dhcpv6_relay.py case test_dhcp_relay_default and test_dhcpv6_relay_counter failure on dualtor.
1. Based on latest dhcprelay code, dhcpv6 relay will use loopback0 ipv6 address as source ip when relay packets to server.
So test case need modify to send Relay-Reply to loopback0 ipv6 address.
2. Improve test case behavior, enable source ipv6 check during test
3. remove unused option order sequence related test code
4. check loopback0 Relay-Reply counter in dualtor instead of vlan interface counter 
5. change DUID LLT to LL, since LLT is different based on different timestamp during test which may cause packet comparation failure

#### How did you do it?
run dhcp_relay/test_dhcpv6_relay.py

#### How did you verify/test it?
Test case pass on dual tor and single tor

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
