### PR TITLE
Fix acl outer vlan test

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -30,7 +30,7 @@ pytestmark = [
 ]
 
 DEFAULT_VLANID = 1000
-ACL_COUNTERS_UPDATE_INTERVAL = 10
+ACL_COUNTERS_UPDATE_INTERVAL = 15
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, "files")
 TEMPLATES_DIR = os.path.join(BASE_DIR, "templates")
@@ -266,8 +266,7 @@ def send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_ac
         dst_port: Destination port
         pkt_action: Packet action (forward or drop)
     """
-
-    ptfadapter.dataplane.flush()
+    ptfadapter.reinit()
     logger.info("Send packet from port {} to port {}".format(src_port, dst_port))
     testutils.send(ptfadapter, src_port, pkt)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to fix `test_acl_outer_vlan.py`.
The test cases are failing because 
1. The `arp_responder.py` in `ansible/roles/test/files/helpers/` is not Python3 compatible. 
There are two `arp_responder.py` script. One is [ansible/roles/test/files/helpers/arp_responder.py](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/test/files/helpers/arp_responder.py), the other one is [tests/scripts/arp_responder.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/scripts/arp_responder.py). 
The outer vlan tests are using the first one, which is not Python3 compatible.

2. The TCP connection between `ptfadapter` and `ptf_nn_agent` is not stable enough. The connection is being reset frequently, which results in packet drop. 
![image](https://github.com/sonic-net/sonic-mgmt/assets/66248323/046de0ec-c2e3-4158-9e91-48c152629308)

To workaround, I reestablish the connection before each sending.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The PR is to fix `test_acl_outer_vlan.py`.

#### How did you do it?
1. Improve `ansible/roles/test/files/helpers/arp_responder.py` to be python3 compatible.
2. Reestablish the TCP connection between `ptfadapter` and `ptf_nn_agent` before each sending.
 
#### How did you verify/test it?
The change is verified on a Mellanox T0 testbed.
```
collected 16 items                                                                                                                                                                                    

acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv4] PASSED                                                                                                         [  6%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4] PASSED                                                                                                           [ 12%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv4]  ^HPASSED                                                                                                       [ 18%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv4] PASSED                                                                                                         [ 25%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv4] PASSED                                                                                                [ 31%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv4] PASSED                                                                                                  [ 37%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv4] PASSED                                                                                              [ 43%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv4] PASSED                                                                                                [ 50%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                       [ 56%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                         [ 62%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                     [ 68%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                       [ 75%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                              [ 81%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                [ 87%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                            [ 93%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                              [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
