### PR TITLE
Reproduce memory spike issue of telemetry server introduced by gNMI client

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -87,14 +87,17 @@ def clear_failed_flag_and_restart(duthost, container_name):
     Returns:
         None
     """
-    logger.info("{} hits start limit and clear reset-failed flag".format(container_name))
+    logger.info("Clearing reset-failed flag of container '{}'".format(container_name))
     duthost.shell("sudo systemctl reset-failed {}.service".format(container_name))
-    duthost.shell("sudo systemctl start {}.service".format(container_name))
+    logger.info("reset-failed flag of container '{}' is cleared".format(container_name))
+    logger.info("Container '{}' is being restarted ...".format(container_name))
+    duthost.shell("sudo systemctl restart {}.service".format(container_name))
     restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
                            CONTAINER_CHECK_INTERVAL_SECS,
                            0,
                            check_container_state, duthost, container_name, True)
     pytest_assert(restarted, "Failed to restart container '{}' after reset-failed was cleared".format(container_name))
+    logger.info("Container '{}' is restarted.".format(container_name))
 
 
 def get_group_program_info(duthost, container_name, group_name):


### PR DESCRIPTION
…ed by gNMI client.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR aims to test whether memory spike issue occurred on gNMI server side can be reproduced or not by gNMI client. The memory spike issue was caused by large amount of TCP connections created by gNMI client.

#### How did you do it?
1. This PR will issue the command to start gNMI client in the corresponding PTF docker.
2. This PR will check whether memory usage of telemetry container increases continuously or not.
3. No matter the testing passed or failed, gNMI client will be terminated and telemetry container will be restarted.

#### How did you verify/test it?
telemetry/test_telemetry.py::test_mem_spike[ if status == 3 for 1 times within 2 cycles then exec "/usr/bin/restart_service telemetry" repeat every 2 cycles]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
