### PR TITLE
Fix testQosSaiQWatermarkAllPorts failure on multi-asic

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1877,8 +1877,9 @@ class TestQosSai(QosSaiBase):
         except KeyError:
             pytest.skip("Need both TC_TO_PRIORITY_GROUP_MAP and DSCP_TO_TC_MAP and key AZURE to run this test.")
         dscp_to_q_map = {tc_to_dscp_map[tc]:tc_to_q_map[tc] for tc in tc_to_dscp_map}
-        allTestPorts.remove(dutConfig["testPorts"]["src_port_id"])
-        allTestPortIps.remove(dutConfig["testPorts"]["src_port_ip"])
+        if get_src_dst_asic_and_duts['single_asic_test']:
+            allTestPorts.remove(dutConfig["testPorts"]["src_port_id"])
+            allTestPortIps.remove(dutConfig["testPorts"]["src_port_ip"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Only single asic scenario need to remove src_port_id from allTestPorts, since allTestPorts is all ports in dst asic, and it doesn't contain src_port_id when multi-asic scenario.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified it on testbed.
```
•	100G/S->100G/S single_dut_multi_asic passed
-------------------------- generated xml file: /run_logs/6064/2023-09-13-22-26-05/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts_2023-09-13-22-26-05.xml ---------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
22:40:58 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=================================================================================== 1 passed in 892.14 seconds ====================================================================================
rraghav@qos-sonic-mgmt-container:/data/tests$ cat /run_logs/6064/2023-09-13-22-26-05/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts_2023-09-13-22-26-05.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="qos-sonic-mgmt-container" name="pytest" skipped="0" tests="1" time="892.151" timestamp="2023-09-13T22:26:06.425248"><properties><property name="topology" value="t2"/><property name="testbed" value="sfd-t2"/><property name="timestamp" value="2023-09-13 22:26:51.667385"/><property name="host" value="sfd-t2-lc0"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-88_lc0_36fh_mo-r0"/><property name="hwsku" value="Cisco-88-LC0-36FH-M-O36"/><property name="os_version" value="azure_cisco_msft_202205.6361-dirty-20230908.171154"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1913" name="testQosSaiQWatermarkAllPorts[wm_q_wm_all_ports]" time="881.623"><properties><property name="start" value="2023-09-13 22:26:16.927459"/><property name="end" value="2023-09-13 22:40:58.551830"/></properties></testcase></testsuite></testsuites>rraghav@qos-sonic-mgmt-container:/data/tests$ 

•	100G/L->100G/L single_dut_multi_asic passed
-------------------------- generated xml file: /run_logs/6064/2023-09-13-22-45-18/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts_2023-09-13-22-45-18.xml ---------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
23:42:41 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=================================================================================== 1 passed in 3442.53 seconds ===================================================================================
rraghav@qos-sonic-mgmt-container:/data/tests$ cat /run_logs/6064/2023-09-13-22-45-18/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts_2023-09-13-22-45-18.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="qos-sonic-mgmt-container" name="pytest" skipped="0" tests="1" time="3442.541" timestamp="2023-09-13T22:45:19.028672"><properties><property name="topology" value="t2"/><property name="testbed" value="sfd-t2"/><property name="timestamp" value="2023-09-13 22:46:04.900884"/><property name="host" value="sfd-t2-lc0"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-88_lc0_36fh_mo-r0"/><property name="hwsku" value="Cisco-88-LC0-36FH-M-O36"/><property name="os_version" value="azure_cisco_msft_202205.6361-dirty-20230908.171154"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1913" name="testQosSaiQWatermarkAllPorts[wm_q_wm_all_ports]" time="3432.092"><properties><property name="start" value="2023-09-13 22:45:29.451719"/><property name="end" value="2023-09-13 23:42:41.544649"/></properties></testcase></testsuite></testsuites>rraghav@qos-sonic-mgmt-container:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
