### PR TITLE
[dualtor_io] Add server to server I/O normal op test (#10124)

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -2,8 +2,11 @@ import collections
 import pytest
 import json
 import time
+import random
 
-from tests.common.dualtor.dual_tor_common import cable_type                             # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import active_active_ports        # noqa F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports       # noqa F401
+from tests.common.dualtor.dual_tor_common import cable_type     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_io import DualTorIO
 from tests.common.helpers.assertions import pytest_assert
@@ -144,11 +147,9 @@ def run_test(
         activehost, peerhost, ptfhost, ptfadapter, tbinfo,
         io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type
     )
+    tor_IO.generate_traffic(traffic_direction)
 
-    send_and_sniff = InterruptableThread(
-        target=tor_IO.start_io_test,
-        kwargs={'traffic_direction': traffic_direction}
-    )
+    send_and_sniff = InterruptableThread(target=tor_IO.start_io_test)
     send_and_sniff.set_error_handler(lambda *args, **kargs: io_ready.set())
 
     send_and_sniff.start()
@@ -367,5 +368,37 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield t1_to_soc_io_test
+
+    cleanup(ptfadapter, duthosts)
+
+
+@pytest.fixture
+def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type,        # noqa F811
+                                      active_active_ports, active_standby_ports):               # noqa F811
+
+    arp_setup(ptfhost)
+
+    if cable_type == CableType.active_active:
+        tor_vlan_port = random.sample(active_active_ports, 2)
+    elif cable_type == CableType.active_standby:
+        tor_vlan_port = random.sample(active_standby_ports, 2)
+    else:
+        raise ValueError("Unsupported cable type %s" % cable_type)
+
+    def server_to_server_io_test(activehost, delay=0, allowed_disruption=0, action=None,
+                                 verify=False, send_interval=0.01, stop_after=None):
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
+                          action, tbinfo, tor_vlan_port, send_interval,
+                          traffic_direction="server_to_server", stop_after=stop_after,
+                          cable_type=cable_type)
+
+        # If a delay is allowed but no numebr of allowed disruptions
+        # is specified, default to 1 allowed disruption
+        if delay and not allowed_disruption:
+            allowed_disruption = 1
+
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption)
+
+    yield server_to_server_io_test
 
     cleanup(ptfadapter, duthosts)

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -92,9 +92,14 @@ class DualTorIO:
 
         self.ptf_intf_to_soc_ip_map = self._generate_soc_ip_map()
 
+        self.ptf_intf_to_mac_map = {}
+        for ptf_intf in list(self.ptf_intf_to_server_ip_map.keys()):
+            self.ptf_intf_to_mac_map[ptf_intf] = self.ptfadapter.dataplane.get_mac(0, ptf_intf)
+
         logger.info("VLAN interfaces: {}".format(str(self.vlan_interfaces)))
         logger.info("PORTCHANNEL interfaces: {}".format(str(self.tor_pc_intfs)))
         logger.info("Selected testing interfaces: %s", self.test_interfaces)
+        logger.info("Selected ToR vlan interfaces: %s", self.tor_vlan_intf)
 
         self.time_to_listen = 300.0
         self.sniff_time_incr = 0
@@ -212,14 +217,7 @@ class DualTorIO:
         self.ptfhost.shell("supervisorctl restart arp_responder")
         logger.info("arp_responder restarted")
 
-    def start_io_test(self, traffic_direction=None):
-        """
-        @summary: The entry point to start the TOR dataplane I/O test.
-        Args:
-            traffic_direction (str): A string to decide the
-                traffic direction (T1 to server / server to T1 / T1 to soc / soc to T1)
-                Allowed values: server_to_t1, t1_to_server, soc_to_t1, t1_to_soc
-        """
+    def generate_traffic(self, traffic_direction=None):
         # Check in a conditional for better readability
         self.traffic_direction = traffic_direction
         if traffic_direction == "server_to_t1":
@@ -230,10 +228,16 @@ class DualTorIO:
             self.generate_upstream_traffic(src="soc")
         elif traffic_direction == "t1_to_soc":
             self.generate_downstream_traffic(dst="soc")
+        elif traffic_direction == "server_to_server":
+            self.generate_server_to_server_traffic()
         else:
             logger.error("Traffic direction not provided or invalid")
             return
 
+    def start_io_test(self):
+        """
+        @summary: The entry point to start the TOR dataplane I/O test.
+        """
         self.send_and_sniff()
 
     def generate_downstream_traffic(self, dst='server'):
@@ -333,10 +337,6 @@ class DualTorIO:
             vlan_src_intfs = self.test_interfaces
 
         ptf_intf_to_ip_map = self.ptf_intf_to_server_ip_map if src == 'server' else self.ptf_intf_to_soc_ip_map
-        ptf_intf_to_mac_map = {}
-
-        for ptf_intf in ptf_intf_to_ip_map.keys():
-            ptf_intf_to_mac_map[ptf_intf] = self.ptfadapter.dataplane.get_mac(0, ptf_intf)
 
         logger.info("-"*20 + "{} to T1 packet".format(src) + "-"*20)
         if self.tor_vlan_intf is None:
@@ -344,7 +344,7 @@ class DualTorIO:
             src_ip = 'random'
         else:
             ptf_port = self.tor_to_ptf_intf_map[self.tor_vlan_intf]
-            src_mac = ptf_intf_to_mac_map[ptf_port]
+            src_mac = self.ptf_intf_to_mac_map[ptf_port]
             src_ip = ptf_intf_to_ip_map[ptf_port]
         logger.info(
             "Ethernet address: dst: {} src: {}".format(
@@ -382,7 +382,7 @@ class DualTorIO:
             for vlan_intf in vlan_src_intfs:
                 ptf_src_intf = self.tor_to_ptf_intf_map[vlan_intf]
                 server_ip = ptf_intf_to_ip_map[ptf_src_intf]
-                eth_src = ptf_intf_to_mac_map[ptf_src_intf]
+                eth_src = self.ptf_intf_to_mac_map[ptf_src_intf]
                 payload = str(i) + payload_suffix
                 packet = tcp_tx_packet_orig.copy()
                 packet[scapyall.Ether].src = eth_src
@@ -394,6 +394,51 @@ class DualTorIO:
                 self.packets_list.append((ptf_src_intf, convert_scapy_packet_to_bytes(packet)))
         self.sent_pkt_dst_mac = self.vlan_mac
         self.received_pkt_src_mac = [self.active_mac, self.standby_mac]
+
+    def generate_server_to_server_traffic(self):
+        """
+        @summary: Generate (not send) the packets to be sent from server to server
+        """
+        logger.info("Generate server to server packets")
+        if not self.tor_vlan_intf or len(self.tor_vlan_intf) != 2:
+            raise ValueError("No vlan interfaces specified.")
+
+        vlan_src_intf, vlan_dst_intf = self.tor_vlan_intf
+        ptf_intf_to_ip_map = self.ptf_intf_to_server_ip_map
+
+        logger.info("-"*20 + "server to server packet" + "-"*20)
+        src_ptf_port = self.tor_to_ptf_intf_map[vlan_src_intf]
+        src_mac = self.ptf_intf_to_mac_map[src_ptf_port]
+        src_ip = ptf_intf_to_ip_map[src_ptf_port]
+        dst_ptf_port = self.tor_to_ptf_intf_map[vlan_dst_intf]
+        dst_ip = ptf_intf_to_ip_map[dst_ptf_port]
+        logger.info("Ethernet address: dst: {} src: {}".format(self.vlan_mac, src_mac))
+        logger.info("IP address: dst: {} src: {}".format(dst_ip, src_ip))
+        logger.info("TCP port: dst: {} src: 1234".format(TCP_DST_PORT))
+        logger.info("DUT ToR MAC: {}, PEER ToR MAC: {}".format(self.active_mac, self.standby_mac))
+        logger.info("VLAN MAC: {}".format(self.vlan_mac))
+        logger.info("-"*50)
+
+        self.packets_list = []
+        tcp_tx_packet_orig = testutils.simple_tcp_packet(
+            eth_dst=self.vlan_mac,
+            tcp_dport=TCP_DST_PORT
+        )
+        tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
+        payload_suffix = "X" * 60
+        for i in range(self.packets_per_server):
+            payload = str(i) + payload_suffix
+            packet = tcp_tx_packet_orig.copy()
+            packet[scapyall.Ether].src = src_mac
+            packet[scapyall.IP].src = src_ip
+            packet[scapyall.IP].dst = dst_ip
+            packet.load = payload
+            packet[scapyall.TCP].chksum = None
+            packet[scapyall.IP].chksum = None
+            self.packets_list.append((src_ptf_port, convert_scapy_packet_to_bytes(packet)))
+
+        self.sent_pkt_dst_mac = self.vlan_mac
+        self.received_pkt_src_mac = [self.vlan_mac]
 
     def random_host_ip(self):
         """
@@ -540,6 +585,8 @@ class DualTorIO:
         elif self.traffic_direction == "t1_to_soc":
             server_addr = packet[scapyall.IP].dst
         elif self.traffic_direction == "soc_to_t1":
+            server_addr = packet[scapyall.IP].src
+        elif self.traffic_direction == "server_to_server":
             server_addr = packet[scapyall.IP].src
         return server_addr
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -2,8 +2,10 @@ import pytest
 
 from tests.common.config_reload import config_reload
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action, send_soc_to_t1_with_action, send_t1_to_soc_with_action
-from tests.common.dualtor.dual_tor_common import cable_type
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action, \
+                                                  send_soc_to_t1_with_action, send_t1_to_soc_with_action, \
+                                                  send_server_to_server_with_action                 # noqa F401
+from tests.common.dualtor.dual_tor_common import cable_type     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, force_active_tor, force_standby_tor
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
@@ -76,6 +78,28 @@ def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                             expected_standby_host=None,
                             cable_type=cable_type)
+
+
+@pytest.mark.enable_active_active
+def test_normal_op_server_to_server(upper_tor_host, lower_tor_host,             # noqa F811
+                                    send_server_to_server_with_action,          # noqa F811
+                                    toggle_all_simulator_ports_to_upper_tor,    # noqa F811
+                                    cable_type):                                # noqa F811
+    """
+    Send server to server traffic and confirm no disruption or switchover occurs.
+    """
+    if cable_type == CableType.active_standby:
+        send_server_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=upper_tor_host,
+                          expected_standby_host=lower_tor_host,
+                          skip_tunnel_route=False)
+
+    if cable_type == CableType.active_active:
+        send_server_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
+                          expected_standby_host=None,
+                          cable_type=cable_type,
+                          skip_tunnel_route=False)
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
Approach
What is the motivation for this PR?
Add server to server normal testcase to cover the east-to-west traffic verification for dualtor.

Signed-off-by: Longxiang Lyu lolv@microsoft.com

How did you do it?
Select two mux ports, one as source port, one as dest port. Send traffic from source port and verify traffic delivery at the dest port.

How did you verify/test it?

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
