### PR TITLE
[qos] support t0-120 qos sai test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -33,7 +33,7 @@ class QosBase:
     Common APIs
     """
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-120", "dualtor",
-                          "t0-80", "t0-backend"]
+                          "t0-120", "t0-80", "t0-backend"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2381,7 +2381,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116']:
+        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-64', 't0-116', 't0-120']:
             # populate ARP
             # sender's MAC address is corresponding PTF port's MAC address
             # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

[Nvidia] Fix qos sai test for supporting LAG port #9587 #10121
break the qos sai test for mlnx device when topo is t0-120

RCA:
complain keyError when accessing testPortIds.
```
    def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts):                                                        """                                                                                                                                                              
            Build map of test ports index and IPs                                                                                                                                                                                                                                                                                                 
            Args:                                                                                                                                                        
                request (Fixture): pytest request object                                                                                                                 
                testPortIds (list): List of QoS SAI test port IDs                                                                                                        
                testPortIps (list): List of QoS SAI test port IPs                                                                                                        
                                                                                                                                                                         
            Returns:                                                                                                                                                     
                testPorts (dict): Map of test ports index and IPs                                                                                                        
        """                                                                                                                                                              
        dstPorts = request.config.getoption("--qos_dst_ports")                                                                                                           
        srcPorts = request.config.getoption("--qos_src_ports")                                                                                                           
                                                                                                                                                                         
>       src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]                                                                                       
E       KeyError: 0                   
```

checed on PDB, "t0-120" topo is not in the self.SUPPORTED_T0_TOPOS:
```
(Pdb) p get_src_dst_asic_and_duts['src_dut_index']
0
(Pdb) p testPortIds
{}
(Pdb) p tbinfo["topo"]["name"]
't0-120'
(Pdb) p self.SUPPORTED_T0_TOPOS
['t0', 't0-56-po2vlan', 't0-64', 't0-116', 't0-35', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend']
(Pdb) p self.SUPPORTED_PTF_TOPOS
['ptf32', 'ptf64']
```

#### How did you do it?

add "t0-120" to self.SUPPORTED_T0_TOPOS

#### How did you verify/test it?

pass local test, not encounter keyError again.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
