### PR TITLE
Skip SNMP IPv6 testcases in 2022xx 2023xx branches

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1046,7 +1046,7 @@ snmp/test_snmp_link_local.py:
     conditions:
       - https://github.com/sonic-net/sonic-buildimage/issues/6108
       - "is_multi_asic==False"
-      - "release in ['202205', '202211', '202305'])"
+      - "release in ['202205', '202211', '202305']"
 
 snmp/test_snmp_pfc_counters.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1044,13 +1044,7 @@ snmp/test_snmp_link_local.py:
   skip:
     reason: "SNMP over IPv6 support not present in 202211 release."
     conditions:
-      - "release in ['202211']"
-
-snmp/test_snmp_loopback.py:
-  skip:
-    reason: "SNMP over Loopback IPv6 support not present in 202211 release."
-    conditions:
-      - "release in ['202211']"
+      - "(is_multi_asic==False) and (release in ['202205', '202211', '202305'])"
 
 snmp/test_snmp_pfc_counters.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1042,9 +1042,11 @@ show_techsupport/test_techsupport.py::test_techsupport:
 #######################################
 snmp/test_snmp_link_local.py:
   skip:
-    reason: "SNMP over IPv6 support not present in 202211 release."
+    reason: "SNMP over IPv6 support not present in release branches."
     conditions:
-      - "(is_multi_asic==False) and (release in ['202205', '202211', '202305'])"
+      - https://github.com/sonic-net/sonic-buildimage/issues/6108
+      - "is_multi_asic==False"
+      - "release in ['202205', '202211', '202305'])"
 
 snmp/test_snmp_pfc_counters.py:
   skip:

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -1,6 +1,8 @@
 import pytest
+import ipaddress
 from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_output
 from tests.common.devices.eos import EosHost
+from tests.common.utilities import skip_release
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
@@ -8,8 +10,9 @@ pytestmark = [
 ]
 
 
+@pytest.mark.parametrize('ip_version', [ipaddress.IPv4Address, ipaddress.IPv6Address])
 def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                       nbrhosts, tbinfo, localhost, creds_all_duts):
+                       nbrhosts, tbinfo, localhost, creds_all_duts, ip_version):
     """
     Test SNMP query to DUT over loopback IP
       - Send SNMP query over loopback IP from one of the BGP Neighbors
@@ -29,6 +32,13 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     for ip in config_facts['LOOPBACK_INTERFACE']['Loopback0']:
         loip = ip.split('/')[0]
+        ipaddr = ipaddress.ip_address(loip)
+        if not isinstance(ipaddr, ip_version):
+            continue
+        if isinstance(ipaddr, ipaddress.IPv6Address):
+            # SNMP over IPv6 not supported in single-asic
+            if not duthost.is_multi_asic:
+                skip_release(duthost, ["202211", "202205", "202305"])
         result = get_snmp_output(loip, duthost, nbr, creds_all_duts)
         assert result is not None, 'No result from snmpget'
         assert len(result['stdout_lines']) > 0, 'No result from snmpget'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Skip SNMP IPv6 related test cases in 202211,202205 and 202305 branches until the approach to fix IPv6 issue is fixed.
PR contains details of the issue and approach https://github.com/sonic-net/SONiC/pull/1457 
#### How did you do it?
Skip single asic IPv6 SNMP loopback test case and link local test case in branches with the testcase added.
#### How did you verify/test it?
Tested on 202205 single asic VS image:
```
snmp/test_snmp_loopback.py::test_snmp_loopback[vlab-01-IPv4Address] PASSED                                              [ 50%]
snmp/test_snmp_loopback.py::test_snmp_loopback[vlab-01-IPv6Address] SKIPPED                                             [100%]

----------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ------------------------------------
=================================================== short test summary info ===================================================
SKIPPED [1] /data/sonic-mgmt/tests/common/utilities.py:67: DUT has version 202205.368253-4ee956506 and test does not support 202211, 202205, 202305
============================================ 1 passed, 1 skipped in 23.30 seconds =============================================
INFO:root:Can not get Allure report URL. Please check logs
```
test_snmp_link_local.py:
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_link_local.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -e "--mark-conditions-files common/plugins/conditional_mark/tests_mark_conditions.yaml" -u -e "--rootdir /data/sonic-mgmt/tests"

SKIPPED [1] snmp/test_snmp_link_local.py:19: SNMP over IPv6 support not present in release branches.
=========================================== 1 skipped, 1 warnings in 15.98 seconds ============================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
