### PR TITLE
Porting 9860 to 202205.

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -739,7 +739,7 @@ qos_params:
                     q4_num_of_pkts: 75
                     q5_num_of_pkts: 70
                     q6_num_of_pkts: 70
-                    limit: 40
+                    limit: 80
                 wrr_chg:
                     ecn: 1
                     q0_num_of_pkts: 40
@@ -749,7 +749,7 @@ qos_params:
                     q4_num_of_pkts: 150
                     q5_num_of_pkts: 40
                     q6_num_of_pkts: 40
-                    limit: 40
+                    limit: 80
                     lossy_weight: 8
                     lossless_weight: 30
             400000_5m:
@@ -1065,7 +1065,7 @@ qos_params:
                 q4_num_of_pkts: 75
                 q5_num_of_pkts: 70
                 q6_num_of_pkts: 70
-                limit: 40
+                limit: 80
             wrr_chg:
                 ecn: 1
                 q0_num_of_pkts: 40
@@ -1075,7 +1075,7 @@ qos_params:
                 q4_num_of_pkts: 150
                 q5_num_of_pkts: 40
                 q6_num_of_pkts: 40
-                limit: 40
+                limit: 80
                 lossy_weight: 8
                 lossless_weight: 30
             100000_300m:
@@ -1089,22 +1089,22 @@ qos_params:
                     pkts_num_trig_pfc: 13660
                     pkts_num_trig_ingr_drp: 14819
                     pkts_num_margin: 375
-                    iterations: 100
+                    iterations: 50
                     cell_size: 384
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 10300
-                    pkts_num_trig_ingr_drp: 10589
+                    pkts_num_trig_pfc: 3415
+                    pkts_num_trig_ingr_drp: 3704
                     packet_size: 1350
                     pkts_num_margin: 20
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 10300
-                    pkts_num_trig_ingr_drp: 10589
+                    pkts_num_trig_pfc: 3415
+                    pkts_num_trig_ingr_drp: 3704
                     packet_size: 1350
                     pkts_num_margin: 20
                 wm_q_wm_all_ports:
@@ -1212,7 +1212,7 @@ qos_params:
                     pkts_num_trig_pfc: 12152
                     pkts_num_trig_ingr_drp: 14816
                     pkts_num_margin: 375
-                    iterations: 100
+                    iterations: 50
                     cell_size: 384
                 xoff_1:
                     dscp: 3
@@ -1335,21 +1335,21 @@ qos_params:
                     pkts_num_trig_pfc: 262144
                     pkts_num_trig_ingr_drp: 524288
                     pkts_num_margin: 13267
-                    iterations: 100
+                    iterations: 30
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
+                    pkts_num_trig_pfc: 3202
+                    pkts_num_trig_ingr_drp: 6404
                     packet_size: 8140
                     pkts_num_margin: 20
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 4481
-                    pkts_num_trig_ingr_drp: 7689
+                    pkts_num_trig_pfc: 3202
+                    pkts_num_trig_ingr_drp: 6404
                     packet_size: 8140
                     pkts_num_margin: 20
                 xon_1:


### PR DESCRIPTION
Fixing up the qos-params for cisco-8000/GB asic, for 100G 300m. The updated numbers are needed since the code is now using a new API: fill_egress_plus_one, which requires much smaller numbers for the packets.