### PR TITLE
cisco: Update qos.yaml params for GB topo-t2.

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -739,7 +739,7 @@ qos_params:
                     q4_num_of_pkts: 75
                     q5_num_of_pkts: 70
                     q6_num_of_pkts: 70
-                    limit: 40
+                    limit: 80
                 wrr_chg:
                     ecn: 1
                     q0_num_of_pkts: 40
@@ -749,7 +749,7 @@ qos_params:
                     q4_num_of_pkts: 150
                     q5_num_of_pkts: 40
                     q6_num_of_pkts: 40
-                    limit: 40
+                    limit: 80
                     lossy_weight: 8
                     lossless_weight: 30
             400000_5m:
@@ -1065,7 +1065,7 @@ qos_params:
                 q4_num_of_pkts: 75
                 q5_num_of_pkts: 70
                 q6_num_of_pkts: 70
-                limit: 40
+                limit: 80
             wrr_chg:
                 ecn: 1
                 q0_num_of_pkts: 40
@@ -1075,7 +1075,7 @@ qos_params:
                 q4_num_of_pkts: 150
                 q5_num_of_pkts: 40
                 q6_num_of_pkts: 40
-                limit: 40
+                limit: 80
                 lossy_weight: 8
                 lossless_weight: 30
             100000_300m:
@@ -1089,22 +1089,22 @@ qos_params:
                     pkts_num_trig_pfc: 13660
                     pkts_num_trig_ingr_drp: 14819
                     pkts_num_margin: 375
-                    iterations: 100
+                    iterations: 50
                     cell_size: 384
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 10300
-                    pkts_num_trig_ingr_drp: 10589
+                    pkts_num_trig_pfc: 3415
+                    pkts_num_trig_ingr_drp: 3704
                     packet_size: 1350
                     pkts_num_margin: 20
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 10300
-                    pkts_num_trig_ingr_drp: 10589
+                    pkts_num_trig_pfc: 3415
+                    pkts_num_trig_ingr_drp: 3704
                     packet_size: 1350
                     pkts_num_margin: 20
                 wm_q_wm_all_ports:
@@ -1211,7 +1211,7 @@ qos_params:
                     pkts_num_trig_pfc: 12152
                     pkts_num_trig_ingr_drp: 14816
                     pkts_num_margin: 375
-                    iterations: 100
+                    iterations: 50
                     cell_size: 384
                 xoff_1:
                     dscp: 3
@@ -1334,21 +1334,21 @@ qos_params:
                     pkts_num_trig_pfc: 262144
                     pkts_num_trig_ingr_drp: 524288
                     pkts_num_margin: 13267
-                    iterations: 100
+                    iterations: 30
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
+                    pkts_num_trig_pfc: 3202
+                    pkts_num_trig_ingr_drp: 6404
                     packet_size: 8140
                     pkts_num_margin: 20
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
+                    pkts_num_trig_pfc: 3202
+                    pkts_num_trig_ingr_drp: 6404
                     packet_size: 8140
                     pkts_num_margin: 20
                 xon_1:


### PR DESCRIPTION
Updating qos.yaml params for topo-t2 accounting for the fill_egress_plus_one API that is used by cisco-8000 specific code.
In this PR:
1. Updated the Xoff numbers for 100G_300m.
2. Reverted the limits for all wrr cases to 80.
3. Reduced the number of iterations for PGDrop to 50 for non-HBM T2 ingress scenario and  to 30 for HBM T2 ingress scenario. This is done account for PTF timeout that happens when the iterations are current value of 100.