### PR TITLE
[Fanout] Refactor ansible-playbook for deploying SONiC 202205 fanout switch

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202205.yml
@@ -27,8 +27,21 @@
       register: teamd_container
 
     - name: disable feature teamd and remove container
-      shell: "config feature state teamd disabled && sleep 10 && docker rm teamd"
-      become: true
+      block:
+        - name: disable feature teamd
+          shell: config feature state teamd disabled
+          become: true
+        - name: ensure teamd container is stopped
+          docker_container:
+            name: teamd
+            state: stopped
+          become: true
+          ignore_errors: yes
+        - name: remove teamd container
+          docker_container:
+            name: teamd
+            state: absent
+          become: true
       when: teamd_container.stdout != ""
 
 - name: SONiC update config db


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Refactor the ansible playbook for deploying SONiC 202205 fanout switches. Use ansible docker module instead of `sleep` to wait for `teamd` container stop.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Refactor the ansible playbook for deploying SONiC 202205 fanout switches. Use ansible docker module instead of `sleep` to wait for `teamd` container stop.

#### How did you do it?
Use ansible docker module instead of `sleep` to wait for `teamd` container stop.

#### How did you verify/test it?
Verified by re-deploy `Nokia-7215` fanout switches.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
