### PR TITLE
Use pytest option for swapping syncd in dscp remapping test

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -344,22 +344,24 @@ def _remove_ssh_tunnel_to_syncd_rpc(duthost):
 
 @pytest.fixture(scope='module')
 def swap_syncd(request, rand_selected_dut, creds):
-    public_docker_reg = request.config.getoption("--public_docker_registry")
-    new_creds = None
-    if public_docker_reg:
-        new_creds = copy.deepcopy(creds)
-        new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
-        new_creds['docker_registry_username'] = ''
-        new_creds['docker_registry_password'] = ''
-    else:
-        new_creds = creds
-    # Swap syncd container
-    docker.swap_syncd(rand_selected_dut, new_creds)
-    _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
+    if request.config.getoption("--qos_swap_syncd"):
+        public_docker_reg = request.config.getoption("--public_docker_registry")
+        new_creds = None
+        if public_docker_reg:
+            new_creds = copy.deepcopy(creds)
+            new_creds['docker_registry_host'] = new_creds['public_docker_registry_host']
+            new_creds['docker_registry_username'] = ''
+            new_creds['docker_registry_password'] = ''
+        else:
+            new_creds = creds
+        # Swap syncd container
+        docker.swap_syncd(rand_selected_dut, new_creds)
+        _create_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
     yield
-    # Restore syncd container
-    docker.restore_default_syncd(rand_selected_dut, new_creds)
-    _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
+    if request.config.getoption("--qos_swap_syncd"):
+        # Restore syncd container
+        docker.restore_default_syncd(rand_selected_dut, new_creds)
+        _remove_ssh_tunnel_to_syncd_rpc(rand_selected_dut)
 
 
 def _update_docker_service(duthost, docker="", action="", service=""):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For Nvidia, we use the RPC image instead of swapping syncd in the qos sai tests. We need an option to control if the swap_syncd should be executed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305 

### Approach
#### What is the motivation for this PR?
The pytest option "--qos_swap_syncd" is used in the regular qos sai test and we should also use it in the dscp remapping test.
The default value of this option is True, so this change won't affect existing test execution.
https://github.com/sonic-net/sonic-mgmt/blob/master/tests/conftest.py#L95-L96
#### How did you do it?
Only swap the syncd when "--qos_swap_syncd" is True.
#### How did you verify/test it?
Verified on dualtor testbed, no issues found.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
