### PR TITLE
Skip condition to skip SNMP IPv6 test case in 202211 branch.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1012,15 +1012,15 @@ show_techsupport/test_techsupport.py::test_techsupport:
 #######################################
 snmp/test_snmp_link_local.py:
   skip:
-    reason: "SNMP over IPv6 support not present in 202211 branch."
+    reason: "SNMP over IPv6 support not present in 202211 release."
     conditions:
-      - "branch in ['202211']"
+      - "release in ['202211']"
 
 snmp/test_snmp_loopback.py:
   skip:
-    reason: "SNMP over Loopback IPv6 support not present in 202211 branch."
+    reason: "SNMP over Loopback IPv6 support not present in 202211 release."
     conditions:
-      - "branch in ['202211']"
+      - "release in ['202211']"
 
 snmp/test_snmp_pfc_counters.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/9630/ was added skip IPv6 related SNMP test cases in 202211 branch.
But the condition checks for branch name instead of release.
This is causing PR checker to fail as the branch name in PR checker is the PR number and not 202211
#### How did you do it?
Change condition to look for 202211 in release and not branch.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
