### PR TITLE
Fixed log handling issues on fast/warm upgrade test

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -450,9 +450,13 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     test_name = request.node.name
-    if "warm" in test_name:
+    if "upgrade_path" in test_name:
+        reboot_type_source = request.config.getoption("--upgrade_type")
+    else:
+        reboot_type_source = test_name
+    if "warm" in reboot_type_source:
         reboot_type = "warm"
-    elif "fast" in test_name:
+    elif "fast" in reboot_type_source:
         reboot_type = "fast"
     else:
         reboot_type = "unknown"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix reboot type source fetch logic: Previously, the reboot type source was based on the test name. However, it doesn't work with the upgrade path test, as it does not include the reboot type in the name of the test. This fix treats the mentioned case by getting the name from the upgrade type parameter.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Ability to fetch reboot logs on upgrade_path test

#### How did you do it?
Changed the reboot source fetching logic, to be based not only on the test name

#### How did you verify/test it?
Ran the upgrade test 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
