### PR TITLE
Fix test issues in verify_dut_health.py

### DIFF
--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -38,8 +38,8 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(330, 30, 0, duthost.critical_services_fully_started),
-                  "dut.critical_services_fully_started is False")
+    if not wait_until(330, 30, 0, duthost.critical_services_fully_started):
+        raise RebootHealthError("dut.critical_services_fully_started is False")
 
     logging.info("Check critical service status")
     for service in duthost.critical_services:
@@ -152,8 +152,8 @@ def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
             'ls /var/core/ | grep -v python | wc -l')['stdout']
     else:
         pre_existing_cores = duthost.shell('ls /var/core/ | wc -l')['stdout']
-    pytest_assert(all(list(test_report.values())), "DUT not ready for test. Health check failed before reboot: {}"
-                  .format(test_report))
+    check_all = all([check is True for check in list(test_report.values())])
+    pytest_assert(check_all, "DUT not ready for test. Health check failed before reboot: {}".format(test_report))
 
     yield
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test issues in verify_dut_health.py, this script is used in the advanced reboot test.
There are two issues:
1. In check_services(), when the service check fails, it should not directly fail the test by pytest_assert. Instead, it should raise the RebootHealthError so the exception can be handled and added to the test report.
2. In the verify_dut_health(), the logic in verify_dut_health before the yield is not correct, the test does not fail on any health errors because any string(failure reason) is considered as True in the all() method.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix test issues in verify_dut_health.py
#### How did you do it?
1.  Raise the RebootHealthError when the service check fails.
2. If there is any failure in the pre-reboot checks, fail the test.
#### How did you verify/test it?
Run the advanced reboot tests in regression, no issues found related to this change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
