### PR TITLE
[chassis] fix flakiness in test_chassisd.py

### DIFF
--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -99,7 +99,8 @@ def wait_data(duthost, expected_key_count):
         return data_key_found == expected_key_count
     pooling_interval = 60
     wait_until(pooling_interval, 10, 20, _collect_data)
-    return shared_scope.data_after_restart
+    from collections import OrderedDict
+    return OrderedDict(sorted(shared_scope.data_after_restart.items()))
 
 
 @pytest.fixture(scope='module')

--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 from tests.common.platform.processes_utils import check_critical_processes
 from tests.common.utilities import compose_dict_from_cli, wait_until
+from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,8 @@ def collect_data(duthost):
         data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
-    return {'keys': keys, 'data': dev_data}
+    data_dict = {'keys': keys, 'data': dev_data}
+    return OrderedDict(sorted(data_dict).items())
 
 
 def wait_data(duthost, expected_key_count):
@@ -99,8 +101,7 @@ def wait_data(duthost, expected_key_count):
         return data_key_found == expected_key_count
     pooling_interval = 60
     wait_until(pooling_interval, 10, 20, _collect_data)
-    from collections import OrderedDict
-    return OrderedDict(sorted(shared_scope.data_after_restart.items()))
+    return shared_scope.data_after_restart
 
 
 @pytest.fixture(scope='module')

--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -85,7 +85,7 @@ def collect_data(duthost):
         data = compose_dict_from_cli(data)
         dev_data[k] = data
     data_dict = {'keys': keys, 'data': dev_data}
-    return OrderedDict(sorted(data_dict).items())
+    return OrderedDict(sorted(data_dict.items()))
 
 
 def wait_data(duthost, expected_key_count):

--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -90,7 +90,7 @@ def collect_data(duthost):
 
 def wait_data(duthost, expected_key_count):
     class shared_scope:
-        data_after_restart = {}
+        data_after_restart = OrderedDict()
 
     def _collect_data():
         shared_scope.data_after_restart = collect_data(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This is to fix flakiness in this test, that wait_data returned unsorted dictionary, but later when comparing unsorted dictionary, it is exact match -- if keys are the same but in different order, it will fail.

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/9863

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
in `def collect_data`, sort return dictionary by keys and return in ordered_dictionary.
this function is used for `data_before_restart` and `data_after_restart`
#### How did you verify/test it?
before:
```
Failed: DB data present before and after restart does not match
data_after_restart = {'data': {u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD0': {}, u'CHASSIS_MODULE_TABLE|SU...IS 1', u'CHASSIS_MODULE_TABLE|LINE-CARD0', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0', u'CHASSIS_MODULE_TABLE|SUPERVISOR0']}
data_before_restart = {'data': {u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD0': {}, u'CHASSIS_MODULE_TABLE|SU...IS 1', u'CHASSIS_MODULE_TABLE|LINE-CARD0', u'CHASSIS_MODULE_TABLE|SUPERVISOR0', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0']}
```

after:
```
(Pdb) data_after_restart
OrderedDict([('data', {u'CHASSIS_MODULE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD': {}, u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_TABLE|CHASSIS 1': {}}), ('keys', [u'CHASSIS_TABLE|CHASSIS 1', u'CHASSIS_MODULE_TABLE|SUPERVISOR0', u'CHASSIS_MODULE_TABLE|LINE-CARD', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0'])])
(Pdb) data_before_restart
{'keys': [u'CHASSIS_TABLE|CHASSIS 1', u'CHASSIS_MODULE_TABLE|SUPERVISOR0', u'CHASSIS_MODULE_TABLE|LINE-CARD', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0'], 'data': {u'CHASSIS_MODULE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD': {}, u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_TABLE|CHASSIS 1': {}}}
(Pdb) data_after_restart == data_before_restart
True
(Pdb) data_before_restart.keys()
['keys', 'data']
(Pdb) data_before_restart['keys']
[u'CHASSIS_TABLE|CHASSIS 1', u'CHASSIS_MODULE_TABLE|SUPERVISOR0', u'CHASSIS_MODULE_TABLE|LINE-CARD', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0']
(Pdb) data_after_restart['keys']
[u'CHASSIS_TABLE|CHASSIS 1', u'CHASSIS_MODULE_TABLE|SUPERVISOR0', u'CHASSIS_MODULE_TABLE|LINE-CARD', u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0']
(Pdb) data_before_restart['data']
{u'CHASSIS_MODULE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD': {}, u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_TABLE|CHASSIS 1': {}}
(Pdb) data_after_restart['data']
{u'CHASSIS_MODULE_TABLE|SUPERVISOR0': {}, u'CHASSIS_MODULE_TABLE|LINE-CARD': {}, u'CHASSIS_MIDPLANE_TABLE|SUPERVISOR0': {}, u'CHASSIS_TABLE|CHASSIS 1': {}}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
