### PR TITLE
Fix test_route_flow_counter

### DIFF
--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -45,7 +45,7 @@ def skip_if_not_supported(is_route_flow_counter_supported):     # noqa F811
 
 
 @pytest.fixture(scope='function', autouse=True)
-def clear_route_flow_counter(rand_selected_dut):
+def clear_route_flow_counter(rand_selected_dut, skip_if_not_supported):
     """Clear route flow counter configuration
 
     Args:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `test_route_flow_counter` when ran on supported platforms
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
When `test_route_flow_counter` is ran on unsupported platform, it fails due to `clear_route_flow_counter` fixture running which assumes that platform is supported.

Independent pytest fixtures can run even if one causes the test function to skip. The `clear_route_flow_counter` fixture should not run if the test is skipped (due to lack of support) so the appropriate fixture arg should be included to mark the dependency.

#### How did you do it?
Added `skip_if_not_supported` as a dependency of `clear_route_flow_counter`. By doing this, if test is skipped because there is a lack of support then `clear_route_flow_counter` will not run.

#### How did you verify/test it?
Verified that test is skipped on unsupported platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
