### PR TITLE
pytest.ini change needed for 202305 branch

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -26,3 +26,4 @@ markers:
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_date_format: %d/%m/%Y %H:%M:%S
+junit_family: xunit1


### PR DESCRIPTION
**Description of PR**
It was observed that for 202305 branch, sonic-mgmt/tests/run_tests.sh file used python3 pytest. 
When running the test using run_tests.sh in 202305 branch, the xml files generated for each test suite do not have 'file' attribute. This causes a problem when parsing the results using sonic-mgmt/test_reporting/junit_xml_parser.py.
This PR is required to fix this issue.

**Summary:** 
From pytest >= 6.1.0, the default value for junit_family is xunit2.
In order to have 'file' attribute in xml files, we need to have  junit_family as xunit1.
Adding a line 'junit_family=xunit1' to pytest.ini file solves this problem

**Type of change**

- [ ] Bug fix
- [x]  Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

**Back port request**

- [ ] 202012
- [ ] 202205
- [x] 202305

**How did you verify/test it?**
Tested it on Cisco internal test setup and verified that it works