### PR TITLE
COPP: Update the PPS max limit to allow bit more tolerance

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -45,7 +45,7 @@ class ControlPlaneBaseTest(BaseTest):
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
     PPS_LIMIT_MAX = PPS_LIMIT * 1.4
-    NO_POLICER_LIMIT = PPS_LIMIT * 1.5
+    NO_POLICER_LIMIT = PPS_LIMIT * 1.4
     TARGET_PORT = "3"  # Historically we have port 3 as a target port
     TASK_TIMEOUT = 600  # Wait up to 10 minutes for tasks to complete
 

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -73,9 +73,9 @@ class ControlPlaneBaseTest(BaseTest):
         self.has_trap = test_params.get('has_trap', True)
         self.hw_sku = test_params.get('hw_sku', None)
         if (self.hw_sku == "Cisco-8111-O64" or
-            self.hw_sku == "Cisco-8111-O32" or
-            self.hw_sku == "Cisco-8111-C32" or
-            self.hw_sku == "Cisco-8111-O62C2"):
+                self.hw_sku == "Cisco-8111-O32" or
+                self.hw_sku == "Cisco-8111-C32" or
+                self.hw_sku == "Cisco-8111-O62C2"):
             self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.4
 
     def log(self, message, debug=False):

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -44,8 +44,8 @@ class ControlPlaneBaseTest(BaseTest):
     MAX_PORTS = 128
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
-    PPS_LIMIT_MAX = PPS_LIMIT * 1.3
-    NO_POLICER_LIMIT = PPS_LIMIT * 1.4
+    PPS_LIMIT_MAX = PPS_LIMIT * 1.4
+    NO_POLICER_LIMIT = PPS_LIMIT * 1.5
     TARGET_PORT = "3"  # Historically we have port 3 as a target port
     TASK_TIMEOUT = 600  # Wait up to 10 minutes for tasks to complete
 

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -44,13 +44,7 @@ class ControlPlaneBaseTest(BaseTest):
     MAX_PORTS = 128
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
-    if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
-        duthost.facts["hwsku"] == "Cisco-8111-O32" or
-        duthost.facts["hwsku"] == "Cisco-8111-C32" or
-        duthost.facts["hwsku"] == "Cisco-8111-O62C2"):
-        PPS_LIMIT_MAX = PPS_LIMIT * 1.4
-    else:
-        PPS_LIMIT_MAX = PPS_LIMIT * 1.3
+    PPS_LIMIT_MAX = PPS_LIMIT * 1.3
     NO_POLICER_LIMIT = PPS_LIMIT * 1.4
     TARGET_PORT = "3"  # Historically we have port 3 as a target port
     TASK_TIMEOUT = 600  # Wait up to 10 minutes for tasks to complete
@@ -77,6 +71,12 @@ class ControlPlaneBaseTest(BaseTest):
 
         self.needPreSend = None
         self.has_trap = test_params.get('has_trap', True)
+        self.hw_sku = test_params.get('hw_sku', None)
+        if (self.hw_sku == "Cisco-8111-O64" or
+            self.hw_sku == "Cisco-8111-O32" or
+            self.hw_sku == "Cisco-8111-C32" or
+            self.hw_sku == "Cisco-8111-O62C2"):
+            self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.4
 
     def log(self, message, debug=False):
         current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -44,7 +44,13 @@ class ControlPlaneBaseTest(BaseTest):
     MAX_PORTS = 128
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
-    PPS_LIMIT_MAX = PPS_LIMIT * 1.4
+    if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
+        duthost.facts["hwsku"] == "Cisco-8111-O32" or
+        duthost.facts["hwsku"] == "Cisco-8111-C32" or
+        duthost.facts["hwsku"] == "Cisco-8111-O62C2"):
+        PPS_LIMIT_MAX = PPS_LIMIT * 1.4
+    else:
+        PPS_LIMIT_MAX = PPS_LIMIT * 1.3
     NO_POLICER_LIMIT = PPS_LIMIT * 1.4
     TARGET_PORT = "3"  # Historically we have port 3 as a target port
     TASK_TIMEOUT = 600  # Wait up to 10 minutes for tasks to complete

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -280,7 +280,8 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True):
               "myip": test_params.myip,
               "peerip": test_params.peerip,
               "send_rate_limit": test_params.send_rate_limit,
-              "has_trap": has_trap}
+              "has_trap": has_trap,
+              "hw_sku": dut.facts["hwsku"]}
 
     dut_ip = dut.mgmt_ip
     device_sockets = ["0-{}@tcp://127.0.0.1:10900".format(test_params.nn_target_port),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The ARPTest for COPP involves PTF sending ARP request packets at some high rate and confirming that the DUT punts them to CPU but at configured policed rate of 600 packets/second.  To account for inaccuracies of the policers and the test itself, the test verifier allows a range around this 600 packets/second. The range is 0.9 * 600 = 540 to 1.3 * 600 = 780.
After some experiments by pumping ARP request from TGEN, it was observed that the punted packet was sometimes slightly more than 780.  In the past, when we  have seen this test pass, the punted packet count was slightly below 780 which means, the test was barely passing before. So we need to modify the limit and allow a bit tolerance.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
