### PR TITLE
Cisco PCBB test support for 202305

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -190,6 +190,36 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
             100000_40m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -318,6 +348,36 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
             100000_5m:
                 pkts_num_leak_out: 0
                 pg_drop:
@@ -446,6 +506,36 @@ qos_params:
                     pkts_num_trig_pfc: 3703
                     cell_size: 384
                     packet_size: 1350
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 3414
+                    packet_size: 1350
+                    pkts_num_margin: 4
             400000_40m:
                 pkts_num_leak_out: 0
                 pg_drop:

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -20,7 +20,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, 
     get_t1_active_ptf_ports, mux_cable_server_ip, is_tunnel_qos_remap_enabled                           # noqa F401
 
 from .tunnel_qos_remap_base import build_testing_packet, check_queue_counter,\
-    dut_config, qos_config, load_tunnel_qos_map, run_ptf_test, toggle_mux_to_host,\
+    dut_config, qos_config, tunnel_qos_maps, run_ptf_test, toggle_mux_to_host,\
     setup_module, update_docker_services, swap_syncd, counter_poll_config                               # noqa F401
 from .tunnel_qos_remap_base import leaf_fanout_peer_info, start_pfc_storm, \
     stop_pfc_storm, get_queue_counter, get_queue_watermark, disable_packet_aging                        # noqa F401
@@ -69,7 +69,7 @@ def _last_port_in_last_lag(lags):
 
 
 def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,                            # noqa F811
-                            toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):       # noqa F811
+                            toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter, tunnel_qos_maps):       # noqa F811
     """
     The test is to verify the dscp rewriting of encapped packets.
     Test steps
@@ -78,7 +78,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,            
     3. Send the generated packets via portchannels
     4. Verify the packets are encapped with expected DSCP value
     """
-    DSCP_COMBINATIONS = [
+    REQUIRED_DSCP_COMBINATIONS = [
         # DSCP in generated packets, expected DSCP in encapped packets
         (8, 8),
         (0, 0),
@@ -90,6 +90,13 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,            
     ]
     dualtor_meta = dualtor_info(
         ptfhost, upper_tor_host, lower_tor_host, tbinfo)
+    if "cisco-8000" in ptfhost.duthost.facts["asic_type"]:
+        DSCP_COMBINATIONS = list(tunnel_qos_maps['inner_dscp_to_outer_dscp_map'].items())
+        for dscp_combination in REQUIRED_DSCP_COMBINATIONS:
+            assert dscp_combination in DSCP_COMBINATIONS, \
+                "Required DSCP combination {} not in inner_dscp_to_outer_dscp_map".format(dscp_combination)
+    else:
+        DSCP_COMBINATIONS = REQUIRED_DSCP_COMBINATIONS
     active_tor_mac = lower_tor_host.facts['router_mac']
 
     t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
@@ -99,6 +106,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,            
     for ports in list(t1_ports.values()):
         dst_ports.extend(ports)
 
+    success = True
     for dscp_combination in DSCP_COMBINATIONS:
         pkt, expected_pkt = build_testing_packet(src_ip=DUMMY_IP,
                                                  dst_ip=SERVER_IP,
@@ -113,7 +121,14 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,            
         # Send original packet
         testutils.send(ptfadapter, src_port, pkt)
         # Verify encaped packet
-        testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports)
+        try:
+            testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports)
+            logger.info("Verified DSCP combination {}".format(str(dscp_combination)))
+        except AssertionError:
+            logger.info("Failed to verify packet on DSCP combination {}".format(str(dscp_combination)))
+            success = False
+    assert success, "Failed inner->outer DSCP verification"
+    logger.info("Verified {} DSCP inner->outer combinations".format(len(DSCP_COMBINATIONS)))
 
 
 def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_tor_host,        # noqa F811
@@ -174,7 +189,7 @@ def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_t
 
 def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_unselected_dut,
                                             toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                            tbinfo, ptfadapter):
+                                            tbinfo, ptfadapter, tunnel_qos_maps): # noqa F811
     """
     The test case is to verify the decapped packet on active ToR are egressed to server from expected queue.
     Test steps:
@@ -191,12 +206,11 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
     active_tor_mac = rand_selected_dut.facts['router_mac']
     # Set queue counter polling interval to 1 second to speed up the test
     counter_poll_config(rand_selected_dut, 'queue', 1000)
-    tunnel_qos_map = load_tunnel_qos_map()
     PKT_NUM = 100
     try:
         # Walk through all DSCP values
         for inner_dscp in range(0, 64):
-            outer_dscp = tunnel_qos_map['inner_dscp_to_outer_dscp_map'][inner_dscp]
+            outer_dscp = tunnel_qos_maps['inner_dscp_to_outer_dscp_map'][inner_dscp]
             _, exp_packet = build_testing_packet(src_ip=DUMMY_IP,
                                                  dst_ip=dualtor_meta['target_server_ip'],
                                                  active_tor_mac=active_tor_mac,
@@ -216,9 +230,9 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
             time.sleep(2)
             # Verify counter at expected queue at the server facing port
             pytest_assert(check_queue_counter(rand_selected_dut, [dualtor_meta['selected_port']],
-                                              tunnel_qos_map['inner_dscp_to_queue_map'][inner_dscp], PKT_NUM),
+                                              tunnel_qos_maps['inner_dscp_to_queue_map'][inner_dscp], PKT_NUM),
                           "The queue counter for DSCP {} Queue {} is not as expected"
-                          .format(inner_dscp, tunnel_qos_map['inner_dscp_to_queue_map'][inner_dscp]))
+                          .format(inner_dscp, tunnel_qos_maps['inner_dscp_to_queue_map'][inner_dscp]))
 
     finally:
         counter_poll_config(rand_selected_dut, 'queue', 10000)
@@ -675,7 +689,7 @@ def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected
 
 
 @pytest.mark.disable_loganalyzer
-def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config, setup_module, creds):     # noqa F811
+def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config, setup_module, creds, tunnel_qos_maps):     # noqa F811
     """
     Test steps:
     1. Toggle all ports to active on randomly selected ToR
@@ -688,14 +702,16 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
     asic = rand_selected_dut.get_asic_name()
     pytest_assert(asic != 'unknown', 'Get unknown asic name')
     # TODO: Get the cell size for other ASIC
+    packet_size = 64
     if asic == 'th2':
         cell_size = 208
     elif 'spc' in asic:
         cell_size = 144
+    elif dut_config["asic_type"] == "cisco-8000":
+        cell_size = 384
+        packet_size = 1350
     else:
         cell_size = 256
-
-    tunnel_qos_map = load_tunnel_qos_map(asic_name=asic)
     test_params = dict()
     test_params.update({
         "src_port_id": dut_config["lag_port_ptf_id"],
@@ -706,10 +722,12 @@ def test_tunnel_decap_dscp_to_pg_mapping(rand_selected_dut, ptfhost, dut_config,
         "standby_tor_mac": dut_config["unselected_tor_mac"],
         "standby_tor_ip": dut_config["unselected_tor_loopback"],
         "src_server": dut_config["selected_tor_mgmt"] + ":" + DEFAULT_RPC_PORT,
-        "inner_dscp_to_pg_map": tunnel_qos_map["inner_dscp_to_pg_map"],
+        "inner_dscp_to_pg_map": tunnel_qos_maps["inner_dscp_to_pg_map"],
+        "inner_dscp_to_queue_map": tunnel_qos_maps["inner_dscp_to_queue_map"],
         "port_map_file_ini": dut_config["port_map_file_ini"],
         "sonic_asic_type": dut_config["asic_type"],
         "platform_asic": dut_config["platform_asic"],
+        "packet_size": packet_size,
         "cell_size": cell_size,
         "dut_username": creds['sonicadmin_user'],
         "dut_password": creds['sonicadmin_password']

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -13,6 +13,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.system_utils import docker
 from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports   # noqa F401
+from tests.common.fixtures.duthost_utils import dut_qos_maps_module                                 # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module                             # noqa F401
 
 logger = logging.getLogger(__name__)
@@ -132,11 +133,14 @@ def counter_poll_config(duthost, type, interval_ms):
         time.sleep(10)
 
 
-def load_tunnel_qos_map(asic_name=None):
+@pytest.fixture(scope='class')
+def tunnel_qos_maps(rand_selected_dut, dut_qos_maps_module): # noqa F811
     """
     Read DSCP_TO_TC_MAP/TC_TO_PRIORITY_GROUP_MAP/TC_TO_DSCP_MAP/TC_TO_QUEUE_MAP from file
+    or config DB depending on the ASIC type.
     return a dict
     """
+    asic_name = rand_selected_dut.get_asic_name()
     is_nvidia_platform = asic_name is not None and 'spc' in asic_name
     if not is_nvidia_platform:
         TUNNEL_QOS_MAP_FILENAME = r"qos/files/tunnel_qos_map.json"
@@ -145,9 +149,20 @@ def load_tunnel_qos_map(asic_name=None):
     TUNNEL_MAP_NAME = "AZURE_TUNNEL"
     UPLINK_MAP_NAME = "AZURE_UPLINK"
     MAP_NAME = "AZURE"
+    asic_type = rand_selected_dut.facts["asic_type"]
+    if 'cisco-8000' in asic_type:
+        # Cisco-8000 does not use the tunneled tc to pg map
+        tc_to_pg_map_name = MAP_NAME
+        # Use config DB for maps
+        maps = {}
+        for map_name in dut_qos_maps_module:
+            maps[map_name.upper()] = dut_qos_maps_module[map_name]
+    else:
+        tc_to_pg_map_name = TUNNEL_MAP_NAME
+        # Load maps from file
+        with open(TUNNEL_QOS_MAP_FILENAME, "r") as f:
+            maps = json.load(f)
     ret = {}
-    with open(TUNNEL_QOS_MAP_FILENAME, "r") as f:
-        maps = json.load(f)
     # inner_dscp_to_pg map, a map for mapping dscp to priority group at decap side
     ret['inner_dscp_to_pg_map'] = {}
     if is_nvidia_platform:
@@ -157,12 +172,16 @@ def load_tunnel_qos_map(asic_name=None):
     else:
         for k, v in maps['DSCP_TO_TC_MAP'][TUNNEL_MAP_NAME].items():
             ret['inner_dscp_to_pg_map'][int(k)] = int(
-                maps['TC_TO_PRIORITY_GROUP_MAP'][TUNNEL_MAP_NAME][v])
+                maps['TC_TO_PRIORITY_GROUP_MAP'][tc_to_pg_map_name][v])
     # inner_dscp_to_outer_dscp_map, a map for rewriting DSCP in the encapsulated packets
     ret['inner_dscp_to_outer_dscp_map'] = {}
-    for k, v in list(maps['DSCP_TO_TC_MAP'][MAP_NAME].items()):
-        ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(
-            maps['TC_TO_DSCP_MAP'][TUNNEL_MAP_NAME][v])
+    if 'cisco-8000' in asic_type:
+        for k, v in list(maps['TC_TO_DSCP_MAP'][TUNNEL_MAP_NAME].items()):
+            ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(v)
+    else:
+        for k, v in list(maps['DSCP_TO_TC_MAP'][MAP_NAME].items()):
+            ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(
+                maps['TC_TO_DSCP_MAP'][TUNNEL_MAP_NAME][v])
     # inner_dscp_to_queue_map, a map for mapping the tunnel traffic to egress queue at decap side
     ret['inner_dscp_to_queue_map'] = {}
     if is_nvidia_platform:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -791,14 +791,15 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
 
     def _build_testing_pkt(self, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp,
-                           outer_dscp, dst_ip, ecn=1):
+                           outer_dscp, dst_ip, packet_size, ecn=1):
         pkt = simple_tcp_packet(
             eth_dst=standby_tor_mac,
             ip_src='1.1.1.1',
             ip_dst=dst_ip,
             ip_dscp=inner_dscp,
             ip_ecn=ecn,
-            ip_ttl=64
+            ip_ttl=64,
+            pktlen=packet_size
         )
 
         ipinip_packet = simple_ipv4ip_packet(
@@ -829,8 +830,11 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_ip = self.test_params['dst_port_ip']
 
         dscp_to_pg_map = self.test_params['inner_dscp_to_pg_map']
+        dscp_to_queue_map = self.test_params['inner_dscp_to_queue_map']
         asic_type = self.test_params['sonic_asic_type']
+        packet_size = self.test_params['packet_size']
         cell_size = self.test_params['cell_size']
+        cell_occupancy = (packet_size + cell_size - 1) // cell_size
         PKT_NUM = 100
         # There is background traffic during test, so we need to add error tolerance to ignore such pakcets
         # and we send 100 packets every 10 seconds, if no backgound traffic impact counter value, and watermark is very
@@ -859,6 +863,10 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
             # There are packet leak even port tx is disabled (18 packets leak on TD3 found)
             # Hence we send some packet to fill the leak before testing
             if asic_type != 'mellanox':
+                leakout_failed = False
+                if 'cisco-8000' in asic_type:
+                    # Only fill queues once
+                    queue_leakouts_filled = [False] * 8
                 for dscp, _ in dscp_to_pg_map.items():
                     pkt = self._build_testing_pkt(
                         active_tor_mac=active_tor_mac,
@@ -867,11 +875,27 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                         standby_tor_ip=standby_tor_ip,
                         inner_dscp=dscp,
                         outer_dscp=0,
-                        dst_ip=dst_port_ip
+                        dst_ip=dst_port_ip,
+                        packet_size=packet_size
                     )
-                    send_packet(self, src_port_id, pkt, 20)
+                    if 'cisco-8000' in asic_type:
+                        queue = dscp_to_queue_map[dscp]
+                        if not queue_leakouts_filled[queue]:
+                            status = fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
+                            if status:
+                                queue_leakouts_filled[queue] = True
+                                print("Filled leakout for dscp {} to queue {}".format(dscp, queue))
+                            else:
+                                print("Failed to fill leakout for dscp {} to queue {}".format(dscp, queue))
+                                leakout_failed = True
+                    else:
+                        send_packet(self, src_port_id, pkt, 20)
+                assert not leakout_failed, "Failed filling leakout"
                 time.sleep(10)
-
+            if 'cisco-8000' in asic_type:
+                PKT_NUM = 50
+            else:
+                PKT_NUM = 100
             for inner_dscp, pg in dscp_to_pg_map.items():
                 logging.info("Iteration: inner_dscp:{}, pg: {}".format(inner_dscp, pg))
                 # Build and send packet to active tor.
@@ -886,7 +910,8 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     standby_tor_ip=standby_tor_ip,
                     inner_dscp=dscp,
                     outer_dscp=0,
-                    dst_ip=dst_port_ip
+                    dst_ip=dst_port_ip,
+                    packet_size=packet_size
                 )
                 pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
                                                                             port_list['src'][src_port_id])
@@ -895,11 +920,12 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 time.sleep(8)
                 pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
                                                                        port_list['src'][src_port_id])
-
-                assert (pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
-                        <= (PKT_NUM + ERROR_TOLERANCE[pg]) * cell_size)
-                assert (pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
-                        >= (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size)
+                pg_wm_inc = pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
+                lower_bounds = (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size * cell_occupancy
+                upper_bounds = (PKT_NUM + ERROR_TOLERANCE[pg]) * cell_size * cell_occupancy
+                print("DSCP {}, PG {}, expectation: {} <= {} <= {}".format(
+                    dscp, pg, lower_bounds, pg_wm_inc, upper_bounds), file=sys.stderr)
+                assert lower_bounds <= pg_wm_inc <= upper_bounds
         finally:
             # Enable tx on dest port
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
@@ -4689,19 +4715,30 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
                                               dst_ip=dst_port_ip,
                                               ecn=ecn,
                                               packet_size=packet_size)
-            # Send packets short of triggering pfc
-            send_packet(self, src_port_id, pkt, pkts_num_trig_pfc // cell_occupancy - 1 - pkts_num_margin)
-            time.sleep(8)
-            # Read TX_OK again to calculate leaked packet number
-            if 'mellanox' == asic_type:
-                # There are not leaked packets on Nvidia dualtor devices
-                leaked_packet_number = 0
+
+            # Send packets short of triggering pfc while compensating for leakout
+            if 'cisco-8000' in asic_type:
+                # Queue is always the inner_dscp due to the TC_TO_QUEUE_MAP redirection
+                queue = inner_dscp
+                assert(fill_leakout_plus_one(self, src_port_id,
+                       dst_port_id, pkt, queue, asic_type))
+                num_pkts = pkts_num_trig_pfc - pkts_num_margin - 1
+                send_packet(self, src_port_id, pkt, num_pkts)
+                print("Sending {} packets to port {}".format(num_pkts, src_port_id), file=sys.stderr)
             else:
-                tx_counters, _ = sai_thrift_read_port_counters(self.dst_client,
-                                                               asic_type, port_list['dst'][dst_port_id])
-                leaked_packet_number = tx_counters[TRANSMITTED_PKTS] - tx_counters_base[TRANSMITTED_PKTS]
-            # Send packets to compensate the leaked packets
-            send_packet(self, src_port_id, pkt, leaked_packet_number)
+                # Send packets short of triggering pfc
+                send_packet(self, src_port_id, pkt, pkts_num_trig_pfc // cell_occupancy - 1 - pkts_num_margin)
+                time.sleep(8)
+                # Read TX_OK again to calculate leaked packet number
+                if 'mellanox' == asic_type:
+                    # There are not leaked packets on Nvidia dualtor devices
+                    leaked_packet_number = 0
+                else:
+                    tx_counters, _ = sai_thrift_read_port_counters(self.dst_client,
+                                                                   asic_type, port_list['dst'][dst_port_id])
+                    leaked_packet_number = tx_counters[TRANSMITTED_PKTS] - tx_counters_base[TRANSMITTED_PKTS]
+                # Send packets to compensate the leaked packets
+                send_packet(self, src_port_id, pkt, leaked_packet_number)
             time.sleep(8)
             # Read rx counter again. No PFC pause frame should be triggered
             rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
@@ -4710,6 +4747,8 @@ class PCBBPFCTest(sai_base_test.ThriftInterfaceDataPlane):
             rx_counters_base = rx_counters
             # Send some packets to trigger PFC
             send_packet(self, src_port_id, pkt, 1 + 2 * pkts_num_margin)
+            print("Sending {} packets to port {} to trigger PFC".format(1 + 2 * pkts_num_margin, src_port_id),
+                  file=sys.stderr)
             time.sleep(8)
             rx_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
             # Verify PFC pause frame is generated on expected PG


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Master PR: #9243

Summary:
Support the following tests for Cisco-8000:
- test_encap_dscp_rewrite[active-standby]
- test_tunnel_decap_dscp_to_queue_mapping
- test_tunnel_decap_dscp_to_pg_mapping
- test_xoff_for_pcbb (4)

Cisco-specific changes:
- Added qos.yml entries
- Leakout filling in various tests
- Packet sizing changes

Changes for all platforms:
- Some debuggability improvements

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Support most PCBB tests for Cisco-8000.

#### How did you do it?

#### How did you verify/test it?

Verified on Cisco-8000 dualtor platform. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
