### PR TITLE
[Cherry-pick] Improvising qos tests by tunning the qos params for…#8222

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -2,7 +2,7 @@ qos_params:
     j2c+:
         topo-any:
             100000_300m:
-                pkts_num_leak_out: 51
+                pkts_num_leak_out: 5
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
@@ -55,7 +55,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_trig_egr_drp: 2396745
-                    pkts_num_margin: 20
+                    pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3298,7 +3298,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 fill_leakout_plus_one(self, src_port_id, dst_port_id,
                        pkt, int(self.test_params['pg']), asic_type)
 
-           # send packets short of triggering egress drop
+            if platform_asic and platform_asic == "broadcom-dnx":
+                if check_leackout_compensation_support(asic_type, hwsku):
+                    send_packet(self, src_port_id, pkt, pkts_num_leak_out)
+                    time.sleep(5)
+                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_base, self, src_port_id, pkt, 10)
+                    pkts_num_leak_out = 0
+
+            # send packets short of triggering egress drop
             if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
                # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +


### PR DESCRIPTION
… single_asic, single_dut_multi_asic and  multi_dut (#8222) from master to 202205

* QoS tunning for LossyQueueTest
* Recommiting the changes of qos.yml to qos_params_j2c.yml
* tx_enable/disable retry check corrected
* Making check to run only for chassis in LossyQueue
* Adding check for sai_base for tx_enable/disable

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Master PR #8222 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
