### PR TITLE
Add the PTF neighbor into the DEVICE_NEIGHBOR_METADATA table

### DIFF
--- a/ansible/roles/sonic/templates/configdb.j2
+++ b/ansible/roles/sonic/templates/configdb.j2
@@ -77,7 +77,7 @@
             "holdtime": "10",
             "keepalive": "3",
             "local_addr": "{{ host['bp_interface']['ipv4'].split('/')[0] }}",
-            "name": "exabgp_v4",
+            "name": "exabgp",
             "nhopself": "0",
             "rrclient": "0"
         },
@@ -87,7 +87,7 @@
             "holdtime": "10",
             "keepalive": "3",
             "local_addr": "{{ host['bp_interface']['ipv6'].split('/')[0] | lower }}",
-            "name": "exabgp_v6",
+            "name": "exabgp",
             "nhopself": "0",
             "rrclient": "0"
         }
@@ -100,6 +100,11 @@
                 "hwsku": "SONiC-VM",
                 "mgmt_addr": "{{ hostvars[dut_name]['ansible_host'] }}",
                 "type": "TorRouter"
+        },
+        "exabgp": {
+                "hwsku": "exabgp",
+                "mgmt_addr": "{{ ptf_ip }}",
+                "type": "SpineRouter"
         }
 {% endfor %}
     },


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

This table may be used for certain purposes such as what BGP rules/policies should get applied for that neighbor. Because of this, add exabgp/PTF into the neighbor table to make sure the correct policies get applied.

Unfortunately, the current template uses for generating the configdb assumes that the downstream device is a TorRouter, and that the PTF/exabgp is a SpineRouter. I'll look at trying to make this dynamic in a future change.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
