### PR TITLE
Run container_down test after monit config change

### DIFF
--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -33,9 +33,9 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
         run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_mem_threshold_exceeded_alert,
                  "mem_threshold_exceeded.json", "sonic-events-host:mem-threshold-exceeded", tag)
         run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, restart_container,
-             "event_stopped_ctr.json", "sonic-events-host:event-stopped-ctr", tag, False)
+                 "event_stopped_ctr.json", "sonic-events-host:event-stopped-ctr", tag, False)
         run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, mask_container,
-             "event_down_ctr.json", "sonic-events-host:event-down-ctr", tag, False)
+                 "event_down_ctr.json", "sonic-events-host:event-down-ctr", tag, False)
     finally:
         restore_monit_config(duthost)
 

--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -15,11 +15,6 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
     logger.info("Beginning to test host events")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_kernel_event,
              "event_kernel.json", "sonic-events-host:event-kernel", tag, False)
-    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, restart_container,
-             "event_stopped_ctr.json", "sonic-events-host:event-stopped-ctr", tag, False)
-    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, mask_container,
-             "event_down_ctr.json", "sonic-events-host:event-down-ctr", tag, False)
-
     backup_monit_config(duthost)
     customize_monit_config(
         duthost,
@@ -37,6 +32,10 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
                  "cpu_usage.json", "sonic-events-host:cpu-usage", tag, False)
         run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_mem_threshold_exceeded_alert,
                  "mem_threshold_exceeded.json", "sonic-events-host:mem-threshold-exceeded", tag)
+        run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, restart_container,
+             "event_stopped_ctr.json", "sonic-events-host:event-stopped-ctr", tag, False)
+        run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, mask_container,
+             "event_down_ctr.json", "sonic-events-host:event-down-ctr", tag, False)
     finally:
         restore_monit_config(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

event-down-ctr test is flaky because we run the test before monit changes are in place which means start delay for monit is at 5 minutes, so container_checker will not catch event.

#### How did you do it?

Move test after monit config is changed

#### How did you verify/test it?

Manual/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
