### PR TITLE
fix the everflow ipv6 failure on dualtor A-A

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -360,7 +360,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
             dut_host.command("sudo config bgp shutdown all")
             dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
     elif 'dualtor' in topo:
-        # set TTL = 1 for T0, don't shutdown bgp, or else the mux becomes standby
+        # set TTL = 1 for dualtor-T0, don't shutdown bgp, or else the mux status on selected DUT becomes standby
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))			
     else:
         duthost.command("sudo config bgp shutdown all")

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -359,6 +359,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
         for dut_host in duthosts.frontend_nodes:
             dut_host.command("sudo config bgp shutdown all")
             dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
+    elif 'dualtor' in topo:
+        # set TTL = 1 for T0, don't shutdown bgp, or else the mux becomes standby
+        duthost.command("mkdir -p {}".format(DUT_RUN_DIR))			
     else:
         duthost.command("sudo config bgp shutdown all")
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
@@ -372,6 +375,8 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
         for dut_host in duthosts.frontend_nodes:
             dut_host.command("sudo config bgp startup all")
             dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
+    elif 'dualtor' in topo:
+        duthost.command("rm -rf {}".format(DUT_RUN_DIR))			
     else:
         duthost.command("sudo config bgp startup all")
         duthost.command("rm -rf {}".format(DUT_RUN_DIR))

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -361,7 +361,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
             dut_host.command("mkdir -p {}".format(DUT_RUN_DIR))
     elif 'dualtor' in topo:
         # set TTL = 1 for dualtor-T0, don't shutdown bgp, or else the mux status on selected DUT becomes standby
-        duthost.command("mkdir -p {}".format(DUT_RUN_DIR))			
+        duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp shutdown all")
         duthost.command("mkdir -p {}".format(DUT_RUN_DIR))
@@ -376,7 +376,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
             dut_host.command("sudo config bgp startup all")
             dut_host.command("rm -rf {}".format(DUT_RUN_DIR))
     elif 'dualtor' in topo:
-        duthost.command("rm -rf {}".format(DUT_RUN_DIR))			
+        duthost.command("rm -rf {}".format(DUT_RUN_DIR))
     else:
         duthost.command("sudo config bgp startup all")
         duthost.command("rm -rf {}".format(DUT_RUN_DIR))

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -5,6 +5,10 @@ import ptf.testutils as testutils
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM
 
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby     # noqa F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup            # noqa F401
+from tests.common.dualtor.dual_tor_common import active_active_ports                            # noqa F401
+
 # Module-level fixtures
 from .everflow_test_utilities import setup_info      # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
@@ -14,6 +18,7 @@ pytestmark = [
 
 EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"
 
+logger = logging.getLogger(__name__)
 
 class EverflowIPv6Tests(BaseEverflowTest):
     """
@@ -83,8 +88,22 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
         yield direction
 
+    @pytest.fixture
+    def setup_active_active_ports(self, active_active_ports, rand_selected_dut, rand_unselected_dut,                  # noqa F811
+                                  config_active_active_dualtor_active_standby,                        # noqa F811
+                                  validate_active_active_dualtor_setup):                                        # noqa F811
+        if active_active_ports:
+            # for active-active dualtor, the upstream traffic is ECMPed to both ToRs, so let's
+            # config the unselected ToR as standby to ensure all ethernet type packets are
+            # forwarded to the selected ToR.
+            logger.info("Configuring {} as active".format(rand_selected_dut.hostname))
+            logger.info("Configuring {} as standby".format(rand_unselected_dut.hostname))
+            config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+
+        return
+
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):   # noqa F811
         """Verify that we can match on Source IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -101,7 +120,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):   # noqa F811
         """Verify that we can match on Destination IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -118,7 +137,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match on the Next Header field."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, next_header=0x7E)
 
@@ -130,7 +149,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match on the L4 Source Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=9000)
 
@@ -142,7 +161,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match on the L4 Destination Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=9001)
 
@@ -155,7 +174,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session,                # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):      # noqa F811
         """Verify that we can match on a range of L4 Source Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=10200)
 
@@ -168,7 +187,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session,                # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):      # noqa F811
         """Verify that we can match on a range of L4 Destination Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=10700)
 
@@ -180,7 +199,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
+                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):      # noqa F811
         """Verify that we can match on TCP Flags."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, flags=0x1B)
 
@@ -192,7 +211,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,               # noqa F811
-                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):           # noqa F811
+                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):           # noqa F811
         """Verify that we can match on DSCP."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dscp=37)
 
@@ -204,7 +223,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,           # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):       # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):       # noqa F811
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -241,7 +260,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
+                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):   # noqa F811
         """Verify that we can match a SYN -> SYN-ACK pattern."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -277,7 +296,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session,              # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match a TCP handshake between a client and server."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -317,7 +336,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session,              # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match UDP traffic between a client and server application."""
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -355,7 +374,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):     # noqa F811
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -405,7 +424,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session,                 # noqa F811
                                     ptfadapter, everflow_dut, everflow_direction,
-                                    toggle_all_simulator_ports_to_rand_selected_tor):       # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):       # noqa F811
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -442,7 +461,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):     # noqa F811
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
         pass
 
@@ -452,7 +471,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         # suite + loganaylzer + the sanity check to fail.
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,            # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):        # noqa F811
+                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):        # noqa F811
         """Verify that we can match packets with a Source IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -472,7 +491,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
+                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):      # noqa F811
         """Verify that we can match packets with a Destination IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -492,7 +511,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):     # noqa F811
         """Verify that we can match packets with both source and destination subnets."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -512,7 +531,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor, setup_active_active_ports):    # noqa F811
         """Verify that we can match packets with non-standard subnet sizes."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -542,13 +561,17 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            sport=2020,
                            dport=8080,
                            flags=0x10):
+        ttl = 64
+        if setup['topo'] in ['t0']:
+            ttl = 1
+						   
         pkt = testutils.simple_tcpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,
             ipv6_dst=dst_ip,
             ipv6_dscp=dscp,
-            ipv6_hlim=64,
+            ipv6_hlim=ttl,
             tcp_sport=sport,
             tcp_dport=dport,
             tcp_flags=flags,
@@ -569,13 +592,17 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dscp=None,
                            sport=2020,
                            dport=8080):
+        ttl = 64
+        if setup['topo'] in ['t0']:
+            ttl = 1
+						   
         pkt = testutils.simple_udpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,
             ipv6_dst=dst_ip,
             ipv6_dscp=dscp,
-            ipv6_hlim=64,
+            ipv6_hlim=ttl,
             udp_sport=sport,
             udp_dport=dport,
         )

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -566,7 +566,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ttl = 64
         if setup['topo'] in ['t0']:
             ttl = 1
-						   
+
         pkt = testutils.simple_tcpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup[direction]["ingress_router_mac"],
@@ -597,7 +597,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ttl = 64
         if setup['topo'] in ['t0']:
             ttl = 1
- 
+
         pkt = testutils.simple_udpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup[direction]["ingress_router_mac"],

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -1,6 +1,7 @@
 """Test cases to support the Everflow IPv6 Mirroring feature in SONiC."""
 import time
 import pytest
+import logging
 import ptf.testutils as testutils
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -597,7 +597,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         ttl = 64
         if setup['topo'] in ['t0']:
             ttl = 1
-						   
+ 
         pkt = testutils.simple_udpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup[direction]["ingress_router_mac"],

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -21,6 +21,7 @@ EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"
 
 logger = logging.getLogger(__name__)
 
+
 class EverflowIPv6Tests(BaseEverflowTest):
     """
     Base class for testing IPv6 match types for the Everflow feature.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
After debug and investigation, this failure of "test_everflow_ipv6" on dualtor A-A including two issues:

1. the mux status is standby on the selected DUT.
2. the test pkts are not sent to selected DUT, which has everflow rule config.

The rootcause of 1 is due to BGP shutdown. In the script, it tries to shutdown all BGP during setup, which makes T1 not reachable from the TOR. Then the DUT moves itself into standby mode. That's from the design of mux state machine.

The rootcause of 2 is similiar to the following issue:
https://github.com/sonic-net/sonic-mgmt/pull/8158

We need fall back to active-standby mode to test this scenario for
active-active ports.

Summary:
Fixes # ([9983](https://github.com/sonic-net/sonic-mgmt/issues/9983))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Verified this fix on A-A, A-S and single T0.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
