### PR TITLE
[Cherry Pick] 202012 fix bgp update timer failure on dual tor 

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -256,7 +256,11 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                     {
                         "local_intf": loopback_intf["name"],
                         "local_addr": "%s/%s" % (loopback_intf_addr, loopback_intf_prefixlen),
-                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interface],
+                        # Note: Config same subnets on PTF will generate two connect routes on PTF.
+                        # This may lead different IPs has same FDB entry on DUT even they are on different
+                        # interface and cause layer3 packet drop on PTF, so here same interface for different
+                        # neighbor.
+                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interfaces[0]],
                         "neighbor_addr": "%s/%s" % (mux_configs[local_interface]["server_ipv4"].split("/")[0], vlan_intf_prefixlen)
                     }
                 )
@@ -264,8 +268,8 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
             ptfhost.remove_ip_addresses()
 
             for conn in connections:
-                ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"],
-                                                  conn["neighbor_addr"]))
+                ptfhost.shell("ip address add %s dev %s" % (conn["neighbor_addr"], conn["neighbor_intf"]))
+
             ptfhost.shell("ip route add %s via %s" % (loopback_intf_addr, vlan_intf_addr))
             yield connections
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9423 to 202012

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry Pick https://github.com/sonic-net/sonic-mgmt/pull/9423 to 202012

Fix bug update timer issue on dual tor, when set up bgp speaker session with dual tor.
Interface selection on PTF has wrong behavior, config IP addresses within same subnet on different interfaces would case connection error. Refer to analysis of https://github.com/sonic-net/sonic-mgmt/pull/8487.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
