### PR TITLE
[202305][acl][fanout] Optimize skip condition for SONiC fanout in test_acl_outer_vlan (#9170)

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -20,6 +20,7 @@ from abc import abstractmethod
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.utilities import check_skip_release
 
 logger = logging.getLogger(__name__)
 
@@ -627,7 +628,14 @@ def skip_sonic_leaf_fanout(fanouthosts):
     """
     for fanouthost in list(fanouthosts.values()):
         if fanouthost.get_fanout_os() == 'sonic':
-            pytest.skip("Not supporteds on SONiC leaf-fanout")
+            # Skips this test if the SONiC image installed on fanout is < 202205
+            is_skip, _ = check_skip_release(fanouthost, ["201811", "201911", "202012", "202106", "202111"])
+            if is_skip:
+                pytest.skip("OS Version of fanout is older than 202205, unsupported")
+            asic_type = fanouthost.facts['asic_type']
+            platform = fanouthost.facts["platform"]
+            if not (asic_type in ["broadcom"] or platform in ["armhf-nokia_ixs7215_52x-r0"]):
+                pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
 
 class TestAclVlanOuter_Ingress(AclVlanOuterTest_Base):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/9170
Currently some SONiC fanout supports tagged packet test. No need to skip for those devices.

#### How did you do it?
Optimize skip condition for SONiC fanout in test_acl_outer_vlan.

#### How did you verify/test it?
Run tests with Nokia 7215 / Broadcom SONiC fanouts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
