### PR TITLE
[CI/CD][Fix] Fix get pr_id is None for some repos PR test azure pipelines

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -565,14 +565,6 @@ if __name__ == "__main__":
         help="The asic number of dut"
     )
     parser_create.add_argument(
-        "--azp-pr-id",
-        type=str,
-        dest="azp_pr_id",
-        default="",
-        required=False,
-        help="Pullrequest ID from Azure Pipelines"
-    )
-    parser_create.add_argument(
         "--repo-name",
         type=str,
         dest="repo_name",
@@ -845,7 +837,8 @@ if __name__ == "__main__":
             env["client_secret"])
 
         if args.action == "create":
-            pr_id = args.azp_pr_id if args.azp_pr_id else os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+            pr_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") or os.environ.get(
+                "SYSTEM_PULLREQUEST_PULLREQUESTID")
             repo = os.environ.get("BUILD_REPOSITORY_PROVIDER")
             reason = os.environ.get("BUILD_REASON")
             build_id = os.environ.get("BUILD_BUILDID")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fix get **pr_id** is None for some repos PR test azure pipelines.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
For `sonic-mgmt` and `sonic-buildimage` repo, in PR test azure pipelines, the **pr_id** is got from the ENV `"SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"`. But for other repos, the ENV name is different.

#### How did you do it?
If `"SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"` exists, use it as **pr_id**, else get from another ENV name.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
