### PR TITLE
[Snappi] Enable safe reboot on snappi_tests reboot cases

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -246,7 +246,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
 
     logger.info("Issuing a {} reboot on the dut {}".format(
         reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
@@ -317,7 +317,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
 
     logger.info("Issuing a {} reboot on the dut {}".format(
         reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -182,7 +182,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,                 # noqa F
 
     logger.info("Issuing a {} reboot on the dut {}".format(
         reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
@@ -252,7 +252,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,                  # noqa F
 
     logger.info("Issuing a {} reboot on the dut {}".format(
         reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -165,7 +165,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
     lossless_prio = int(lossless_prio)
 
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
@@ -227,7 +227,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
     testbed_config, port_config_list = snappi_testbed_config
 
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Ansible failure is seen on pfcwd basic test because we don't wait for a safe reboot for these tests - since Ansible is not waiting for enough time before trying to reconnect. Also, setting all snappi_tests reboots to safe. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205

### Approach
#### What is the motivation for this PR?
Nightly triage fix for pfcwd basic test
#### How did you do it?
Allow safe reboot
#### How did you verify/test it?
Tested on lab device
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
