### PR TITLE
[202205][testfix] test cleanup and bfd_responder fix

### DIFF
--- a/ansible/roles/test/files/ptftests/bfd_responder.py
+++ b/ansible/roles/test/files/ptftests/bfd_responder.py
@@ -104,16 +104,21 @@ class BFD_Responder(BaseTest):
                 continue
 
             session = {}
+            if self.sessions[ip_dst] != {}:
+                session['my_disc'] = self.sessions[ip_dst]['my_disc']
+                session["src_port"] = self.sessions[ip_dst]["src_port"]
+            else:
+                session["src_port"] = self.local_src_port
+                self.local_disc_base += 1
+                self.local_src_port += 1
+                session['my_disc'] = self.local_disc_base
+
             session['addr'] = ip_dst
             session['remote_addr'] = ip_src
             session['intf'] = result.port
             session['multihop'] = True
             session['mac'] = mac_dst
             session['pkt'] = ''
-            session["src_port"] = self.local_src_port
-            self.local_disc_base += 1
-            self.local_src_port += 1
-            session['my_disc'] = self.local_disc_base
             session["other_disc"] = bfd_remote_disc
 
             bfd_pkt_init = self.craft_bfd_packet(

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -632,7 +632,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
         self.dump_self_info_and_run_ptf("tc5", encap_type, False)
 
         # Restoring dest_to_nh_map to old values
-        self.setup[encap_type]['dest_to_nh_map'][vnet] = backup_dest.copy()
+        self.setup[encap_type]['dest_to_nh_map'][vnet] = copy.deepcopy(backup_dest)
         self.dump_self_info_and_run_ptf("tc5", encap_type, True)
 
     def test_vxlan_configure_route1_ecmp_group_b(self, setUp, encap_type):
@@ -2015,7 +2015,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
 
         Logger.info("Choose a vnet.")
         vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
-
+        backup_dest = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map'][vnet])
         Logger.info("Create a new list of endpoint(s).")
         tc1_end_point_list = []
         for _ in range(2):
@@ -2149,7 +2149,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
                 tc1_end_point_list,
                 [tc1_end_point_list[0]],
                 "DEL")
-            self.setup[encap_type]['dest_to_nh_map'] = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map_orignal'])
+            self.setup[encap_type]['dest_to_nh_map'][vnet] = copy.deepcopy(backup_dest)
 
         except Exception:
             ecmp_utils.create_and_apply_priority_config(
@@ -2194,7 +2194,7 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
 
         Logger.info("Choose a vnet.")
         vnet = self.setup[encap_type]['vnet_vni_map'].keys()[0]
-
+        backup_dest = copy.deepcopy(self.setup[encap_type]['dest_to_nh_map'][vnet])
         Logger.info("Create a new list of endpoint(s).")
         tc2_end_point_list = []
         for _ in range(4):
@@ -2492,6 +2492,15 @@ class Test_VxLAN_ECMP_Priority_endpoints(Test_VxLAN):
 
             time.sleep(10)
             self.dump_self_info_and_run_ptf("test2", encap_type, True)
+            self.setup[encap_type]['dest_to_nh_map'][vnet] = copy.deepcopy(backup_dest)
+            ecmp_utils.create_and_apply_priority_config(
+                self.setup['duthost'],
+                vnet,
+                tc2_new_dest,
+                ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
+                tc2_end_point_list,
+                primary_nhg,
+                "DEL")
 
         except Exception:
             ecmp_utils.create_and_apply_priority_config(


### PR DESCRIPTION
The bfd responder was creating a new discriminator for every attempt to create the same session. this causes BFD logic or SN2700 to throw errors. Also some tests were not doing cleanup which resulted in subsequent tests failing. This was also fixed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
