### PR TITLE
[TACACS] Ensure tacacs server running after UT stop it.

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -10,7 +10,7 @@ from .test_authorization import ssh_connect_remote, ssh_run_command, \
         remove_all_tacacs_server
 from .utils import stop_tacacs_server, start_tacacs_server, \
         check_server_received, per_command_accounting_skip_versions, \
-        change_and_wait_aaa_config_update
+        change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -10,7 +10,7 @@ from .test_authorization import ssh_connect_remote, ssh_run_command, \
         remove_all_tacacs_server
 from .utils import stop_tacacs_server, start_tacacs_server, \
         check_server_received, per_command_accounting_skip_versions, \
-        change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut
+        change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut # noqa: F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
@@ -172,7 +172,7 @@ def test_accounting_tacacs_only_all_tacacs_server_down(
                                                     tacacs_creds,
                                                     check_tacacs,
                                                     rw_user_client,
-                                                    ensure_tacacs_server_running_after_ut):
+                                                    ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting tacacs+")
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -284,7 +284,7 @@ def test_accounting_tacacs_and_local_all_tacacs_server_down(
                                                         tacacs_creds,
                                                         check_tacacs,
                                                         rw_user_client,
-                                                        ensure_tacacs_server_running_after_ut):
+                                                        ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
     cleanup_tacacs_log(ptfhost, rw_user_client)

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -171,7 +171,8 @@ def test_accounting_tacacs_only_all_tacacs_server_down(
                                                     enum_rand_one_per_hwsku_hostname,
                                                     tacacs_creds,
                                                     check_tacacs,
-                                                    rw_user_client):
+                                                    rw_user_client,
+                                                    ensure_tacacs_server_running_after_ut):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting tacacs+")
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -282,7 +283,8 @@ def test_accounting_tacacs_and_local_all_tacacs_server_down(
                                                         enum_rand_one_per_hwsku_hostname,
                                                         tacacs_creds,
                                                         check_tacacs,
-                                                        rw_user_client):
+                                                        rw_user_client,
+                                                        ensure_tacacs_server_running_after_ut):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
     cleanup_tacacs_log(ptfhost, rw_user_client)

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -10,7 +10,7 @@ from .test_authorization import ssh_connect_remote, ssh_run_command, \
         remove_all_tacacs_server
 from .utils import stop_tacacs_server, start_tacacs_server, \
         check_server_received, per_command_accounting_skip_versions, \
-        change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut # noqa: F401
+        change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut  # noqa: F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -268,7 +268,7 @@ def test_authorization_tacacs_only_some_server_down(
 
 def test_authorization_tacacs_only_then_server_down_after_login(
         setup_authorization_tacacs, ptfhost, check_tacacs,
-        remote_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
+        remote_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
 
     # Verify when server are accessible, TACACS+ user can run command in server side whitelist.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "show aaa")
@@ -322,7 +322,7 @@ def test_authorization_tacacs_and_local(
 def test_authorization_tacacs_and_local_then_server_down_after_login(
         duthosts, enum_rand_one_per_hwsku_hostname,
         setup_authorization_tacacs_local, tacacs_creds, ptfhost,
-        check_tacacs, remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
+        check_tacacs, remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Shutdown tacacs server
@@ -367,7 +367,7 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(
 def test_authorization_local(
         duthosts, enum_rand_one_per_hwsku_hostname,
         tacacs_creds, ptfhost, check_tacacs,
-        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     """
@@ -465,7 +465,7 @@ def test_bypass_authorization(
 def test_backward_compatibility_disable_authorization(
         duthosts, enum_rand_one_per_hwsku_hostname,
         tacacs_creds, ptfhost, check_tacacs,
-        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Verify domain account can run command if have permission in local.

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -6,7 +6,8 @@ import time
 
 from tests.tacacs.utils import stop_tacacs_server, start_tacacs_server
 from tests.tacacs.utils import per_command_authorization_skip_versions, \
-        remove_all_tacacs_server, get_ld_path, change_and_wait_aaa_config_update
+        remove_all_tacacs_server, get_ld_path, change_and_wait_aaa_config_update, \
+        ensure_tacacs_server_running_after_ut
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
 from .utils import check_server_received

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -7,7 +7,7 @@ import time
 from tests.tacacs.utils import stop_tacacs_server, start_tacacs_server
 from tests.tacacs.utils import per_command_authorization_skip_versions, \
         remove_all_tacacs_server, get_ld_path, change_and_wait_aaa_config_update, \
-        ensure_tacacs_server_running_after_ut
+        ensure_tacacs_server_running_after_ut                             # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
 from .utils import check_server_received
@@ -268,7 +268,7 @@ def test_authorization_tacacs_only_some_server_down(
 
 def test_authorization_tacacs_only_then_server_down_after_login(
         setup_authorization_tacacs, ptfhost, check_tacacs,
-        remote_user_client, ensure_tacacs_server_running_after_ut):
+        remote_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
 
     # Verify when server are accessible, TACACS+ user can run command in server side whitelist.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "show aaa")
@@ -322,7 +322,7 @@ def test_authorization_tacacs_and_local(
 def test_authorization_tacacs_and_local_then_server_down_after_login(
         duthosts, enum_rand_one_per_hwsku_hostname,
         setup_authorization_tacacs_local, tacacs_creds, ptfhost,
-        check_tacacs, remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
+        check_tacacs, remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Shutdown tacacs server
@@ -367,7 +367,7 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(
 def test_authorization_local(
         duthosts, enum_rand_one_per_hwsku_hostname,
         tacacs_creds, ptfhost, check_tacacs,
-        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     """
@@ -465,7 +465,7 @@ def test_bypass_authorization(
 def test_backward_compatibility_disable_authorization(
         duthosts, enum_rand_one_per_hwsku_hostname,
         tacacs_creds, ptfhost, check_tacacs,
-        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut): # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Verify domain account can run command if have permission in local.

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -266,7 +266,8 @@ def test_authorization_tacacs_only_some_server_down(
 
 
 def test_authorization_tacacs_only_then_server_down_after_login(
-        setup_authorization_tacacs, ptfhost, check_tacacs, remote_user_client):
+        setup_authorization_tacacs, ptfhost, check_tacacs,
+        remote_user_client, ensure_tacacs_server_running_after_ut):
 
     # Verify when server are accessible, TACACS+ user can run command in server side whitelist.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "show aaa")
@@ -319,7 +320,8 @@ def test_authorization_tacacs_and_local(
 
 def test_authorization_tacacs_and_local_then_server_down_after_login(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        setup_authorization_tacacs_local, tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
+        setup_authorization_tacacs_local, tacacs_creds, ptfhost,
+        check_tacacs, remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Shutdown tacacs server
@@ -363,7 +365,8 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(
 
 def test_authorization_local(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
+        tacacs_creds, ptfhost, check_tacacs,
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     """
@@ -460,7 +463,8 @@ def test_bypass_authorization(
 
 def test_backward_compatibility_disable_authorization(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
+        tacacs_creds, ptfhost, check_tacacs,
+        remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Verify domain account can run command if have permission in local.

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -51,7 +51,7 @@ def stop_tacacs_server(ptfhost):
 
 
 @pytest.fixture
-def ensure_tacacs_server_running_after_ut(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
+def ensure_tacacs_server_running_after_ut(duthosts, enum_rand_one_per_hwsku_hostname):
     """make sure tacacs server running after UT finish"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 import binascii
 import time
+import pytest
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, check_skip_release, delete_running_config
@@ -47,6 +48,16 @@ def stop_tacacs_server(ptfhost):
         return "tacacs+ apparently not running" in out
     ptfhost.shell("service tacacs_plus stop")
     return wait_until(5, 1, 0, tacacs_not_running, ptfhost)
+
+
+@pytest.fixture
+def ensure_tacacs_server_running_after_ut(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
+    """make sure tacacs server running after UT finish"""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    yield
+
+    start_tacacs_server(duthost)
 
 
 def setup_local_user(duthost, tacacs_creds):


### PR DESCRIPTION
Ensure tacacs server running after UT stop it.

##### Work item tracking
- Microsoft ADO: 25136260

### Description of PR
Ensure tacacs server running after UT stop it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
UT randomly failed because SSH login failed.

#### How did you do it?
Ensure tacacs server running after UT stop it.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
