### PR TITLE
[Cherry Pick] 202012 limit parallel_run cct tasks number to avoid connection issue

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -64,7 +64,7 @@ def check_results(results):
 
 
 @pytest.fixture(scope='module')
-def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
+def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo, cct=24):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -132,7 +132,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
             )
         results[node['host'].hostname] = node_results
 
-    results = parallel_run(configure_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
+    results = parallel_run(configure_nbr_gr, (), {}, nbrhosts.values(), timeout=120, concurrent_tasks=cct)
 
     check_results(results)
 
@@ -150,12 +150,12 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
 
     if not res:
         # Disable graceful restart in case of failure
-        parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
+        parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120, concurrent_tasks=cct)
         pytest.fail(err_msg)
 
     yield
 
-    results = parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
+    results = parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120, concurrent_tasks=cct)
 
     check_results(results)
 

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -17,7 +17,8 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhosts, setup_bgp_graceful_restart, tbinfo):
+def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhosts,
+                                        setup_bgp_graceful_restart, tbinfo, cct=8):
     """Verify that routes received from one neighbor are all preserved during peer graceful restart."""
 
     def _find_test_bgp_neighbors(test_neighbor_name, bgp_neighbors):


### PR DESCRIPTION

### Description of PR
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/8084 to 202012

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/8084 to 202012

Fix ansible connection to server issue during testing, when T1 has multiple neighbors (In testing failure it's 24), sometime parallel bgp related check will failure due to connection to server failure.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
