### PR TITLE
[dualtor-io] Change the health expectation for bgp shutdown case

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -197,6 +197,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
         verify_tor_states(
             expected_active_host=lower_tor_host,
             expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
             cable_type=cable_type
         )
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
When BGP is shutdown, default route n/a, linkmgrd will write unhealthy.
So let's change the expected health for the standby to `unhealthy`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
```
dualtor_io/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_sessions_upstream[active-standby] PASSED                                                                            [100%]

===================================================================================== warnings summary =====================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
