### PR TITLE
Adding PG7 check to DscpToPgMapping

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1035,11 +1035,15 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     # pg = 7 => packets from cpu to front panel ports
                     if platform_asic and platform_asic == "broadcom-dnx":
                         if i == pg:
-                            assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
-                        elif i in [0, 4, 7]:
-                            assert (pg_cntrs[i] >= pg_cntrs_base[i])
+                            if i == 3:
+                                assert (pg_cntrs[pg] == pg_cntrs_base[pg] + len(dscps))
+                            else:
+                                assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
                         else:
-                            assert (pg_cntrs[i] == pg_cntrs_base[i])
+                            if i in [0, 4, 7]:
+                                assert (pg_cntrs[i] >= pg_cntrs_base[i])
+                            else:
+                                assert (pg_cntrs[i] == pg_cntrs_base[i])
                     else:
                         if i == pg:
                             assert (pg_cntrs[pg] == pg_cntrs_base[pg] + len(dscps))

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1028,18 +1028,18 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
                       file=sys.stderr)
                 for i in range(0, PG_NUM):
+                    # LACP packets are mapped to queue0 and tcp syn packets for BGP to queue4
+                    # CPU sends LACP/LLDP/BGP control pkts to queue7
+                    # So for those queues the count could be more
                     if i == pg:
-                        if i == 0 or i == 4:
-                            assert (pg_cntrs[pg] >=
-                                    pg_cntrs_base[pg] + len(dscps))
+                        if i == 0 or i == 4 or i == 7:
+                            assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
                         else:
                             assert (pg_cntrs[pg] ==
                                     pg_cntrs_base[pg] + len(dscps))
                     else:
-                        # LACP packets are mapped to queue0 and tcp syn packets for BGP to queue4
-                        # So for those queues the count could be more
-                        if i == 0 or i == 4:
-                            assert (pg_cntrs[i] >= pg_cntrs_base[i])
+                        if i == 0 or i == 4 or i == 7:
+                            assert(pg_cntrs[i] >= pg_cntrs_base[i])
                         else:
                             assert (pg_cntrs[i] == pg_cntrs_base[i])
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1028,9 +1028,8 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
                       file=sys.stderr)
                 for i in range(0, PG_NUM):
-                    # LACP packets are mapped to queue0 and tcp syn packets for BGP to queue4
-                    # CPU sends LACP/LLDP/BGP control pkts to queue7
-                    # So for those queues the count could be more
+                    # In DNX, ip2me packets trapped to cpu mapped to TC 1 -> PG 0 and
+                    # all other control packets trapped to cpu mapped to TC 4 -> PG 4.
                     if i == pg:
                         if i == 0 or i == 4 or i == 7:
                             assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -997,7 +997,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_id = get_rx_port(
             self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip)
         print("actual dst_port_id: %d" % (dst_port_id), file=sys.stderr)
-
+        time.sleep(3)
         try:
             for pg, dscps in list(pg_dscp_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
@@ -1032,13 +1032,13 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     # CPU sends LACP/LLDP/BGP control pkts to queue7
                     # So for those queues the count could be more
                     if i == pg:
-                        if i == 0 or i == 4 or i == 7:
+                        if i == 7:
                             assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
                         else:
                             assert (pg_cntrs[pg] ==
                                     pg_cntrs_base[pg] + len(dscps))
                     else:
-                        if i == 0 or i == 4 or i == 7:
+                        if i == 7:
                             assert(pg_cntrs[i] >= pg_cntrs_base[i])
                         else:
                             assert (pg_cntrs[i] == pg_cntrs_base[i])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -997,7 +997,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_id = get_rx_port(
             self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip)
         print("actual dst_port_id: %d" % (dst_port_id), file=sys.stderr)
-        time.sleep(3)
+
         try:
             for pg, dscps in list(pg_dscp_map.items()):
                 pg_cntrs_base = sai_thrift_read_pg_counters(
@@ -1032,13 +1032,13 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     # CPU sends LACP/LLDP/BGP control pkts to queue7
                     # So for those queues the count could be more
                     if i == pg:
-                        if i == 7:
+                        if i == 0 or i == 4 or i == 7:
                             assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
                         else:
                             assert (pg_cntrs[pg] ==
                                     pg_cntrs_base[pg] + len(dscps))
                     else:
-                        if i == 7:
+                        if i == 0 or i == 4 or i == 7:
                             assert(pg_cntrs[i] >= pg_cntrs_base[i])
                         else:
                             assert (pg_cntrs[i] == pg_cntrs_base[i])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -960,6 +960,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         dscp_to_pg_map = self.test_params.get('dscp_to_pg_map', None)
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         asic_type = self.test_params.get("sonic_asic_type")
+        platform_asic = self.test_params['platform_asic']
 
         print("dst_port_id: %d, src_port_id: %d" %
               (dst_port_id, src_port_id), file=sys.stderr)
@@ -1031,13 +1032,13 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     # In DNX, ip2me packets trapped to cpu mapped to TC 1 -> PG 0 and
                     # all other control packets trapped to cpu mapped to TC 4 -> PG 4.
                     if i == pg:
-                        if i == 0 or i == 4 or i == 7:
+                        if platform_asic and platform_asic == "broadcom-dnx" and i in [0, 4, 7]:
                             assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
                         else:
                             assert (pg_cntrs[pg] ==
                                     pg_cntrs_base[pg] + len(dscps))
                     else:
-                        if i == 0 or i == 4 or i == 7:
+                        if platform_asic and platform_asic == "broadcom-dnx" and i in [0, 4, 7]:
                             assert(pg_cntrs[i] >= pg_cntrs_base[i])
                         else:
                             assert (pg_cntrs[i] == pg_cntrs_base[i])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1029,20 +1029,22 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 print(list(map(operator.sub, pg_cntrs, pg_cntrs_base)),
                       file=sys.stderr)
                 for i in range(0, PG_NUM):
-                    # In DNX, ip2me packets trapped to cpu mapped to TC 1 -> PG 0 and
-                    # all other control packets trapped to cpu mapped to TC 4 -> PG 4.
-                    if i == pg:
-                        if platform_asic and platform_asic == "broadcom-dnx" and i in [0, 4, 7]:
+                    # DNX/Chassis:
+                    # pg = 0 => Some extra packets with unmarked TC
+                    # pg = 4 => Extra packets for LACP/BGP packets
+                    # pg = 7 => packets from cpu to front panel ports
+                    if platform_asic and platform_asic == "broadcom-dnx":
+                        if i == pg:
                             assert (pg_cntrs[pg] >= pg_cntrs_base[pg] + len(dscps))
-                        else:
-                            assert (pg_cntrs[pg] ==
-                                    pg_cntrs_base[pg] + len(dscps))
-                    else:
-                        if platform_asic and platform_asic == "broadcom-dnx" and i in [0, 4, 7]:
-                            assert(pg_cntrs[i] >= pg_cntrs_base[i])
+                        elif i in [0, 4, 7]:
+                            assert (pg_cntrs[i] >= pg_cntrs_base[i])
                         else:
                             assert (pg_cntrs[i] == pg_cntrs_base[i])
-
+                    else:
+                        if i == pg:
+                            assert (pg_cntrs[pg] == pg_cntrs_base[pg] + len(dscps))
+                        else:
+                            assert (pg_cntrs[i] == pg_cntrs_base[i])
                 # confirm that dscp pkts are received
                 total_recv_cnt = 0
                 dscp_recv_cnt = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
With the new SAI image & the fix as part of PR# https://github.com/sonic-net/sonic-buildimage/pull/16254, the DscpToPgMapping  qos test needs a check on the  PG7 as well because, the control packets from CPU will now come to PG7 and may increase the packet count.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
Adding  pg7 to verification along with pg0 & pg4 as, the control packets from CPU will now come to pg7 and may increase the packet count. 
#### What is the motivation for this PR?
DscpToPgMapping failed in test run.
#### How did you do it?

#### How did you verify/test it?
Executed the  qos test suite. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
