### PR TITLE
[configlet] Remove transciver check

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -110,9 +110,6 @@ scan_dbs = {
             "db_no": 6,
             "keys_to_compare": {
                 "NEIGH_STATE_TABLE",
-                "TRANSCEIVER_DOM_SENSOR",
-                "TRANSCEIVER_INFO",
-                "TRANSCEIVER_STATUS",
                 "VLAN_MEMBER_TABLE",
                 "VLAN_TABLE"
             },

--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -111,6 +111,7 @@ scan_dbs = {
             "keys_to_compare": {
                 "NEIGH_STATE_TABLE",
                 "TRANSCEIVER_INFO",
+                "TRANSCEIVER_STATUS",
                 "VLAN_MEMBER_TABLE",
                 "VLAN_TABLE"
             },

--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -110,6 +110,7 @@ scan_dbs = {
             "db_no": 6,
             "keys_to_compare": {
                 "NEIGH_STATE_TABLE",
+                "TRANSCEIVER_INFO",
                 "VLAN_MEMBER_TABLE",
                 "VLAN_TABLE"
             },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove transceiver check in add rack scenario.
Fixes # (issue) 24817075

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The transceiver data such as rx_power and tx_power is different as expected.
For example, the rxpower before test is
{'rx1power': '0.547', 'rx2power': 'N/A', 'rx3power': 'N/A', 'rx4power': 'N/A', 'temperature': '24.652', 'tx1bias': '7.106', 'tx1power': '0.617', 'tx2bias': 'N/A', 'tx2power': 'N/A', 'tx3bias': 'N/A', 'tx3power': 'N/A', 'tx4bias': 'N/A', 'tx4power': 'N/A', 'voltage': '3.32'} 
which is different with 
{'rx1power': '0.549', 'rx2power': 'N/A', 'rx3power': 'N/A', 'rx4power': 'N/A', 'temperature': '24.0', 'tx1bias': '7.014', 'tx1power': '0.609', 'tx2bias': 'N/A', 'tx2power': 'N/A', 'tx3bias': 'N/A', 'tx3power': 'N/A', 'tx4bias': 'N/A', 'tx4power': 'N/A', 'voltage': '3.32'}
#### How did you do it?
Remove the transceiver check.
#### How did you verify/test it?
E2E test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
