### PR TITLE
New Test Cases for Chassis DB cleanup when asic comes up PR (sonic-buildimage/pull/16213)

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -85,8 +85,7 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     """
     is_chassis = duthosts.supervisor_nodes[0].get_facts().get("modular_chassis")
     if not is_chassis and reload_check in ["dut_reload", "dut_reboot"]:
-        pytest.skip(
-            "Skip test as it is_chassis {} and relod_check param is ".format(is_chassis, reload_check))
+        pytest.skip("Skip test as it is_chassis {} and relod_check param is {} ".format(is_chassis, reload_check))
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     int_facts = asichost.interface_facts()['ansible_facts']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR



<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- This PR Enhances "test_po_update" test under pc test suite.
"pc/test_po_update.py::test_po_update"  to incorporate test cases for https://github.com/sonic-net/sonic-buildimage/pull/16213.
The Test Case added is to verify any temporary change in config which modifies the below table should be cleaned up after config_reload or system reboot  
(1) SYSTEM_NEIGH
(2) SYSTEM_INTERFACE
(3) SYSTEM_LAG_MEMBER_TABLE
(4) SYSTEM_LAG_TABLE
from the  chassis app db in redis_chassis server in the supervisor


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
New Test Cases for  verification of DB Consistency https://github.com/sonic-net/sonic-buildimage/pull/16213 

#### How did you do it?
The Previous test assign members from another port channel to the new created temporary port channel in which the config is not saved.
In current scenario two new test cases are added 
- Test Case 1: A pre database dump of impacted tables is stored before any changes is done, after the test, config reload is 
                     done and a post data dump of impacted table is compared against the pre database dump, No difference is 
                     expected.
- Test Case 2: A pre data base dump of impacted tables is stored before any changes is done, after the changes in config a new 
                     database dump of impacted tables is stored and a system reboot is performed, with assertion 1st being no 
                     changes should be expected in chassis app db during the reboot it should have the changes, after successful 
                     reboot a post data dump of impacted table is compared against the pre data base dump, No difference is 
                     expected is the 2nd assertion


#### How did you verify/test it?
Ran the  test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Tested on a multi-asic line card in a T2 chassis.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Refer PR :https://github.com/sonic-net/sonic-buildimage/pull/16213