### PR TITLE
 Added a logic in which the removal of config db file occurs only when installing a base version with sonic installer

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -169,13 +169,6 @@ def install_new_sonic_image(module, new_image_url, save_as=None):
             module.fail_json(msg="Image installation failed: rc=%d, out=%s, err=%s" %
                              (rc, out, err))
 
-    # If sonic device is configured with minigraph, remove config_db.json
-    # to force next image to load minigraph.
-    if path.exists("/host/old_config/minigraph.xml"):
-        exec_command(module,
-                     cmd="rm -f /host/old_config/config_db.json",
-                     msg="Remove config_db.json in preference of minigraph.xml")
-
 
 def work_around_for_slow_disks(module):
     # Increase hung task timeout to 600 seconds to avoid kernel panic

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -60,11 +60,15 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
             logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
             # Install base image
             logger.info("Installing {}".format(from_image))
-            target_version = install_sonic(duthost, from_image, tbinfo)
+            base_version = install_sonic(duthost, from_image, tbinfo)
+            # Remove old config_db before rebooting the DUT
+            logger.info("Remove old config_db file, if exists, to load minigraph from scratch")
+            if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True):
+                duthost.shell("rm -f /host/old_config/config_db.json")
             # Perform a cold reboot
             logger.info("Cold reboot the DUT to make the base image as current")
             reboot(duthost, localhost)
-            check_sonic_version(duthost, target_version)
+            check_sonic_version(duthost, base_version)
 
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
@@ -100,11 +104,11 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
             logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
             # Install base image
             logger.info("Installing {}".format(from_image))
-            target_version = install_sonic(duthost, from_image, tbinfo)
+            base_version = install_sonic(duthost, from_image, tbinfo)
             # Perform a cold reboot
             logger.info("Cold reboot the DUT to make the base image as current")
             reboot(duthost, localhost)
-            check_sonic_version(duthost, target_version)
+            check_sonic_version(duthost, base_version)
 
             # Install target image
             logger.info("Upgrading to {}".format(to_image))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Previously, the removal of config db happened each time we use "install_sonic" method.
This method is being used both on installation of base version and target version.
The removal of config db after installing the target version, caused the following issue:
The switch performs a cold boot instead of fast boot, due to minigraph deployment.
This PR sets the removal of old config db to occur only after installing a base version of sonic and loading clean minigraph.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
To reduce unnecessary minigraph loading, which are adding to the reboot time.

#### How did you do it?
Moved the removal part to the base version installation section, instead of using it each time in "install sonic"

#### How did you verify/test it?
Ran the upgrade test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
