### PR TITLE
[snmp][multi-asic][202205]: Fix test_snmp_queue to support multi-asic platform

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -1,6 +1,5 @@
 import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
-from tests.common.helpers.sonic_db import redis_get_keys
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -11,14 +10,28 @@ pytestmark = [
 def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,
                      collect_techsupport_all_duts):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if duthost.is_supervisor_node():
-        pytest.skip("interfaces not present on supervisor node")
-    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    q_keys = []
 
-    q_keys = redis_get_keys(duthost, "CONFIG_DB", "QUEUE|*")
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+    port_name_to_alias_map = {}
 
-    if q_keys is None:
+    for asic_id in duthost.get_asic_ids():
+        namespace = duthost.get_namespace_from_asic_id(asic_id)
+        config_facts_ns = duthost.config_facts(host=duthost.hostname, source="running",
+                                               namespace=namespace)['ansible_facts']
+        asic = duthost.asic_instance(asic_id)
+        q_keys_ns = asic.run_sonic_db_cli_cmd('CONFIG_DB KEYS "QUEUE|*"')['stdout_lines']
+        if q_keys_ns:
+            q_keys.extend(q_keys_ns)
+        if config_facts_ns and 'port_name_to_alias_map' in config_facts_ns:
+            port_name_to_alias_map.update(config_facts_ns['port_name_to_alias_map'])
+
+    if not q_keys:
         pytest.skip("No queues configured on interfaces")
+
+    # Get alias : port_name map
+    alias_port_name_map = {k: v for v, k in port_name_to_alias_map.items()}
 
     q_interfaces = set()
     # get interfaces which has configured queues
@@ -27,15 +40,23 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
         # 'QUEUE|Ethernet*|2'
         if len(intf) == 3:
             q_interfaces.add(intf[1])
+        # Packet chassis 'QUEUE|<hostname>|<asic_ns>|Ethernet*|2'
+        elif len(intf) == 5:
+            q_interfaces.add(intf[3])
 
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c",
                                 community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
                                 wait=True)['ansible_facts']
 
+    snmp_ifnames = [alias_port_name_map[v['name']]
+                    for k, v in list(snmp_facts['snmp_interfaces'].items()) if v['name'] in alias_port_name_map]
+
+    for intf in q_interfaces:
+        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)
+
     for k, v in snmp_facts['snmp_interfaces'].items():
-        if "Ethernet" in v['description']:
-            intf = v['description'].split(':')
-            # 'ARISTA*:Ethernet*'
-            if len(intf) == 2:
-                if intf[1] in q_interfaces and 'queues' not in v:
-                    pytest.fail("port %s does not have queue counters" % v['name'])
+        # v['name'] is  alias for example Ethernet1/1
+        if v['name'] in alias_port_name_map:
+            intf = alias_port_name_map[v['name']]
+            if intf in q_interfaces and 'queues' not in v:
+                pytest.fail("port %s does not have queue counters" % v['name'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/9115
test_snmp_queue was modified to get keys "QUEUE|*" from config_db in https://github.com/sonic-net/sonic-mgmt/pull/6744.
This has to be modified to get keys from all namespace config_db on mulit-asic platform.
Currently, test tries to retrieve from host config_db and skips the test for multi-asic platform.

Test is currently skipped for supervisor node, but should not be skipped for supervisor node of packet chassis.
#### How did you do it?

1. Modified to get interfaces with queue configuration from all namespaces.
2. The test case was not checking the right field in snmp_interfaces SNMP result. Test case was checking for "description" of each interface, from description, interface name was extracted and checked if the interface name is present in QUEUE table.
This check will always be false and pytest fail condition was never hit. The test case was always incorrectly passing.
```
(Pdb) snmp_facts['snmp_interfaces']['117']['description']
u'ARISTA02T1:Ethernet1'

   for k, v in list(snmp_facts['snmp_interfaces'].items()):
        if "Ethernet" in v['description']:
            intf = v['description'].split(':')
            # 'ARISTA*:Ethernet*'
            if len(intf) == 2:
                if intf[1] in q_interfaces and 'queues' not in v: -- intf[1] in q_interfaces will always be false
                    pytest.fail(
                        "port %s does not have queue counters" % v['name'])  -- will never hit this condition
                intf[1] will always be Ethernet1 which is the interface of the neighbor
```
Modified test to use 'name' which gives the interface alias instead of interface name present in 'description'
```
(Pdb) snmp_facts['snmp_interfaces']['117']['name']
u'fortyGigE0/116'
```
3. Remove skip of supervisor node.
4.  On voq chassis LC, QUEUE configuration will include hostname and asic namespace as queue configuration is created on system port. Test is modified to get the interface name for voq chassis.
```
"QUEUE": {
        "<hostname>|asic0|Ethernet0|0": {
            "scheduler": "scheduler.0"
        },
```

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
