### PR TITLE
Updating ingress drop counters for 100G_120k profile in qos

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -327,14 +327,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -351,7 +351,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
@@ -397,7 +397,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -406,7 +406,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 37549
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Aligning to the change in PR# https://github.com/sonic-net/sonic-buildimage/pull/16690
Summary:
The ingress drop counter value adjusted in qos_params.j2c to align with change in total headroom pool size (PR#16690 ) 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
PCFXoff  test cases failure
#### How did you do it?

#### How did you verify/test it?
Executed qos  test for T2 topology.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
