### PR TITLE
[Cherry Pick] 202205 fix bgp update timer failure on dual tor

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -238,7 +238,11 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                     {
                         "local_intf": loopback_intf["name"],
                         "local_addr": "%s/%s" % (loopback_intf_addr, loopback_intf_prefixlen),
-                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interface],
+                        # Note: Config same subnets on PTF will generate two connect routes on PTF.
+                        # This may lead different IPs has same FDB entry on DUT even they are on different
+                        # interface and cause layer3 packet drop on PTF, so here same interface for different
+                        # neighbor.
+                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interfaces[0]],
                         "neighbor_addr": "%s/%s" % (mux_configs[local_interface]["server_ipv4"].split("/")[0], vlan_intf_prefixlen)
                     }
                 )
@@ -251,8 +255,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
 
             first_neighbor_port = None
             for conn in connections:
-                ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"],
-                                                  conn["neighbor_addr"]))
+                ptfhost.shell("ip address add %s dev %s" % (conn["neighbor_addr"], conn["neighbor_intf"]))
                 if not first_neighbor_port:
                     first_neighbor_port = conn["neighbor_intf"]
                 # NOTE: this enables the standby ToR to passively learn


### PR DESCRIPTION
### Description of PR
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9423 to 202205

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9423 to 202205

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
