### PR TITLE
data need to be sorted before they are compared

### DIFF
--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -77,13 +77,14 @@ def check_if_daemon_restarted(duthost, daemon_name, pre_daemon_pid):
 
 def collect_data(duthost):
     keys = duthost.shell('sonic-db-cli STATE_DB KEYS "CHASSIS_*TABLE|*"')['stdout_lines']
+    sorted_keys = sorted(keys)
 
     dev_data = {}
-    for k in keys:
+    for k in sorted_keys:
         data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
-    return {'keys': keys, 'data': dev_data}
+    return {'keys': sorted_keys, 'data': dev_data}
 
 
 def wait_data(duthost, expected_key_count):


### PR DESCRIPTION
### Description of PR
data data_before_restart and data_after_restart need to be sorted before they are compared 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
The assert statement compares data with assert as: pytest_assert(data_after_restart == data_before_restart). ( data_before_start is populated once per module while data_after_restart is collected for test)
Neither data are sorted, so when compared if the data is obtained is different order during the test  it will fail the test even though content is identical based on keys and their data.
If you provide us the data or someone on your side can check if that is case it would require enhancing the test to take care of this case

#### How did you do it?
data_before_restart  and  data_after_restart are sorted before they are compared

#### How did you verify/test it?
Tested chassisd testcase on a MultiAsics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
