### PR TITLE
Add platform test for kdump

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -30,6 +30,7 @@ REBOOT_TYPE_UNKNOWN = "Unknown"
 REBOOT_TYPE_THERMAL_OVERLOAD = "Thermal Overload"
 REBOOT_TYPE_BIOS = "bios"
 REBOOT_TYPE_ASIC = "asic"
+REBOOT_TYPE_KERNEL_PANIC = "Kernel Panic"
 
 # Event to signal DUT activeness
 DUT_ACTIVE = threading.Event()
@@ -105,6 +106,12 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         "cause": "ASIC",
+        "test_reboot_cause_only": True
+    },
+    REBOOT_TYPE_KERNEL_PANIC: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "Kernel Panic",
         "test_reboot_cause_only": True
     }
 }

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -109,6 +109,7 @@ reboot_ctrl_dict = {
         "test_reboot_cause_only": True
     },
     REBOOT_TYPE_KERNEL_PANIC: {
+        "command": 'nohup bash -c "sleep 5 && echo c > /proc/sysrq-trigger" &',
         "timeout": 300,
         "wait": 120,
         "cause": "Kernel Panic",

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -4,7 +4,8 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX, wait_for_startup, REBOOT_TYPE_COLD
+from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX, wait_for_startup,\
+    check_reboot_cause, REBOOT_TYPE_COLD, REBOOT_TYPE_KERNEL_PANIC
 from tests.platform_tests.test_reboot import check_interfaces_and_services
 
 pytestmark = [
@@ -83,8 +84,7 @@ class TestKernelPanic:
         dut_uptime = duthost.get_up_time()
         pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))
 
-        out = duthost.command('show reboot-cause')
-        if "Kernel Panic" not in out["stdout"]:
+        if not check_reboot_cause(duthost, REBOOT_TYPE_KERNEL_PANIC):
             pytest.fail('DUT {}: Incorrect reboot-cause, not due to kernel panic'.format(hostname))
 
     def check_ssh_state(self, localhost, dut_ip, expected_state, timeout=60):

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -1,0 +1,113 @@
+import logging
+import time
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX, wait_for_startup
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
+
+SSH_SHUTDOWN_TIMEOUT = 360
+SSH_STARTUP_TIMEOUT = 420
+
+SSH_STATE_ABSENT = "absent"
+SSH_STATE_STARTED = "started"
+
+
+class TestKernelPanic:
+    """
+    This test case is used to verify that DUT will load kdump crashkernel on kernel panic.
+    """
+    def wait_lc_healthy_if_sup(self, duthost, duthosts, localhost):
+        # For sup, we also need to ensure linecards are back and healthy for following tests
+        is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
+        if is_sup:
+            for lc in duthosts.frontend_nodes:
+                wait_for_startup(lc, localhost, delay=10, timeout=300)
+                wait_critical_processes(lc)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                 localhost, pdu_controller):
+        yield
+        # If the SSH connection is not established, or any critical process is exited,
+        # try to recover the DUT by PDU reboot.
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        dut_ip = duthost.mgmt_ip
+        hostname = duthost.hostname
+        if not self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED):
+            if pdu_controller is None:
+                logging.error("No PDU controller for {}, failed to recover DUT!".format(hostname))
+                return
+            self.pdu_reboot(pdu_controller)
+            # Waiting for SSH connection startup
+            pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
+                          'Recover {} by PDU reboot failed'.format(hostname))
+            # Wait until all critical processes are healthy.
+            wait_critical_processes(duthost)
+            self.wait_lc_healthy_if_sup(duthost, duthosts, localhost)
+
+    def test_kernel_panic(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        dut_ip = duthost.mgmt_ip
+        hostname = duthost.hostname
+        dut_datetime = duthost.get_now_time()
+
+        out = duthost.command('show kdump config')
+        if "Enabled" not in out["stdout"]:
+            pytest.skip('DUT {}: Skip test since kdump is not enabled'.format(hostname))
+
+        cmd = 'nohup bash -c "sleep 5 && echo c > /proc/sysrq-trigger" &'
+        res = duthost.shell(cmd)
+        if not res.is_successful:
+            pytest.fail('DUT {} run command {} failed'.format(hostname, cmd))
+
+        # Waiting for SSH connection shutdown
+        pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_ABSENT, SSH_SHUTDOWN_TIMEOUT),
+                      'DUT {} did not shutdown'.format(hostname))
+        # Waiting for SSH connection startup
+        pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
+                      'DUT {} did not startup'.format(hostname))
+        # Wait until all critical processes are healthy.
+        wait_critical_processes(duthost)
+        self.wait_lc_healthy_if_sup(duthost, duthosts, localhost)
+        # Verify DUT uptime is later than the time when the test case started running.
+        dut_uptime = duthost.get_up_time()
+        pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))
+
+        out = duthost.command('show reboot-cause')
+        if "Kernel Panic" not in out["stdout"]:
+            pytest.fail('DUT {}: Incorrect reboot-cause, not due to kernel panic'.format(hostname))
+
+    def check_ssh_state(self, localhost, dut_ip, expected_state, timeout=60):
+        """
+        Check the SSH state of DUT.
+
+        :param localhost: A `tests.common.devices.local.Localhost` Object.
+        :param dut_ip: A string, the IP address of DUT.
+        :param expected_state: A string, the expected SSH state.
+        :param timeout: An integer, the maximum number of seconds to wait for.
+        :return: A boolean, True if SSH state is the same as expected
+                          , False otherwise.
+        """
+        res = localhost.wait_for(host=dut_ip,
+                                 port=SONIC_SSH_PORT,
+                                 state=expected_state,
+                                 search_regex=SONIC_SSH_REGEX,
+                                 delay=10,
+                                 timeout=timeout,
+                                 module_ignore_errors=True)
+        return not res.is_failed and 'Timeout' not in res.get('msg', '')
+
+    def pdu_reboot(self, pdu_controller):
+        hostname = pdu_controller.dut_hostname
+        if not pdu_controller.turn_off_outlet():
+            logging.error("Turn off the PDU outlets of {} failed".format(hostname))
+            return
+        time.sleep(10)  # sleep 10 second to ensure there is gap between power off and on
+        if not pdu_controller.turn_on_outlet():
+            logging.error("Turn on the PDU outlets of {} failed".format(hostname))

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -58,9 +58,7 @@ class TestKernelPanic:
     def test_kernel_panic(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
                           conn_graph_facts, xcvr_skip_list):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        dut_ip = duthost.mgmt_ip
         hostname = duthost.hostname
-        dut_datetime = duthost.get_now_time()
 
         out = duthost.command('show kdump config')
         if "Enabled" not in out["stdout"]:

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -18,6 +18,7 @@ SSH_STARTUP_TIMEOUT = 420
 SSH_STATE_ABSENT = "absent"
 SSH_STATE_STARTED = "started"
 
+
 class TestKernelPanic:
     """
     This test case is used to verify that DUT will load kdump crashkernel on kernel panic.


### PR DESCRIPTION
Summary:
Add test_kdump.py to platform_tests.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Add automation test for kdump functionality.

#### How did you do it?
Induce kernel panic thru sysrq-trigger.

#### How did you verify/test it?
For platform with kdump enabled, trigger kernel panic, and check for reboot-cause on subsequent bootup.
Validated on Cisco-8000 platforms thru internal sonic-mgmt test.

![image](https://github.com/sonic-net/sonic-mgmt/assets/127834195/0bfe9b34-af29-4321-bcc6-923fee2f2e71)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Any platform with kdump enabled, else test will be skipped.