### PR TITLE
[Cherry Pick] 202205 Fix dual-tor dhcpv6 relay test cases failure

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -82,6 +82,8 @@ class DHCPCounterTest(DataplaneBaseTest):
         self.dut_mac = self.test_params['dut_mac']
         self.vlan_ip = self.test_params['vlan_ip']
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
+        self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
         self.reference = 0
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
@@ -127,7 +129,10 @@ class DHCPCounterTest(DataplaneBaseTest):
 
     def create_server_packet(self, message):
         packet = ptf.packet.Ether(dst=self.dut_mac)
-        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         if self.reference % 3 == 0:
@@ -141,7 +146,10 @@ class DHCPCounterTest(DataplaneBaseTest):
 
     def create_unknown_server_packet(self):
         packet = ptf.packet.Ether(dst=self.dut_mac)
-        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
 

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -1,5 +1,6 @@
 import os
 import ast
+import socket
 import subprocess
 import scapy
 import ipaddress
@@ -28,7 +29,7 @@ DHCP6OptClientId = scapy.layers.dhcp6.DHCP6OptClientId
 DHCP6OptOptReq = scapy.layers.dhcp6.DHCP6OptOptReq
 DHCP6OptElapsedTime = scapy.layers.dhcp6.DHCP6OptElapsedTime
 DHCP6OptIA_NA = scapy.layers.dhcp6.DHCP6OptIA_NA
-DUID_LLT = scapy.layers.dhcp6.DUID_LLT
+DUID_LL = scapy.layers.dhcp6.DUID_LL
 DHCP6OptIfaceId = scapy.layers.dhcp6.DHCP6OptIfaceId
 DHCP6OptServerId = scapy.layers.dhcp6.DHCP6OptServerId
 
@@ -122,11 +123,11 @@ class DHCPTest(DataplaneBaseTest):
         self.relay_iface_mac = self.test_params['relay_iface_mac']
         self.relay_link_local = self.test_params['relay_link_local']
         self.relay_linkaddr = '::'
-
         self.vlan_ip = self.test_params['vlan_ip']
-
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
         self.uplink_mac = self.test_params['uplink_mac']
+        self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
         # Shutdown and startup the client interface to generate a proper IPv6 link-local address
@@ -157,30 +158,26 @@ class DHCPTest(DataplaneBaseTest):
         solicit_packet /= IPv6(src=self.client_link_local, dst=self.BROADCAST_IP)
         solicit_packet /= packet.UDP(sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_packet /= DHCP6_Solicit(trid=12345)
-        solicit_packet /= DHCP6OptClientId(duid=DUID_LLT(lladdr=self.client_mac))
+        solicit_packet /= DHCP6OptClientId(duid=DUID_LL(lladdr=self.client_mac))
         solicit_packet /= DHCP6OptIA_NA()
         solicit_packet /= DHCP6OptOptReq(reqopts=[23, 24, 29])
         solicit_packet /= DHCP6OptElapsedTime(elapsedtime=0)
 
         return solicit_packet
 
-    # order: relay forward option list sequence
-    # 0 - increase order, 1 - decrease order
-    def create_dhcp_solicit_relay_forward_packet(self, order):
+    def create_dhcp_solicit_relay_forward_packet(self):
         solicit_relay_forward_packet = packet.Ether(src=self.uplink_mac)
         solicit_relay_forward_packet /= IPv6()
         solicit_relay_forward_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip,
                                                            peeraddr=self.client_link_local)
-        if order == 1:
-            solicit_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
-
         solicit_relay_forward_packet /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345) /
-                                                         DHCP6OptClientId(duid=DUID_LLT(lladdr=self.client_mac)) /
+                                                         DHCP6OptClientId(duid=DUID_LL(lladdr=self.client_mac)) /
                                                          DHCP6OptIA_NA()/DHCP6OptOptReq(reqopts=[23, 24, 29]) /
                                                          DHCP6OptElapsedTime(elapsedtime=0)])
-        if order == 0:
-            solicit_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
+        if self.is_dualtor:
+            solicit_relay_forward_packet /= DHCP6OptIfaceId(ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
+        solicit_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
 
         return solicit_relay_forward_packet
 
@@ -194,7 +191,10 @@ class DHCPTest(DataplaneBaseTest):
 
     def create_dhcp_advertise_relay_reply_packet(self):
         advertise_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
-        advertise_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            advertise_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            advertise_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         advertise_relay_reply_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         advertise_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,
                                                          peeraddr=self.client_link_local)
@@ -209,20 +209,17 @@ class DHCPTest(DataplaneBaseTest):
 
         return request_packet
 
-    # order: relay forward option list sequence
-    # 0 - increase order, 1 - decrease order
-    def create_dhcp_request_relay_forward_packet(self, order):
+    def create_dhcp_request_relay_forward_packet(self):
         request_relay_forward_packet = packet.Ether(src=self.uplink_mac)
         request_relay_forward_packet /= IPv6()
         request_relay_forward_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         request_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip,
                                                            peeraddr=self.client_link_local)
-        if order == 1:
-            request_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
-
         request_relay_forward_packet /= DHCP6OptRelayMsg(message=[DHCP6_Request(trid=12345)])
-        if order == 0:
-            request_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
+
+        if self.is_dualtor:
+            request_relay_forward_packet /= DHCP6OptIfaceId(ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
+        request_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
 
         return request_relay_forward_packet
 
@@ -236,7 +233,10 @@ class DHCPTest(DataplaneBaseTest):
 
     def create_dhcp_reply_relay_reply_packet(self):
         reply_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
-        reply_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            reply_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            reply_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         reply_relay_reply_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         reply_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,
                                                      peeraddr=self.client_link_local)
@@ -266,18 +266,23 @@ class DHCPTest(DataplaneBaseTest):
         relayed_relay_packet /= DHCP6_RelayForward(msgtype=12, hopcount=1, linkaddr=self.relay_linkaddr,
                                                    peeraddr=self.client_link_local)
         relayed_relay_packet /= DHCP6OptRelayMsg(message=[packet_inside])
+        if self.is_dualtor:
+            relayed_relay_packet /= DHCP6OptIfaceId(ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
 
         return relayed_relay_packet
 
     def create_dhcp_relay_relay_reply_packet(self):
         relay_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
-        relay_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        if self.is_dualtor:
+            relay_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            relay_relay_reply_packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         relay_relay_reply_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         relay_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, hopcount=1, linkaddr=self.vlan_ip,
                                                      peeraddr=self.client_link_local)
         packet_inside = DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
-        relay_relay_reply_packet /= DHCP6OptServerId(duid=DUID_LLT(lladdr="00:11:22:33:44:55"))
+        relay_relay_reply_packet /= DHCP6OptServerId(duid=DUID_LL(lladdr="00:11:22:33:44:55"))
         relay_relay_reply_packet /= DHCP6OptRelayMsg(message=[packet_inside])
 
         return relay_relay_reply_packet
@@ -304,9 +309,9 @@ class DHCPTest(DataplaneBaseTest):
 
     # Verify that the DHCP relay actually received and relayed the DHCPv6 SOLICIT message to all of
     # its known DHCP servers.
-    def verify_relayed_solicit_relay_forward(self, try_count=0):
+    def verify_relayed_solicit_relay_forward(self):
         # Create a packet resembling a DHCPv6 RELAY-FORWARD encapsulating SOLICIT packet
-        solicit_relay_forward_packet = self.create_dhcp_solicit_relay_forward_packet(order=try_count)
+        solicit_relay_forward_packet = self.create_dhcp_solicit_relay_forward_packet()
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(solicit_relay_forward_packet)
@@ -322,17 +327,8 @@ class DHCPTest(DataplaneBaseTest):
         masked_packet.set_do_not_care_scapy(scapy.layers.dhcp6.DHCP6_RelayForward, "linkaddr")
         masked_packet.set_do_not_care_scapy(DHCP6OptClientLinkLayerAddr, "clladdr")
 
-        # Count the number of these packets received on the ports connected to our leaves
-        solicit_count = testutils.count_matched_packets_all_ports(self, masked_packet,
-                                                                  self.server_port_indices, timeout=4.0)
-
-        if try_count == 0:
-            if solicit_count >= 1:
-                return True
-            return False
-
-        self.assertTrue(solicit_count >= 1, "Failed: Solicit count of %d" % solicit_count)
-        return True
+        # verify packets received on the ports connected to our leaves
+        testutils.verify_packet_any_port(self, masked_packet, self.server_port_indices)
 
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating ADVERTISE packet message to client.
     # We do this by injecting a RELAY-REPLY encapsulating ADVERTISE message on the link connected to one
@@ -351,7 +347,7 @@ class DHCPTest(DataplaneBaseTest):
         # Mask off fields we don't care about matching
         masked_packet = Mask(advertise_packet)
         masked_packet.set_do_not_care_scapy(IPv6, "fl")
-        masked_packet.set_do_not_care_scapy(IPv6, "src")  # dual tor uses relay_iface_ip as ip src
+        # dual tor uses loopback0 ipv6 address as source
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 
@@ -366,9 +362,9 @@ class DHCPTest(DataplaneBaseTest):
 
     # Verify that the DHCP relay actually received and relayed the DHCPv6 REQUEST message to all of
     # its known DHCP servers.
-    def verify_relayed_request_relay_forward(self, try_count=0):
+    def verify_relayed_request_relay_forward(self):
         # Create a packet resembling a DHCPv6 RELAY-FORWARD encapsulating REQUEST packet
-        request_relay_forward_packet = self.create_dhcp_request_relay_forward_packet(try_count)
+        request_relay_forward_packet = self.create_dhcp_request_relay_forward_packet()
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(request_relay_forward_packet)
@@ -384,17 +380,8 @@ class DHCPTest(DataplaneBaseTest):
         masked_packet.set_do_not_care_scapy(scapy.layers.dhcp6.DHCP6_RelayForward, "linkaddr")
         masked_packet.set_do_not_care_scapy(DHCP6OptClientLinkLayerAddr, "clladdr")
 
-        # Count the number of these packets received on the ports connected to our leaves
-        request_count = testutils.count_matched_packets_all_ports(self, masked_packet,
-                                                                  self.server_port_indices, timeout=4.0)
-
-        if try_count == 0:
-            if request_count >= 1:
-                return True
-            return False
-
-        self.assertTrue(request_count >= 1, "Failed: Request count of %d" % request_count)
-        return True
+        # verify packets received on the ports connected to our leaves
+        testutils.verify_packet_any_port(self, masked_packet, self.server_port_indices)
 
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating REPLY packet message to client.
     def server_send_reply_relay_reply(self):
@@ -411,7 +398,7 @@ class DHCPTest(DataplaneBaseTest):
         # Mask off fields we don't care about matching
         masked_packet = Mask(reply_packet)
         masked_packet.set_do_not_care_scapy(IPv6, "fl")
-        masked_packet.set_do_not_care_scapy(IPv6, "src")  # dual tor uses relay_iface_ip as ip src
+        #  dual tor uses loopback0 ipv6 address as source
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 
@@ -441,10 +428,8 @@ class DHCPTest(DataplaneBaseTest):
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
 
-        relayed_relay_forward_count = testutils.count_matched_packets_all_ports(self, masked_packet,
-                                                                                self.server_port_indices, timeout=4.0)
-        self.assertTrue(relayed_relay_forward_count >= 1, "Failed: Relayed Relay Forward count of %d"
-                        % relayed_relay_forward_count)
+        # verify packets received on the ports connected to our leaves
+        testutils.verify_packet_any_port(self, masked_packet, self.server_port_indices)
 
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating RELAY-REPLY packet message to next relay agent
     def server_send_relay_relay_reply(self):
@@ -469,18 +454,12 @@ class DHCPTest(DataplaneBaseTest):
         testutils.verify_packet(self, masked_packet, self.client_port_index)
 
     def runTest(self):
-        for x in range(2):
-            self.client_send_solicit()
-            if self.verify_relayed_solicit_relay_forward(x):
-                break
-
+        self.client_send_solicit()
+        self.verify_relayed_solicit_relay_forward()
         self.server_send_advertise_relay_reply()
         self.verify_relayed_advertise()
-        for x in range(2):
-            self.client_send_request()
-            if self.verify_relayed_request_relay_forward(x):
-                break
-
+        self.client_send_request()
+        self.verify_relayed_request_relay_forward()
         self.server_send_reply_relay_reply()
         self.verify_relayed_reply()
         self.client_send_relayed_relay_forward()

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_202205.yaml
@@ -28,14 +28,6 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[wa
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6656
 
-dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
-  xfail:
-    reason: "test issue or image issue, to be RCA'ed"
-    conditions:
-      - "release in ['202205']"
-      - "'dualtor' in topo_name"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6658
-
 ipfwd/test_dir_bcast.py::test_dir_bcast:
   xfail:
     reason: "test issue or image issue, to be RCA'ed"

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -64,7 +64,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
     """
     duthost = duthosts[rand_one_dut_hostname]
     dhcp_relay_data_list = []
-    uplink_interface_link_local = ""
+    downlink_interface_link_local = ""
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -127,19 +127,24 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
                     if not iface_is_portchannel_member:
                         uplink_interfaces.append(iface_name)
                     uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
-        if uplink_interface_link_local == "":
+        if downlink_interface_link_local == "":
             command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1"\
-                      .format(uplink_interfaces[0])
+                      .format(downlink_vlan_iface['name'])
             res = duthost.shell(command)
             if res['stdout'] != "":
-                uplink_interface_link_local = res['stdout']
+                downlink_interface_link_local = res['stdout']
 
         dhcp_relay_data = {}
         dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
         dhcp_relay_data['client_iface'] = client_iface
         dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
-        dhcp_relay_data['uplink_interface_link_local'] = uplink_interface_link_local
+        dhcp_relay_data['downlink_interface_link_local'] = downlink_interface_link_local
+        dhcp_relay_data['loopback_ipv6'] = mg_facts['minigraph_lo_interfaces'][1]['addr']
+        if 'dualtor' in tbinfo['topo']['name']:
+            dhcp_relay_data['is_dualtor'] = True
+        else:
+            dhcp_relay_data['is_dualtor'] = False
 
         res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
         dhcp_relay_data['uplink_mac'] = res['stdout']
@@ -212,19 +217,27 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['downlink_interface_link_local']),
                            "dut_mac": str(dhcp_relay['uplink_mac']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
+                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log", is_python3=True)
 
         for message in messages:
-            get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'\
-                          .format(dhcp_relay['downlink_vlan_iface']['name'], message)
-            message_count = duthost.shell(get_message)['stdout']
-            assert int(message_count) > 0, "Missing {} count".format(message)
+            if message == "Relay-Reply" and dhcp_relay['is_dualtor']:
+                get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|Loopback0" {}'.format(message)
+                message_count = duthost.shell(get_message)['stdout']
+                assert int(message_count) > 0, "Missing {} count".format(message)
+            else:
+                get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'\
+                              .format(dhcp_relay['downlink_vlan_iface']['name'], message)
+                message_count = duthost.shell(get_message)['stdout']
+                assert int(message_count) > 0, "Missing {} count".format(message)
 
 
-def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
+def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                            toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
@@ -244,9 +257,11 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['downlink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -288,9 +303,11 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['downlink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -343,7 +360,9 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
+                           "relay_link_local": str(dhcp_relay['downlink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac'])},
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)


### PR DESCRIPTION
Summary:
Cherry pick (https://github.com/sonic-net/sonic-mgmt/pull/9842) to 202205

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry pick (https://github.com/sonic-net/sonic-mgmt/pull/9842) to 202205
Code gap is big, solution refined based on 202205 base code.

#### How did you do it?


#### How did you verify/test it?
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter

<img width="1073" alt="image" src="https://github.com/sonic-net/sonic-mgmt/assets/111116206/c21adae6-fb0a-4649-a136-db3a8b1c62be">


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
