### PR TITLE
[VM]Convert bgp sentinel target route type

### DIFF
--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -347,7 +347,7 @@ def get_target_routes(duthost):
         "vtysh -c \'show bgp ipv6 neighbors {} received-routes json\'".format(v6_peer))['stdout'])
 
     target_v6_routes = [route for route in bgp_v6_routes['receivedRoutes'].keys() if '/128' not in route]
-    return bgp_v4_routes['receivedRoutes'].keys(), target_v6_routes
+    return list(bgp_v4_routes['receivedRoutes'].keys()), target_v6_routes
 
 
 @pytest.fixture(scope="module", params=['no-export', None])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Python is updated and dict_keys would not plus list.
#### How did you do it?
Convert dict_keys to list
#### How did you verify/test it?
Run testcase and testcase would pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
