### PR TITLE
Always cleanup cEOS mount dir before creating cEOS

### DIFF
--- a/ansible/roles/eos/tasks/ceos_config.yml
+++ b/ansible/roles/eos/tasks/ceos_config.yml
@@ -18,6 +18,13 @@
 - name: Set EOS backplane port name
   set_fact: bp_ifname="Ethernet{{ fp_num.stdout|int - 1}}"
 
+- name: cleanup previous ceos mount dir
+  become: yes
+  file:
+    path: "/{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}/"
+    state: absent
+  delegate_to: "{{ VM_host[0] }}"
+
 - name: create directory for ceos config
   become: yes
   file:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Host dir like "/data/ceos/ceos_vms6-1_VM0100" is mounted to cEOS container as flash disk. This dir contains all kinds of configuration files that may affect cEOS behaviors.

For example, older version of cEOS has file ".arista_archive_config" which enables archiving of configs every 1 minute. On newer version of cEOS, this config file is removed by default.
However, after cEOS is upgraded, the left over ".arista_archive_config" file will cause newer cEOS to archive configs every 1 minute by default.

#### How did you do it?
To ensure that the cEOS container is always "cleanly" started, this change added code to always cleanup the mount dir before creating cEOS.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
