### PR TITLE
Handle eth1-midplane being a kernel intf altname

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -364,7 +364,8 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
 
 def append_midplane_traffic_rules(duthost, iptables_rules):
     # Get the kernel intf name in the event that eth1-midplane is an altname
-    result = duthost.shell('ip link show eth1-midplane | awk \'NR==1{print$2}\' | cut -f1 -d"@" | cut -f1 -d":"', module_ignore_errors=True)['stdout']
+    result = duthost.shell('ip link show eth1-midplane | awk \'NR==1{print$2}\' | cut -f1 -d"@" | cut -f1 -d":"',
+                           module_ignore_errors=True)['stdout']
     if result:
         midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1',
                                     module_ignore_errors=True)['stdout']

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -363,11 +363,12 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
 
 
 def append_midplane_traffic_rules(duthost, iptables_rules):
-    result = duthost.shell('ip link show | grep -w "eth1-midplane"', module_ignore_errors=True)['stdout']
+    # Get the kernel intf name in the event that eth1-midplane is an altname
+    result = duthost.shell('ip link show eth1-midplane | awk \'NR==1{print$2}\' | cut -f1 -d"@" | cut -f1 -d":"', module_ignore_errors=True)['stdout']
     if result:
         midplane_ip = duthost.shell('ip -4 -o addr show eth1-midplane | awk \'{print $4}\' | cut -d / -f1 | head -1',
                                     module_ignore_errors=True)['stdout']
-        iptables_rules.append("-A INPUT -i eth1-midplane -j ACCEPT")
+        iptables_rules.append("-A INPUT -i {} -j ACCEPT".format(result))
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 
 


### PR DESCRIPTION
### Description of PR

Extract the kernel name eth1-midplane is attached to in the event it's an altname and use that kernel name in the ip rules

Summary:
Fixes #10223 

### Type of change
[x] Bug fix

### Back port request
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
test_cacl_application.py::test_cacl_application_nondualtor is failing today because it's expecting the wrong ip table rule:
```
(Pdb) set(expected_iptables_rules) - set(actual_iptables_rules)
set(['-A INPUT -i eth1-midplane -j ACCEPT'])
(Pdb) set(actual_iptables_rules) - set(expected_iptables_rules)
set([u'-A INPUT -i br1 -j ACCEPT'])
```

#### How did you do it?
`ip link show <name>` seems to return the same data regardless of whether we pass the kernel name or an altname.
So either way we should cut out the kernel name and use it:
```
root@nfc420:~# ip link show br1
7: br1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 00:10:18:00:00:00 brd ff:ff:ff:ff:ff:ff
    altname eth1-midplane
root@nfc420:~# ip link show eth1-midplane
7: br1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 00:10:18:00:00:00 brd ff:ff:ff:ff:ff:ff
    altname eth1-midplane
```

#### How did you verify/test it?
I saw test_cacl_application.py passing all testcases after this change.