### PR TITLE
[console] Add skip logic in test_console_baud_rate

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -1,6 +1,6 @@
 import pytest
 import time
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
 from tests.common.reboot import reboot
 

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -11,13 +11,14 @@ pytestmark = [
 ]
 
 BAUD_RATE_MAP = {
-    "default": "9600"
+    "default": "9600",
+    "x86_64-mlnx_msn4700-r0": "115200"
 }
 BOOT_TYPE = {
     "armhf-nokia_ixs7215_52x-r0": "UBoot-ONIE",
     "x86_64-arista_720dt_48s": "ABoot"
 }
-pass_config_test = True
+pass_config_test = False
 
 
 def is_sonic_console(conn_graph_facts, dut_hostname):
@@ -30,14 +31,14 @@ def test_console_baud_rate_config(duthost):
     res = duthost.shell("cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d ',' -f2")
     pytest_require(res["stdout"] != "", "Cannot get baud rate")
     if res["stdout"] != expected_baud_rate:
-        global pass_config_test
-        pass_config_test = False
         pytest.fail("Baud rate {} is unexpected!".format(res["stdout"]))
+    global pass_config_test
+    pass_config_test = True
 
 
 @pytest.fixture(scope="module")
 def console_client_setup_teardown(duthost, conn_graph_facts, creds):
-    pytest_assert(pass_config_test, "Fail due to failure in test_console_baud_rate_config.")
+    pytest_require(pass_config_test, "Skip due to not pass test_console_baud_rate_config.")
     dut_hostname = duthost.hostname
     console_host = conn_graph_facts['device_console_info'][dut_hostname]['ManagementIp']
     pytest_require(is_sonic_console(conn_graph_facts, dut_hostname), "Unsupport non-sonic console swith.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
**Pending: need to check whether sn4700 default baud rate is 115200**

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_console_baud_rate failed in 4700.

#### How did you do it?
1. Add baud rate config for 4700
2. Add skip logic in test

#### How did you verify/test it?
Run tests
```
collected 3 items                                                                                                                                                       

dut_console/test_console_baud_rate.py::test_console_baud_rate_config PASSED                                                                                       [ 33%]
dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect SKIPPED (Unsupport non-sonic console swith.)                                                  [ 66%]
dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect SKIPPED (Unsupport non-sonic console swith.)                                                   [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
