### PR TITLE
[IPv6][SNMP][202205]: Remove skip of IPv6 loopback testing

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -62,10 +62,8 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
     ipaddr = ipaddress.ip_address(ip)
     iptables_cmd = "iptables"
 
-    # TODO : Fix snmp query over loopback v6 and remove this check and add IPv6 ACL table/rule.
     if isinstance(ipaddr, ipaddress.IPv6Address):
         iptables_cmd = "ip6tables"
-        return None
 
     ip_tbl_rule_add = "sudo {} -I INPUT 1 -p udp --dport 161 -d {} -j ACCEPT".format(
         iptables_cmd, ip)

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -1,5 +1,4 @@
 import pytest
-import ipaddress
 from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_output
 from tests.common.devices.eos import EosHost
 
@@ -23,14 +22,9 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrh
     # Get first neighbor VM information
     nbr = nbrhosts[list(nbrhosts.keys())[0]]
 
-    # TODO: Fix snmp query over Management IPv6 adderess and add SNMP test over management IPv6 address.
 
     for ip in config_facts[u'LOOPBACK_INTERFACE'][u'Loopback0']:
         loip = ip.split('/')[0]
-        loip = ipaddress.ip_address(loip)
-        # TODO: Fix SNMP query over IPv6 and remove the below check.
-        if not isinstance(loip, ipaddress.IPv4Address):
-            continue
         result = get_snmp_output(loip, duthost, nbr, creds_all_duts)
         assert result is not None, 'No result from snmpget'
         assert len(result['stdout_lines']) > 0, 'No result from snmpget'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry-pick with conflict resolution of https://github.com/sonic-net/sonic-mgmt/pull/8824
SNMP over Loopback ipv6 is currently being skipped.
https://github.com/sonic-net/sonic-buildimage/pull/15487 -fixes snmp over ipv6.
After the above fix, SNMP over Loopback and management should work.

#### How did you do it?
Remove skip of ipv6.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
