### PR TITLE
[Testbed] Fix the MAC address of br1 on server during add/remove topo

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -179,6 +179,7 @@
     - name: Explicitly set current br1 MAC address to br1
       shell: ip link set dev br1 address {{ br1_mac.stdout }}
       become: yes
+      when: br1_mac.stdout != "00:00:00:00:00:00"
 
 - block:
     - getent:

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -171,6 +171,15 @@
   include_tasks: internal_mgmt_network.yml
   when: internal_mgmt_network is defined and internal_mgmt_network == True
 
+- name: Fix the MAC address of br1 on server
+  block:
+    - name: Get current MAC address of br1
+      shell: cat /sys/class/net/br1/address
+      register: br1_mac
+    - name: Explicitly set current br1 MAC address to br1
+      shell: ip link set dev br1 address {{ br1_mac.stdout }}
+      become: yes
+
 - block:
     - getent:
         database: passwd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the MAC address of `br1` on server during add/remove topo.

As we configure the MGMT IP address of server on a virtual bridge `br1`, it's MAC address is not fixed if it's not manually set. This makes the MAC address of `br1` changeable during add/remove topo. When the MAC address change, the other servers may not update their ARP table in time and temporarily lose the connection. In this PR, I added one step in add/remove topo to fix the MAC address of `br1` to avoid potential packet loss.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the MAC address of `br1` on server during add/remove topo.

#### How did you do it?
Add one step to explicitly set the MAC address of `br1`.

#### How did you verify/test it?
* For physical testbeds, verified on physical servers.
* For virtual testbeds, verified by PR test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
