### PR TITLE
[Mellanox] add mock for temperature threshold in psu power threshold 

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1355,6 +1355,12 @@ class PsuPowerThresholdMocker(object):
     def mock_port_ambient_thermal(self, temperature):
         self.mock_helper.mock_value(self.PORT_AMBIENT_TEMP, int(temperature))
 
+    def mock_ambient_temp_critical_threshold(self, temperature):
+        self.mock_helper.mock_value(self.AMBIENT_TEMP_CRITICAL_THRESHOLD, int(temperature))
+
+    def mock_ambient_temp_warning_threshold(self, temperature):
+        self.mock_helper.mock_value(self.AMBIENT_TEMP_WARNING_THRESHOLD, int(temperature))
+
     def read_psu_power_threshold(self, psu):
         return int(self.mock_helper.read_value(self.PSU_POWER_CAPACITY.format(psu)))
 


### PR DESCRIPTION
Enhance test case test_psu_power_threshold - add mock for temperature threshold at the beginning of the test.
The temperature on some setup may exceed the threshold at the begining of the test start, and will cause test failure.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The temperature on some setup may exceed the threshold at the begining of the test start, and will cause test failure. Enhance test case test_psu_power_threshold with adding mock for temperature threshold  at the beginning of the test

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
Add mock for temperature threshold to make sure the tempperature will not exceed the threshold.
#### What is the motivation for this PR?
Test will not fail due to the temperature exceed the threshold.

#### How did you do it?
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
