### PR TITLE
Verify BFD traffic egress queue

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -2,8 +2,10 @@ import pytest
 import random
 import time
 import json
+import logging
 
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.snappi_tests.common_helpers import get_egress_queue_count
 
 pytestmark = [
     pytest.mark.topology('t1')
@@ -12,6 +14,7 @@ pytestmark = [
 BFD_RESPONDER_SCRIPT_SRC_PATH = '../ansible/roles/test/files/helpers/bfd_responder.py'
 BFD_RESPONDER_SCRIPT_DEST_PATH = '/opt/bfd_responder.py'
 
+logger = logging.getLogger(__name__)
 
 def is_dualtor(tbinfo):
     """Check if the testbed is dualtor."""
@@ -141,6 +144,7 @@ def get_neighbors_multihop(duthost, tbinfo, ipv6=False, count=1):
     index = random.sample(list(range(len(t0_intfs))), k=1)[0]
     port_intf = t0_intfs[index]
     ptf_intf = ptf_ports[index]
+    logger.debug("BFD multihop, DUT interface name: {}".format(port_intf))
     nexthop_ip = ""
     neighbour_dev_name = mg_facts['minigraph_neighbors'][port_intf]['name']
     for bgpinfo in mg_facts['minigraph_bgp']:
@@ -162,7 +166,7 @@ def get_neighbors_multihop(duthost, tbinfo, ipv6=False, count=1):
         else:
             neighbor_addrs.append(t0_ipv4_pattern.format((idx % 250), idx2))
 
-    return loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs
+    return loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs, port_intf
 
 
 def init_ptf_bfd(ptfhost):
@@ -263,6 +267,7 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
     bfd_config = []
     ptf_config = []
     for neighbor_addr in neighbor_addrs:
+        logger.info("create BFD sessions, loopback {} neighbor ip {}".format(loopback_addr, neighbor_addr))
         bfd_config.append({
             "BFD_SESSION_TABLE:default:default:{}".format(neighbor_addr): {
                 "local_addr": loopback_addr,
@@ -299,7 +304,8 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
     ptfhost.command('supervisorctl reread')
     ptfhost.command('supervisorctl update')
     ptfhost.command('supervisorctl start bfd_responder')
-
+    temp = duthost.shell('show bfd summary')
+    logger.info("BFD Summary dump: {}".format(temp['stdout']))
 
 def remove_bfd_sessions(duthost, neighbor_addrs):
     # Create a tempfile for BFD sessions
@@ -329,6 +335,19 @@ def update_bfd_session_state(ptfhost, neighbor_addr, local_addr, state):
 def update_bfd_state(ptfhost, neighbor_addr, local_addr, state):
     ptfhost.shell("bfdd-control session local {} remote {} {}".format(neighbor_addr, local_addr, state))
 
+def verify_bfd_queue_counters(duthost, dut_intf):
+    queue_output = duthost.shell("show queue counters {}".format(dut_intf))
+    logger.debug("Queue output: {}".format(queue_output['stdout']))
+
+    for queue_val in range(0, 7):
+      queue_pkt_count, _ = get_egress_queue_count(duthost, dut_intf, int(queue_val))
+      logger.debug("Interface {}, Queue {}, counter {}".format(dut_intf, queue_val, queue_pkt_count))
+      if queue_pkt_count != 0:
+        pytest.fail('Queue {} count is not zero, BFD packets might use this'.format(queue_val))
+
+    bfd_queue = 7
+    queue_pkt_count, _ = get_egress_queue_count(duthost, dut_intf, int(bfd_queue))
+    logger.debug("Queue counters: {}".format(queue_pkt_count))
 
 @pytest.mark.parametrize('dut_init_first', [True, False], ids=['dut_init_first', 'ptf_init_first'])
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
@@ -419,8 +438,9 @@ def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
     duthost = rand_selected_dut
 
     bfd_session_cnt = int(request.config.getoption('--num_sessions'))
-    loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs = get_neighbors_multihop(duthost, tbinfo, ipv6,
-                                                                                 count=bfd_session_cnt)
+    loopback_addr, ptf_intf, nexthop_ip, neighbor_addrs, dut_intf = get_neighbors_multihop(duthost,
+                                                                               tbinfo, ipv6,
+                                                                               count=bfd_session_cnt)
     try:
         cmd_buffer = ""
         for neighbor in neighbor_addrs:
@@ -432,7 +452,10 @@ def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
         time.sleep(1)
         for neighbor_addr in neighbor_addrs:
             check_dut_bfd_status(duthost, neighbor_addr, "Up")
-
+        duthost.shell("sonic-clear queuecounters")
+        # sleep for 10 seconds to check queue counters
+        time.sleep(10)
+        verify_bfd_queue_counters(duthost, dut_intf)
     finally:
         remove_bfd_sessions(duthost, neighbor_addrs)
         cmd_buffer = ""


### PR DESCRIPTION
### Description of PR
Verify BFD traffic egressing out of Queue 7.

Summary:
Fixes # (issue)
When the BFD state is up, check queue counters to validate BFD packets using queue 7.

## Type of change
improvement

### Approach
#### What is the motivation for this PR?
To verify egress queue of BFD traffic.

#### How did you do it?
Use DUT's 'show queue counter <interface>' and check for non-zero packets in queue 7.