### PR TITLE
[202205] Skip verify_dhcp_relay_pkt_with_no_padding on dualtor testbed

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -756,7 +756,9 @@ class DHCPTest(DataplaneBaseTest):
         self.verify_ack_received()
         self.assertTrue(self.verified_option82,"Failed: Verifying option 82")
 
-        ## Below verification will be done only when client port is set in ptf_runner
-        if 'other_client_port' in self.test_params:
-            self.verify_dhcp_relay_pkt_on_other_client_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)
-            self.verify_dhcp_relay_pkt_on_server_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)
+        # Below verification will be done only when client port is set in ptf_runner
+        if not self.dual_tor and 'other_client_port' in self.test_params:
+            self.verify_dhcp_relay_pkt_on_other_client_port_with_no_padding(
+                self.dest_mac_address, self.client_udp_src_port)
+            self.verify_dhcp_relay_pkt_on_server_port_with_no_padding(
+                self.dest_mac_address, self.client_udp_src_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Cherry-pick of PR https://github.com/sonic-net/sonic-mgmt/pull/10201
Summary: Skip checking for packet flood on dual tor testbed
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Proxy Arp is enabled on dual tor testbeds, which will disable flooding of packets in hardware

#### How did you do it?
Skip verify_dhcp_relay_pkt_on_other_client_port_with_no_padding and verify_dhcp_relay_pkt_on_server_port_with_no_padding on dual tor testbeds

#### How did you verify/test it?
Ran test on a dualtor testbed, corresponding tests were not ran and test suite passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
