### PR TITLE
GCU Fix for DHCP Head PR

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -415,6 +415,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         delete_untagged_vlan: check to delete unttaged vlan
     '''
     cmds = []
+    port_mode_added = {}    # Keep track of whether switchport mode has been added for each port
     logger.info("Add vlans, assign IPs")
     for k, v in list(vlan_intfs_dict.items()):
         if v['orig']:
@@ -438,8 +439,10 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-            if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
-                cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
+            if vlan_port['dev'] not in port_mode_added:
+                if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
+                    cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
+            port_mode_added[vlan_port['dev']] = True
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -458,8 +461,10 @@ def check_switchport_cmd(duthost, tport):
         cmds = 'config switchport mode routed {port}'.format(port=tport)
         logger.info("Commands: {}".format(cmds))
         out = duthost.shell(cmds, module_ignore_errors=True)
-        return True
-
+        if out['rc'] == 0:
+            return True
+        else:
+            return False
     return False
 
 

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -442,7 +442,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             if vlan_port['dev'] not in port_mode_added:
                 if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
                     cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
-            port_mode_added[vlan_port['dev']] = True
+                port_mode_added[vlan_port['dev']] = True
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -463,8 +463,6 @@ def check_switchport_cmd(duthost, tport):
         out = duthost.shell(cmds, module_ignore_errors=True)
         if out['rc'] == 0:
             return True
-        else:
-            return False
     return False
 
 


### PR DESCRIPTION
#### Description of PR
This PR is created to resolve issues in KVM test which are failing in advance utilities HEAD PR. KVM Elastic test are failing in generic_config_updater/test_dhcp_relay.py file due to missing mode attribute.

#### What is the motivation for this PR?
Modified GCU fixtures/duthost_utilities.py to make it compatible for HEAD PR . We have added "switchport mode command" in duthost_utilites to add mode trunk on Ethernet4 so that it will allow addition of vlan membership on ports. Added a function to check "switchport mode explicitly". The check was missing in earlier case due to which all port are running "switchport" command twice and change mode everytime.