### PR TITLE
Revert 7 commits related to manipulate PORT/mode in test

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -415,6 +415,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         delete_untagged_vlan: check to delete unttaged vlan
     '''
     cmds = []
+    port_mode_added = {}    # Keep track of whether switchport mode has been added for each port
     logger.info("Add vlans, assign IPs")
     for k, v in list(vlan_intfs_dict.items()):
         if v['orig']:
@@ -439,8 +440,10 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-            switchport_mode_set(duthost, vlan_port['dev'])
-            logger.info("trunk mode added")
+            if vlan_port['dev'] not in port_mode_added:
+                switchport_mode_set(duthost, vlan_port['dev'])
+                logger.info("trunk mode added")
+                port_mode_added[vlan_port['dev']] = True
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -415,7 +415,6 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         delete_untagged_vlan: check to delete unttaged vlan
     '''
     cmds = []
-    port_mode_added = {}    # Keep track of whether switchport mode has been added for each port
     logger.info("Add vlans, assign IPs")
     for k, v in list(vlan_intfs_dict.items()):
         if v['orig']:
@@ -439,10 +438,8 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-            if vlan_port['dev'] not in port_mode_added:
-                if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
-                    cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
-                port_mode_added[vlan_port['dev']] = True
+            if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
+                cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -461,8 +458,8 @@ def check_switchport_cmd(duthost, tport):
         cmds = 'config switchport mode routed {port}'.format(port=tport)
         logger.info("Commands: {}".format(cmds))
         out = duthost.shell(cmds, module_ignore_errors=True)
-        if out['rc'] == 0:
-            return True
+        return True
+
     return False
 
 

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -465,18 +465,9 @@ cat << EOF >  %s
 }
 EOF
 ''' % (mode_json)
-    duthost.shell(mode_set)
-    jq_command = (
-     'sudo jq --argfile modeJson {} '
-     '\'.PORT |= with_entries(if $modeJson.PORT[.key] '
-     'and (.mode == null or .mode == "trunk" or .mode == "routed") '
-     'then .value.mode = "trunk" else . end)\' '
-     '/etc/sonic/config_db.json > /tmp/dump.json'
-    ).format(mode_json)
-    duthost.shell(jq_command)
-    duthost.command("sudo config load -y {}".format(mode_json))
-    duthost.command("sudo mv /tmp/dump.json /etc/sonic/config_db.json")
 
+    duthost.shell(mode_set)
+    duthost.command("sudo config load {} -y".format(mode_json))
     yield
     duthost.command("rm {}".format(mode_json))
     logger.info("Json dump-file added in to the DUT")

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -421,6 +421,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             continue
         cmds.append('config vlan add {}'.format(k))
         cmds.append("config interface ip add Vlan{} {}".format(k, v['ip'].upper()))
+
     # Delete untagged vlans from interfaces to avoid error message
     # when adding untagged vlan to interface that already have one
     if delete_untagged_vlan and '201911' not in duthost.os_version:
@@ -438,6 +439,7 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
+
             if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
                 cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
@@ -452,14 +454,9 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
 def check_switchport_cmd(duthost, tport):
     cmds = 'config switchport mode trunk {port}'.format(port=tport)
     logger.info("Commands: {}".format(cmds))
-    out = duthost.shell(cmds, module_ignore_errors=True)
-
-    if out['rc'] == 0:
-        cmds = 'config switchport mode routed {port}'.format(port=tport)
-        logger.info("Commands: {}".format(cmds))
-        out = duthost.shell(cmds, module_ignore_errors=True)
+    output = duthost.shell(cmds, module_ignore_errors=True)
+    if (output['rc'] == 0):
         return True
-
     return False
 
 

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -322,6 +322,7 @@ def utils_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tb
                 vlan_port['permit_vlanid'].append(vlan['vlanid'])
         if 'pvid' in vlan_port:
             vlan_ports_list.append(vlan_port)
+
     return vlan_ports_list
 
 
@@ -415,7 +416,6 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         delete_untagged_vlan: check to delete unttaged vlan
     '''
     cmds = []
-    port_mode_added = {}    # Keep track of whether switchport mode has been added for each port
     logger.info("Add vlans, assign IPs")
     for k, v in list(vlan_intfs_dict.items()):
         if v['orig']:
@@ -435,15 +435,12 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
                     cmds.append("config vlan member del {} {}".format(vid, vlan_port['dev']))
             except KeyError:
                 continue
+
     logger.info("Add members to Vlans")
     for vlan_port in vlan_ports_list:
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-            if vlan_port['dev'] not in port_mode_added:
-                switchport_mode_set(duthost, vlan_port['dev'])
-                logger.info("trunk mode added")
-                port_mode_added[vlan_port['dev']] = True
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -451,29 +448,6 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             ))
     logger.info("Commands: {}".format(cmds))
     duthost.shell_cmds(cmds=cmds)
-
-
-def switchport_mode_set(duthost, port):
-
-    mode_json = "/tmp/mode_set.json"
-
-    mode_set = '''
-cat << EOF >  %s
-{
-   "PORT": {
-        "{port}": {
-            "mode": "trunk"
-        }
-  }
-}
-EOF
-''' % (mode_json)
-
-    duthost.shell(mode_set)
-    duthost.command("sudo config load {} -y".format(mode_json))
-    yield
-    duthost.command("rm {}".format(mode_json))
-    logger.info("Json dump-file added in to the DUT")
 
 
 def _dut_qos_map(dut):

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -165,11 +165,7 @@ def ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
-    config_ports = {
-        k: {**v, 'mode': 'trunk'}
-        for k, v in list(cfg_facts['PORT'].items())
-        if v.get('admin_status', 'down') == 'up'
-        }
+    config_ports = {k: v for k, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', 'down') == 'up'}
     config_port_indices = {k: v for k, v in list(mg_facts['minigraph_ptf_indices'].items()) if k in config_ports}
     ptf_ports_available_in_topo = {
         port_index: 'eth{}'.format(port_index) for port_index in list(config_port_indices.values())
@@ -269,11 +265,7 @@ def utils_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tb
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     vlan_ports_list = []
-    config_ports = {
-        k: {**v, 'mode': 'trunk'}
-        for k, v in list(cfg_facts['PORT'].items())
-        if v.get('admin_status', 'down') == 'up'
-        }
+    config_ports = {k: v for k, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', 'down') == 'up'}
     config_portchannels = cfg_facts.get('PORTCHANNEL_MEMBER', {})
     config_port_indices = {k: v for k, v in list(mg_facts['minigraph_ptf_indices'].items()) if k in config_ports}
     config_ports_vlan = collections.defaultdict(list)
@@ -447,6 +439,8 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
+            switchport_mode_set(duthost, vlan_port['dev'])
+            logger.info("trunk mode added")
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -454,6 +448,38 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             ))
     logger.info("Commands: {}".format(cmds))
     duthost.shell_cmds(cmds=cmds)
+
+
+def switchport_mode_set(duthost, port):
+
+    mode_json = "/tmp/mode_set.json"
+
+    mode_set = '''
+cat << EOF >  %s
+{
+   "PORT": {
+        "{port}": {
+            "mode": "trunk"
+        }
+  }
+}
+EOF
+''' % (mode_json)
+    duthost.shell(mode_set)
+    jq_command = (
+     'sudo jq --argfile modeJson {} '
+     '\'.PORT |= with_entries(if $modeJson.PORT[.key] '
+     'and (.mode == null or .mode == "trunk" or .mode == "routed") '
+     'then .value.mode = "trunk" else . end)\' '
+     '/etc/sonic/config_db.json > /tmp/dump.json'
+    ).format(mode_json)
+    duthost.shell(jq_command)
+    duthost.command("sudo config load -y {}".format(mode_json))
+    duthost.command("sudo mv /tmp/dump.json /etc/sonic/config_db.json")
+
+    yield
+    duthost.command("rm {}".format(mode_json))
+    logger.info("Json dump-file added in to the DUT")
 
 
 def _dut_qos_map(dut):

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -165,7 +165,11 @@ def ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
-    config_ports = {k: v for k, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', 'down') == 'up'}
+    config_ports = {
+        k: {**v, 'mode': 'trunk'}
+        for k, v in list(cfg_facts['PORT'].items())
+        if v.get('admin_status', 'down') == 'up'
+        }
     config_port_indices = {k: v for k, v in list(mg_facts['minigraph_ptf_indices'].items()) if k in config_ports}
     ptf_ports_available_in_topo = {
         port_index: 'eth{}'.format(port_index) for port_index in list(config_port_indices.values())
@@ -265,7 +269,11 @@ def utils_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tb
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     vlan_ports_list = []
-    config_ports = {k: v for k, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', 'down') == 'up'}
+    config_ports = {
+        k: {**v, 'mode': 'trunk'}
+        for k, v in list(cfg_facts['PORT'].items())
+        if v.get('admin_status', 'down') == 'up'
+        }
     config_portchannels = cfg_facts.get('PORTCHANNEL_MEMBER', {})
     config_port_indices = {k: v for k, v in list(mg_facts['minigraph_ptf_indices'].items()) if k in config_ports}
     config_ports_vlan = collections.defaultdict(list)
@@ -439,9 +447,6 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
         for permit_vlanid in vlan_port['permit_vlanid']:
             if vlan_intfs_dict[int(permit_vlanid)]['orig']:
                 continue
-
-            if (check_switchport_cmd(duthost, vlan_port['dev']) is True):
-                cmds.append('config switchport mode trunk {port}'.format(port=vlan_port['dev']))
             cmds.append('config vlan member add {tagged} {id} {port}'.format(
                 tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
                 id=permit_vlanid,
@@ -449,15 +454,6 @@ def utils_create_test_vlans(duthost, cfg_facts, vlan_ports_list, vlan_intfs_dict
             ))
     logger.info("Commands: {}".format(cmds))
     duthost.shell_cmds(cmds=cmds)
-
-
-def check_switchport_cmd(duthost, tport):
-    cmds = 'config switchport mode trunk {port}'.format(port=tport)
-    logger.info("Commands: {}".format(cmds))
-    output = duthost.shell(cmds, module_ignore_errors=True)
-    if (output['rc'] == 0):
-        return True
-    return False
 
 
 def _dut_qos_map(dut):

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -70,6 +70,7 @@ def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
     |       109 | 192.168.9.1/24   | Ethernet4 | tagged         | disabled    |                       |
     +-----------+------------------+-----------+----------------+-------------+-----------------------+
     """
+
     logger.info("CREATE TEST VLANS START")
     vlan_ports_list = [{
         'dev': first_avai_vlan_port,

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -43,10 +43,7 @@ def first_avai_vlan_port(rand_selected_dut, tbinfo):
     for v in list(mg_facts['minigraph_vlans'].values()):
         for p in v['members']:
             if p.startswith("Ethernet"):
-                if 'mode' not in mg_facts['minigraph_ports'][p]:
-                    logger.info("trunk mode in Port added")
-                    mg_facts['minigraph_ports'][p]['mode'] = 'trunk'
-                    return p
+                return p
 
     logger.error("No vlan port member ready for test")
     pytest_assert(False, "No vlan port member ready for test")

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -8,6 +8,7 @@ from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig, \
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload, rollback
+
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
 ]
@@ -42,7 +43,10 @@ def first_avai_vlan_port(rand_selected_dut, tbinfo):
     for v in list(mg_facts['minigraph_vlans'].values()):
         for p in v['members']:
             if p.startswith("Ethernet"):
-                return p
+                if 'mode' not in mg_facts['minigraph_ports'][p]:
+                    logger.info("trunk mode in Port added")
+                    mg_facts['minigraph_ports'][p]['mode'] = 'trunk'
+                    return p
 
     logger.error("No vlan port member ready for test")
     pytest_assert(False, "No vlan port member ready for test")
@@ -152,7 +156,6 @@ def setup_vlan(duthosts, rand_one_dut_hostname, vlan_intfs_dict, first_avai_vlan
 
     dhcp_relay_info_before_test = get_dhcp_relay_info_from_all_vlans(duthost)
     create_checkpoint(duthost, SETUP_ENV_CP)
-
     # --------------------- Testing -----------------------
     yield
 
@@ -160,7 +163,6 @@ def setup_vlan(duthosts, rand_one_dut_hostname, vlan_intfs_dict, first_avai_vlan
     # Rollback twice. First rollback to checkpoint just before 'yield'
     # Second rollback is to back to original setup
     try:
-        # load first
         output = rollback(duthost, SETUP_ENV_CP)
         pytest_assert(
             not output['rc'] and "Config rolled back successfull" in output['stdout'],


### PR DESCRIPTION
### Description of PR
PORT/mode is not yang modelled. I see open PR https://github.com/sonic-net/sonic-buildimage/pull/13580.
This PR will revert all the commits related to manipulate PORT/mode in test, in order to unblock https://github.com/sonic-net/sonic-buildimage/pull/16267

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
