### PR TITLE
Fix 're' not defined issue in 202012 PR test static analysis

### DIFF
--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
@@ -266,12 +267,12 @@ def verify_orchagent_running_or_assert(duthost):
     """
     Verifies that orchagent is running, asserts otherwise
 
-    Args: 
+    Args:
         duthost: Device Under Test (DUT)
     """
-   
+
     def _orchagent_running():
-        cmds = 'docker exec swss supervisorctl status orchagent' 
+        cmds = 'docker exec swss supervisorctl status orchagent'
         output = duthost.shell(cmds, module_ignore_errors=True)
         pytest_assert(not output['rc'], "Unable to check orchagent status output")
         return 'RUNNING' in output['stdout']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1124,8 +1124,8 @@ def generate_dut_feature_list(request, duts_selected, asics_selected):
                 else:
                     tuple_list.append((a_dut, a_asic, None))
         else:
-            if "features" in meta[dut]:
-                for a_feature in meta[dut]["features"].keys():
+            if "features" in meta[a_dut]:
+                for a_feature in meta[a_dut]["features"].keys():
                     if a_feature not in skip_feature_list:
                         tuple_list.append((a_dut, None, a_feature))
             else:

--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert

--- a/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
+++ b/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_require

--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -1,3 +1,6 @@
+import re
+
+
 REQUIRED_PATTERNS = {
     "time_span": [
         "SAI_CREATE_SWITCH",

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -4,6 +4,7 @@ Test the feature of monitoring critical processes on 20191130 image (Monit),
 """
 from collections import defaultdict
 import logging
+import time
 
 import pytest
 

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -1,4 +1,5 @@
 import os
+import time
 import pytest
 import logging
 

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import logging
 
@@ -151,7 +152,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         # Redirect logs to tmpfs
         #
         duthost.shell("sudo mkdir {}".format(LOG_DIR))
-        
+
         conf_path = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "000-ro_disk.conf")
         duthost.copy(src=conf_path, dest="/etc/rsyslog.d/000-ro_disk.conf")
@@ -166,7 +167,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         time.sleep(2)
 
         # Remove file, so the reboot at the end of test will revert this logs redirect.
-        duthost.shell("rm /etc/rsyslog.d/000-ro_disk.conf") 
+        duthost.shell("rm /etc/rsyslog.d/000-ro_disk.conf")
 
         # Set disk in RO state
         simulate_ro(duthost)
@@ -178,7 +179,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         #   Monit does not start upon boot for 5 minutes.
         #   Note: Monit invokes disk check every 5 cycles/minutes
         #   We need to wait solid +10mins before concluding.
-        #         
+        #
         res = wait_until(900, 20, 0, chk_ssh_remote_run, localhost, dutip,
                 ro_user, ro_pass, "cat /etc/passwd")
         logger.info("res={}".format(res))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
All PR test of 202012 branch failed at static analysis stage with below error:
```
E   ConftestImportFailure: (local('/var/src/sonic-mgmt/tests/platform_tests/conftest.py'), (<type 'exceptions.NameError'>, NameError("name 're' is not defined",), <traceback object at 0x7f97b817ba00>))
```

The reason is that module 're' is not imported in file `tests/platform_tests/reboot_timing_constants.py`. The issue has been there for a long time. Recently the sonic-mgmt docker image was upgraded to use python3 as default and somehow exposed this issue.

#### How did you do it?
The fix is to add `import re` to the affected file. Only 202012 branch has this issue.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
