### PR TITLE
[Platform_tests/test_watchdog]: Added platform check to disarm watchdog for nokia_ixs7215

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -39,10 +39,14 @@ class TestWatchdogApi(PlatformApiTestBase):
     ''' Hardware watchdog platform API test cases '''
 
     @pytest.fixture(scope='function', autouse=True)
-    def watchdog_not_running(self, platform_api_conn):
+    def watchdog_not_running(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):
         ''' Fixture that automatically runs on each test case and
         verifies that watchdog is not running before the test begins
         and disables it after the test ends'''
+
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
+            duthost.shell("watchdogutil disarm")
 
         assert not watchdog.is_armed(platform_api_conn)
 
@@ -50,6 +54,8 @@ class TestWatchdogApi(PlatformApiTestBase):
             yield
         finally:
             watchdog.disarm(platform_api_conn)
+            if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
+                duthost.shell("systemctl start cpu_wdt.service")
 
     @pytest.fixture(scope='module')
     def conf(self, request, duthosts, enum_rand_one_per_hwsku_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Since watchdog was implemented in Nokia 7215, the api testcase 'test_watchdog'  needs additional improvements. The test checks if watchdog is disarmed before running the tests. Since watchdog has now been implemented in Nokia 7215 platform as a service (cpu_wdt.service), watchdog will be armed. The watchdog api tests fail as watchdog is already armed. 
#### How did you do it?
The addition here to check if the platform is 'armhf-nokia_ixs7215_52x-r0' and then disarm the watchdog before the tests start. Once watchdog is disarmed, watchdog api tests will run successfully. After these testcases are complete, we arm the watchdog again by starting the cpu_wdt.service.  
#### How did you verify/test it?
Ran all the watchdog api testcases to verify is they pass. Also checked if the watchdog service is up and running once the testcases are complete.
#### Any platform specific information?
This conditional check and execution of watchdog disarm and then starting the service after the tests run is specific to nokia 7215 platform. 
#### Supported testbed topology if it's a new test case?


