### PR TITLE
Fix test_gnmi_configdb_incremental_01 failure

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -36,20 +36,10 @@ def get_first_interface(duthost):
 
 
 def get_interface_status(duthost, field, interface='Ethernet0'):
-    cmds = "show interface status {}".format(interface)
+    cmds = 'sonic-db-cli CONFIG_DB hget "PORT|{}" {}'.format(interface, field)
     output = duthost.shell(cmds)
     assert (not output['rc']), "No output"
-    status_data = output["stdout_lines"]
-    if field not in status_data[0]:
-        return None
-    field_index = status_data[0].split().index(field)
-    for line in status_data:
-        if interface in line:
-            interface_status = line.strip()
-            assert len(interface_status) > 0, "Failed to read {} interface properties".format(interface)
-            status = re.split(r" {2,}", interface_status)[field_index]
-            return status
-    return None
+    return output["stdout"]
 
 
 def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, localhost):
@@ -71,7 +61,7 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, localhost
     ret, msg = gnmi_set(duthost, localhost, [], update_list, [])
     assert ret == 0, msg
     # Check interface status and gnmi_get result
-    status = get_interface_status(duthost, "Admin", interface)
+    status = get_interface_status(duthost, "admin_status", interface)
     assert status == "down", "Incremental config failed to toggle interface %s status" % interface
     ret, msg_list = gnmi_get(duthost, localhost, path_list)
     assert ret == 0, msg_list[0]
@@ -84,7 +74,7 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, localhost
     ret, msg = gnmi_set(duthost, localhost, [], update_list, [])
     assert ret == 0, msg
     # Check interface status and gnmi_get result
-    status = get_interface_status(duthost, "Admin", interface)
+    status = get_interface_status(duthost, "admin_status", interface)
     assert status == "up", "Incremental config failed to toggle interface %s status" % interface
     ret, msg_list = gnmi_get(duthost, localhost, path_list)
     assert ret == 0, msg_list[0]
@@ -133,7 +123,7 @@ def test_gnmi_configdb_full_01(duthosts, rand_one_dut_hostname, localhost):
     ret, msg = gnmi_set(duthost, localhost, delete_list, update_list, [])
     assert ret == 0, msg
     # Check interface status and gnmi_get result
-    status = get_interface_status(duthost, "Admin", interface)
+    status = get_interface_status(duthost, "admin_status", interface)
     assert status == "up", "Port status is changed"
     # GNOI reboot
     ret, msg = gnoi_reboot(duthost, localhost, 0, 0, "abc")
@@ -145,7 +135,7 @@ def test_gnmi_configdb_full_01(duthosts, rand_one_dut_hostname, localhost):
         wait_until(300, 10, 0, check_interface_status_of_up_ports, duthost),
         "Not all ports that are admin up on are operationally up")
     # Check interface status
-    status = get_interface_status(duthost, "Admin", interface)
+    status = get_interface_status(duthost, "admin_status", interface)
     assert status == "down", "Full config failed to toggle interface %s status" % interface
     # Startup interface
     duthost.shell("config interface startup %s" % interface)

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import pytest
-import re
 
 from .helper import gnmi_set, gnmi_get, gnoi_reboot
 from tests.common.helpers.assertions import pytest_assert


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
"show interface status" is wrong after gnmi incremental config, this command reads from APPL_DB, and we should read from CONFIG_DB.

Microsoft ADO: 25136266

#### How did you do it?
Read CONFIG_DB to get admin_status.

#### How did you verify/test it?
Run gnmi end2end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
