### PR TITLE
[202205|Mellanox] enable dynamic ecmp on Mellanox switches and updated test nhop_group per vendor

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -460,9 +460,6 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
     Test SONiC and SAI Vendor capability are same for ordered ecmp feature
     and SAI vendor is honoring the Ordered nature of nexthop group member
     """
-    if is_mellanox_device(duthost):
-        # Note: Need remove this check once Mellanox committed Ordered ECMP
-        pytest.skip("Ordered ECMP currently not supported on Mellanox DUT")
 
     asic = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
@@ -520,7 +517,7 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
             recvd_pkt_result[flow_count].add(scapy.Ether(recv_pkt).dst)
 
     # Test/Iteration Scenario 1: Verify After ecmp member remove/add flow order remains same.
-    # Test/Iteration Scenario 2: Veirfy Neighbor created in different order but flow order remains same.
+    # Test/Iteration Scenario 2: Verify Neighbor created in different order but flow order remains same.
     for iter_count in range(2):
         try:
             # create neighbor entry in different order list
@@ -544,9 +541,9 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
             if iter_count == 0:
                 fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
                                                                 gather_facts['src_port'][0])
-                # Simulate ECMP Acceleration with link flap where ECMP memeber are removed
+                # Simulate ECMP Acceleration with link flap where ECMP member are removed
                 # and added back to the group
-                # BGP service is stoped so we don't get Route Removal message
+                # BGP service is stopped so we don't get Route Removal message
                 # from FRR and it is just member add/remove trigger
                 asic.stop_service("bgp")
                 time.sleep(15)
@@ -694,14 +691,64 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
                          46: 'c0:ff:ee:00:00:0c', 47: 'c0:ff:ee:00:00:0f',
                          48: 'c0:ff:ee:00:00:0d', 49: 'c0:ff:ee:00:00:12'}
 
-    # Make sure a givenflow always hash to same nexthop/neighbor. This is done to try to find issue
+    gr_asic_flow_map = {0: 'c0:ff:ee:00:00:12', 1: 'c0:ff:ee:00:00:10',
+                        2: 'c0:ff:ee:00:00:0c',
+                        3: 'c0:ff:ee:00:00:0b', 4: 'c0:ff:ee:00:00:0b',
+                        5: 'c0:ff:ee:00:00:0b', 6: 'c0:ff:ee:00:00:11',
+                        7: 'c0:ff:ee:00:00:12', 8: 'c0:ff:ee:00:00:0d',
+                        9: 'c0:ff:ee:00:00:0c',
+                        10: 'c0:ff:ee:00:00:0f', 11: 'c0:ff:ee:00:00:0e',
+                        12: 'c0:ff:ee:00:00:11', 13: 'c0:ff:ee:00:00:10',
+                        14: 'c0:ff:ee:00:00:0b',
+                        15: 'c0:ff:ee:00:00:12', 16: 'c0:ff:ee:00:00:0b',
+                        17: 'c0:ff:ee:00:00:12', 18: 'c0:ff:ee:00:00:11',
+                        19: 'c0:ff:ee:00:00:10', 20: 'c0:ff:ee:00:00:10',
+                        21: 'c0:ff:ee:00:00:11', 22: 'c0:ff:ee:00:00:12',
+                        23: 'c0:ff:ee:00:00:0b', 24: 'c0:ff:ee:00:00:0c',
+                        25: 'c0:ff:ee:00:00:0d',
+                        26: 'c0:ff:ee:00:00:0e', 27: 'c0:ff:ee:00:00:0f',
+                        28: 'c0:ff:ee:00:00:10', 29: 'c0:ff:ee:00:00:11',
+                        30: 'c0:ff:ee:00:00:12', 31: 'c0:ff:ee:00:00:0b',
+                        32: 'c0:ff:ee:00:00:12', 33: 'c0:ff:ee:00:00:0b',
+                        34: 'c0:ff:ee:00:00:10',
+                        35: 'c0:ff:ee:00:00:11', 36: 'c0:ff:ee:00:00:11',
+                        37: 'c0:ff:ee:00:00:10', 38: 'c0:ff:ee:00:00:0b',
+                        39: 'c0:ff:ee:00:00:12',
+                        40: 'c0:ff:ee:00:00:0e', 41: 'c0:ff:ee:00:00:10',
+                        42: 'c0:ff:ee:00:00:0d', 43: 'c0:ff:ee:00:00:0e',
+                        44: 'c0:ff:ee:00:00:0b', 45: 'c0:ff:ee:00:00:0c',
+                        46: 'c0:ff:ee:00:00:11',
+                        47: 'c0:ff:ee:00:00:11', 48: 'c0:ff:ee:00:00:11',
+                        49: 'c0:ff:ee:00:00:11'}
+
+    spc_asic_flow_map = {0: 'c0:ff:ee:00:00:0b', 1: 'c0:ff:ee:00:00:12', 2: 'c0:ff:ee:00:00:0e',
+                         3: 'c0:ff:ee:00:00:0f', 4: 'c0:ff:ee:00:00:10', 5: 'c0:ff:ee:00:00:0d',
+                         6: 'c0:ff:ee:00:00:11', 7: 'c0:ff:ee:00:00:0c', 8: 'c0:ff:ee:00:00:0b',
+                         9: 'c0:ff:ee:00:00:12', 10: 'c0:ff:ee:00:00:0e', 11: 'c0:ff:ee:00:00:0f',
+                         12: 'c0:ff:ee:00:00:0e', 13: 'c0:ff:ee:00:00:0f', 14: 'c0:ff:ee:00:00:0b',
+                         15: 'c0:ff:ee:00:00:12', 16: 'c0:ff:ee:00:00:0e', 17: 'c0:ff:ee:00:00:0f',
+                         18: 'c0:ff:ee:00:00:0b', 19: 'c0:ff:ee:00:00:12', 20: 'c0:ff:ee:00:00:11',
+                         21: 'c0:ff:ee:00:00:0c', 22: 'c0:ff:ee:00:00:10', 23: 'c0:ff:ee:00:00:0d',
+                         24: 'c0:ff:ee:00:00:0c', 25: 'c0:ff:ee:00:00:11', 26: 'c0:ff:ee:00:00:0d',
+                         27: 'c0:ff:ee:00:00:10', 28: 'c0:ff:ee:00:00:0e', 29: 'c0:ff:ee:00:00:0f',
+                         30: 'c0:ff:ee:00:00:0b', 31: 'c0:ff:ee:00:00:12', 32: 'c0:ff:ee:00:00:0e',
+                         33: 'c0:ff:ee:00:00:0f', 34: 'c0:ff:ee:00:00:0b', 35: 'c0:ff:ee:00:00:12',
+                         36: 'c0:ff:ee:00:00:11', 37: 'c0:ff:ee:00:00:0c', 38: 'c0:ff:ee:00:00:10',
+                         39: 'c0:ff:ee:00:00:0d', 40: 'c0:ff:ee:00:00:0e', 41: 'c0:ff:ee:00:00:0f',
+                         42: 'c0:ff:ee:00:00:0b', 43: 'c0:ff:ee:00:00:12', 44: 'c0:ff:ee:00:00:0b',
+                         45: 'c0:ff:ee:00:00:12', 46: 'c0:ff:ee:00:00:0e', 47: 'c0:ff:ee:00:00:0f',
+                         48: 'c0:ff:ee:00:00:0b', 49: 'c0:ff:ee:00:00:12'}
+
+    # Make sure a given flow always hash to same nexthop/neighbor. This is done to try to find issue
     # where SAI vendor changes Hash Function across SAI releases. Please note this will not catch the issue every time
     # as there is always probability even after change of Hash Function same nexthop/neighbor is selected.
 
     # Fill this array after first run of test case which will give neighbor selected
     SUPPORTED_ASIC_TO_NEXTHOP_SELECTED_MAP = {"th": th_asic_flow_map, "gb": gb_asic_flow_map, "gblc": gb_asic_flow_map,
                                               "td2": td2_asic_flow_map, "th2": th2_asic_flow_map,
-                                              "td3": td3_asic_flow_map}
+                                              "td3": td3_asic_flow_map, "gr": gr_asic_flow_map,
+                                              "spc1": spc_asic_flow_map, "spc2": spc_asic_flow_map,
+                                              "spc3": spc_asic_flow_map, "spc4": spc_asic_flow_map}
 
     vendor = duthost.facts["asic_type"]
     hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/9738/ from master to 202205
Updated test nhop_group according to Nvidia ASICs behavior

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Updated test nhop_group according to Nvidia ASICs behavior

#### How did you do it?
Created dict with expected traffic redistribution for Nvidia-related ASICs
Removed test ignore for Mellanox/Nvidia platforms

#### How did you verify/test it?
Executed tests from file test_nhop_group.py

#### Any platform specific information?
Nvidia

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
