### PR TITLE
[202205]Revert vxlan-decap.py PTF Python3 migration

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -123,7 +123,7 @@ class Vxlan(BaseTest):
     def generate_ArpResponderConfig(self):
         config = {}
         for test in self.tests:
-            for port, ip in list(test['vlan_ip_prefixes'].items()):
+            for port, ip in test['vlan_ip_prefixes'].items():
                 config['eth%d' % port] = [ip]
 
         with open('/tmp/vxlan_arpresponder.conf', 'w') as fp:
@@ -195,7 +195,7 @@ class Vxlan(BaseTest):
 
         self.pc_info = []
         self.net_ports = []
-        for name, val in list(graph['minigraph_portchannels'].items()):
+        for name, val in graph['minigraph_portchannels'].items():
             members = [graph['minigraph_port_indices'][member] for member in val['members']]
             self.net_ports.extend(members)
             ip = None
@@ -211,7 +211,7 @@ class Vxlan(BaseTest):
 
         self.tests = []
         vni_base = 336
-        for name, data in list(graph['minigraph_vlans'].items()):
+        for name, data in graph['minigraph_vlans'].items():
             test = {}
             test['name'] = name
             test['intf_alias'] = data['members']
@@ -458,7 +458,7 @@ class Vxlan(BaseTest):
         exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
 
         self.dataplane.flush()
-        for i in range(self.nr):
+        for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
         nr_rcvd = count_matched_packets_all_ports_helper(self, exp_packet, self.nr, pc_ports, timeout=20)
         rv = nr_rcvd == self.nr
@@ -491,7 +491,7 @@ class Vxlan(BaseTest):
                        )
 
         self.dataplane.flush()
-        for i in range(self.nr):
+        for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
         # We don't care if expected packet is received during warming up
         if not wu:
@@ -533,7 +533,7 @@ class Vxlan(BaseTest):
                  )
 
         self.dataplane.flush()
-        for i in range(self.nr):
+        for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
         nr_rcvd = count_matched_packets_helper(self, inpacket, self.nr, acc_port, timeout=20)
         rv = nr_rcvd == self.nr

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -172,5 +172,4 @@ def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfho
                         "sonic_admin_alt_password": sonic_admin_alt_password,
                         "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']},
                 qlen=10000,
-                log_file=log_file,
-                is_python3=True)
+                log_file=log_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revert modification to PTF script vxlan-decap.py in PR #9603 and #9761

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test failure due to Python3 migration.

#### How did you do it?
Revert PR #9603 and #9761

#### How did you verify/test it?
Test with physical t0-2700 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
