### PR TITLE
[202205][acl_outer_vlan] Fix teardown error in test_acl_outer_vlan

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -719,7 +719,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
 
     def _teardown_arp_responder(self, ptfhost):
         logger.info("Stopping arp_responder")
-        ptfhost.command('supervisorctl stop arp_responder')
+        ptfhost.command('supervisorctl stop arp_responder', module_ignore_errors=True)
         ptfhost.file(path=ARP_RESPONDER_SCRIPT_DEST_PATH, state="absent")
 
     def pre_running_hook(self, duthost, ptfhost, ip_version, vlan_setup_info):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
`_setup_arp_responder` may be skipped in func `pre_running_hook`, which would cause `_teardown_arp_responder` error in func `post_running_hook` because arp_responder is not running.
The issue fixed by this PR was also fixed in https://github.com/sonic-net/sonic-mgmt/pull/7748, which should not be backport, so manually update it.
```
{
	"changed": true,
	"cmd": ["supervisorctl", "stop", "arp_responder"],
	"delta": "0:00:00.166638",
	"end": "2023-08-29 13:01:45.802702",
	"failed": true,
	"msg": "non-zero return code",
	"rc": 1,
	"start": "2023-08-29 13:01:45.636064",
	"stderr": "",
	"stderr_lines": [],
	"stdout": "arp_responder: ERROR (no such process)",
	"stdout_lines": ["arp_responder: ERROR (no such process)"]
}
```

#### How did you do it?
Add ignore_errors to `_teardown_arp_responder`

#### How did you verify/test it?
Run tests.
```
collected 32 items                                                                                                                                                    

acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_forwarded[ipv4] PASSED                                                                        [  3%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_dropped[ipv4] PASSED                                                                          [  6%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_forwarded[ipv4] PASSED                                                                      [  9%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_dropped[ipv4] PASSED                                                                        [ 12%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_forwarded[ipv4] PASSED                                                               [ 15%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_dropped[ipv4] PASSED                                                                 [ 18%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_forwarded[ipv4] PASSED                                                             [ 21%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_dropped[ipv4] PASSED                                                               [ 25%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv4] SKIPPED                                                                        [ 28%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4] SKIPPED                                                                          [ 31%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv4] SKIPPED                                                                      [ 34%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv4] SKIPPED                                                                        [ 37%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv4] SKIPPED                                                               [ 40%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv4] SKIPPED                                                                 [ 43%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv4] SKIPPED                                                             [ 46%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv4] SKIPPED                                                               [ 50%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_forwarded[ipv6] PASSED                                                                        [ 53%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_dropped[ipv6] PASSED                                                                          [ 56%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_forwarded[ipv6] PASSED                                                                      [ 59%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_dropped[ipv6] PASSED                                                                        [ 62%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_forwarded[ipv6] PASSED                                                               [ 65%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_dropped[ipv6] PASSED                                                                 [ 68%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_forwarded[ipv6] PASSED                                                             [ 71%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_dropped[ipv6] PASSED                                                               [ 75%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6] SKIPPED                                                                        [ 78%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6] SKIPPED                                                                          [ 81%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6] SKIPPED                                                                      [ 84%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6] SKIPPED                                                                        [ 87%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv6] SKIPPED                                                               [ 90%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6] SKIPPED                                                                 [ 93%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv6] SKIPPED                                                             [ 96%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6] SKIPPED                                                               [100%]

----------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/acl/test_acl_outer_vlan.xml ------------------------------------------
======================================================================= short test summary info =======================================================================
SKIPPED [16] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Egress ACLs are not currently supported on "broadcom" ASICs
=============================================================== 16 passed, 16 skipped in 725.49 seconds ===============================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
