### PR TITLE
Add the ability to download a SONiC image for use as the neighbor image

### DIFF
--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -58,7 +58,30 @@
 
     - name: Fail if there are no SONiC image and skip image downloading is active
       fail: msg="Please put {{ sonic_image_filename }} to {{ root_path }}/images"
-      when: not img_stat.stat.exists
+      when: not img_stat.stat.exists and skip_image_downloading
+
+    - name: Fail if there is no SONiC image download URL specified
+      fail: msg="Please set sonic_image_url to the URL where the SONiC image can be downloaded from"
+      when: not img_stat.stat.exists and not skip_image_downloading and sonic_image_url is not defined
+
+    - name: Download SONiC image
+      get_url: url="{{ sonic_image_url }}" dest="{{ root_path }}/images/{{ sonic_image_filename }}"
+      environment: "{{ proxy_env | default({}) }}"
+      when: not img_stat.stat.exists and not skip_image_downloading and sonic_image_url is defined
+
+    - name: Get downloaded SONiC image info
+      stat: path={{ root_path }}/images/{{ sonic_image_filename }}
+      register: downloaded_img_stat
+
+    - block:
+
+        - name: Rename file to have a .gz suffix
+          command: mv {{ root_path }}/images/{{ sonic_image_filename }} {{ root_path }}/images/{{ sonic_image_filename }}.gz
+
+        - name: Decompress file
+          command: gunzip {{ root_path }}/images/{{ sonic_image_filename }}.gz
+
+      when: '"application/gzip" in downloaded_img_stat.stat.mimetype'
 
     - set_fact:
         src_image_name: "{{ sonic_image_filename }}"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

When the neighbor devices are specified to be the type vsonic, allow downloading a SONiC image if the file doesn't exist already. This matches the behavior that is present with veos, but requires the user to specify a file name.

This can (indirectly) be used to also have different SONiC images used for different testbeds.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

This is needed to be able to easily run tests on servers with vsonic neighbors that don't already have a SONiC image downloaded.

#### How did you do it?

Allow specifying the download URL, which will get used if the image doesn't already exist. (It may actually be useful to replace the existing SONiC image, so that a fixed image is used always, but for now, the image on disk takes precedence.) Also decompress the image if it is in gzip format.

#### How did you verify/test it?

Tested locally only, with both having a missing image without `sonic_image_url` specified, and with a missing image with `sonic_image_url` specified.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
