### PR TITLE
Fix bgp suppress fib test

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -57,8 +57,8 @@ IP_ROUTE_LIST = [
 
 # ipv6 route injection from T0
 IPV6_ROUTE_LIST = [
-    '1000:1001::1/128',
-    '1000:1001::2/128'
+    '1000:1001::/64',
+    '1000:1002::/64'
 ]
 
 TRAFFIC_DATA_FORWARD = [
@@ -66,7 +66,7 @@ TRAFFIC_DATA_FORWARD = [
     ("91.0.1.1", FORWARD),
     ("91.0.2.1", FORWARD),
     ("1000:1001::1", FORWARD),
-    ("1000:1001::2", FORWARD)
+    ("1000:1002::1", FORWARD)
 ]
 
 TRAFFIC_DATA_DROP = [
@@ -74,7 +74,7 @@ TRAFFIC_DATA_DROP = [
     ("91.0.1.1", DROP),
     ("91.0.2.1", DROP),
     ("1000:1001::1", DROP),
-    ("1000:1001::2", DROP),
+    ("1000:1002::1", DROP),
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure in `test_bgp_suppress_fib.py`.
The error message is 
```
Failed: Vrf:Vrf1 - route:1000:1001::1/128 is not in queued state
```
The failure is because the advertised IPv6 route from T0 is denied by route-map on T1.
To work around the issue, I changed the route to `/64`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure in `test_bgp_suppress_fib.py`.

#### How did you do it?
Change the advertised route to `/64`'

#### How did you verify/test it?
Verified on a SN2700 T1 testbed. Now the tese can pass
```
ollected 5 items                                                                                                                                                                                                             

bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress[default]  ^HPASSED                                                                                                                                              [ 20%]
bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress[Vrf1]  ^H ^H ^HPASSED                                                                                                                                                 [ 40%]
bgp/test_bgp_suppress_fib.py::test_bgp_route_without_suppress PASSED                                                                                                                                                    [ 60%]
bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress_negative_operation PASSED                                                                                                                                    [ 80%]
bgp/test_bgp_suppress_fib.py::test_credit_loop 
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
