### PR TITLE
Fix testcase failure for test_check_sfp_using_ethtool

### DIFF
--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -33,7 +33,7 @@ def test_check_sfp_using_ethtool(duthosts, rand_one_dut_hostname,
     for intf in conn_graph_facts["device_conn"][duthost.hostname]:
         if intf not in xcvr_skip_list[duthost.hostname]:
             intf_lanes = ports_config[intf]["lanes"]
-            sfp_id = int(intf_lanes.split(",")[0])/lanes_divider + 1
+            sfp_id = int(intf_lanes.split(",")[0])//lanes_divider + 1
 
             ethtool_sfp_output = duthost.command(
                 "sudo ethtool -m sfp%s" % str(sfp_id))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
It seems that testcase test_check_sfp_using_ethtool is failing with the below traceback on Mellanox with 202305 image.

```

  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 116, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 80, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 192, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/azp/_work/32/s/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py", line 38, in test_check_sfp_using_ethtool
    ethtool_sfp_output = duthost.command(
  File "/azp/_work/32/s/tests/common/devices/multi_asic.py", line 118, in _run_on_asics
    return getattr(self.sonichost, self.multi_asic_attr)(*module_args, **complex_args)
  File "/azp/_work/32/s/tests/common/devices/base.py", line 127, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
tests.common.errors.RunAnsibleModuleFail: run module command failed, Ansible Results =>
{"changed": true, "cmd": ["sudo", "ethtool", "-m", "sfp1.0"], "delta": "0:00:00.249949", "end": "2023-09-08 08:18:37.337801", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2023-09-08 08:18:37.087852", "stderr": "Cannot get module EEPROM information: No such device", "stderr_lines": ["Cannot get module EEPROM information: No such device"], "stdout": "", "stdout_lines": [], "warnings": ["Consider using 'become', 'become_method', and 'become_user' rather than running sudo"]}

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The traceback mentioned above is seen on 202305 image since sfp_id is invalid on 202305 and master image.
https://github.com/sonic-net/sonic-mgmt/blob/1b71d445b5a3bce48e03ebbad1a5a7fce2334fab/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py#L36

This is because with Python version < 3, the operator "/" returned an integer. However, with Python version >=3, the operator "/" returns float.
This creates an invalid sfp_id (for example sfp_id=sfp1**.0** instead of sfp_id=sfp1)

#### How did you do it?
For fixing this issue, we are now using "//" instead of "/" to divide so that the result is an integer.

#### How did you verify/test it?
Ran automated test on Mellanox and ensured that the testcase passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
