### PR TITLE
use a custom table type for stress test

### DIFF
--- a/tests/acl/templates/acltb_test_stress_acl_table.j2
+++ b/tests/acl/templates/acltb_test_stress_acl_table.j2
@@ -1,6 +1,6 @@
 {
 	"ACL_TABLE_TYPE": {
-		"L3": {
+		"STRESS_L3": {
 			"MATCHES": "SRC_IP",
 			"ACTIONS": "PACKET_ACTION",
 			"BIND_POINTS": "PORT"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

After running "test_stress_acl.py", the DUT could not create new L3 table anymore.
If we run "test_acl.py" after "test_stress_acl.py", it will report 400 TCs error with ：

Expected Messages that are missing:
E               .Created ACL table.


For exmaple, after running "test_stress_acl.py", then we try to create a L3 table manually：

cisco@mth64-m5-2:~$ date
Fri 22 Sep 2023 09:27:32 PM UTC
cisco@mth64-m5-2:~$ sudo config acl add table DATA_INGRESS_IPV4_TEST_2 L3 -s ingress -p PortChannel1011,PortChannel1010,PortChannel1013,PortChannel1012,PortChannel1015,PortChannel1014,PortChannel1017,PortChannel1016,PortChannel1019,PortChannel1018,PortChannel105,PortChannel104,PortChannel107,PortChannel106,PortChannel101,PortChannel103,PortChannel102,PortChannel109,PortChannel108,PortChannel1024,PortChannel1020,PortChannel1021,PortChannel1022,PortChannel1023
cisco@mth64-m5-2:~$ 
cisco@mth64-m5-2:~$ show log | grep "Created A"
....
Sep 22 20:28:10.338382 mth64-m5-2 NOTICE swss#orchagent: :- addAclTable: Created ACL table EVERFLOWV6 oid:7000000000a42
Sep 22 21:05:10.703453 mth64-m5-2 NOTICE swss#orchagent: :- doAclTableTypeTask: Created ACL table type L3
Sep 22 21:05:22.519428 mth64-m5-2 NOTICE swss#orchagent: :- addAclTable: Created ACL table STRESS_ACL oid:7000000000aec
cisco@mth64-m5-2:~$ 


### Summary:
In test_stress_acl.py, it defines a custom ACL table type "L3" also.

After run this script, it tries to delete this ACL table type "L3".

So, later we could not create L3 ACL table anymore.

That's the rootcause.  We should use a custom name instread of the existing hidden type "L3" in sonic.

BTW, This issue is exposed because the following PR:
[[Remove key `ACL_TABLE_TYPE` in running config after module `acl/test_stress_acl.py` running. by yutongzhang-microsoft · Pull Request #8762 · sonic-net/sonic-mgmt (github.com)](https://github.com/sonic-net/sonic-mgmt/pull/8762)](https://github.com/sonic-net/sonic-mgmt/pull/8762)

After this merge, no "config reload" to recover after running "test_stress_acl.py"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
