### PR TITLE
limit the modification of pg_num to only occur on the specific platform to fix testQosSaiHeadroomPoolWatermark failure

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -843,16 +843,23 @@ class TestQosSai(QosSaiBase):
         dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
-        src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
-        if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
-            # Src and dst are the same asics, leave one for dst port and the rest for src ports
-            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
-            qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
-            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
-        else:
-            qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
-            qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
-            qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
+        if ('platform_asic' in dutTestParams["basicParams"] and
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+            # Need to adjust hdrm_pool_size src_port_ids, dst_port_id and pgs_num based on how many source and dst ports
+            # present
+            src_ports = dutConfig['testPortIds'][src_dut_index][src_asic_index]
+            if get_src_dst_asic_and_duts['src_asic'] == get_src_dst_asic_and_duts['dst_asic']:
+                # Src and dst are the same asics, leave one for dst port and the rest for src ports
+                qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports[:-1]
+                qosConfig["hdrm_pool_size"]["dst_port_id"] = src_ports[-1]
+                qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+            else:
+                qosConfig["hdrm_pool_size"]["src_port_ids"] = src_ports
+                qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
+                qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?

different input qos parameter for testQosSaiHeadroomPoolSize and 

wrong qos paramreter for testQosSaiHeadroomPoolWatermark,
```
"/root/env-python3/bin/ptf","--test-dir","saitests/py3","sai_qos_tests.HdrmPoolSizeTest",
... ... omitted ... ...
pgs_num=46;
pgs=[3, 4]",

... ... omitted ... .... 
[(0, 3, 5), (0, 4, 6), (1, 3, 5), (1, 4, 6), (2, 3, 5), (2, 4, 6), (3, 3, 5), (3, 4, 6), (4, 3, 5), (4, 4, 6), (5, 3, 5), (5, 4, 6), (6, 3, 5), (6, 4, 6), (7, 3, 5), (7, 4, 6), (8, 3, 5), (8, 4, 6), (9, 3, 5), (9, 4, 6), (10, 3, 5), (10, 4, 6), (11, 3, 5), (11, 4, 6), (12, 3, 5), (12, 4, 6), (13, 3, 5), (13, 4, 6), (14, 3, 5), (14, 4, 6), (15, 3, 5), (15, 4, 6), (16, 3, 5), (16, 4, 6), (17, 3, 5), (17, 4, 6), (18, 3, 5), (18, 4, 6), (19, 3, 5), (19, 4, 6), (20, 3, 5), (20, 4, 6), (21, 3, 5), (21, 4, 6), (22, 3, 5), (22, 4, 6)]       >>>>> and then it will test 46 couple of parameters
```

RCA:
for this case pgs_num value should be 4.
but here, its value is 46, and then it will test consume share buffer using 46 couple of parameters.
finally, caused test failure

the reason is that pg_num was increated in PR #8213 before ptf test.

#### How did you do it?

there is conditional statement to limit the modification of pg_num to only occur on the specific platform in similar test case "testQosSaiHeadroomPoolSize".
so, limit the modification of pg_num for testQosSaiHeadroomPoolWatermark as well

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
