### PR TITLE
Skip bgp/test_bgp_fact.py for sonic-t0 testbed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,7 @@ stages:
         VM_TYPE: vsonic
         KVM_IMAGE_BRANCH: "202205"
         MGMT_BRANCH: "202205"
+        SCRIPTS_EXCLUDE: "bgp/test_bgp_fact.py"
 
   - job: dualtor_elastictest
     pool: ubuntu-20.04


### PR DESCRIPTION

#### What is the motivation for this PR?
This is a follow up of the fix earlier made to skip macsec tests from pipeline t0-sonic via this PR : https://github.com/sonic-net/sonic-mgmt/pull/9874

Even with this PR merged, there was still failures in one of the tests run in t0-sonic pipeline.

Further debugging showed that, we have this special param, to **enable macsec** (as shown below) which results in macsec setup with macsec enabled links which will fail again.

REF: 
```
specific_param:

  t0-sonic:
  - name: bgp/test_bgp_fact.py
    param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI" <<<<<<<
#  all the test modules under macsec directory
  - name: macsec
    param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"   <<<<<<<<
~                                                                                                                                                                                                                                                               
".azure-pipelines/pr_test_scripts.yaml" line 73 of 143 --51%-- col 1
```

#### How did you do it?
So idea here is to skip the test test_bgp_fact.py for t0-sonic pipeline alone.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
