### PR TITLE
[Mellanox] skip test_check_sfp_using_ethtool for 202305 release

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -828,6 +828,11 @@ platform_tests/daemon/test_chassisd.py:
     conditions:
       - "release in ['201811', '201911', '202012']"
 
+platform_tests/mellanox/test_check_sfp_using_ethtool.py:
+  skip:
+    reason: "Deprecated as Mellanox do not use ethtool in release 202305 or higher"
+    conditions: "release in ['202305', 'master']"
+
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
   skip:
     reason: "Get/Set low power mode is not supported in Cisco 8000 platform"
@@ -840,6 +845,7 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
     conditions:
       - "platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6218
+
 
 platform_tests/test_auto_negotiation.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/8198)
Added skip for release 202305 + master branch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
deprecated, ethtool is not being used for 202305 an higher 
#### How did you do it?
Add skip to conditional_marks
#### How did you verify/test it?
Run TC, skipped for 202305
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
