### PR TITLE
Stabilize acl_outer_vlan test

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -714,6 +714,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
 
         logger.info("Start arp_responder")
         ptfhost.command('supervisorctl start arp_responder')
+        time.sleep(10)
         return ip_list
 
     def _teardown_arp_responder(self, ptfhost):
@@ -736,7 +737,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
         # Populate ARP table on DUT
         cmds = []
         for ip in ip_list:
-            cmds.append("ping -c 1 {}".format(ip))
+            cmds.append("ping -c 3 {}".format(ip))
         duthost.shell_cmds(cmds=cmds, module_ignore_errors=True)
 
     def post_running_hook(self, duthost, ptfhost, ip_version):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_acl_outer_vlan.py`.
The test is flaky because of `arp_responder` running on ptf is not fully ready when the first test case starts to run.
This PR improve the test case by
1. Add a 10 seconds delay after starting `arp_responder`
2. Ping 3 times instead of 1 time to populate ARP entry.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_acl_outer_vlan.py`.

#### How did you do it?
1. Add a 10 seconds delay after starting `arp_responder`
2. Ping 3 times instead of 1 time to populate ARP entry

#### How did you verify/test it?
The change is verified on a SN2700 testbed.

```
collected 16 items                                                                                                                                                                                    

acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv4] PASSED                                                                                                         [  6%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4] PASSED                                                                                                           [ 12%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv4]  ^HPASSED                                                                                                       [ 18%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv4] PASSED                                                                                                         [ 25%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv4] PASSED                                                                                                [ 31%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv4] PASSED                                                                                                  [ 37%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv4] PASSED                                                                                              [ 43%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv4] PASSED                                                                                                [ 50%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                       [ 56%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                         [ 62%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                     [ 68%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                       [ 75%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                              [ 81%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                                [ 87%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                            [ 93%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6] SKIPPED (IPV6 EGRESS test not supported)                                                              [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
