### PR TITLE
Cisco-8000: Return from cisco qos param gen if the current platform doesn't support param gen yet.

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -60,6 +60,8 @@ class QosParamCisco(object):
         Each function takes common parameters and outputs to the relevant section of the
         self.qos_params structure.
         '''
+        if not self.supports_autogen:
+            return self.qos_params
         self.__define_shared_reservation_size()
         self.__define_pfc_xoff_limit()
         self.__define_pfc_xon_limit()


### PR DESCRIPTION
When a platform or topo doesn't support paramgen, we should return the existing params read from qos-yaml.
Currently it gives this error:
<img width="1792" alt="Screenshot 2023-10-06 at 12 21 34 PM" src="https://github.com/sonic-net/sonic-mgmt/assets/58446052/4e45014f-8c6e-4d53-a6eb-d80ec93bc63d">
