### PR TITLE
Fix BufferPoolWatermarkTest failure for cisco long-link

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -261,6 +261,7 @@ qos_params:
                     pkts_num_trig_pfc: 6412
                     cell_size: 8192
                     packet_size: 8140
+                    pkts_num_margin: 6
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 3000
@@ -343,6 +344,7 @@ qos_params:
                     pkts_num_trig_pfc: 23085
                     cell_size: 8192
                     packet_size: 8140
+                    pkts_num_margin: 20
                 wm_q_shared_lossless:
                     dscp: 3
                     ecn: 1

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -950,6 +950,7 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig[bufPool]["ecn"],
             "pg": qosConfig[bufPool]["pg"],
             "queue": qosConfig[bufPool]["queue"],
+            "pkts_num_margin": qosConfig[bufPool].get("pkts_num_margin", 0),
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4547,6 +4547,9 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_fill_shared = int(self.test_params['pkts_num_fill_shared'])
         cell_size = int(self.test_params['cell_size'])
+        pkts_num_margin = int(self.test_params['pkts_num_margin'])
+        if pkts_num_margin == 0:
+            pkts_num_margin = 2
 
         print("buf_pool_roid: %s" %
               (self.test_params['buf_pool_roid']), file=sys.stderr)
@@ -4581,9 +4584,9 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
-        upper_bound_margin = 2 * cell_occupancy
+        upper_bound_margin = pkts_num_margin * cell_occupancy
         if 'cisco-8000' in asic_type:
-            lower_bound_margin = 2 * cell_occupancy
+            lower_bound_margin = pkts_num_margin * cell_occupancy
         else:
             # On TD2, we found the watermark value is always short of the expected
             # value by 1

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4639,6 +4639,7 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 # but small margin still needed during boundary checks below
                 pkts_num = 1
                 expected_wm = pkts_num_fill_min * cell_occupancy
+                total_shared = pkts_num_fill_shared * cell_occupancy
             else:
                 pkts_num = (1 + upper_bound_margin) // cell_occupancy
             while (expected_wm < total_shared):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, For cisco-8000, pkts_num_fill_min is the maximum packet number in sms before evicted to hbm. These packets are also counted in buffer pool watermark after evicted to hbm.
2, Added some margin to BufferPoolWatermarkTest. 8140 B packets has 99.8% probability to increase SQ buffer counter by 1, and the 99.8% is not accurate for each test run that we can not count on. And we can't use 8156 B packet since one packet will occupy 2 hbm blocks.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified it in testbed.
```
---------------------------------- generated xml file: /run_logs/6237-qos/2023-09-19-21-59-25/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark.xml ----------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
22:17:48 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=================================================================================== 2 passed in 1101.73 seconds ===================================================================================
sonic@fb821b92d27e:/masic/tests$ cat /run_logs/6237-qos/2023-09-19-21-59-25/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="fb821b92d27e" name="pytest" skipped="0" tests="2" time="1101.740" timestamp="2023-09-19T21:59:26.876808"><properties><property name="topology" value="t2"/><property name="testbed" value="sfd-vt2"/><property name="timestamp" value="2023-09-19 22:01:03.205516"/><property name="host" value="sfd-vt2-lc0"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-88_lc0_36fh_mo-r0"/><property name="hwsku" value="Cisco-88-LC0-36FH-M-O36"/><property name="os_version" value="azure_cisco_msft_202205.6431-dirty-20230915.035820"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="910" name="testQosSaiBufferPoolWatermark[wm_buf_pool_lossless]" time="517.910"><properties><property name="start" value="2023-09-19 21:59:37.768956"/><property name="end" value="2023-09-19 22:08:15.680021"/></properties></testcase><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="910" name="testQosSaiBufferPoolWatermark[wm_buf_pool_lossy]" time="572.903"><properties><property name="start" value="2023-09-19 22:08:15.684931"/><property name="end" value="2023-09-19 22:17:48.589191"/></properties></testcase></testsuite></testsuites>sonic@fb821b92d27e:/masic/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
