### PR TITLE
[ansible/library/conn_graph_facts] convert interface aliases to interface names when all input links use aliases

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -276,8 +276,12 @@ class LabGraph(object):
                 elif all([port in self._get_port_alias_set(device) for port in ports_group_by_devices[device]]):
                     convert_alias_to_name.append(device)
                 elif not all([port in self._get_port_name_set(device) for port in ports_group_by_devices[device]]):
-                    raise Exception("[Failed] For device {}, please check {} and ensure all ports use port name, "
-                            "or ensure all ports use port alias.".format(device, ports_group_by_devices[device]))
+                    raise Exception(
+                        "[Failed] For device {}, please check {} and ensure all ports use "
+                        "port name, or ensure all ports use port alias.".format(
+                            device, ports_group_by_devices[device]
+                        )
+                    )
 
         logging.debug("convert_alias_to_name {}".format(convert_alias_to_name))
 

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -217,25 +217,12 @@ class LabGraph(object):
         self._cache_port_name_to_alias[hwsku] = port_name_to_alias_map
         return port_name_to_alias_map
 
-    def _get_port_name_set(self, device_hostname):
-        """
-        Retrive port name set of a specific hwsku.
-        """
-        hwsku = self.graph_facts["devices"][device_hostname]['HwSku']
-        return set(self._get_port_name_to_alias_map(hwsku).keys())
-
     def _get_port_alias_set(self, device_hostname):
         """
         Retrive port alias set of a specific hwsku.
         """
         hwsku = self.graph_facts["devices"][device_hostname]['HwSku']
         return set(self._get_port_alias_to_name_map(hwsku).keys())
-
-    def sorted_dict(self, myDict):
-        myKeys = list(myDict.keys())
-        myKeys.sort()
-        rst_dict = {i: myDict[i] for i in myKeys}
-        return rst_dict
 
     def csv_to_graph_facts(self):
         devices = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
24947066

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Some sonic devices config the interface using interface name instead of interface alias, which causes graph facts mismatch.

#### How did you do it?
Per device, get all ports first, and check whether the input is alias or name, if the input is interface alias, then modify it to interface name.

#### How did you verify/test it?
Deploy several testbeds, no issue

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
