### PR TITLE
reduce the burst rate for " test_po_update_io_no_loss"

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -306,7 +306,7 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             testutils.send(ptfadapter, in_ptf_index, pkt)
             send_count += 1
             if send_count > 100:
-                time.sleep(0)
+                time.sleep(0.001)
             member_update_thread_finished = (not member_update_finished_flag.empty()) and member_update_finished_flag.get()
             reach_max_time = time.time() > t_max
             stop_sending = reach_max_time or member_update_thread_finished


### PR DESCRIPTION
same as : 
https://github.com/sonic-net/sonic-mgmt/pull/9716

This PR is for 202205