### PR TITLE
[qos] reduce execution time of ping command

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -343,9 +343,11 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
 
             # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
             if self.test_port_ips:
-                for ip in get_peer_addresses(self.test_port_ips):
+                ips = [ip for ip in get_peer_addresses(self.test_port_ips)]
+                if ips:
+                    cmd = 'for ip in {}; do ping -c 4 -i 0.2 -W 1 -q $ip > /dev/null 2>&1 & done'.format(' '.join(ips))
                     self.exec_cmd_on_dut(self.server, self.test_params['dut_username'],
-                                         self.test_params['dut_password'], 'ping -q -c 3 {}'.format(ip))
+                                         self.test_params['dut_password'], cmd)
 
         time.sleep(8)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

Taking too much time to run ping at the beginning of a qos sai test if there are a bunch of ip addresses that need to be pinged.
It causes some qos sai cases to fail.

#### How did you do it?

- combine multiple ping command to one-line script, so just need to login DUT once via ssh to run multiple ping commands
- adjust ping options to save time
- parallel run ping command in background to save time

#### How did you verify/test it?

run test on t0-120 device, to compare test result before and after applying this fix.
- before apply this fix:
![image](https://github.com/sonic-net/sonic-mgmt/assets/112069142/78dee884-3e79-46f6-a63a-fa70c2612986)
execution time of "sai_qos_tests.ARPpopulate" is around 5 minutes

- after apply this fix:
![image](https://github.com/sonic-net/sonic-mgmt/assets/112069142/c3b43f98-2725-47a5-88d5-72311c10b7d7)
execution time of  "sai_qos_tests.ARPpopulate" is around 30 seconds

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
