### PR TITLE
Fix mux-simulator script not starting due to Werkzeug update

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -14,16 +14,28 @@
   - name: Set default Flask version
     set_fact:
       flask_version: "1.1.2"
+      werkzeug_version: "1.0.1"
       python_command: "python"
 
   - name: Use newer Flask version for pip3
     set_fact:
-      flask_version: "2.0.3"
+      flask_version: "2.3.3"
+      python_command: "python3"
+    when: pip_executable == "pip3"
+
+  - name: Use newer Werkzeug version for pip3
+    set_fact:
+      werkzeug_version: "2.3.7"
       python_command: "python3"
     when: pip_executable == "pip3"
 
   - name: Install flask
     pip: name=flask version={{ flask_version }} state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+
+  - name: Install werkzeug
+    pip: name=werkzeug version={{ werkzeug_version }} state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 
@@ -45,6 +57,18 @@
       state: started
       daemon_reload: yes
     become: yes
+
+  - name: wait for mux-simulator service to fully start for {{ testbed_name }}
+    pause: seconds=1
+
+  - name: Get the mux-simulator service for testbed {{ testbed_name }}
+    systemd:
+      name: mux-simulator-{{ mux_simulator_port }}
+    register: mux_simulator_status
+
+  - name: Fail if the mux-simulator service has exited for testbed {{ testbed_name }}
+    fail: msg="Mux simulator service is not running for {{ testbed_name }}"
+    when: mux_simulator_status.status.ActiveState != "active"
 
   when: mux_simulator_action == "start"
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Starting on/around September 29th, the mux-simulator script on the host server failed to start. This is because both the Flask and Werkzeug python packages updated to version 3.0.0 on that day, and there were breaking changes in Werkzeug 3.0.0. Our yaml script installs a fixed Flask version of 2.0.3, and the dependency list for that package only specified "Werkzeug >= 2.0". This means that pip will happily install version 3.0.0 even though it is incompatible with this version of Flask.

#### How did you do it?

As a fix, install specifically Flask 2.3.3 and Werkzeug 2.3.7. In addtion, to make it easier to notice failures here, check to see that the systemd service is actually running after it gets started.

#### How did you verify/test it?

Tested locally with dualtor KVM

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
