### PR TITLE
[PR test issue]Fix br1 mac issue

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -171,16 +171,6 @@
   include_tasks: internal_mgmt_network.yml
   when: internal_mgmt_network is defined and internal_mgmt_network == True
 
-- name: Fix the MAC address of br1 on server
-  block:
-    - name: Get current MAC address of br1
-      shell: cat /sys/class/net/br1/address
-      register: br1_mac
-    - name: Explicitly set current br1 MAC address to br1
-      shell: ip link set dev br1 address {{ br1_mac.stdout }}
-      become: yes
-      when: br1_mac.stdout != "00:00:00:00:00:00"
-
 - block:
     - getent:
         database: passwd

--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -46,16 +46,6 @@ if ! ifconfig br1; then
     echo "br1 not found, creating bridge network"
     brctl addbr br1
     brctl show br1
-else
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    echo
-    echo "  br1 exists, possibly lab server, are you sure you want to continue?"
-    echo
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    echo
-    echo
-    echo "Please double check and manually configure IP for br1 to avoid breaking lab server connectivity"
-    exit 0
 fi
 echo
 

--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -41,15 +41,33 @@ if ! command -v ethtool; then
 fi
 echo
 
-echo "STEP 5: Checking if bridge br1 already exists..."
+# todo, add parameter to indicate whether remove br1 forcefully
+echo "STEP 5: Remove existed br1..."
+if ifconfig br1; then
+    echo "br1 exists, remove it."
+    ifconfig br1 down
+    brctl delbr br1
+fi
+
+echo "STEP 6: Checking if bridge br1 already exists..."
 if ! ifconfig br1; then
     echo "br1 not found, creating bridge network"
     brctl addbr br1
     brctl show br1
+else
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo
+    echo "  br1 exists, possibly lab server, are you sure you want to continue?"
+    echo
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo
+    echo
+    echo "Please double check and manually configure IP for br1 to avoid breaking lab server connectivity"
+    exit 0
 fi
 echo
 
-echo "STEP 6: Configuring br1 interface..."
+echo "STEP 7: Configuring br1 interface..."
 echo "Assigning 10.250.0.1/24 to br1"
 ifconfig br1 10.250.0.1/24
 ifconfig br1 inet6 add fec0::1/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
New PR test issue detected: ptf's mgmt-ip not ready after 5 mins during add-topo.

Sample:

 
[Test plan 64fe6dd33c845190cd12fd82: GitHub_PullRequest_PR_15836_BUILD_359729_JOB_kvmtest-t0_by_Elastictest - Elastictest (elastictest.org)](https://elastictest.org/scheduler/testplan/64fe6dd33c845190cd12fd82?testcase=testbed_q_sonic-elastictest-prod-vmss-D8s-v3_19465_vms-kvm-t0_prepare.log&type=prepare)

This is caused by [#9877](https://github.com/sonic-net/sonic-mgmt/pull/9877), it causes the newly initialized br1 to have the wrong mac address so ptf’s mgmt-ip is not reachable.
The issue only can be reproduced on the VM that haven’t set up br1 yet, so it can pass the PR test.

The fix will remove br1 to refresh, so that this kind of corner case will be gated away as expected.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
