### PR TITLE
[tests/route]: Use minigraph_ptf_indices to get ptf port indices

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -410,7 +410,7 @@ def test_perf_add_remove_routes(
 
         # Traffic verification with 10 random routes
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        port_indices = mg_facts["minigraph_port_indices"]
+        port_indices = mg_facts["minigraph_ptf_indices"]
         nexthop_intf = str_intf_nexthop["ifname"].split(",")
         src_port = random.choice(nexthop_intf)
         ptf_src_port = (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
port_indices obtained using port_indices mg_facts["minigraph_port_indices"] are not valid for dualtor testbeds causing test failures. The right way is to use mg_facts["minigraph_ptf_indices"] to get ptf port indices so the test passes on all testbeds.

Summary:
Fixes # 24668985

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
port_indices obtained using port_indices mg_facts["minigraph_port_indices"] are not valid for dualtor testbeds causing test failures
#### How did you do it?
Use mg_facts["minigraph_ptf_indices"] to get ptf port indices so the test passes on all testbeds.
#### How did you verify/test it?
By running sonic-mgmt test route/test_route_perf.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
