### PR TITLE
[test_reload_config] Fix `test_reload_configuration_checks`

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -44,29 +44,12 @@ def config_system_checks_passed(duthost, delayed_services=[]):
         if int(out['stdout'].strip()) < 120:
             return False
 
-    logging.info("Checking delayed services")
-    # let's cache the delayed services in the function argument
-    if not delayed_services:
-        list_timer_out = duthost.shell(
-            "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'",
-            module_ignore_errors=True
-        )
-        if not list_timer_out["failed"]:
-            check_timer_out = duthost.shell(
-                "systemctl is-enabled %s" % list_timer_out["stdout"].replace("\n", " "),
-                module_ignore_errors=True
-            )
-            if not check_timer_out["failed"]:
-                timers = [_.strip() for _ in list_timer_out["stdout"].strip().splitlines()]
-                states = [_.strip() for _ in check_timer_out["stdout"].strip().splitlines()]
-                delayed_services.extend(
-                    timer.replace("timer", "service") for timer, state in zip(timers, states) if state == "enabled"
-                )
-
+    logging.info("Checking delayed services: %s", delayed_services)
     for service in delayed_services:
         out = duthost.shell("systemctl is-active %s" % service, module_ignore_errors=True)
         if out["stdout"].strip().lower() != "active":
             return False
+
     logging.info("All checks passed")
     return True
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -85,6 +85,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     @summary: This test case is to test various system checks in config reload
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    delayed_services = []
 
     if not config_force_option_supported(duthost):
         return
@@ -103,7 +104,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     # config reload command shouldn't work immediately after system reboot
     assert "Retry later" in out['stdout']
 
-    assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
+    assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
 
     # After the system checks succeed the config reload command should not throw error
     out = duthost.shell("sudo config reload -y",
@@ -119,7 +120,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     out = duthost.shell("sudo config reload -y",
                         executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
-    assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
+    assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
 
     logging.info("Stopping swss docker and checking config reload")
     if duthost.is_multi_asic:
@@ -138,7 +139,7 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     out = duthost.shell("sudo config reload -y -f", executable="/bin/bash")
     assert "Retry later" not in out['stdout']
 
-    assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
+    assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
 
 
 def check_interfaces_config_service_status(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

`test_reload_configuration_checks` failed occasionally due to:
1. `config reload` fails after reboot due to the delayed services are not active.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Enable `config_system_checks_passed` to check delayed services' states.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
