### PR TITLE
Add t1-64-lag topo for test_lag_2.py::test_lag_db_status_with_po_update

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -705,9 +705,9 @@ override_config_table/test_override_config_table.py:
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
-    reason: "Only support t1-lag, t1-56-lag and t2 topology"
+    reason: "Only support t1-lag, t1-56-lag, t1-64-lag and t2 topology"
     conditions:
-        - "topo_name not in ['t1-lag', 't1-56-lag'] and 't2' not in topo_name"
+        - "topo_name not in ['t1-lag', 't1-56-lag', 't1-64-lag'] and 't2' not in topo_name"
 
 pc/test_lag_member.py:
   skip:


### PR DESCRIPTION
…te case

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_lag_2.py::test_lag_db_status_with_po_update supports t1-64-lag topo.


#### How did you do it?
Add t1-64-lag topo in conditions yaml file

#### How did you verify/test it?
Choose t1-64-lag testbed and run  test_lag_2.py::test_lag_db_status_with_po_update.
```
----------------------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------------------------------------
08:23:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=================== 24 passed, 3 warnings in 2551.00 seconds ===================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
