### PR TITLE
[sonic-mgmt snmp] Fix test_snmp_queue.py multi-asic support for multiple linecards

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -42,7 +42,9 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
             q_interfaces.add(intf[1])
         # Packet chassis 'QUEUE|<hostname>|<asic_ns>|Ethernet*|2'
         elif len(intf) == 5:
-            q_interfaces.add(intf[3])
+            # Choose only interfaces on current linecard.
+            if intf[1] == duthost.hostname:
+                q_interfaces.add(intf[3])
 
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c",
                                 community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -40,7 +40,7 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
         # 'QUEUE|Ethernet*|2'
         if len(intf) == 3:
             q_interfaces.add(intf[1])
-        # Packet chassis 'QUEUE|<hostname>|<asic_ns>|Ethernet*|2'
+        # Voq chassis 'QUEUE|<hostname>|<asic_ns>|Ethernet*|2'
         elif len(intf) == 5:
             # Choose only interfaces on current linecard.
             if intf[1] == duthost.hostname:


### PR DESCRIPTION
### Description of PR
Addresses https://github.com/sonic-net/sonic-mgmt/issues/10099 by adding filtering for the queue interfaces fetched from CONFIG_DB to choose only those on the current linecard.

Summary:
Fixes #10099 10099

### Type of change

- [x] Bug fix

### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix [10099](https://github.com/sonic-net/sonic-mgmt/issues/10099)

#### How did you do it?
Filtered interfaces on the current linecard.

#### How did you verify/test it?
Ran updates test against a DUT that has both a single-asic and a multi-asic linecard.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

