### PR TITLE
[testfix]Fixed failures caused by python 3 conversion.

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
@@ -43,6 +43,7 @@
 
 import os.path
 import json
+import base64
 from datetime import datetime
 import logging
 import random
@@ -416,7 +417,7 @@ class VXLAN(BaseTest):
                             vxlan_vni=vni,
                             inner_frame=exp_pkt,
                             **options_v6)
-                    send_packet(self, ptf_port, str(pkt))
+                    send_packet(self, ptf_port, pkt)
 
                 # After we sent all packets, wait for the responses.
                 if expect_success:
@@ -482,8 +483,6 @@ class VXLAN(BaseTest):
                         masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
                                                              "hlim")
                         masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "chksum")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
                                                              "dst")
                         masked_exp_pkt.set_do_not_care_scapy(scapy.UDP,
                                                              "sport")
@@ -513,7 +512,9 @@ class VXLAN(BaseTest):
                     self.downed_endpoints)
 
             pkt.load = '0' * 60 + str(len(self.packets))
-            self.packets.append((ptf_port, str(pkt).encode("base64")))
+            b = base64.b64encode(bytes(str(pkt), 'utf-8')) # bytes
+            base64_str = b.decode('utf-8') # convert bytes to string
+            self.packets.append((ptf_port, base64_str))
 
         finally:
             Logger.info("")
@@ -671,7 +672,7 @@ class VxLAN_in_VxLAN(VXLAN):
                             vxlan_vni=vni,
                             inner_frame=exp_pkt,
                             **options_v6)
-                    send_packet(self, ptf_port, str(pkt))
+                    send_packet(self, ptf_port, pkt)
 
                 # After we sent all packets, wait for the responses.
                 if expect_success:
@@ -768,7 +769,9 @@ class VxLAN_in_VxLAN(VXLAN):
                     self.downed_endpoints)
 
             pkt.load = '0' * 60 + str(len(self.packets))
-            self.packets.append((ptf_port, str(pkt).encode("base64")))
+            b = base64.b64encode(bytes(str(pkt), 'utf-8')) # bytes
+            base64_str = b.decode('utf-8') # convert bytes to string
+            self.packets.append((ptf_port, base64_str))
 
         finally:
             Logger.info("")

--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
@@ -512,8 +512,8 @@ class VXLAN(BaseTest):
                     self.downed_endpoints)
 
             pkt.load = '0' * 60 + str(len(self.packets))
-            b = base64.b64encode(bytes(str(pkt), 'utf-8')) # bytes
-            base64_str = b.decode('utf-8') # convert bytes to string
+            b = base64.b64encode(bytes(str(pkt), 'utf-8'))  # bytes
+            base64_str = b.decode('utf-8')  # convert bytes to string
             self.packets.append((ptf_port, base64_str))
 
         finally:
@@ -769,8 +769,8 @@ class VxLAN_in_VxLAN(VXLAN):
                     self.downed_endpoints)
 
             pkt.load = '0' * 60 + str(len(self.packets))
-            b = base64.b64encode(bytes(str(pkt), 'utf-8')) # bytes
-            base64_str = b.decode('utf-8') # convert bytes to string
+            b = base64.b64encode(bytes(str(pkt), 'utf-8'))  # bytes
+            base64_str = b.decode('utf-8')  # convert bytes to string
             self.packets.append((ptf_port, base64_str))
 
         finally:

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -374,7 +374,7 @@ class Test_VxLAN():
     '''
         Base class for all VxLAN+BFD tests.
     '''
-    setup = {}
+    vxlan_test_setup = {}
 
     def dump_self_info_and_run_ptf(self,
                                    tcname,
@@ -392,19 +392,19 @@ class Test_VxLAN():
         '''
 
         if tolerance is None:
-            tolerance = self.setup['tolerance']
+            tolerance = self.vxlan_test_setup['tolerance']
         if ecmp_utils.Constants['DEBUG']:
             config_filename = "/tmp/vxlan_configs.json"
         else:
             config_filename = "/tmp/vxlan_configs." + tcname +\
                 "-" + encap_type + "-" + str(time.time()) + ".json"
-        self.setup['ptfhost'].copy(content=json.dumps(
+        self.vxlan_test_setup['ptfhost'].copy(content=json.dumps(
             {
-                'vnet_vni_map': self.setup[encap_type]['vnet_vni_map'],
-                'vnet_intf_map': self.setup[encap_type]['vnet_intf_map'],
-                'dest_to_nh_map': self.setup[encap_type]['dest_to_nh_map'],
-                'neighbors': self.setup[encap_type]['neighbor_config'],
-                'intf_to_ip_map': self.setup[encap_type]['intf_to_ip_map'],
+                'vnet_vni_map': self.vxlan_test_setup[encap_type]['vnet_vni_map'],
+                'vnet_intf_map': self.vxlan_test_setup[encap_type]['vnet_intf_map'],
+                'dest_to_nh_map': self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
+                'neighbors': self.vxlan_test_setup[encap_type]['neighbor_config'],
+                'intf_to_ip_map': self.vxlan_test_setup[encap_type]['intf_to_ip_map'],
             },
             indent=4), dest=config_filename)
 
@@ -414,33 +414,33 @@ class Test_VxLAN():
             "show vnet route all",
             "show ip bgp summary",
             "show ipv6 bgp summary"]
-        if self.setup['enable_bfd']:
+        if self.vxlan_test_setup['enable_bfd']:
             cmds.append("show bfd summary")
         for cmd in cmds:
-            self.setup['duthost'].shell(cmd)
+            self.vxlan_test_setup['duthost'].shell(cmd)
 
         ptf_params = {
             "topo_file": "/tmp/vxlan_topo_info.json",
             "config_file": config_filename,
             "t0_ports": ecmp_utils.get_ethernet_ports(
-                self.setup[encap_type]['selected_interfaces'],
-                self.setup['minigraph_facts']),
-            "t2_ports": self.setup[encap_type]['t2_ports'],
-            "dut_mac": self.setup['dut_mac'],
-            "vxlan_port": self.setup['vxlan_port'],
+                self.vxlan_test_setup[encap_type]['selected_interfaces'],
+                self.vxlan_test_setup['minigraph_facts']),
+            "t2_ports": self.vxlan_test_setup[encap_type]['t2_ports'],
+            "dut_mac": self.vxlan_test_setup['dut_mac'],
+            "vxlan_port": self.vxlan_test_setup['vxlan_port'],
             "expect_encap_success": expect_encap_success,
             "packet_count": packet_count,
             "random_dport": random_dport,
             "random_sport": random_sport,
             "random_src_ip": random_src_ip,
             "tolerance": tolerance,
-            "downed_endpoints": list(self.setup['list_of_downed_endpoints'])
+            "downed_endpoints": list(self.vxlan_test_setup['list_of_downed_endpoints'])
         }
         Logger.info("ptf arguments:%s", ptf_params)
         Logger.info(
-            "dest->nh mapping:%s", self.setup[encap_type]['dest_to_nh_map'])
+            "dest->nh mapping:%s", self.vxlan_test_setup[encap_type]['dest_to_nh_map'])
 
-        ptf_runner(self.setup['ptfhost'],
+        ptf_runner(self.vxlan_test_setup['ptfhost'],
                    "ptftests",
                    "vxlan_traffic.VxLAN_in_VxLAN" if payload == 'vxlan'
                    else "vxlan_traffic.VXLAN",
@@ -463,13 +463,13 @@ class Test_VxLAN():
             return
         if isinstance(ip_address_list, str):
             ip_address_list = [ip_address_list]
-        self.setup['list_of_bfd_monitors'] = \
-            self.setup['list_of_bfd_monitors'] | set(ip_address_list)
+        self.vxlan_test_setup['list_of_bfd_monitors'] = \
+            self.vxlan_test_setup['list_of_bfd_monitors'] | set(ip_address_list)
         ecmp_utils.update_monitor_file(
-            self.setup['ptfhost'],
-            self.setup['monitor_file'],
-            self.setup[encap_type]['t2_ports'],
-            list(self.setup['list_of_bfd_monitors']))
+            self.vxlan_test_setup['ptfhost'],
+            self.vxlan_test_setup['monitor_file'],
+            self.vxlan_test_setup[encap_type]['t2_ports'],
+            list(self.vxlan_test_setup['list_of_bfd_monitors']))
 
     def update_down_list(self, bfd_enable, encap_type, ip_address_list):
         '''
@@ -481,15 +481,15 @@ class Test_VxLAN():
             return
         if isinstance(ip_address_list, str):
             ip_address_list = [ip_address_list]
-        self.setup['list_of_downed_endpoints'] = \
-            self.setup['list_of_downed_endpoints'] | set(ip_address_list)
-        self.setup['list_of_bfd_monitors'] = \
-            self.setup['list_of_bfd_monitors'] - set(ip_address_list)
+        self.vxlan_test_setup['list_of_downed_endpoints'] = \
+            self.vxlan_test_setup['list_of_downed_endpoints'] | set(ip_address_list)
+        self.vxlan_test_setup['list_of_bfd_monitors'] = \
+            self.vxlan_test_setup['list_of_bfd_monitors'] - set(ip_address_list)
         ecmp_utils.update_monitor_file(
-            self.setup['ptfhost'],
-            self.setup['monitor_file'],
-            self.setup[encap_type]['t2_ports'],
-            list(self.setup['list_of_bfd_monitors']))
+            self.vxlan_test_setup['ptfhost'],
+            self.vxlan_test_setup['monitor_file'],
+            self.vxlan_test_setup[encap_type]['t2_ports'],
+            list(self.vxlan_test_setup['list_of_bfd_monitors']))
 
 
 class Test_VxLAN_route_tests(Test_VxLAN):
@@ -502,7 +502,7 @@ class Test_VxLAN_route_tests(Test_VxLAN):
             tc1:Create a tunnel route to a single endpoint a.
             Send packets to the route prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.dump_self_info_and_run_ptf("tc1", encap_type, True)
         self.dump_self_info_and_run_ptf("tc1", encap_type, True,
                                         payload="vxlan")
@@ -513,12 +513,12 @@ class Test_VxLAN_route_tests(Test_VxLAN):
             tc2: change the route to different endpoint.
             Packets are received only at endpoint b.")
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         Logger.info("Choose a vnet")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Choose a destination, which is already present.")
-        tc2_dest = list(self.setup[encap_type]
+        tc2_dest = list(self.vxlan_test_setup[encap_type]
                         ['dest_to_nh_map'][vnet].keys())[0]
 
         Logger.info("Create a new endpoint, or endpoint-list.")
@@ -529,7 +529,7 @@ class Test_VxLAN_route_tests(Test_VxLAN):
                 netid=NEXTHOP_PREFIX))
 
         Logger.info("Map the destination to the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc2_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc2_dest] = \
             tc2_new_end_point_list
 
         Logger.info("Create the json and apply the config in the DUT swss.")
@@ -544,15 +544,15 @@ class Test_VxLAN_route_tests(Test_VxLAN):
         #   }
         # ]
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc2_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc2_new_end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc2_new_end_point_list)
 
@@ -566,12 +566,12 @@ class Test_VxLAN_route_tests(Test_VxLAN):
             Send packets to the route prefix dst. packets should not
             be received at any ports with dst ip of b")
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         try:
             Logger.info("Remove the existing routes in the DUT.")
             ecmp_utils.set_routes_in_dut(
-                self.setup['duthost'],
-                self.setup[encap_type]['dest_to_nh_map'],
+                self.vxlan_test_setup['duthost'],
+                self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
                 ecmp_utils.get_payload_version(encap_type),
                 "DEL")
             Logger.info("Verify that the traffic is not coming back.")
@@ -579,11 +579,11 @@ class Test_VxLAN_route_tests(Test_VxLAN):
         finally:
             Logger.info("Restore the routes in the DUT.")
             ecmp_utils.set_routes_in_dut(
-                self.setup['duthost'],
-                self.setup[encap_type]['dest_to_nh_map'],
+                self.vxlan_test_setup['duthost'],
+                self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
                 ecmp_utils.get_payload_version(encap_type),
                 "SET",
-                bfd=self.setup['enable_bfd'])
+                bfd=self.vxlan_test_setup['enable_bfd'])
 
 
 class Test_VxLAN_ecmp_create(Test_VxLAN):
@@ -598,10 +598,10 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             packets to the route 1's prefix dst. packets are received at either
             a1 or a2.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         tc4_end_point_list = []
@@ -616,20 +616,20 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
             tc4_end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc4_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc4_end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'], encap_type, tc4_end_point_list)
+            self.vxlan_test_setup['enable_bfd'], encap_type, tc4_end_point_list)
 
         Logger.info("Verify that the new config takes effect and run traffic.")
 
@@ -643,12 +643,12 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             Remove tunnel route 1. Send multiple packets (varying tuple) to the
             route 1's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
-        backup_dest = self.setup[encap_type]['dest_to_nh_map'][vnet].copy()
+        backup_dest = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].copy()
 
         Logger.info("Create a new list of endpoint(s).")
         ecmp_route1_end_point_list = []
@@ -664,20 +664,20 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][ecmp_route1_new_dest] =\
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][ecmp_route1_new_dest] =\
             ecmp_route1_end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             ecmp_route1_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             ecmp_route1_end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             ecmp_route1_end_point_list)
 
@@ -686,21 +686,21 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
 
         # Deleting Tunnel route 1
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             ecmp_route1_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             ecmp_route1_end_point_list,
             "DEL")
 
-        self.setup[encap_type]['dest_to_nh_map'][vnet] =\
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] =\
             {ecmp_route1_new_dest: ecmp_route1_end_point_list}
 
         Logger.info("Verify that the new config takes effect and run traffic.")
         self.dump_self_info_and_run_ptf("tc5", encap_type, False)
 
         # Restoring dest_to_nh_map to old values
-        self.setup[encap_type]['dest_to_nh_map'][vnet] = backup_dest.copy()
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = backup_dest.copy()
         self.dump_self_info_and_run_ptf("tc5", encap_type, True)
 
     def test_vxlan_configure_route1_ecmp_group_b(self, setUp, encap_type):
@@ -709,7 +709,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             packets to route 2"s prefix dst. packets are received at either a1
             or a2
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_ecmp_group_b(encap_type)
         Logger.info("Verify the configs work and traffic flows correctly.")
         self.dump_self_info_and_run_ptf("tc5", encap_type, True)
@@ -719,14 +719,14 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             Function for handling the dependency of tc6 on tc5. This function
             is essentially tc5.
         '''
-        if self.setup[encap_type].get('tc5_dest', None):
+        if self.vxlan_test_setup[encap_type].get('tc5_dest', None):
             return
         Logger.info("Choose a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Select an existing endpoint.")
         tc5_end_point_list = \
-            list(self.setup[encap_type]['dest_to_nh_map'][vnet].values())[0]
+            list(self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].values())[0]
 
         Logger.info("Create a new destination to use.")
         tc5_new_dest = ecmp_utils.get_ip_address(
@@ -734,25 +734,25 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination to the endpoint.")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc5_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc5_new_dest] = \
             tc5_end_point_list
 
         Logger.info("Create the new config and apply to the DUT.")
 
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc5_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc5_end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc5_end_point_list)
 
-        self.setup[encap_type]['tc5_dest'] = tc5_new_dest
+        self.vxlan_test_setup[encap_type]['tc5_dest'] = tc5_new_dest
 
     def test_vxlan_configure_route2_ecmp_group_b(self, setUp, encap_type):
         '''
@@ -760,11 +760,11 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             packets to route 2"s prefix dst. packets are received at either
             b1 or b2.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_ecmp_group_b(encap_type)
 
         Logger.info("Choose a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoints.")
         tc6_end_point_list = []
@@ -775,23 +775,23 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
                     netid=NEXTHOP_PREFIX))
 
         Logger.info("Choose one of the existing destinations.")
-        tc6_new_dest = self.setup[encap_type]['tc5_dest']
+        tc6_new_dest = self.vxlan_test_setup[encap_type]['tc5_dest']
 
         Logger.info("Map the destination to the new endpoints.")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc6_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc6_new_dest] = \
             tc6_end_point_list
 
         Logger.info("Create the config and apply on the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc6_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc6_end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc6_end_point_list)
         Logger.info("Verify that the traffic works.")
@@ -808,10 +808,10 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             (varying tuple) to the route 1's prefix dst. Packets are received
             only at endpoint a1. Verify advertise table is present.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         end_point_list = []
@@ -827,25 +827,25 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
             end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc4_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         # Only a1 is up, bfd-responder will not respond to a2.
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list[0])
         self.update_down_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list[1])
 
@@ -861,10 +861,10 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             packets (varying tuple) to the route 1's prefix dst. Packets
             are not received at any ports. Verify advertise table is removed.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         end_point_list = []
@@ -879,21 +879,21 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
             end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc4_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         # No adding to the monitor_list.
         self.update_down_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list)
 
@@ -914,10 +914,10 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             dst. Packets are received only at endpoint a2. Verify advertise
             table is present
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         end_point_list = []
@@ -933,25 +933,25 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
             end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc4_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         # Only a2 is up, but a1 is down.
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list[1])
         self.update_down_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list[0])
 
@@ -964,10 +964,10 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             tuple) to the route 1's prefix dst. Packets are received at both
             a1 and a2. Verify advertise table is present
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         end_point_list = []
@@ -982,20 +982,20 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc4_new_dest] = \
             end_point_list
 
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc4_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list)
 
@@ -1006,15 +1006,15 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
         # perform cleanup by removing all the routes added by this test class.
         # reset to add only the routes added in the setup phase.
         ecmp_utils.set_routes_in_dut(
-            self.setup['duthost'],
-            self.setup[encap_type]['dest_to_nh_map'],
+            self.vxlan_test_setup['duthost'],
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
             ecmp_utils.get_payload_version(encap_type),
             "DEL")
 
-        self.setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map_orignal']) # noqa F821
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.vxlan_test_setup[encap_type]['dest_to_nh_map_orignal']) # noqa F821
         ecmp_utils.set_routes_in_dut(
-            self.setup['duthost'],
-            self.setup[encap_type]['dest_to_nh_map'],
+            self.vxlan_test_setup['duthost'],
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
             ecmp_utils.get_payload_version(encap_type),
             "SET")
 
@@ -1028,20 +1028,20 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         '''
             Function to handle dependency of tc9 on tc8.
         '''
-        if self.setup[encap_type].get('tc8_dest', None):
+        if self.vxlan_test_setup[encap_type].get('tc8_dest', None):
             return
 
         Logger.info("Pick a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info(
             "Choose a route 2 destination and a new single endpoint for it.")
         tc8_new_dest = list(
-            self.setup[encap_type]['dest_to_nh_map'][vnet].keys())[0]
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].keys())[0]
         tc8_new_nh = ecmp_utils.get_ip_address(
             af=ecmp_utils.get_outer_layer_version(encap_type),
             netid=NEXTHOP_PREFIX)
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc8_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc8_new_dest] = \
             [tc8_new_nh]
         Logger.info(
             "Using destinations: dest:%s => nh:%s",
@@ -1050,41 +1050,41 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
 
         Logger.info("Map the destination and new endpoint.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc8_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             [tc8_new_nh],
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc8_new_nh)
 
         Logger.info("Apply the new config in the DUT and run traffic test.")
-        self.setup[encap_type]['tc8_dest'] = tc8_new_dest
+        self.vxlan_test_setup[encap_type]['tc8_dest'] = tc8_new_dest
 
     def setup_route2_shared_endpoints(self, encap_type):
         '''
             Function to handle dependency of tc10 on tc9
         '''
-        if self.setup[encap_type].get('tc9_dest', None):
+        if self.vxlan_test_setup[encap_type].get('tc9_dest', None):
             return
         self.setup_route2_single_endpoint(encap_type)
 
         Logger.info("Choose a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info(
             "Select 2 already existing destinations. "
             "They must have 2 different nexthops.")
-        tc9_new_dest1 = self.setup[encap_type]['tc8_dest']
-        nh1 = self.setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1][0]
+        tc9_new_dest1 = self.vxlan_test_setup[encap_type]['tc8_dest']
+        nh1 = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1][0]
 
         nh2 = None
-        for dest in list(self.setup[encap_type]['dest_to_nh_map'][vnet].keys()):
-            nexthops = self.setup[encap_type]['dest_to_nh_map'][vnet][dest]
+        for dest in list(self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].keys()):
+            nexthops = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][dest]
             for nh in nexthops:
                 if nh == nh1:
                     continue
@@ -1101,7 +1101,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             raise RuntimeError(
                 "Couldnot find different nexthop for this test."
                 "The current list: {}".format(
-                    self.setup[encap_type]['dest_to_nh_map']))
+                    self.vxlan_test_setup[encap_type]['dest_to_nh_map']))
 
         Logger.info(
             "Use the selected nexthops(tunnel endpoints)."
@@ -1109,46 +1109,46 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         tc9_new_nhs = [nh1, nh2]
 
         Logger.info("Map the destination 1 to the combined list.")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1] = \
             tc9_new_nhs
 
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc9_new_dest1,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc9_new_nhs,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc9_new_nhs)
 
-        self.setup[encap_type]['tc9_dest'] = tc9_new_dest1
+        self.vxlan_test_setup[encap_type]['tc9_dest'] = tc9_new_dest1
 
     def setup_route2_shared_different_endpoints(self, encap_type):
         '''
             Function to handle dependency of tc9.2 on tc9
         '''
-        if self.setup[encap_type].get('tc9_dest', None):
+        if self.vxlan_test_setup[encap_type].get('tc9_dest', None):
             return
         self.setup_route2_single_endpoint(encap_type)
 
         Logger.info("Choose a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info(
             "Select 2 already existing destinations. "
             "They must have 2 different nexthops.")
-        tc9_new_dest1 = self.setup[encap_type]['tc8_dest']
+        tc9_new_dest1 = self.vxlan_test_setup[encap_type]['tc8_dest']
         old_nh = \
-            self.setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1][0]
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1][0]
 
         nh1 = None
         nh2 = None
-        for dest in list(self.setup[encap_type]['dest_to_nh_map'][vnet].keys()):
-            nexthops = self.setup[encap_type]['dest_to_nh_map'][vnet][dest]
+        for dest in list(self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].keys()):
+            nexthops = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][dest]
             for nh in nexthops:
                 if nh == old_nh:
                     continue
@@ -1169,7 +1169,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             raise RuntimeError(
                 "Couldnot find different nexthop for this test."
                 "The current list: {}".format(
-                    self.setup[encap_type]['dest_to_nh_map']))
+                    self.vxlan_test_setup[encap_type]['dest_to_nh_map']))
 
         Logger.info(
             "Use the selected nexthops(tunnel endpoints)."
@@ -1177,19 +1177,19 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         tc9_new_nhs = [nh1, nh2]
 
         Logger.info("Map the destination 1 to the combined list.")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc9_new_dest1] = \
             tc9_new_nhs
-        self.setup[encap_type]['tc9_dest'] = tc9_new_dest1
+        self.vxlan_test_setup[encap_type]['tc9_dest'] = tc9_new_dest1
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc9_new_dest1,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc9_new_nhs,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc9_new_nhs)
 
@@ -1198,10 +1198,10 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             tc7:send packets to route 1's prefix dst. by removing route 2 from
             group a, no change expected to route 1.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Pick a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info(
             "Setup: Create two destinations with the same endpoint group.")
@@ -1216,7 +1216,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             tc7_destinations.append(ecmp_utils.get_ip_address(
                 af=ecmp_utils.get_payload_version(encap_type),
                 netid=DESTINATION_PREFIX))
-        dest_nh_map = self.setup[encap_type]['dest_to_nh_map']
+        dest_nh_map = self.vxlan_test_setup[encap_type]['dest_to_nh_map']
         Logger.info("Map the new destinations to the same endpoint list.")
         for i in range(2):
             dest_nh_map[vnet][tc7_destinations[i]] = \
@@ -1226,16 +1226,16 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         payload_af = ecmp_utils.get_payload_version(encap_type)
         for i in range(2):
             ecmp_utils.create_and_apply_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc7_destinations[i],
                 ecmp_utils.HOST_MASK[payload_af],
                 tc7_end_point_list,
                 "SET",
-                bfd=self.setup['enable_bfd'])
+                bfd=self.vxlan_test_setup['enable_bfd'])
 
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc7_end_point_list)
         Logger.info("Verify the setup works.")
@@ -1246,12 +1246,12 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         Logger.info("Pick one out of the two TC7 destinations.")
         tc7_removed_dest = tc7_destinations[0]
         tc7_removed_endpoint = \
-            self.setup[encap_type]['dest_to_nh_map'][vnet][tc7_removed_dest]
-        del self.setup[encap_type]['dest_to_nh_map'][vnet][tc7_removed_dest]
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc7_removed_dest]
+        del self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc7_removed_dest]
 
         Logger.info("Remove the chosen dest/endpoint from the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc7_removed_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
@@ -1266,7 +1266,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             tc8: set tunnel route 2 to single endpoint b1.
             Send packets to route 2's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_single_endpoint(encap_type)
         self.dump_self_info_and_run_ptf("tc8", encap_type, True)
         self.dump_self_info_and_run_ptf("tc8", encap_type, True,
@@ -1278,7 +1278,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             Send packets to route 2's
             prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_shared_endpoints(encap_type)
         self.dump_self_info_and_run_ptf("tc9", encap_type, True)
 
@@ -1288,7 +1288,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             shared(no-reuse) endpoints a1 and b1. send packets
             to route 2's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_shared_different_endpoints(encap_type)
         self.dump_self_info_and_run_ptf("tc9.2", encap_type, True)
 
@@ -1296,11 +1296,11 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         '''
             tc10: remove tunnel route 2. send packets to route 2's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.setup_route2_shared_endpoints(encap_type)
         Logger.info("Backup the current route config.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
-        full_map = self.setup[encap_type]['dest_to_nh_map'][vnet].copy()
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
+        full_map = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet].copy()
         payload_af = ecmp_utils.get_payload_version(encap_type)
 
         Logger.info(
@@ -1311,9 +1311,9 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             Logger.info("Choose a vnet for testing.")
 
             Logger.info("Choose a destination and its nhs to delete.")
-            tc10_dest = self.setup[encap_type]['tc9_dest']
+            tc10_dest = self.vxlan_test_setup[encap_type]['tc9_dest']
             tc10_nhs = \
-                self.setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
+                self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
             Logger.info(
                 "Using destination: dest:%s, nh:%s",
                 tc10_dest,
@@ -1321,7 +1321,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
 
             Logger.info("Delete the dest and nh in the DUT.")
             ecmp_utils.create_and_apply_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc10_dest,
                 ecmp_utils.HOST_MASK[payload_af],
@@ -1336,8 +1336,8 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             Logger.info(
                 "Clear out the mappings, and keep only "
                 "the deleted dest and nhs.")
-            self.setup[encap_type]['dest_to_nh_map'][vnet] = {}
-            self.setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest] =\
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = {}
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest] =\
                 tc10_nhs
 
             Logger.info("The deleted route should fail to receive traffic.")
@@ -1346,19 +1346,19 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             # all others should be working.
             # Housekeeping:
             Logger.info("Restore the mapping of dest->nhs.")
-            self.setup[encap_type]['dest_to_nh_map'][vnet] = full_map.copy()
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = full_map.copy()
             Logger.info("Remove the deleted entry alone.")
-            del self.setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
+            del self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
             del_needed = False
 
             Logger.info("Check the traffic is working in the other routes.")
             self.dump_self_info_and_run_ptf("tc10", encap_type, True)
 
         except BaseException:
-            self.setup[encap_type]['dest_to_nh_map'][vnet] = full_map.copy()
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = full_map.copy()
             Logger.info("Remove the deleted entry alone.")
             if del_needed:
-                del self.setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
+                del self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc10_dest]
             raise
 
 
@@ -1377,10 +1377,10 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
             Ensure c1, c2, and c3 matches to underlay default route.
             Send 1000 pkt with random hash to route 3's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Chose a vnet for testing.")
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new destination and 3 nhs for it.")
         tc11_new_dest = ecmp_utils.get_ip_address(
@@ -1397,18 +1397,18 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
         # so it is already taken care of.
 
         Logger.info("Map the new dest and nhs.")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc11_new_dest] =\
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc11_new_dest] =\
             tc11_new_nhs
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             tc11_new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             tc11_new_nhs,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             tc11_new_nhs)
 
@@ -1438,7 +1438,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
             tc12: modify the underlay default route nexthop/s. send packets to
             route 3's prefix dst.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         '''
         First step: pick one or two of the interfaces connected to t2, and
         bring them down. verify that the encap is still working, and ptf
@@ -1449,7 +1449,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         '''
 
         all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             "T2",
             minigraph_facts))
 
@@ -1466,7 +1466,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         # Keep a copy of the internal housekeeping list of t2 ports.
         # This is the full list of DUT ports connected to T2 neighbors.
         # It is one of the arguments to the ptf code.
-        all_t2_ports = list(self.setup[encap_type]['t2_ports'])
+        all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
 
         # A distinction in this script between ports and interfaces:
         # Ports are physical (Ethernet) only.
@@ -1481,12 +1481,12 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 selected_intfs.append(all_t2_intfs[i])
 
             for intf in selected_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface shutdown {}".format(intf))
             downed_ports = ecmp_utils.get_corresponding_ports(
                 selected_intfs,
                 minigraph_facts)
-            self.setup[encap_type]['t2_ports'] = \
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
                 list(set(all_t2_ports) - set(downed_ports))
             downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
                 selected_intfs, minigraph_facts)
@@ -1496,7 +1496,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost'],
+                    self.vxlan_test_setup['duthost'],
                     down_list=downed_bgp_neighbors),
                 "BGP neighbors didn't come up after all "
                 "interfaces have been brought up.")
@@ -1511,13 +1511,13 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "Reverse the action: bring up the selected_intfs"
                 " and shutdown others.")
             for intf in selected_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
             Logger.info("Shutdown other interfaces.")
             remaining_interfaces = list(
                 set(all_t2_intfs) - set(selected_intfs))
             for intf in remaining_interfaces:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface shutdown {}".format(intf))
             downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
                 remaining_interfaces,
@@ -1528,11 +1528,11 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost'],
+                    self.vxlan_test_setup['duthost'],
                     down_list=downed_bgp_neighbors),
                 "BGP neighbors didn't come up after all interfaces have been"
                 "brought up.")
-            self.setup[encap_type]['t2_ports'] = \
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
                 ecmp_utils.get_corresponding_ports(
                     selected_intfs,
                     minigraph_facts)
@@ -1543,10 +1543,10 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
             downed ports, we have a problem!
             '''
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
             self.dump_self_info_and_run_ptf(
                 "tc12",
@@ -1556,7 +1556,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
 
             Logger.info("Recovery. Bring all up, and verify traffic works.")
             for intf in all_t2_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
             Logger.info("Wait for all bgp is up.")
             pytest_assert(
@@ -1565,16 +1565,16 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost']),
+                    self.vxlan_test_setup['duthost']),
                 "BGP neighbors didn't come up after "
                 "all interfaces have been brought up.")
             Logger.info("Verify traffic flows after recovery.")
-            self.setup[encap_type]['t2_ports'] = all_t2_ports
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
             self.dump_self_info_and_run_ptf(
                 "tc12",
@@ -1585,14 +1585,14 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         except Exception:
             # If anything goes wrong in the try block, atleast bring the intf
             # back up.
-            self.setup[encap_type]['t2_ports'] = all_t2_ports
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             for intf in all_t2_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
             pytest_assert(
                 wait_until(
@@ -1600,7 +1600,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost']),
+                    self.vxlan_test_setup['duthost']),
                 "BGP neighbors didn't come up after all interfaces "
                 "have been brought up.")
             raise
@@ -1613,12 +1613,12 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
            tc13: remove the underlay default route.
            tc14: add the underlay default route.
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         Logger.info(
             "Find all the underlay default routes' interfaces. This means all "
             "T2 interfaces.")
         all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             "T2",
             minigraph_facts))
         if not all_t2_intfs:
@@ -1633,7 +1633,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         try:
             Logger.info("Bring down the T2 interfaces.")
             for intf in all_t2_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface shutdown {}".format(intf))
             downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
                 all_t2_intfs,
@@ -1644,7 +1644,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost'],
+                    self.vxlan_test_setup['duthost'],
                     down_list=downed_bgp_neighbors),
                 "BGP neighbors have not reached the required state after "
                 "T2 intf are shutdown.")
@@ -1654,7 +1654,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
             # tc14: Re-add the underlay default route.
             Logger.info("Bring up the T2 interfaces.")
             for intf in all_t2_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
             Logger.info("Wait for all bgp is up.")
             pytest_assert(
@@ -1663,7 +1663,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost']),
+                    self.vxlan_test_setup['duthost']),
                 "BGP neighbors didn't come up after all interfaces"
                 " have been brought up.")
             Logger.info("Verify the traffic is flowing through, again.")
@@ -1677,7 +1677,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "If anything goes wrong in the try block,"
                 " atleast bring the intf back up.")
             for intf in all_t2_intfs:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
             pytest_assert(
                 wait_until(
@@ -1685,7 +1685,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     30,
                     0,
                     ecmp_utils.bgp_established,
-                    self.setup['duthost']),
+                    self.vxlan_test_setup['duthost']),
                 "BGP neighbors didn't come up after all"
                 " interfaces have been brought up.")
             raise
@@ -1695,10 +1695,10 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
             Create a more specific underlay route to c1.
             Verify c1 packets are received only on the c1's nexthop interface
         '''
-        self.setup = setUp
-        vnet = list(self.setup[encap_type]['vnet_vni_map'].keys())[0]
-        endpoint_nhmap = self.setup[encap_type]['dest_to_nh_map'][vnet]
-        backup_t2_ports = self.setup[encap_type]['t2_ports']
+        self.vxlan_test_setup = setUp
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
+        endpoint_nhmap = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet]
+        backup_t2_ports = self.vxlan_test_setup[encap_type]['t2_ports']
         # Gathering all T2 Neighbors
         all_t2_neighbors = ecmp_utils.get_all_bgp_neighbors(
             minigraph_facts,
@@ -1732,12 +1732,12 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                         nexthop,
                         "68",
                         gateway))
-                    self.setup['duthost'].copy(
+                    self.vxlan_test_setup['duthost'].copy(
                         content="\n".join(vtysh_config_commands),
                         dest="/tmp/specific_route_v6.txt")
-                    self.setup['duthost'].command(
+                    self.vxlan_test_setup['duthost'].command(
                         "docker cp /tmp/specific_route_v6.txt bgp:/")
-                    self.setup['duthost'].command(
+                    self.vxlan_test_setup['duthost'].command(
                         "vtysh -f /specific_route_v6.txt")
                 elif outer_layer_version == "v4":
                     static_route = []
@@ -1751,8 +1751,8 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                             ecmp_utils.HOST_MASK[outer_layer_version],
                             gateway))
 
-                    self.setup['duthost'].shell_cmds(cmds=static_route)
-        self.setup[encap_type]['t2_ports'] = ret_list
+                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
+        self.vxlan_test_setup[encap_type]['t2_ports'] = ret_list
 
         '''
             Traffic verification to see if specific route is preferred before
@@ -1774,12 +1774,12 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                     vtysh_config_commands.append(
                         "no ipv6 route {}/{} {}".format(
                             nexthop, "68", gateway))
-                    self.setup['duthost'].copy(
+                    self.vxlan_test_setup['duthost'].copy(
                         content="\n".join(vtysh_config_commands),
                         dest="/tmp/specific_route_v6.txt")
-                    self.setup['duthost'].command(
+                    self.vxlan_test_setup['duthost'].command(
                         "docker cp /tmp/specific_route_v6.txt bgp:/")
-                    self.setup['duthost'].command(
+                    self.vxlan_test_setup['duthost'].command(
                         "vtysh -f /specific_route_v6.txt")
 
                 elif ecmp_utils.get_outer_layer_version(encap_type) == "v4":
@@ -1794,8 +1794,8 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                             ecmp_utils.HOST_MASK[outer_layer_version],
                             gateway))
 
-                    self.setup['duthost'].shell_cmds(cmds=static_route)
-        self.setup[encap_type]['t2_ports'] = backup_t2_ports
+                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
+        self.vxlan_test_setup[encap_type]['t2_ports'] = backup_t2_ports
 
         Logger.info(
             "Allow some time for recovery of default route"
@@ -1819,7 +1819,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
             Bring down one of the port-channels.
             Packets are equally recieved at c1, c2 or c3
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         # Verification of traffic before shutting down port channel
         self.dump_self_info_and_run_ptf("tc12", encap_type, True)
@@ -1827,7 +1827,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         # Gathering all portchannels
         all_t2_portchannel_intfs = \
             list(ecmp_utils.get_portchannels_to_neighbors(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 "T2",
                 minigraph_facts))
         all_t2_portchannel_members = {}
@@ -1840,46 +1840,46 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         try:
             # Shutting down the ethernet interfaces
             for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface shutdown {}".format(intf))
 
-            all_t2_ports = list(self.setup[encap_type]['t2_ports'])
+            all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
             downed_ports = ecmp_utils.get_corresponding_ports(
                 all_t2_portchannel_members[selected_portchannel],
                 minigraph_facts)
-            self.setup[encap_type]['t2_ports'] = \
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
                 list(set(all_t2_ports) - set(downed_ports))
 
             # Verification of traffic
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
             self.dump_self_info_and_run_ptf("tc12", encap_type, True)
 
             for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
-            self.setup[encap_type]['t2_ports'] = all_t2_ports
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
             self.dump_self_info_and_run_ptf("tc12", encap_type, True)
         except BaseException:
             for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.setup['duthost'].shell(
+                self.vxlan_test_setup['duthost'].shell(
                     "sudo config interface startup {}".format(intf))
-            self.setup[encap_type]['t2_ports'] = all_t2_ports
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
             ecmp_utils.update_monitor_file(
-                self.setup['ptfhost'],
-                self.setup['monitor_file'],
-                self.setup[encap_type]['t2_ports'],
-                list(self.setup['list_of_bfd_monitors']))
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
             raise
 
 
@@ -1907,7 +1907,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         '''
 
         Logger.info("Choose a vnet.")
-        vnet = list(self.setup[encap_type]['dest_to_nh_map'].keys())[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['dest_to_nh_map'].keys())[0]
         Logger.info("Create a new list of endpoint(s).")
         end_point_list = []
         for _ in range(2):
@@ -1919,19 +1919,19 @@ class Test_VxLAN_entropy(Test_VxLAN):
             af=ecmp_utils.get_payload_version(encap_type),
             netid=DESTINATION_PREFIX)
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][new_dest] = \
             end_point_list
         Logger.info("Create a new config and Copy to the DUT.")
         ecmp_utils.create_and_apply_config(
-            self.setup['duthost'],
+            self.vxlan_test_setup['duthost'],
             vnet,
             new_dest,
             ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
             end_point_list,
             "SET",
-            bfd=self.setup['enable_bfd'])
+            bfd=self.vxlan_test_setup['enable_bfd'])
         self.update_monitor_list(
-            self.setup['enable_bfd'],
+            self.vxlan_test_setup['enable_bfd'],
             encap_type,
             end_point_list)
         Logger.info("Verify that the new config takes effect and run traffic.")
@@ -1950,7 +1950,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         Verification of entropy - Create tunnel route 4 to endpoint group A.
         Send packets (fixed tuple) to route 4's prefix dst
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.verify_entropy(
             encap_type,
             random_dport=True,
@@ -1963,7 +1963,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         Verification of entropy - Change the udp dst port of original packet to
         route 4's prefix dst
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.verify_entropy(encap_type, tolerance=0.03)
 
     def test_vxlan_random_src_port(self, setUp, encap_type):
@@ -1971,7 +1971,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         Verification of entropy - Change the udp src port of original packet
         to route 4's prefix dst
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.verify_entropy(
             encap_type,
             random_dport=False,
@@ -1983,7 +1983,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         Verification of entropy - Change the udp src ip of original packet to
         route 4's prefix dst
         '''
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
         self.verify_entropy(
             encap_type,
             random_dport=False,
@@ -2007,10 +2007,10 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
         '''
         if encap_type in ['v4_in_v6', 'v6_in_v6']:
             pytest.skip("Skipping test. v6 underlay is not supported in priority tunnels.")
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         tc1_end_point_list = []
@@ -2025,7 +2025,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc1_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc1_new_dest] = \
             tc1_end_point_list
 
         Logger.info("Create a new priority endpoint config and Copy to the DUT.")
@@ -2045,7 +2045,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
         # ]
         try:
             ecmp_utils.create_and_apply_priority_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc1_new_dest,
                 ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
@@ -2058,20 +2058,20 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             down_list = tc1_end_point_list[1]
             if isinstance(down_list, str):
                 down_list = [down_list]
-            self.setup['list_of_downed_endpoints'] = set(down_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(down_list)
             # setting both primary and secondary as up. only primary will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[1], "up")
             time.sleep(10)
             # verifying overlay_dmac
             result = \
-                self.setup['duthost'].shell("sonic-db-cli APPL_DB HGET 'VNET_MONITOR_TABLE:{}:{}/{}' 'overlay_dmac'"
+                self.vxlan_test_setup['duthost'].shell("sonic-db-cli APPL_DB HGET 'VNET_MONITOR_TABLE:{}:{}/{}' 'overlay_dmac'"
                                             .format(
                                                 tc1_end_point_list[0],
                                                 tc1_new_dest,
@@ -2089,9 +2089,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             down_list = tc1_end_point_list[0]
             if isinstance(down_list, str):
                 down_list = [down_list]
-            self.setup['list_of_downed_endpoints'] = set(down_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(down_list)
             # setting primary down. only secondary will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "down")
@@ -2107,9 +2107,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             down_list = tc1_end_point_list[1]
             if isinstance(down_list, str):
                 down_list = [down_list]
-            self.setup['list_of_downed_endpoints'] = set(down_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(down_list)
             # setting primary up. only primary will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "up")
@@ -2124,13 +2124,13 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             down_list = tc1_end_point_list
             if isinstance(down_list, str):
                 down_list = [down_list]
-            self.setup['list_of_downed_endpoints'] = set(down_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(down_list)
             # setting both down. no traffic is recieved.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[1], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc1_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "down")
@@ -2138,18 +2138,18 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             time.sleep(10)
             self.dump_self_info_and_run_ptf("test1", encap_type, True)
             ecmp_utils.create_and_apply_priority_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc1_new_dest,
                 ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                 tc1_end_point_list,
                 [tc1_end_point_list[0]],
                 "DEL")
-            self.setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map_orignal'])
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.vxlan_test_setup[encap_type]['dest_to_nh_map_orignal'])
 
         except Exception:
             ecmp_utils.create_and_apply_priority_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc1_new_dest,
                 ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
@@ -2187,10 +2187,10 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
         '''
         if encap_type in ['v4_in_v6', 'v6_in_v6']:
             pytest.skip("Skipping test. v6 underlay is not supported in priority tunnels.")
-        self.setup = setUp
+        self.vxlan_test_setup = setUp
 
         Logger.info("Choose a vnet.")
-        vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
 
         Logger.info("Create a new list of endpoint(s).")
         tc2_end_point_list = []
@@ -2205,7 +2205,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             netid=DESTINATION_PREFIX)
 
         Logger.info("Map the new destination and the new endpoint(s).")
-        self.setup[encap_type]['dest_to_nh_map'][vnet][tc2_new_dest] = \
+        self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet][tc2_new_dest] = \
             tc2_end_point_list
 
         Logger.info("Create a new priority endpoint config and Copy to the DUT.")
@@ -2228,7 +2228,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             secondary_nhg = tc2_end_point_list[2:4]
 
             ecmp_utils.create_and_apply_priority_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc2_new_dest,
                 ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
@@ -2238,19 +2238,19 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
 
             time.sleep(5)
             # Bringing all endpoints UP.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc2_end_point_list[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc2_end_point_list[1], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc2_end_point_list[2], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc2_end_point_list[3], "up")
@@ -2259,7 +2259,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(secondary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             time.sleep(10)
             # ensure that the traffic is distributed to all 3 primary Endpoints.
             self.dump_self_info_and_run_ptf("test2", encap_type, True)
@@ -2273,9 +2273,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list.append(primary_nhg[0])
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting A down. B,C getting traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "down")
@@ -2290,9 +2290,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(primary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting C down, now all backups are up and recieving traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "down")
@@ -2309,9 +2309,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list.append(secondary_nhg[1])
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting C` down, now A` and B` are up and recieving traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
@@ -2327,9 +2327,9 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list += secondary_nhg
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting A up. only A will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "up")
@@ -2344,13 +2344,13 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(secondary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "up")
@@ -2366,21 +2366,21 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(tc2_end_point_list)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[0], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
@@ -2395,21 +2395,21 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(secondary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "up")
@@ -2425,21 +2425,21 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(tc2_end_point_list)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[0], "down")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
@@ -2454,13 +2454,13 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(primary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "up")
@@ -2476,13 +2476,13 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             inactive_list = list(secondary_nhg)
             if isinstance(inactive_list, str):
                 inactive_list = [inactive_list]
-            self.setup['list_of_downed_endpoints'] = set(inactive_list)
+            self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             # setting B, C and C` up. only A,B,C will recieve traffic.
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "up")
-            ecmp_utils.set_vnet_monitor_state(self.setup['duthost'],
+            ecmp_utils.set_vnet_monitor_state(self.vxlan_test_setup['duthost'],
                                               tc2_new_dest,
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "up")
@@ -2492,7 +2492,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
 
         except Exception:
             ecmp_utils.create_and_apply_priority_config(
-                self.setup['duthost'],
+                self.vxlan_test_setup['duthost'],
                 vnet,
                 tc2_new_dest,
                 ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -2071,11 +2071,11 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
             time.sleep(10)
             # verifying overlay_dmac
             result = \
-                self.vxlan_test_setup['duthost'].shell("sonic-db-cli APPL_DB HGET 'VNET_MONITOR_TABLE:{}:{}/{}' 'overlay_dmac'"
-                                            .format(
-                                                tc1_end_point_list[0],
-                                                tc1_new_dest,
-                                                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)]))
+                self.vxlan_test_setup['duthost'].shell(
+                    "sonic-db-cli APPL_DB HGET 'VNET_MONITOR_TABLE:{}:{}/{}' 'overlay_dmac'".format(
+                        tc1_end_point_list[0],
+                        tc1_new_dest,
+                        ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)]))
             assert str(result['stdout']) == ecmp_utils.OVERLAY_DMAC
 
             self.dump_self_info_and_run_ptf("test1", encap_type, True)
@@ -2145,7 +2145,8 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
                 tc1_end_point_list,
                 [tc1_end_point_list[0]],
                 "DEL")
-            self.vxlan_test_setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.vxlan_test_setup[encap_type]['dest_to_nh_map_orignal'])
+            self.vxlan_test_setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(
+                self.vxlan_test_setup[encap_type]['dest_to_nh_map_orignal'])
 
         except Exception:
             ecmp_utils.create_and_apply_priority_config(


### PR DESCRIPTION
Pytest in python3 gets confused if a variable is named **setup** as it hunts for setup and teardown functions. In the recent python 3 conversion, this caused all the the vxlan ecmp tests to fail. SOme other failures were caused by python 3 conversion of ptf scripts as wells. These have been fixed this PR.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
