### PR TITLE
Add macsec skip in 202305

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -76,12 +76,12 @@ t0-2vlans:
   - dhcp_relay/test_dhcpv6_relay.py
 
 t0-sonic:
-  - bgp/test_bgp_fact.py
-  - macsec/test_controlplane.py
-  - macsec/test_dataplane.py
-  - macsec/test_deployment.py
-  - macsec/test_fault_handling.py
-  - macsec/test_interop_protocol.py
+  # - bgp/test_bgp_fact.py
+  # - macsec/test_controlplane.py
+  # - macsec/test_dataplane.py
+  # - macsec/test_deployment.py
+  # - macsec/test_fault_handling.py
+  # - macsec/test_interop_protocol.py
   - pc/test_retry_count.py
   - platform_tests/test_advanced_reboot.py::test_warm_reboot
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,6 +150,7 @@ stages:
           VM_TYPE: vsonic
           KVM_IMAGE_BRANCH: "202305"
           MGMT_BRANCH: "202305"
+          SCRIPTS_EXCLUDE: "bgp/test_bgp_fact.py"
 
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -636,6 +636,12 @@ ipfwd/test_mtu.py:
 #######################################
 #####           macsec            #####
 #######################################
+macsec:
+  skip:
+    reason: 'Skip for t0-sonic to prevent deadlock with code PR merge'
+    conditions:
+      - "'t0' in topo_name"
+
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:
     reason: 'test_server_to_neighbor needs downstream neighbors, which is not present in this topo'


### PR DESCRIPTION
#### What is the motivation for this PR?
Following what as done in master and 202205 for macsec type7 changes 

Add the remove first and later revert REF: https://github.com/sonic-net/sonic-mgmt/pull/10132

MSFT ADO : 25261395


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
