### PR TITLE
[202205][advanced-reboot][dualtor] Update Loopback0 ping test: expect same count for sent and rcvd packets

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -2032,11 +2032,6 @@ class ReloadTest(BaseTest):
 
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.ping_dut_exp_packet, self.vlan_ports, timeout=self.PKT_TOUT)
 
-        if self.is_dualtor:
-            # handle two-for-one icmp reply for dual tor (when vlan and dut mac are diff):
-            # icmp_responder will also generate a response for this ICMP req, ignore that reply
-            total_rcv_pkt_cnt = total_rcv_pkt_cnt - self.ping_dut_pkts
-
         self.log("Send %5d Received %5d ping DUT" % (self.ping_dut_pkts, total_rcv_pkt_cnt), True)
 
         return total_rcv_pkt_cnt


### PR DESCRIPTION
Raising PR for cherry-pick conflict:
225e2570c [advanced-reboot][dualtor] Update Loopback0 ping test: expect same count for sent and rcvd packets (#9599)

sign-off: Jing Zhang zhangjing@microsoft.com 