### PR TITLE
Change to capture BaseException instead of Exception in sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -257,7 +257,7 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                     for action in infra_recovery_actions:
                         action()
 
-                except Exception as e:
+                except BaseException as e:
                     request.config.cache.set("pre_sanity_check_failed", True)
                     logger.error("Recovery of sanity check failed with exception: ")
                     pt_assert(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
If something wrong with testbed, sanity check will try to recover testbed with reboot method.
But after https://github.com/sonic-net/sonic-mgmt/pull/9453, it uses safe reload instead, test case will terminate in reboot function, that's why sanity check won't fail and exit, it will run next test case, and same termination will happen.
That's not we expect, if unhealthy testbed can't be recovered, the whole pipeline will exit.
In reboot funciton, it uses pytest_assert to terminate the running. It raised Failed exception which is inherited from BaseException.

```
        if safe_reboot:
            # The wait time passed in might not be guaranteed to cover the actual
            # time it takes for containers to come back up. Therefore, add 5
            # minutes to the maximum wait time. If it's ready sooner, then the
            # function will return sooner.
            pytest_assert(wait_until(wait + 300, 20, 0, duthost.critical_services_fully_started),
>                         "All critical services should be fully started!")
E           Failed: All critical services should be fully started!
```


The code stack of pytest_assert, eventually, it will raise Failed exception which is inherited from BaseException.
BaseException can't be captured in sanity check with "`Except Exception as e`".

```
def pytest_assert(condition, message = None):
    __tracebackhide__ = True
    if not condition:
        pytest.fail(message)
```


```
@_with_exception(Failed)
def fail(reason: str = "", pytrace: bool = True, msg: Optional[str] = None) -> NoReturn:
    __tracebackhide__ = True
    reason = _resolve_msg_to_reason("fail", reason, msg)
    raise Failed(msg=reason, pytrace=pytrace)
```


```
class Failed(OutcomeException):
    """Raised from an explicit call to pytest.fail()."""

    __module__ = "builtins"
```

```
class OutcomeException(BaseException):
    """OutcomeException and its subclass instances indicate and contain info
    about test and collection outcomes."""
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Sanity check won't exit even reboot failed.

#### How did you do it?
Sanity check uses safe reload instead, test case will terminate in reboot function, It raised Failed exception which is inherited from BaseException.
Change to capture BaseException instead of Exception in sanity check.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
