### PR TITLE
[qos] fix keyerror dst

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -127,7 +127,7 @@ class ThriftInterface(BaseTest):
             self.dst_protocol = TBinaryProtocol.TBinaryProtocol(self.dst_transport)
             self.dst_client = switch_sai_rpc.Client(self.dst_protocol)
             self.dst_transport.open()
-            self.clients['dst'] = self.dst_client
+        self.clients['dst'] = self.dst_client
 
         self.platform_asic = self.test_params.get('platform_asic', None)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

qos sai case encounter lots of  "KeyError: 'dst'" for master branch

```
======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCtest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 1310, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PFCXonTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PFCXonTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2039, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.SharedResSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest
    dst_port_id, pkt, queue, self.asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.SharedResSizeTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 2847, in runTest",
"    dst_port_id, pkt, queue, self.asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.BufferPoolWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest
    dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.BufferPoolWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4660, in runTest",
"    dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.LossyQueueTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.LossyQueueTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.LossyQueueTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.LossyQueueTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.LossyQueueTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest
    pkt, int(self.test_params['pg']), asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.LossyQueueTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3321, in runTest",
"    pkt, int(self.test_params['pg']), asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.PGSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest
    self, src_port_id, dst_port_id, pkt, pg, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.PGSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 3758, in runTest",
"    self, src_port_id, dst_port_id, pkt, pg, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",

======================================================================
ERROR: sai_qos_tests.QSharedWatermarkTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest
    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))
  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one
    test_case.clients['dst'], \"dst\", dst_port_id)
KeyError: 'dst'

"======================================================================",
"ERROR: sai_qos_tests.QSharedWatermarkTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
"  File \"saitests/py3/sai_qos_tests.py\", line 4417, in runTest",
"    assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type))",
"  File \"saitests/py3/sai_qos_tests.py\", line 246, in fill_leakout_plus_one",
"    test_case.clients['dst'], \"dst\", dst_port_id)",
"KeyError: 'dst'",
```





#### How did you do it?

202205 relevant code is working well,
porting them to fix keyerror "dst"

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
