### PR TITLE
add vnet route cleanup and re-setup after test_vxlan_remove_route2

### DIFF
--- a/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
+++ b/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
+command=/usr/bin/python /opt/ptf_nn_agent.py --set-iface-rcv-buffer 157286400 --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
 
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log

--- a/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
+++ b/tests/common/plugins/ptfadapter/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --set-iface-rcv-buffer 157286400 --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
 
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -1261,6 +1261,21 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         Logger.info("Verify the rest of the traffic still works.")
         self.dump_self_info_and_run_ptf("tc7", encap_type, True)
 
+        # perform cleanup by removing all the routes added by this test class.
+        # reset to add only the routes added in the setup phase.
+        ecmp_utils.set_routes_in_dut(
+            self.setup['duthost'],
+            self.setup[encap_type]['dest_to_nh_map'],
+            ecmp_utils.get_payload_version(encap_type),
+            "DEL")
+
+        self.setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map_orignal']) # noqa F821
+        ecmp_utils.set_routes_in_dut(
+            self.setup['duthost'],
+            self.setup[encap_type]['dest_to_nh_map'],
+            ecmp_utils.get_payload_version(encap_type),
+            "SET")
+
     def test_vxlan_route2_single_nh(self, setUp, encap_type):
         '''
             tc8: set tunnel route 2 to single endpoint b1.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
[Description] 
The system keep printing the following message, which lead to loganalyzer failure.
Sep  5 20:38:00.798086 m64-zz-2 ERR swss#orchagent: :- delOperation: VNET 'Vnet_v4_in_v4-0': Routes are still present

[Analysis]
Sometimes, after running the following two testcases, they could leave vnet routes in our system.
vxlan/test_vxlan_ecmp.py::Test_VxLAN_NHG_Modify::test_vxlan_remove_route2[v4_in_v4]
vxlan/test_vxlan_ecmp.py::Test_VxLAN_NHG_Modify::test_vxlan_remove_route2[v6_in_v4]

For example: 
cisco@chu-dut:~$ show vnet routes all
...
vnet name        prefix                    endpoint                mac address    vni    status
Vnet_v4_in_v4-0  150.0.30.1/32             100.0.27.1,100.0.28.1                         inactive
Vnet_v6_in_v4-0  fddd:a150:a0::a102:1/128  100.0.99.1,100.0.100.1            inactive

Sonic keeps deleting this vnet, yet always fail since its routes are still present.

In the testcase of “test_vxlan_remove_route2”,  it adds two vnet routes and del one. The other one could be left in system always (depends on the IP).

Why this vnet route is not deleted during fixture_setUp teardown?
That should be related to the following code in other testcases:
self.setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map_orignal'])

This code will override the data map to the original data, which may not include the route included in “test_vxlan_remove_route2”.


[Solution]
We need the same solution for “test_vxlan_remove_route2” from the following PR:
[[testfix] test_vxlan_ecmp cleanup of routes after test runs. by siqbal1986 · Pull Request #9175 · sonic-net/sonic-mgmt (github.com)](https://github.com/sonic-net/sonic-mgmt/pull/9175/files)

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
