### PR TITLE
[202205] [cherry-pick] Ignore pmon error for getting sensor data

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -177,3 +177,6 @@ r, ".*WARNING kernel: .*linux_knet_cb.*linux_bcm_knet.*linux_user_bde.*linux_ker
 r, ".* ERR .*CounterCheck: Invalid port oid.*"
 
 r, ".*ERR syncd[0-9]*#SDK.*sai_get_attributes: Failed to get attribute.*"
+
+# https://msazure.visualstudio.com/One/_workitems/edit/24564189
+r, ".* ERR pmon#sensord: Error getting sensor data: dps.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cherry-pick #9009 to `202205` after resolving conflict.

This PR is to ignore log pattern
```
 Error getting sensor data: dps460/#10: Can't read
```
The error log was seen on `Mellanox` platform. It has been confirmed that the log message has no impact, and it's only seen on old PSU. The new PSU will address the issue.
To reduce noise, we ignore the error log pattern.

**Case Number:** 00577909

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?
This PR is to ignore a certain pmon error log pattern.

#### How did you verify/test it?
As the error log doesn't show up frequently, I verified the regex by running a python script.

#### Any platform specific information?
The error message is seen on `Mellanox` devices for now.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
