### PR TITLE
Temporarily skip macsec tests on sonic t0 testbed.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,7 @@ stages:
           VM_TYPE: vsonic
           KVM_IMAGE_BRANCH: "master"
           MGMT_BRANCH: "master"
+          SCRIPTS_EXCLUDE: "bgp/test_bgp_fact.py"
 
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -641,6 +641,12 @@ ipfwd/test_nhop_group.py::test_nhop_group_member_order_capability:
 #######################################
 #####           macsec            #####
 #######################################
+macsec:
+  skip:
+    reason: 'Skip for t0-sonic to prevent deadlock with code PR merge'
+    conditions:
+      - "'t0' in topo_name"
+
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:
     reason: 'test_server_to_neighbor needs downstream neighbors, which is not present in this topo'


### PR DESCRIPTION
### Approach
#### What is the motivation for this PR?
Similar to PR's done in 202205

https://github.com/sonic-net/sonic-mgmt/pull/9874
https://github.com/sonic-net/sonic-mgmt/pull/9903

These changes will be reverted later (new PR similar to below one, to be raised in master) once sonic-swss submodule is updated in master branch
https://github.com/sonic-net/sonic-mgmt/pull/9909

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
