### PR TITLE
test_ro_disk:  Enhancement for reboot of supervisor card

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -11,6 +11,8 @@ from tests.common.utilities import wait
 from tests.common.reboot import reboot
 from .test_ro_user import ssh_remote_run
 from .utils import setup_tacacs_client
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.platform.processes_utils import wait_critical_processes
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -88,9 +90,9 @@ def do_reboot(duthost, localhost, duthosts):
         for host in duthosts:
             if host != duthost:
                 logger.info("checking if {} critical services are up".format(host.hostname))
-                assert wait_until(300, 20, 0, host.critical_services_fully_started), \
-                    "All critical services of {} should fully started!".format(host.hostname)
-
+                wait_critical_processes(host)
+                assert wait_until(300, 20, 0, check_interface_status_of_up_ports, host), \
+                          "Not all ports that are admin up on are operationally up"
 
 def do_setup_tacacs(ptfhost, duthost, tacacs_creds):
     logger.info('Upon reboot: setup tacacs_creds')

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -92,7 +92,8 @@ def do_reboot(duthost, localhost, duthosts):
                 logger.info("checking if {} critical services are up".format(host.hostname))
                 wait_critical_processes(host)
                 assert wait_until(300, 20, 0, check_interface_status_of_up_ports, host), \
-                          "Not all ports that are admin up on are operationally up"
+                    "Not all ports that are admin up on are operationally up"
+
 
 def do_setup_tacacs(ptfhost, duthost, tacacs_creds):
     logger.info('Upon reboot: setup tacacs_creds')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The Test Case  tacacs/test_ro_disk.py::test_ro_disk, in finally block a reboot is performed, currently, the condition for reboot to be successful is to check the docker is running, the enhancement done is to wait till all the critical process in the docker are up and the interfaces are also up for all the line cards in case the supervisor is rebooted
The Particular improvement is required due to the changes with respect to PR https://github.com/sonic-net/sonic-buildimage/pull/16213.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The Particular improvement is required due to the changes with respect to PR https://github.com/sonic-net/sonic-buildimage/pull/16213. 
#### How did you do it?
Assertion for successful reboot of supervisor card is updated to check all the process are up on critical docker and interfaces are also up on line cards.

#### How did you verify/test it?
Ran the  test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/135994174/032ea34b-953a-4f80-bcb0-4df59c7c2c12)

