### PR TITLE
Exclude unsupported DSCP values

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -257,10 +257,9 @@ class DecapPacketTest(BaseTest):
         # Set DSCP value for the outer layer
         dscp_out = self.DSCP_RANGE[self.dscp_out_idx]
         if dscp_out in self.DSCP_EXCLUDE and \
-            self.topo in ["t1"] and \
-            self.qos_remap_enabled:
-             self.dscp_out_idx = (self.dscp_out_idx + 1) % len(self.DSCP_RANGE)
-             dscp_out = self.DSCP_RANGE[self.dscp_out_idx]
+           self.topo in ["t1"] and self.qos_remap_enabled:
+            self.dscp_out_idx = (self.dscp_out_idx + 1) % len(self.DSCP_RANGE)
+            dscp_out = self.DSCP_RANGE[self.dscp_out_idx]
         # Next packet will use a different DSCP
         self.dscp_out_idx = (self.dscp_out_idx + 1) % len(self.DSCP_RANGE)
 

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -74,6 +74,7 @@ class DecapPacketTest(BaseTest):
     DEFAULT_INNER2_V6_PKT_DST_IP = '3::3'
 
     # Allowed DSCP and TTL values
+    DSCP_EXCLUDE = {2, 6}
     DSCP_RANGE = list(range(0, 33))
     TTL_RANGE = list(range(2, 65))
 
@@ -248,6 +249,9 @@ class DecapPacketTest(BaseTest):
 
         # Set DSCP value for the outer layer
         dscp_out = self.DSCP_RANGE[self.dscp_out_idx]
+        if dscp_out in self.DSCP_EXCLUDE:
+            self.dscp_out_idx = (self.dscp_out_idx + 1) % len(self.DSCP_RANGE)
+            dscp_out = self.DSCP_RANGE[self.dscp_out_idx]
         # Next packet will use a different DSCP
         self.dscp_out_idx = (self.dscp_out_idx + 1) % len(self.DSCP_RANGE)
 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -32,7 +32,7 @@ from tests.common.dualtor.dual_tor_common import active_standby_ports           
 from tests.common.dualtor.dual_tor_common import mux_config                                         # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side    # noqa F401
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                # noqa F401
-
+from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +222,9 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
                            "ptf_test_port_map": ptf_test_port_map_active_active(
                                ptfhost, tbinfo, duthosts, mux_server_url,
                                duts_running_config_facts, duts_minigraph_facts,
-                               mux_status_from_nic_simulator())
+                               mux_status_from_nic_simulator()),
+                            "topo": tbinfo['topo']['type'],
+                            "qos_remap_enabled": is_tunnel_qos_remap_enabled(duthosts[0])
                            },
                    qlen=PTFRUNNER_QLEN,
                    log_file=log_file,

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -223,8 +223,8 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
                                ptfhost, tbinfo, duthosts, mux_server_url,
                                duts_running_config_facts, duts_minigraph_facts,
                                mux_status_from_nic_simulator()),
-                            "topo": tbinfo['topo']['type'],
-                            "qos_remap_enabled": is_tunnel_qos_remap_enabled(duthosts[0])
+                           "topo": tbinfo['topo']['type'],
+                           "qos_remap_enabled": is_tunnel_qos_remap_enabled(duthosts[0])
                            },
                    qlen=PTFRUNNER_QLEN,
                    log_file=log_file,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 On T1 testbeds, outer DSCP values 2 and 6 which map to PG 2 and 6 respectively are not supported, so those DSCP values are excluded in tests to avoid RX_DRPs.

Summary:
Fixes # 24920851

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
PG(2) and PG(6) do not have buffers for uplink and consequently packets mapping to those PGs will get dropped.
#### How did you do it?
Exclude DSCP 2 and 6 for outer DSCP in ip_decap tests
#### How did you verify/test it?
Running sonic-mgmt test decap/test_decap.py
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
