### PR TITLE
Revert "[PTF python3 migration] Modify test_advanced_reboot PTF script"

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -679,7 +679,7 @@ class ReloadTest(BaseTest):
 
         self.random_vlan = random.choice(self.vlan_ports)
         self.from_server_src_port = self.random_vlan
-        self.from_server_src_addr = random.choice(list(self.vlan_host_map[self.random_vlan].keys()))
+        self.from_server_src_addr = random.choice(self.vlan_host_map[self.random_vlan].keys())
         self.from_server_src_mac = self.hex_to_mac(self.vlan_host_map[self.random_vlan][self.from_server_src_addr])
         self.from_server_dst_addr = self.random_ip(self.test_params['default_ip_range'])
         self.from_server_dst_ports = self.dualtor_portchannel_ports if self.is_dualtor else self.portchannel_ports
@@ -791,7 +791,7 @@ class ReloadTest(BaseTest):
                                            ip_ttl=255,
                                            tcp_dport=5000)
 
-                self.from_t1.append((src_port, bytes(packet)))
+                self.from_t1.append((src_port, str(packet)))
 
         # expect any packet with dport 5000
         exp_packet = simple_tcp_packet(
@@ -824,7 +824,7 @@ class ReloadTest(BaseTest):
                     tcp_dport=5000
                 )
 
-                self.from_servers.append((from_port, bytes(packet)))
+                self.from_servers.append((from_port, str(packet)))
 
         exp_packet = simple_tcp_packet(
             ip_dst=self.from_server_dst_addr,
@@ -849,14 +849,14 @@ class ReloadTest(BaseTest):
         dut_lo_ipv4 = self.lo_prefix.split('/')[0]
 
         for src_port in self.active_port_indices if self.is_dualtor else self.vlan_host_ping_map:
-            src_addr = random.choice(list(self.vlan_host_ping_map[src_port].keys()))
+            src_addr = random.choice(self.vlan_host_ping_map[src_port].keys())
             src_mac = self.hex_to_mac(
                 self.vlan_host_ping_map[src_port][src_addr])
             packet = simple_icmp_packet(eth_src=src_mac,
                                         eth_dst=self.vlan_mac,
                                         ip_src=src_addr,
                                         ip_dst=dut_lo_ipv4)
-            self.ping_dut_packets.append((src_port, bytes(packet)))
+            self.ping_dut_packets.append((src_port, str(packet)))
 
         exp_packet = simple_icmp_packet(eth_src=self.vlan_mac,
                                         ip_src=dut_lo_ipv4,
@@ -876,7 +876,7 @@ class ReloadTest(BaseTest):
         vlan = next(k for k, v in self.ports_per_vlan.items() if v)
         vlan_ip_range = self.vlan_ip_range[vlan]
 
-        vlan_port_canadiates = list(range(len(self.ports_per_vlan[vlan])))
+        vlan_port_canadiates = range(len(self.ports_per_vlan[vlan]))
         vlan_port_canadiates.remove(0)  # subnet prefix
         vlan_port_canadiates.remove(1)  # subnet IP on dut
         src_idx = random.choice(vlan_port_canadiates)
@@ -895,7 +895,7 @@ class ReloadTest(BaseTest):
                  (src_idx, src_port, src_mac, src_addr))
         self.log("ARP ping: dst idx %d port %d addr %s" %
                  (dst_idx, dst_port, dst_addr))
-        self.arp_ping = bytes(packet)
+        self.arp_ping = str(packet)
         self.arp_resp = Mask(expect)
         self.arp_resp.set_do_not_care_scapy(scapy.Ether, 'src')
         self.arp_resp.set_do_not_care_scapy(scapy.ARP,   'hwtype')
@@ -1687,7 +1687,7 @@ class ReloadTest(BaseTest):
                     packet.load = payload
                     from_port = src_port
                     sent_count_t1_to_vlan += 1
-                testutils.send_packet(self, from_port, bytes(packet))
+                testutils.send_packet(self, from_port, str(packet))
                 self.sent_packet_count = self.sent_packet_count + 1
 
             self.log("Sent count vlan to t1: {}".format(sent_count_vlan_to_t1))
@@ -1839,7 +1839,7 @@ class ReloadTest(BaseTest):
         It returns True if a packet is not corrupted and has a valid TCP sequential TCP Payload
         """
         try:
-            int(bytes(packet[scapyall.TCP].payload)
+            int(str(packet[scapyall.TCP].payload)
                 ) in range(self.sent_packet_count)
             return True
         except Exception:
@@ -1849,12 +1849,12 @@ class ReloadTest(BaseTest):
         """
         This method filters packets which are unique (i.e. no floods).
         """
-        if (not int(bytes(packet[scapyall.TCP].payload)) in self.unique_id) and \
+        if (not int(str(packet[scapyall.TCP].payload)) in self.unique_id) and \
                 (packet[scapyall.Ether].src == self.dut_mac or packet[scapyall.Ether].src == self.vlan_mac):
             # This is a unique (no flooded) received packet.
             # for dualtor, t1->server rcvd pkt will have src MAC as vlan_mac,
             # and server->t1 rcvd pkt will have src MAC as dut_mac
-            self.unique_id.append(int(bytes(packet[scapyall.TCP].payload)))
+            self.unique_id.append(int(str(packet[scapyall.TCP].payload)))
             return True
         elif packet[scapyall.Ether].dst == self.dut_mac or packet[scapyall.Ether].dst == self.vlan_mac:
             # This is a sent packet.
@@ -1909,7 +1909,7 @@ class ReloadTest(BaseTest):
 
         # Re-arrange packets, if delayed, by Payload ID and Timestamp:
         packets = sorted(filtered_packets, key=lambda packet: (
-            int(bytes(packet[scapyall.TCP].payload)), packet.time))
+            int(str(packet[scapyall.TCP].payload)), packet.time))
         self.lost_packets = dict()
         self.max_disrupt, self.total_disruption = 0, 0
         sent_packets = dict()
@@ -1933,7 +1933,7 @@ class ReloadTest(BaseTest):
                     # for dualtor both MACs are needed:
                     #   t1->server sent pkt will have dst MAC as dut_mac,
                     #   and server->t1 sent pkt will have dst MAC as vlan_mac
-                    sent_payload = int(bytes(packet[scapyall.TCP].payload))
+                    sent_payload = int(str(packet[scapyall.TCP].payload))
                     sent_packets[sent_payload] = packet.time
                     sent_counter += 1
                     continue
@@ -1943,7 +1943,7 @@ class ReloadTest(BaseTest):
                     #   t1->server rcvd pkt will have src MAC as vlan_mac,
                     #   and server->t1 rcvd pkt will have src MAC as dut_mac
                     received_time = packet.time
-                    received_payload = int(bytes(packet[scapyall.TCP].payload))
+                    received_payload = int(str(packet[scapyall.TCP].payload))
                     if (received_payload % 5) == 0:   # From vlan to T1.
                         received_vlan_to_t1 += 1
                     else:
@@ -2264,10 +2264,8 @@ class ReloadTest(BaseTest):
     def reachability_watcher(self):
         # This function watches the reachability of the CPU port, and ASIC. It logs the state
         # changes for future analysis
-        self.log('Reachability watcher started')
         self.watcher_is_stopped.clear()  # Watcher is running.
         while self.watching:
-            self.log('Reachability watcher - checking data plane')
             if self.dataplane_io_lock.acquire(False):
                 vlan_to_t1, t1_to_vlan = self.ping_data_plane(self.light_probe)
                 reachable = (t1_to_vlan > self.nr_vl_pkts * 0.7 and
@@ -2281,9 +2279,6 @@ class ReloadTest(BaseTest):
                 self.log_asic_state_change(
                     reachable, partial, t1_to_vlan, flooding)
                 self.dataplane_io_lock.release()
-            else:
-                self.log("Reachability watcher - Dataplane is busy. Skipping the check")
-            self.log('Reachability watcher - checking control plane')
             total_rcv_pkt_cnt = self.pingDut()
             reachable = total_rcv_pkt_cnt > 0 and total_rcv_pkt_cnt > self.ping_dut_pkts * 0.7
             partial = total_rcv_pkt_cnt > 0 and total_rcv_pkt_cnt < self.ping_dut_pkts
@@ -2293,7 +2288,6 @@ class ReloadTest(BaseTest):
             reachable = total_rcv_pkt_cnt >= self.arp_ping_pkts
             self.log_vlan_state_change(reachable)
             self.watcher_is_running.set()   # Watcher is running.
-        self.log('Reachability watcher stopped')
         self.watcher_is_stopped.set()       # Watcher has stopped.
         self.watcher_is_running.clear()     # Watcher has stopped.
 
@@ -2301,6 +2295,7 @@ class ReloadTest(BaseTest):
         for _ in range(self.nr_pc_pkts):
             entry = next(self.watcher_from_server_iter)
             testutils.send_packet(self, *entry)
+
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(
             self, self.from_vlan_exp_packet, self.from_server_dst_ports, timeout=self.PKT_TOUT)
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -6,7 +6,6 @@ import re
 import paramiko
 import pickle
 import ast
-import six
 
 from operator import itemgetter
 from collections import defaultdict
@@ -105,7 +104,7 @@ class Arista(host_device.HostDevice):
                 continue
 
             try:
-                input_buffer += six.ensure_str(self.shell.recv(16384))
+                input_buffer += self.shell.recv(16384)
             except Exception as err:
                 msg = 'Receive ssh command result error: cmd={} msg={} type={}'.format(
                     cmd, err, type(err))
@@ -392,7 +391,7 @@ class Arista(host_device.HostDevice):
         return result
 
     def parse_lacp(self, output):
-        return six.ensure_str(output).find('Bundled') != -1
+        return output.find('Bundled') != -1
 
     def parse_bgp_neighbor_once(self, output):
         is_gr_ipv4_enabled = False

--- a/ansible/roles/test/files/ptftests/py3/arista.py
+++ b/ansible/roles/test/files/ptftests/py3/arista.py
@@ -1,1 +1,0 @@
-../arista.py

--- a/ansible/roles/test/files/ptftests/py3/host_device.py
+++ b/ansible/roles/test/files/ptftests/py3/host_device.py
@@ -1,1 +1,0 @@
-../host_device.py

--- a/ansible/roles/test/files/ptftests/py3/sad_path.py
+++ b/ansible/roles/test/files/ptftests/py3/sad_path.py
@@ -1,1 +1,0 @@
-../sad_path.py

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 import scapy.all as scapyall
 import ast
 import socket
-import six
+
 import host_device
 
 
@@ -309,7 +309,7 @@ class Sonic(host_device.HostDevice):
         return 0, num_lag_flaps
 
     def parse_lacp(self, output):
-        return six.ensure_str(output).find('Bundled') != -1
+        return output.find('Bundled') != -1
 
     def parse_bgp_neighbor_once(self, output):
         is_gr_ipv4_enabled = False

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -756,8 +756,7 @@ class AdvancedReboot:
             params=params,
             log_file='/tmp/advanced-reboot.ReloadTest.log',
             module_ignore_errors=self.moduleIgnoreErrors,
-            timeout=REBOOT_CASE_TIMEOUT,
-            is_python3=True
+            timeout=REBOOT_CASE_TIMEOUT
         )
 
         return result


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#9550, fe0d44d68c0fa17838dd91e2e83d7545b07c118f

This is causing a breakage when running on physical testbeds, due to (at least) the following error:

```
Exception in thread Thread-7:
Traceback (most recent call last):
  File \"/usr/lib/python3.7/threading.py\", line 917, in _bootstrap_inner
    self.run()
  File \"/usr/lib/python3.7/threading.py\", line 865, in run
    self._target(*self._args, **self._kwargs)
  File \"ptftests/py3/advanced-reboot.py\", line 1664, in send_in_background
    'not (arp and ether src {}) and not tcp'.format(self.test_params['dut_mac']))
  File \"ptftests/py3/advanced-reboot.py\", line 1648, in apply_filter_all_ports
    scapyall.attach_filter(port.socket, filter_expression)
AttributeError: module 'scapy.all' has no attribute 'attach_filter'
```