### PR TITLE
Skip dualtor in test_acl_outer_vlan

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -695,15 +695,6 @@ def skip_sonic_leaf_fanout(fanouthosts):
                 pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
 
-@pytest.fixture(scope='module', autouse=True)
-def skip_sonic_dualtor(tbinfo):
-    """
-    dualtor does not need portchannel in vlan
-    """
-    if 'dualtor' in tbinfo['topo']['name']:
-        pytest.skip("Not supported on dualtor platform")
-
-
 class TestAclVlanOuter_Ingress(AclVlanOuterTest_Base):
     """
     Verify ACL rule matching outer vlan id in ingress

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -695,6 +695,15 @@ def skip_sonic_leaf_fanout(fanouthosts):
                 pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
 
+@pytest.fixture(scope='module', autouse=True)
+def skip_sonic_dualtor(tbinfo):
+    """
+    dualtor does not need portchannel in vlan
+    """
+    if 'dualtor' in tbinfo['topo']['name']:
+        pytest.skip("Not supported on dualtor platform")
+
+
 class TestAclVlanOuter_Ingress(AclVlanOuterTest_Base):
     """
     Verify ACL rule matching outer vlan id in ingress

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -23,6 +23,10 @@ acl/test_acl_outer_vlan.py:
     reason: "Cisco platform does not support ACL Outer VLAN ID tests"
     conditions:
       - "asic_type in ['cisco-8000']"
+  skip:
+    reason: "Skip running on dualtor testbed"
+    conditions:
+      - "'dualtor' in topo_name"
 
 #######################################
 #####            arp              #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 22637175

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Dualtor platform does not need portchannel in vlan

#### How did you do it?
If testbed is dualtor, skip test_acl_outer_vlan

#### How did you verify/test it?
Run end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
