### PR TITLE
[202205] Skip SNMP IPv6 testcases in 2022xx 2023xx branches (#10097)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -993,6 +993,14 @@ show_techsupport/test_techsupport.py::test_techsupport:
 #######################################
 #####            snmp             #####
 #######################################
+snmp/test_snmp_link_local.py:
+  skip:
+    reason: "SNMP over IPv6 support not present in release branches."
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/6108
+      - "is_multi_asic==False"
+      - "release in ['202205', '202211', '202305']"
+
 snmp/test_snmp_pfc_counters.py:
   skip:
     reason: "M0/MX topo does not support test_snmp_pfc_counters"

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -1,6 +1,8 @@
 import pytest
+import ipaddress
 from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_output
 from tests.common.devices.eos import EosHost
+from tests.common.utilities import skip_release
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -8,7 +10,9 @@ pytestmark = [
 ]
 
 
-def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrhosts, tbinfo, localhost, creds_all_duts):
+@pytest.mark.parametrize('ip_version', [ipaddress.IPv4Address, ipaddress.IPv6Address])
+def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                       nbrhosts, tbinfo, localhost, creds_all_duts, ip_version):
     """
     Test SNMP query to DUT over loopback IP
       - Send SNMP query over loopback IP from one of the BGP Neighbors
@@ -25,6 +29,13 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrh
 
     for ip in config_facts[u'LOOPBACK_INTERFACE'][u'Loopback0']:
         loip = ip.split('/')[0]
+        ipaddr = ipaddress.ip_address(loip)
+        if not isinstance(ipaddr, ip_version):
+            continue
+        if isinstance(ipaddr, ipaddress.IPv6Address):
+            # SNMP over IPv6 not supported in single-asic
+            if not duthost.is_multi_asic:
+                skip_release(duthost, ["202211", "202205", "202305"])
         result = get_snmp_output(loip, duthost, nbr, creds_all_duts)
         assert result is not None, 'No result from snmpget'
         assert len(result['stdout_lines']) > 0, 'No result from snmpget'


### PR DESCRIPTION
What is the motivation for this PR?
Skip SNMP IPv6 related test cases in 202211,202205 and 202305 branches until the approach to fix IPv6 issue is fixed. PR contains details of the issue and approach sonic-net/SONiC#1457

How did you do it?
Skip single asic IPv6 SNMP loopback test case and link local test case in branches with the testcase added.

How did you verify/test it?
Tested on 202205 single asic VS image

(cherry picked from commit a72a4db2955f78fbed1acddc85b13265e595f546)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
