### PR TITLE
[testfix] stress_test_routes. Added syslog ignore

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -44,7 +44,8 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
     if loganalyzer:
         ignoreRegex = [
             ".*ERR route_check.py:.*",
-            ".*ERR.* \'routeCheck\' status failed.*"
+            ".*ERR.* \'routeCheck\' status failed.*",
+            ".*Process \'orchagent\' is stuck in namespace \'host\'.*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
this log is expected because its a stress test and can keep the orchagent busy long enough to make this log appear.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
ADO 25061640
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
