### PR TITLE
Update qos params and add sleep for pgdrop, decrease pkts_num_egr_mem…

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -655,7 +655,7 @@ qos_params:
                     packet_size: 1350
             100000_120000m:
                 pkts_num_leak_out: 0
-                pkts_num_egr_mem: 1276
+                pkts_num_egr_mem: 1256
                 pg_drop:
                     dscp: 3
                     ecn: 1
@@ -663,15 +663,16 @@ qos_params:
                     queue: 3
                     pkts_num_trig_pfc: 262144
                     pkts_num_trig_ingr_drp: 524288
-                    pkts_num_margin: 13267
+                    pkts_num_margin: 30000
                     iterations: 30
+                    cell_size: 8192
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 3202
                     pkts_num_trig_ingr_drp: 6404
-                    packet_size: 8140
+                    packet_size: 8156
                     pkts_num_margin: 20
                 xoff_2:
                     dscp: 4
@@ -679,7 +680,7 @@ qos_params:
                     pg: 4
                     pkts_num_trig_pfc: 3202
                     pkts_num_trig_ingr_drp: 6404
-                    packet_size: 8140
+                    packet_size: 8156
                     pkts_num_margin: 20
                 xon_1:
                     dscp: 3
@@ -765,6 +766,7 @@ qos_params:
                     pkts_num_trig_ingr_drp: 1887437
                     pkts_num_margin: 108000
                     iterations: 30
+                    cell_size: 8192
                 xoff_1:
                     dscp: 3
                     ecn: 1

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4165,6 +4165,7 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts_num_trig_ingr_drp, actual_num_trig_ingr_drp, ingr_drop_diff), file=sys.stderr)
 
                 self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+                time.sleep(4)
 
             print("pass iterations: {}, total iterations: {}, margin: {}".format(
                 pass_iterations, iterations, margin), file=sys.stderr)


### PR DESCRIPTION
… for longlink->shortlink scenario

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, Update qos params for PGDrop case, pkts_num_margin 30,000 for longlink scenario.
2, Add sleep to drain packets between iterations for PGDrop case.
3, Decrease pkts_num_egr_mem to 1256 for longlink->shortlink scenario.
4. Fox XOFF testcase send packet size 8156 to accurately increase SQ counter by 1 always.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified it on testbed.
```
100G/L single-asic
============================================================================================= PASSES ==============================================================================================
___________________________________________________________________________________ TestQosSai.testQosSaiPGDrop ___________________________________________________________________________________
------------------------------------------ generated xml file: /run_logs/6361/2023-09-15-23-36-24/qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop.xml -------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
00:05:53 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop
=================================================================================== 1 passed in 1768.04 seconds ===================================================================================
AzDevOps@qos-sonic-mgmt:/data/tests$ cat /run_logs/6361/2023-09-15-23-36-24/qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="qos-sonic-mgmt" name="pytest" skipped="0" tests="1" time="1768.050" timestamp="2023-09-15T23:36:25.287515"><properties><property name="topology" value="t2"/><property name="testbed" value="t2-xx37-ls"/><property name="timestamp" value="2023-09-15 23:37:15.080557"/><property name="host" value="xx37-lc0"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-88_lc0_36fh_m-r0"/><property name="hwsku" value="Cisco-88-LC0-36FH-M-O36"/><property name="os_version" value="azure_cisco_msft_202205.6361-dirty-20230908.171154"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1550" name="testQosSaiPGDrop" time="1756.019"><properties><property name="start" value="2023-09-15 23:36:37.291180"/><property name="end" value="2023-09-16 00:05:53.311705"/></properties></testcase></testsuite></testsuites>AzDevOps@qos-sonic-mgmt:/data/tests$ 

100G/L - 100G/S (M-Dut)
============================================================================================= PASSES ==============================================================================================
___________________________________________________________________________________ TestQosSai.testQosSaiPGDrop ___________________________________________________________________________________
------------------------------------------ generated xml file: /run_logs/6361/2023-09-16-02-06-37/qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop.xml -------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
02:39:28 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop
=================================================================================== 1 passed in 1969.69 seconds ===================================================================================
AzDevOps@qos-sonic-mgmt:/data/tests$ cat /run_logs/6361/2023-09-16-02-06-37/qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="qos-sonic-mgmt" name="pytest" skipped="0" tests="1" time="1969.703" timestamp="2023-09-16T02:06:38.727258"><properties><property name="topology" value="t2"/><property name="testbed" value="t2-xx37-ls"/><property name="timestamp" value="2023-09-16 02:07:26.622500"/><property name="host" value="xx37-lc0"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-88_lc0_36fh_m-r0"/><property name="hwsku" value="Cisco-88-LC0-36FH-M-O36"/><property name="os_version" value="azure_cisco_msft_202205.6361-dirty-20230908.171154"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1550" name="testQosSaiPGDrop" time="1957.720"><properties><property name="start" value="2023-09-16 02:06:50.678345"/><property name="end" value="2023-09-16 02:39:28.400039"/></properties></testcase></testsuite></testsuites>AzDevOps@qos-sonic-mgmt:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
