### PR TITLE
[TACACS] Fix per-command authorization UT failed because server-side update log delay issue.

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -293,7 +293,7 @@ def check_server_received(ptfhost, data):
         res = ptfhost.shell(sed_command)
         logger.info(sed_command)
         logger.info(res["stdout_lines"])
-        if len(res["stdout_lines"]) > 0p:
+        if len(res["stdout_lines"]) > 0:
             return
 
         time.sleep(1)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -286,10 +286,20 @@ def check_server_received(ptfhost, data):
             E501 : Line too long. Following sed command difficult to split to multiple line.
     """
     sed_command = "sed -n 's/.*-> 0x\(..\).*/\\1/p'  /var/log/tac_plus.log | sed ':a; N; $!ba; s/\\n//g' | grep '{0}'".format(hex_string)   # noqa W605 E501
-    res = ptfhost.shell(sed_command)
-    logger.info(sed_command)
-    logger.info(res["stdout_lines"])
-    pytest_assert(len(res["stdout_lines"]) > 0)
+
+    # After tacplus service receive data, it need take some time to update to log file.
+    wait_time = 0
+    while wait_time <= timeout:
+        res = ptfhost.shell(sed_command)
+        logger.info(sed_command)
+        logger.info(res["stdout_lines"])
+        if len(res["stdout_lines"]) > 0p:
+            return
+
+        time.sleep(1)
+        wait_time += 1
+
+    pytest_assert(False, "Not found data: {} in tacplus server log".format(data))
 
 
 def get_auditd_config_reload_timestamp(duthost):

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -2,7 +2,6 @@ import crypt
 import logging
 import re
 import binascii
-import time
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, check_skip_release, delete_running_config

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -258,7 +258,7 @@ def remove_all_tacacs_server(duthost):
             duthost.shell("sudo config tacacs delete %s" % tacacs_server)
 
 
-def check_server_received(ptfhost, data):
+def check_server_received(ptfhost, data, timeout=10):
     """
         Check if tacacs server received the data.
     """

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -268,7 +268,7 @@ def remove_all_tacacs_server(duthost):
             duthost.shell("sudo config tacacs delete %s" % tacacs_server)
 
 
-def check_server_received(ptfhost, data, timeout=10):
+def check_server_received(ptfhost, data, timeout=30):
     """
         Check if tacacs server received the data.
     """


### PR DESCRIPTION
Fix per-command authorization UT failed because server-side update log delay issue.

### Description of PR
Fix per-command authorization UT failed because server-side update log delay issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix per-command authorization UT failed because server-side update log delay issue.

#### How did you do it?
Retry when log or output not ready.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
