### PR TITLE
Conditionally install env-python3 in setup-container.sh

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -242,8 +242,15 @@ RUN chmod 0600 ${HOME}/.ssh/authorized_keys
 
 WORKDIR ${HOME}
 
-# Setup python3 virtual env
-RUN if [ '{{ USER_NAME }}' != 'AzDevOps' ] && [ -d /var/AzDevOps/env-python3 ]; then \
+# Setup python3 virtual env if some conditions are met:
+# 1. pytest is not globally installed. If pytest is gloablly installed, this assumes that all the packages in
+#    the python3 virtual env are installed globally. No need to create python3 virtual env.
+# 2. The user is not AzDevOps. By default python3 virtual env is installed for AzDevOps user.
+#    No need to install it again when current user is AzDevOps.
+# 3. The python3 virtual env is not installed for AzDevOps. Then, it is not required for other users either.
+RUN if ! pip3 list | grep -c pytest >/dev/null && \
+[ '{{ USER_NAME }}' != 'AzDevOps' ] && \
+[ -d /var/AzDevOps/env-python3 ]; then \
 /bin/bash -c 'python3 -m venv ${HOME}/env-python3'; \
 /bin/bash -c '${HOME}/env-python3/bin/pip install pip --upgrade'; \
 /bin/bash -c '${HOME}/env-python3/bin/pip install wheel'; \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
The sonic-mgmt docker image has been updated to globally install all the packages in env-python3. Now, in the global python3 environment, we have all the required packages for running tests. Then it is unnecessary to have the env-python3 virtual environment. Before "env-python3" is deprecated in sonic-mgmt docker image, we can skip creating "env-python3" in the setup-container.sh script which is used for setting up sonic-mgmt container for user different than "AzDevOps" to solve permission issues of mapped directory.

#### How did you do it?
This change added code to check if pytest is globally installed in python3 environment. If yes, then we can assume that all the env-python3 packages are also globally installed. Then we can skip creating env-python3 in setup-container.sh script.

#### How did you verify/test it?
Run setup-container.sh using old and new sonic-mgmt docker images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
