### PR TITLE
[Cherry Pick] 202012 Fix dual-tor dhcpv6 relay test cases failure

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_counter_test.py
@@ -61,6 +61,8 @@ class DHCPCounterTest(DataplaneBaseTest):
         self.dut_mac = self.test_params['dut_mac']
         self.vlan_ip = self.test_params['vlan_ip']
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
+        self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
         # Shutdown and startup the client interface to generate a proper IPv6 link-local address
@@ -97,7 +99,10 @@ class DHCPCounterTest(DataplaneBaseTest):
 
     def create_server_packet(self, message):
         packet = Ether(dst=self.dut_mac)
-        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet /= DHCP6OptRelayMsg()


### PR DESCRIPTION
Summary:
Cherry pick (https://github.com/sonic-net/sonic-mgmt/pull/9842) to 202012

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry pick (https://github.com/sonic-net/sonic-mgmt/pull/9842) to 202012
Code gap is big, solution refined based on 202012 base code.

#### How did you do it?


#### How did you verify/test it?
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter

<img width="1068" alt="image" src="https://github.com/sonic-net/sonic-mgmt/assets/111116206/aa3379ea-2e64-41ad-a7d2-76d73e090962">

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
