### PR TITLE
Skip test_read_mac_metadata if required parameters are missing

### DIFF
--- a/tests/read_mac/conftest.py
+++ b/tests/read_mac/conftest.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
         action="store",
         type=int,
         help="Number of image installing iterations",
-        required=True,
+        required=False,
     )
 
     read_mac_group.addoption(
@@ -22,7 +22,7 @@ def pytest_addoption(parser):
         action='store',
         type=str,
         help='1st image to download and install',
-        required=True,
+        required=False,
     )
 
     read_mac_group.addoption(
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
         action='store',
         type=str,
         help='2nd image to download and install',
-        required=True,
+        required=False,
     )
 
     read_mac_group.addoption(

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -46,11 +46,13 @@ def cleanup_read_mac(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localh
 
 class ReadMACMetadata():
     def __init__(self, request):
-        image1 = request.config.getoption("--image1")
-        image2 = request.config.getoption("--image2")
-        self.iteration = request.config.getoption("--iteration")
-        self.minigraph1 = request.config.getoption("--minigraph1")
-        self.minigraph2 = request.config.getoption("--minigraph2")
+        image1 = request.config.getoption("--image1", default=None)
+        image2 = request.config.getoption("--image2", default=None)
+        self.iteration = request.config.getoption("--iteration", default=1)
+        self.minigraph1 = request.config.getoption("--minigraph1", default=None)
+        self.minigraph2 = request.config.getoption("--minigraph2", default=None)
+        if not image1 or not image2:
+            pytest.skip("Skip test due to missing --image1 or --image2")
 
         if self.iteration < 1:
             pytest.fail("Please specify --iteration in correct range")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test arguments `image1`, `image2` and `iteration` are set to required arguments in test module `test_read_mac_metadata.py` . If the test pipeline doesn't set the argument, an error is thrown
```
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: the following arguments are required: --iteration, --image1, --image2
```
To reduce noise, the arguments are changed to be optional, and the test will be skipped if any of the arguments is missing. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to skip test_read_mac_metadata if required parameters are missing.

#### How did you do it?
To reduce noise, the arguments are changed to be optional, and the test will be skipped if any of the arguments is missing. 

#### How did you verify/test it?
The change is verified on a physical testbed. The test is skipped if the argument is not set.
```
collected 1 item                                                                                                                                                                                      

read_mac/test_read_mac_metadata.py::test_read_mac_metadata[str-msn2700-22] SKIPPED (Skip test due to missing --image1 or --image2)                                                              [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
