### PR TITLE
dualtor_test_tor_ecn mixed and a-a topo failure fix

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1444,7 +1444,7 @@ def is_tunnel_qos_remap_enabled(duthost):
     try:
         tunnel_qos_remap_status = duthost.shell('sonic-cfggen -d -v \'SYSTEM_DEFAULTS.tunnel_qos_remap.status\'',
                                                 module_ignore_errors=True)["stdout_lines"][0]
-    except IndexError:
+    except (IndexError, NameError):
         return False
     return "enabled" == tunnel_qos_remap_status
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -30,7 +30,8 @@ from tests.common.fixtures.ptfhost_utils import run_garp_service                
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp, derive_out_dscp_from_inner_dscp
-from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -103,8 +104,7 @@ def build_encapsulated_ip_packet(
 
     inner_ttl = random.choice(list(range(3, 65)))
     inner_ecn = random.choice(list(range(0, 3)))
-    if is_tunnel_qos_remap_enabled(tor):
-        outer_dscp = derive_out_dscp_from_inner_dscp(tor, inner_dscp)
+    outer_dscp = derive_out_dscp_from_inner_dscp(tor, inner_dscp)
     outer_ecn = inner_ecn
 
     logging.info("Inner DSCP: {0:06b}, Inner ECN: {1:02b}".format(inner_dscp, inner_ecn))
@@ -327,6 +327,18 @@ def write_standby(rand_selected_dut):
         pytest.skip('file {} not found'.format(file))
 
 
+@pytest.fixture
+def setup_active_active_ports(active_active_ports, rand_selected_dut, rand_unselected_dut,                  # noqa F811
+                              config_active_active_dualtor_active_standby,                                  # noqa F811
+                              validate_active_active_dualtor_setup):                                        # noqa F811
+    if active_active_ports:
+        logging.info("Configuring {} as active".format(rand_unselected_dut.hostname))
+        logging.info("Configuring {} as standby".format(rand_selected_dut.hostname))
+        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, active_active_ports)
+
+    return
+
+
 @pytest.mark.parametrize("dscp", [3, 4, 2, 6])      # lossless queue is 3 or 4 or 2 or 6.
 def test_dscp_to_queue_during_encap_on_standby(
     dscp,
@@ -337,7 +349,8 @@ def test_dscp_to_queue_during_encap_on_standby(
     tunnel_traffic_monitor,                         # noqa F811
     duthosts,
     rand_one_dut_hostname,
-    write_standby
+    write_standby,
+    setup_active_active_ports
 ):
     """
     Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
@@ -397,7 +410,8 @@ def test_ecn_during_encap_on_standby(
     setup_dualtor_tor_standby,
     rand_selected_interface, ptfadapter,                    # noqa F811
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
-    write_standby
+    write_standby,
+    setup_active_active_ports
 ):
     """
     Test if the ECN stamping on outer header is matching with inner during encap on standby

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -30,8 +30,8 @@ from tests.common.fixtures.ptfhost_utils import run_garp_service                
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp, derive_out_dscp_from_inner_dscp
-from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby
-from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby      # noqa F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup             # noqa F401
 
 pytestmark = [
     pytest.mark.topology("dualtor")


### PR DESCRIPTION
Summary: 
When test_dscp_to_queue_during_encap_on_standby and test_ecn_during_encap_on_standby are run in mixed or A-A topology, while randomly selecting PTF IP to test we sometimes select IP mapped to a port with active-active config.. If we select such PTF IP, we won't see expected behavior. With this PR we have added a check to force A-S if this test case is run.

Second part of the change in related to handling the code flow for test cases in test_tor_ecn.py if SYSTEM_DEFAULTS config is not present.

Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/10078

Type of change

[x ] Test case(new/improvement)
Back port request
202205

Approach

Why I did it
To select PTF IP mapped to a port with active-standby mux config AND to avoid below error when SYSTEM_DEFAULTS is not present.

cisco@m64-tor-0-yy41:~$ sonic-cfggen -d -v 'SYSTEM_DEFAULTS.tunnel_qos_remap.status'
 Traceback (most recent call last):
 File "/usr/local/bin/sonic-cfggen", line 443, in <module>
 main()
 File "/usr/local/bin/sonic-cfggen", line 416, in main
 print(template.render(data))
 File "/usr/local/lib/python3.9/dist-packages/jinja2/environment.py", line 1301, in render
 self.environment.handle_exception()
 File "/usr/local/lib/python3.9/dist-packages/jinja2/environment.py", line 936, in handle_exception
 raise rewrite_traceback_stack(source=source)
 File "<template>", line 1, in top-level template code
 File "/usr/local/lib/python3.9/dist-packages/jinja2/environment.py", line 485, in getattr
 return getattr(obj, attribute)
 jinja2.exceptions.UndefinedError: 'SYSTEM_DEFAULTS' is undefined

This makes the script fail at [https://github.com/sonic-net/sonic-mgmt/blob/202205/tests/dualtor/test_tor_ecn.py#L101] and outer_dscp is not defined in the script.
How I did it
Introduced a new fn to select neigh IP randomly with a check for active-standby mux config

How to verify it
Verified that PTF IP mapped to a port with active-standby mux config is selected to test and test case passes on mixed topo AND these test cases are skipped on A-A topo

Mixed Run:

----------------- generated xml file: /data/tests/logs/anant_debug_9468/0912/with-3-changes-full-4/tr_2023-09-12-07-29-30.xml -----------------
INFO:root:Can not get Allure report URL. Please check logs
----------------------------------------------------------- live log sessionfinish ------------------------------------------------------------
07:44:11 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================================================= 16 passed in 879.22 seconds =========================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f14b055ebe0>> ignored
A-A Run:

----------------------------------------------------------- live log sessionfinish ------------------------------------------------------------
18:55:55 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=========================================================== short test summary info ===========================================================
SKIPPED [8] /data/tests/common/dualtor/dual_tor_utils.py:1289: no active-standby port found in mux config. Skip cable type 'active-active'
==================================================== 8 passed, 8 skipped in 550.13 seconds ====================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7fc25883e910>> ignored
sonic@sonic-ucs-m6-1:/data/tests$ 
Which release branch to backport (provide reason below if selected)
202205

Any platform specific information?

NA

Supported testbed topology if it's a new test case?

NA