### PR TITLE
Skip /proc/dma command check in Marvel arm64 platform

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -442,7 +442,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             )
     # Remove /proc/dma for armh
     elif duthost.facts["asic_type"] == "marvell":
-        if 'armhf-' in duthost.facts["platform"]:
+        if 'arm' in duthost.facts["platform"]:
             cmds.copy_proc_files.remove("/proc/dma")
 
     return cmds_to_check


### PR DESCRIPTION
Summary: Skip /proc/dma command check in Marvel arm64 platform

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Marvel arm64 platform does not have /proc/dma. Remove "copy /proc/dma command check for Marvel arm64 platform

#### How did you do it?
modified: tests/show_techsupport/test_techsupport.py
Remove /proc/dma command check for Marvel arm64 platform

#### How did you verify/test it?
Test case: show_techsupport/test_techsupport.py::test_techsupport::test_techsupport_commands
Verified tests on arm64-supermicro_sse_g3748-r0

#### Any platform specific information?
Marvell arm64 

#### Supported testbed topology if it's a new test case?
Any

