### PR TITLE
Enable Parallel announcement/withdrawal of routes for T2 topologies

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -9,7 +9,8 @@ import ipaddress
 import json
 import sys
 import socket
-
+import random
+from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
 
 if sys.version_info.major == 3:
@@ -91,7 +92,6 @@ M0_SUBNET_PREFIX_LEN_V6 = 64
 # Describe default start asn of M1s
 M1_ASN_START = 65200
 
-
 def wait_for_http(host_ip, http_port, timeout=10):
     """
     Waits for HTTP server to open.
@@ -124,6 +124,7 @@ def get_topo_type(topo_name):
     if topo_type in ['mc0']:
         topo_type = 'm0'
     return topo_type
+
 
 
 def read_topo(topo_name, path):
@@ -160,6 +161,36 @@ def change_routes(action, ptf_ip, port, routes):
                 r.text
             )
         )
+
+def send_routes_for_each_set(args):
+    routes, port, action, ptf_ip = args
+    change_routes(action, ptf_ip, port, routes)
+
+
+def send_routes_in_parallel(route_set):
+    """
+    Sends the given set of routes in parallel using a thread pool.
+
+    Args:
+        route_set (list): A list of route sets to send.
+
+    Returns:
+        None
+    """
+    # Create a pool of worker processes
+    pool = ThreadPool(processes=len(route_set))
+
+    # Use the ThreadPool.map function to apply the function to each set of routes
+    results = pool.map(send_routes_for_each_set, route_set)
+
+    # Optionally, process the results
+    for result in results:
+        # Process individual results here
+        pass
+
+    # Close the pool and wait for all processes to complete
+    pool.close()
+    pool.join()
 
 
 # AS path from Leaf router for T0 topology
@@ -823,9 +854,8 @@ We would have the following distribution:
    - 193.177.xx.xx - 194.55.xx.xx (4K routes) from all 24 T3 VM's on linecard1 (VM1-VM24)
    - default route from all 24 T3 VM's on linecard1 (VM1-VM24)
 """
-
-
 def fib_t2_lag(topo, ptf_ip, action="announce"):
+    route_set = []
     vms = topo['topology']['VMs']
     # T1 VMs per linecard(asic) - key is the dut index, and value is a list of T1 VMs
     t1_vms = {}
@@ -844,14 +874,16 @@ def fib_t2_lag(topo, ptf_ip, action="announce"):
             if dut_index not in t3_vms:
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)
-    generate_t2_routes(t1_vms, topo, ptf_ip, action="announce")
-    generate_t2_routes(t3_vms, topo, ptf_ip, action="announce")
+    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action)
+    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action)
+    send_routes_in_parallel(route_set)
 
 
 def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
     common_config = topo['configuration_properties'].get('common', {})
     vms = topo['topology']['VMs']
     vms_config = topo['configuration']
+    r_set = []
 
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -904,8 +936,10 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
                                             nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t2",
                                             router_type=router_type, tor_index=tor_index, set_num=set_num,
                                             core_ra_asn=core_ra_asn)
-                change_routes(action, ptf_ip, port, routes_v4)
-                change_routes(action, ptf_ip, port6, routes_v6)
+                random.shuffle(routes_v4)
+                random.shuffle(routes_v6)
+                r_set.append((routes_v4, port, action, ptf_ip))
+                r_set.append((routes_v6, port6, action, ptf_ip))
 
                 if 'vips' in vms_config[a_vm]:
                     routes_vips = []
@@ -913,6 +947,8 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
                         routes_vips.append(
                             (prefix, nhipv4, vms_config[a_vm]["vips"]["ipv4"]["asn"]))
                     change_routes(action, ptf_ip, port, routes_vips)
+    return r_set
+
 
 
 def fib_t0_mclag(topo, ptf_ip, action="announce"):

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -92,6 +92,7 @@ M0_SUBNET_PREFIX_LEN_V6 = 64
 # Describe default start asn of M1s
 M1_ASN_START = 65200
 
+
 def wait_for_http(host_ip, http_port, timeout=10):
     """
     Waits for HTTP server to open.
@@ -124,7 +125,6 @@ def get_topo_type(topo_name):
     if topo_type in ['mc0']:
         topo_type = 'm0'
     return topo_type
-
 
 
 def read_topo(topo_name, path):
@@ -161,6 +161,7 @@ def change_routes(action, ptf_ip, port, routes):
                 r.text
             )
         )
+
 
 def send_routes_for_each_set(args):
     routes, port, action, ptf_ip = args
@@ -854,6 +855,8 @@ We would have the following distribution:
    - 193.177.xx.xx - 194.55.xx.xx (4K routes) from all 24 T3 VM's on linecard1 (VM1-VM24)
    - default route from all 24 T3 VM's on linecard1 (VM1-VM24)
 """
+
+
 def fib_t2_lag(topo, ptf_ip, action="announce"):
     route_set = []
     vms = topo['topology']['VMs']
@@ -948,7 +951,6 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
                             (prefix, nhipv4, vms_config[a_vm]["vips"]["ipv4"]["asn"]))
                     change_routes(action, ptf_ip, port, routes_vips)
     return r_set
-
 
 
 def fib_t0_mclag(topo, ptf_ip, action="announce"):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Route Announce/Withdraw in Parallel for T2 topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
There are 2 motivations for this.
1. As the route scale and number of neighbors are higher for various T2 topologies, the announce-route script takes longer(6+ mins for T2 topology), which increases the overall time for add-topo. We are coming up with even higher scaled t2 topologies, which would make this even worse.
2. New testcases are being added to verify stress route churns. this change could be reused in those testcases.

#### How did you do it?
Created route sets as part of generate_route code. And used python's Threadpool functionality to create pool of processes to process these sets in parallel.

Also fixed a typo where action was hardcoded("announce") for t2 topologies.

 #### How did you verify/test it?
Executed add-topo script for T2 topology
Executed announce route script for T2 topology.

Confirmed that after this change, announce_route completes in less than 1 min(earlier it was 6+ min).
```
Before:
Announce routes -------------------------------------------- 328.96s

After:
Announce routes ------------------------------------------- 48.32s
```

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
