### PR TITLE
[M0/Mx] Skip unsupported testcases on M0/Mx topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -106,6 +106,12 @@ bgp/test_bgp_multipath_relax.py:
     conditions:
       - "'backend' in topo_name"
 
+bgp/test_bgp_queue.py:
+  skip:
+    reason: "Unsupported topology"
+    conditions:
+      - "topo_type in ['m0', 'mx']"
+
 bgp/test_bgp_slb.py:
   skip:
     reason: "Skip over topologies which doesn't support slb."
@@ -535,6 +541,12 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic
 generic_config_updater/test_pfcwd_status.py:
   skip:
     reason: "PFC watchdog is not supported on M0/Mx topology"
+    conditions:
+      - "topo_type in ['m0', 'mx']"
+
+generic_config_updater/test_pg_headroom_update.py:
+  skip:
+    reason: "Unsupported topology."
     conditions:
       - "topo_type in ['m0', 'mx']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip below testcases on M0/Mx topology:
- bgp/test_bgp_queue.py
- generic_config_updater/test_pg_headroom_update.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Skip below testcases on M0/Mx topology:
- bgp/test_bgp_queue.py
- generic_config_updater/test_pg_headroom_update.py

#### How did you do it?
Updated conditional mark file.

#### How did you verify/test it?
Verified on Mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
