### PR TITLE
[Cherry Pick] 202012 fix bgp slb test case dual tor issue

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -164,7 +164,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
 
 
 @pytest.fixture(scope="module")
-def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, request, tbinfo, topo_scenario):
+def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo, topo_scenario):
     """Setup interfaces for the new BGP peers on PTF."""
 
     def _is_ipv4_address(ip_addr):
@@ -459,7 +459,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
     else:
         raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
 
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     with setup_func(mg_facts, peer_count) as connections:
         yield connections

--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -2,8 +2,7 @@ import pytest
 
 from tests.common import reboot
 from tests.common.helpers.bgp import BGPNeighbor
-from tests.common.dualtor.mux_simulator_control import mux_server_url                                   # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.utilities import wait_until, delete_running_config
 
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -12,8 +12,7 @@ from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.mux_simulator_control import mux_server_url
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 pytestmark = [
@@ -71,9 +70,9 @@ def log_bgp_updates(duthost, iface, save_path, ns):
 
 
 @pytest.fixture
-def is_quagga(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def is_quagga(duthosts, rand_one_dut_hostname):
     """Return True if current bgp is using Quagga."""
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     show_res = duthost.asic_instance().run_vtysh("-c 'show version'")
     return "Quagga" in show_res["stdout"]
 
@@ -84,8 +83,8 @@ def is_dualtor(tbinfo):
 
 
 @pytest.fixture
-def common_setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces, tbinfo):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     conn0, conn1 = setup_interfaces
     conn0_ns = DEFAULT_NAMESPACE if "namespace" not in conn0.keys() else conn0["namespace"]
@@ -176,8 +175,8 @@ def is_neighbor_sessions_established(duthost, neighbors):
     return is_established
 
 
-def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                          toggle_all_simulator_ports_to_rand_selected_tor_m):
+def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_dut_hostname,
+                          toggle_all_simulator_ports_to_rand_selected_tor):
 
     def bgp_update_packets(pcap_file):
         """Get bgp update packets from pcap file."""
@@ -230,7 +229,7 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_
         else:
             return False
 
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
 
     n0, n1 = common_setup_teardown
     try:


### PR DESCRIPTION

### Description of PR
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9239 to 202012

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9239 to 202012

Fixes test_bgp_slb_neighbor_persistence_across_advanced_reboot test failure on dual tor.
In script using setup_interfaces for bgp connections which already use toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m and enum_rand_one_per_hwsku_frontend_hostname for muxcable toggle operation/selection on dualtor.
But script use toggle_all_simulator_ports_to_rand_selected_tor and rand_one_dut_hostname in test case, which may not same as
setup_interfaces and finally cause test case failure.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
