### PR TITLE
Fix bgp notification test

### DIFF
--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -25,6 +25,9 @@ def drop_tcp_packets(duthost):
     ret = duthost.shell("iptables -I INPUT -p tcp --sport 179 -j DROP")
     assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
 
+    ret = duthost.shell("iptables -L")
+    assert ret["rc"] == 0, "Unable to list iptables rules"
+
     time.sleep(10)  # Give time for hold timer expiry notif to fire, val from config db
 
     ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Add step in bgp holdtimer repro to list iptables rules.

The default chain policy is to accept all packets. When I add the rule to drop all packets (including bgp packets), when we list the iptable rules, the rules are reevaluated such that they take place into effect.

#### How did you do it?

code change

#### How did you verify/test it?

manual/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
