### PR TITLE
[202205][dualtor-io] show mux port flaps (#9568)

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -294,6 +294,8 @@ class UpstreamECMPGroup(OVSGroup):
         self.group_str_cache = {}
 
     def set_upper_tor_forwarding_state(self, state):
+        if state == self.upper_tor_forwarding_state:
+            return False
         if state == ForwardingState.ACTIVE:
             if self.upper_tor_forwarding_state == ForwardingState.STANDBY:
                 self.output_ports.add(self.upper_tor_port)
@@ -304,8 +306,11 @@ class UpstreamECMPGroup(OVSGroup):
                 self.output_ports.remove(self.upper_tor_port)
                 self.upper_tor_forwarding_state = ForwardingState.STANDBY
                 self.reset()
+        return True
 
     def set_lower_tor_forwarding_state(self, state):
+        if state == self.lower_tor_forwarding_state:
+            return False
         if state == ForwardingState.ACTIVE:
             if self.lower_tor_forwarding_state == ForwardingState.STANDBY:
                 self.output_ports.add(self.lower_tor_port)
@@ -316,6 +321,7 @@ class UpstreamECMPGroup(OVSGroup):
                 self.output_ports.remove(self.lower_tor_port)
                 self.lower_tor_forwarding_state = ForwardingState.STANDBY
                 self.reset()
+        return True
 
     def __str__(self):
         return self.group_str_cache.setdefault(
@@ -333,10 +339,10 @@ class UpstreamECMPFlow(OVSFlow):
         super(UpstreamECMPFlow, self).__init__(in_port, group=group, priority=priority)
 
     def set_upper_tor_forwarding_state(self, state):
-        self.group.set_upper_tor_forwarding_state(state)
+        return self.group.set_upper_tor_forwarding_state(state)
 
     def set_lower_tor_forwarding_state(self, state):
-        self.group.set_lower_tor_forwarding_state(state)
+        return self.group.set_lower_tor_forwarding_state(state)
 
     def get_upper_tor_forwarding_state(self):
         return self.group.upper_tor_forwarding_state
@@ -376,7 +382,8 @@ class OVSBridge(object):
         "upstream_nic_flow",
         "upstream_icmp_flow",
         "upstream_arp_flow",
-        "upstream_icmpv6_flow"
+        "upstream_icmpv6_flow",
+        "flap_counter"
     )
 
     def __init__(self, bridge_name):
@@ -404,6 +411,10 @@ class OVSBridge(object):
         self.downstream_flows = {
             1: self.downstream_upper_tor_flow,
             0: self.downstream_lower_tor_flow
+        }
+        self.flap_counter = {
+            1: 0,
+            0: 0
         }
 
     def _init_ports(self):
@@ -497,9 +508,11 @@ class OVSBridge(object):
         """Set forwarding state."""
         with self.lock:
             for portid, state in zip(portids, states):
-                logging.info("Set bridge %s port %s forwarding state: %s", self.bridge_name, portid, ForwardingState.STATE_LABELS[state])
-                self.states_setter[portid](state)
-            OVSCommand.ovs_ofctl_mod_groups(self.bridge_name, self.upstream_ecmp_group)
+                logging.info("Set bridge %s port %s forwarding state: %s",
+                             self.bridge_name, portid, ForwardingState.STATE_LABELS[state])
+                self.flap_counter[portid] += self.states_setter[portid](state)
+            OVSCommand.ovs_ofctl_mod_groups(
+                self.bridge_name, self.upstream_ecmp_group)
             return self.query_forwarding_state(portids)
 
     def query_forwarding_state(self, portids):
@@ -581,6 +594,25 @@ class OVSBridge(object):
                         raise ValueError("Invalid direction %s, please use 0 for downstream and 1 for upstream" % (direction))
                 result.append(True)
             return result
+
+    def query_flap_counter(self, portids):
+        """Query flap counter."""
+        with self.lock:
+            flap_counter = [self.flap_counter[portid] for portid in portids]
+            logging.info("Query bridge %s flap counter for ports %s: %s",
+                         self.bridge_name, portids, flap_counter)
+            return flap_counter
+
+    def reset_flap_counter(self, portids):
+        """Reset flap counter."""
+        with self.lock:
+            flap_counter = []
+            for portid in portids:
+                self.flap_counter[portid] = 0
+                flap_counter.append(0)
+            logging.info("Reset bridge %s flap counter for ports %s: %s",
+                         self.bridge_name, portids, flap_counter)
+            return flap_counter
 
 
 class InterruptableThread(threading.Thread):
@@ -675,6 +707,30 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
         logging.debug("SetDrop: response to client %s from server %s\n%s", context.peer(), self.nic_addr, response)
         return response
 
+    def QueryFlapCounter(self, request, context):
+        logging.debug("QueryFlapCounter: request to server %s from client %s\n",
+                      self.nic_addr, context.peer())
+        portids = request.portid
+        response = nic_simulator_grpc_service_pb2.FlapCounterReply(
+            portid=portids,
+            flaps=self.ovs_bridge.query_flap_counter(portids)
+        )
+        logging.debug("QueryFlapCounter: response to client %s from server %s:\n%s",
+                      context.peer(), self.nic_addr, response)
+        return response
+
+    def ResetFlapCounter(self, request, context):
+        logging.debug("ResetFlapCounter: request to server %s from client %s\n",
+                      self.nic_addr, context.peer())
+        portids = request.portid
+        response = nic_simulator_grpc_service_pb2.FlapCounterReply(
+            portid=portids,
+            flaps=self.ovs_bridge.reset_flap_counter(portids)
+        )
+        logging.debug("ResetFlapCounter: response to client %s from server %s:\n%s",
+                      context.peer(), self.nic_addr, response)
+        return response
+
     def _run_server(self, binding_port):
         """Run the gRPC server."""
         self.server = grpc.server(
@@ -730,16 +786,15 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
 
     def QueryAdminForwardingPortState(self, request, context):
         nic_addresses = request.nic_addresses
-        logging.debug("QueryAdminForwardingPortState[mgmt]: request query admin port state for %s\n", nic_addresses)
+        admin_requests = request.admin_requests
+        logging.debug(
+            "QueryAdminForwardingPortState[mgmt]: request query admin port state for %s\n", nic_addresses)
         query_responses = []
-        for nic_address in nic_addresses:
+        for nic_address, admin_request in zip(nic_addresses, admin_requests):
             client_stub = self._get_client_stub(nic_address)
             try:
                 state = client_stub.QueryAdminForwardingPortState(
-                    nic_simulator_grpc_service_pb2.AdminRequest(
-                        portid=[0, 1],
-                        state=[True, True]
-                    ),
+                    admin_request,
                     timeout=GRPC_TIMEOUT
                 )
                 query_responses.append(state)
@@ -840,6 +895,64 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
             successes=successes
         )
         logging.debug("SetNicServerAdminState[mgmt]: response of set nic server admin state:%s\n", response)
+        return response
+
+    def QueryFlapCounter(self, request, context):
+        nic_addresses = request.nic_addresses
+        flap_counter_requests = request.flap_counter_requests
+        logging.debug(
+            "QueryFlapCounter[mgmt]: request query port flap counter for %s\n", nic_addresses)
+
+        query_responses = []
+        for nic_address, flap_counter_request in zip(nic_addresses, flap_counter_requests):
+            client_stub = self._get_client_stub(nic_address)
+            try:
+                flap_counter_reply = client_stub.QueryFlapCounter(
+                    flap_counter_request,
+                    timeout=GRPC_TIMEOUT
+                )
+                query_responses.append(flap_counter_reply)
+            except Exception as e:
+                context.set_code(grpc.StatusCode.ABORTED)
+                context.set_details(
+                    "Error in QueryFlapCounter to %s: %s" % (nic_address, repr(e)))
+                return nic_simulator_grpc_mgmt_service_pb2.ListOfFlapCounterReply()
+
+        response = nic_simulator_grpc_mgmt_service_pb2.ListOfFlapCounterReply(
+            nic_addresses=nic_addresses,
+            flap_counter_replies=query_responses
+        )
+        logging.debug(
+            "QueryFlapCounter[mgmt]: response of query: %s", response)
+        return response
+
+    def ResetFlapCounter(self, request, context):
+        nic_addresses = request.nic_addresses
+        flap_counter_requests = request.flap_counter_requests
+        logging.debug(
+            "ResetFlapCounter[mgmt]: request reset port flap counter for %s\n", nic_addresses)
+
+        reset_responses = []
+        for nic_address, flap_counter_request in zip(nic_addresses, flap_counter_requests):
+            client_stub = self._get_client_stub(nic_address)
+            try:
+                flap_counter_reply = client_stub.ResetFlapCounter(
+                    flap_counter_request,
+                    timeout=GRPC_TIMEOUT
+                )
+                reset_responses.append(flap_counter_reply)
+            except Exception as e:
+                context.set_code(grpc.StatusCode.ABORTED)
+                context.set_details(
+                    "Error in ResetFlapCounter to %s: %s" % (nic_address, repr(e)))
+                return nic_simulator_grpc_mgmt_service_pb2.ListOfFlapCounterReply()
+
+        response = nic_simulator_grpc_mgmt_service_pb2.ListOfFlapCounterReply(
+            nic_addresses=nic_addresses,
+            flap_counter_replies=reset_responses
+        )
+        logging.debug(
+            "ResetFlapCounter[mgmt]: response of reset: %s", response)
         return response
 
     def start(self):

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service.proto
@@ -11,7 +11,11 @@ service DualTorMgmtService {
 
   rpc SetDrop(ListOfDropRequest) returns (ListOfDropReply) {}
 
-  rpc SetNicServerAdminState(ListOfNiCServerAdminStateRequest) returns (ListOfNiCServerAdminStateReply) {}
+  rpc SetNicServerAdminState(ListOfNiCServerAdminStateRequest) returns(ListOfNiCServerAdminStateReply) {}
+
+  rpc QueryFlapCounter(ListOfFlapCounterRequest) returns(ListOfFlapCounterReply) {}
+
+  rpc ResetFlapCounter(ListOfFlapCounterRequest) returns(ListOfFlapCounterReply) {}
 }
 
 message ListOfAdminRequest {
@@ -54,3 +58,13 @@ message ListOfNiCServerAdminStateReply {
   repeated bool admin_states = 2;
   repeated bool successes = 3;
 }
+
+message ListOfFlapCounterRequest {
+    repeated string nic_addresses = 1;
+    repeated FlapCounterRequest flap_counter_requests = 2;
+};
+
+message ListOfFlapCounterReply {
+    repeated string nic_addresses = 1;
+    repeated FlapCounterReply flap_counter_replies = 2;
+};

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2.py
@@ -12,11 +12,10 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-import nic_simulator_grpc_service_pb2 as nic__simulator__grpc__service__pb2
+import nic_simulator_grpc_service_pb2 as nic__simulator__grpc__service__pb2                                             # noqa E402 F401
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%nic_simulator_grpc_mgmt_service.proto\x1a nic_simulator_grpc_service.proto\"R\n\x12ListOfAdminRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12%\n\x0e\x61\x64min_requests\x18\x02 \x03(\x0b\x32\r.AdminRequest\"M\n\x10ListOfAdminReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\"\n\radmin_replies\x18\x02 \x03(\x0b\x32\x0b.AdminReply\"^\n\x16ListOfOperationRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12-\n\x12operation_requests\x18\x02 \x03(\x0b\x32\x11.OperationRequest\"Y\n\x14ListOfOperationReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12*\n\x11operation_replies\x18\x02 \x03(\x0b\x32\x0f.OperationReply\"O\n\x11ListOfDropRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12#\n\rdrop_requests\x18\x02 \x03(\x0b\x32\x0c.DropRequest\"J\n\x0fListOfDropReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12 \n\x0c\x64rop_replies\x18\x02 \x03(\x0b\x32\n.DropReply\"O\n ListOfNiCServerAdminStateRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\x14\n\x0c\x61\x64min_states\x18\x02 \x03(\x08\"`\n\x1eListOfNiCServerAdminStateReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\x14\n\x0c\x61\x64min_states\x18\x02 \x03(\x08\x12\x11\n\tsuccesses\x18\x03 \x03(\x08\x32\x88\x03\n\x12\x44ualTorMgmtService\x12I\n\x1dQueryAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12G\n\x1bSetAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12K\n\x17QueryOperationPortState\x12\x17.ListOfOperationRequest\x1a\x15.ListOfOperationReply\"\x00\x12\x31\n\x07SetDrop\x12\x12.ListOfDropRequest\x1a\x10.ListOfDropReply\"\x00\x12^\n\x16SetNicServerAdminState\x12!.ListOfNiCServerAdminStateRequest\x1a\x1f.ListOfNiCServerAdminStateReply\"\x00\x62\x06proto3')
-
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%nic_simulator_grpc_mgmt_service.proto\x1a nic_simulator_grpc_service.proto\"R\n\x12ListOfAdminRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12%\n\x0e\x61\x64min_requests\x18\x02 \x03(\x0b\x32\r.AdminRequest\"M\n\x10ListOfAdminReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\"\n\radmin_replies\x18\x02 \x03(\x0b\x32\x0b.AdminReply\"^\n\x16ListOfOperationRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12-\n\x12operation_requests\x18\x02 \x03(\x0b\x32\x11.OperationRequest\"Y\n\x14ListOfOperationReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12*\n\x11operation_replies\x18\x02 \x03(\x0b\x32\x0f.OperationReply\"O\n\x11ListOfDropRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12#\n\rdrop_requests\x18\x02 \x03(\x0b\x32\x0c.DropRequest\"J\n\x0fListOfDropReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12 \n\x0c\x64rop_replies\x18\x02 \x03(\x0b\x32\n.DropReply\"O\n ListOfNiCServerAdminStateRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\x14\n\x0c\x61\x64min_states\x18\x02 \x03(\x08\"`\n\x1eListOfNiCServerAdminStateReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\x14\n\x0c\x61\x64min_states\x18\x02 \x03(\x08\x12\x11\n\tsuccesses\x18\x03 \x03(\x08\"e\n\x18ListOfFlapCounterRequest\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12\x32\n\x15\x66lap_counter_requests\x18\x02 \x03(\x0b\x32\x13.FlapCounterRequest\"`\n\x16ListOfFlapCounterReply\x12\x15\n\rnic_addresses\x18\x01 \x03(\t\x12/\n\x14\x66lap_counter_replies\x18\x02 \x03(\x0b\x32\x11.FlapCounterReply2\x9c\x04\n\x12\x44ualTorMgmtService\x12I\n\x1dQueryAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12G\n\x1bSetAdminForwardingPortState\x12\x13.ListOfAdminRequest\x1a\x11.ListOfAdminReply\"\x00\x12K\n\x17QueryOperationPortState\x12\x17.ListOfOperationRequest\x1a\x15.ListOfOperationReply\"\x00\x12\x31\n\x07SetDrop\x12\x12.ListOfDropRequest\x1a\x10.ListOfDropReply\"\x00\x12^\n\x16SetNicServerAdminState\x12!.ListOfNiCServerAdminStateRequest\x1a\x1f.ListOfNiCServerAdminStateReply\"\x00\x12H\n\x10QueryFlapCounter\x12\x19.ListOfFlapCounterRequest\x1a\x17.ListOfFlapCounterReply\"\x00\x12H\n\x10ResetFlapCounter\x12\x19.ListOfFlapCounterRequest\x1a\x17.ListOfFlapCounterReply\"\x00\x62\x06proto3')     # noqa E501
 
 
 _LISTOFADMINREQUEST = DESCRIPTOR.message_types_by_name['ListOfAdminRequest']
@@ -25,8 +24,12 @@ _LISTOFOPERATIONREQUEST = DESCRIPTOR.message_types_by_name['ListOfOperationReque
 _LISTOFOPERATIONREPLY = DESCRIPTOR.message_types_by_name['ListOfOperationReply']
 _LISTOFDROPREQUEST = DESCRIPTOR.message_types_by_name['ListOfDropRequest']
 _LISTOFDROPREPLY = DESCRIPTOR.message_types_by_name['ListOfDropReply']
-_LISTOFNICSERVERADMINSTATEREQUEST = DESCRIPTOR.message_types_by_name['ListOfNiCServerAdminStateRequest']
-_LISTOFNICSERVERADMINSTATEREPLY = DESCRIPTOR.message_types_by_name['ListOfNiCServerAdminStateReply']
+_LISTOFNICSERVERADMINSTATEREQUEST = DESCRIPTOR.message_types_by_name[
+    'ListOfNiCServerAdminStateRequest']
+_LISTOFNICSERVERADMINSTATEREPLY = DESCRIPTOR.message_types_by_name[
+    'ListOfNiCServerAdminStateReply']
+_LISTOFFLAPCOUNTERREQUEST = DESCRIPTOR.message_types_by_name['ListOfFlapCounterRequest']
+_LISTOFFLAPCOUNTERREPLY = DESCRIPTOR.message_types_by_name['ListOfFlapCounterReply']
 ListOfAdminRequest = _reflection.GeneratedProtocolMessageType('ListOfAdminRequest', (_message.Message,), {
   'DESCRIPTOR' : _LISTOFADMINREQUEST,
   '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
@@ -69,40 +72,58 @@ ListOfDropReply = _reflection.GeneratedProtocolMessageType('ListOfDropReply', (_
   })
 _sym_db.RegisterMessage(ListOfDropReply)
 
-ListOfNiCServerAdminStateRequest = _reflection.GeneratedProtocolMessageType('ListOfNiCServerAdminStateRequest', (_message.Message,), {
-  'DESCRIPTOR' : _LISTOFNICSERVERADMINSTATEREQUEST,
-  '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
-  # @@protoc_insertion_point(class_scope:ListOfNiCServerAdminStateRequest)
-  })
+ListOfNiCServerAdminStateRequest = _reflection.GeneratedProtocolMessageType('ListOfNiCServerAdminStateRequest', (_message.Message,), {                          # noqa E501
+    'DESCRIPTOR': _LISTOFNICSERVERADMINSTATEREQUEST,
+    '__module__': 'nic_simulator_grpc_mgmt_service_pb2'
+    # @@protoc_insertion_point(class_scope:ListOfNiCServerAdminStateRequest)
+})
 _sym_db.RegisterMessage(ListOfNiCServerAdminStateRequest)
 
-ListOfNiCServerAdminStateReply = _reflection.GeneratedProtocolMessageType('ListOfNiCServerAdminStateReply', (_message.Message,), {
-  'DESCRIPTOR' : _LISTOFNICSERVERADMINSTATEREPLY,
-  '__module__' : 'nic_simulator_grpc_mgmt_service_pb2'
-  # @@protoc_insertion_point(class_scope:ListOfNiCServerAdminStateReply)
-  })
+ListOfNiCServerAdminStateReply = _reflection.GeneratedProtocolMessageType('ListOfNiCServerAdminStateReply', (_message.Message,), {                              # noqa E501
+    'DESCRIPTOR': _LISTOFNICSERVERADMINSTATEREPLY,
+    '__module__': 'nic_simulator_grpc_mgmt_service_pb2'
+    # @@protoc_insertion_point(class_scope:ListOfNiCServerAdminStateReply)
+})
 _sym_db.RegisterMessage(ListOfNiCServerAdminStateReply)
 
-_DUALTORMGMTSERVICE = DESCRIPTOR.services_by_name['DualTorMgmtService']
-if _descriptor._USE_C_DESCRIPTORS == False:
+ListOfFlapCounterRequest = _reflection.GeneratedProtocolMessageType('ListOfFlapCounterRequest', (_message.Message,), {
+    'DESCRIPTOR': _LISTOFFLAPCOUNTERREQUEST,
+    '__module__': 'nic_simulator_grpc_mgmt_service_pb2'
+    # @@protoc_insertion_point(class_scope:ListOfFlapCounterRequest)
+})
+_sym_db.RegisterMessage(ListOfFlapCounterRequest)
 
-  DESCRIPTOR._options = None
-  _LISTOFADMINREQUEST._serialized_start=75
-  _LISTOFADMINREQUEST._serialized_end=157
-  _LISTOFADMINREPLY._serialized_start=159
-  _LISTOFADMINREPLY._serialized_end=236
-  _LISTOFOPERATIONREQUEST._serialized_start=238
-  _LISTOFOPERATIONREQUEST._serialized_end=332
-  _LISTOFOPERATIONREPLY._serialized_start=334
-  _LISTOFOPERATIONREPLY._serialized_end=423
-  _LISTOFDROPREQUEST._serialized_start=425
-  _LISTOFDROPREQUEST._serialized_end=504
-  _LISTOFDROPREPLY._serialized_start=506
-  _LISTOFDROPREPLY._serialized_end=580
-  _LISTOFNICSERVERADMINSTATEREQUEST._serialized_start=582
-  _LISTOFNICSERVERADMINSTATEREQUEST._serialized_end=661
-  _LISTOFNICSERVERADMINSTATEREPLY._serialized_start=663
-  _LISTOFNICSERVERADMINSTATEREPLY._serialized_end=759
-  _DUALTORMGMTSERVICE._serialized_start=762
-  _DUALTORMGMTSERVICE._serialized_end=1154
+ListOfFlapCounterReply = _reflection.GeneratedProtocolMessageType('ListOfFlapCounterReply', (_message.Message,), {
+    'DESCRIPTOR': _LISTOFFLAPCOUNTERREPLY,
+    '__module__': 'nic_simulator_grpc_mgmt_service_pb2'
+    # @@protoc_insertion_point(class_scope:ListOfFlapCounterReply)
+})
+_sym_db.RegisterMessage(ListOfFlapCounterReply)
+
+_DUALTORMGMTSERVICE = DESCRIPTOR.services_by_name['DualTorMgmtService']
+if _descriptor._USE_C_DESCRIPTORS == False:                                                                                                                     # noqa E712
+
+    DESCRIPTOR._options = None
+    _LISTOFADMINREQUEST._serialized_start = 75
+    _LISTOFADMINREQUEST._serialized_end = 157
+    _LISTOFADMINREPLY._serialized_start = 159
+    _LISTOFADMINREPLY._serialized_end = 236
+    _LISTOFOPERATIONREQUEST._serialized_start = 238
+    _LISTOFOPERATIONREQUEST._serialized_end = 332
+    _LISTOFOPERATIONREPLY._serialized_start = 334
+    _LISTOFOPERATIONREPLY._serialized_end = 423
+    _LISTOFDROPREQUEST._serialized_start = 425
+    _LISTOFDROPREQUEST._serialized_end = 504
+    _LISTOFDROPREPLY._serialized_start = 506
+    _LISTOFDROPREPLY._serialized_end = 580
+    _LISTOFNICSERVERADMINSTATEREQUEST._serialized_start = 582
+    _LISTOFNICSERVERADMINSTATEREQUEST._serialized_end = 661
+    _LISTOFNICSERVERADMINSTATEREPLY._serialized_start = 663
+    _LISTOFNICSERVERADMINSTATEREPLY._serialized_end = 759
+    _LISTOFFLAPCOUNTERREQUEST._serialized_start = 761
+    _LISTOFFLAPCOUNTERREQUEST._serialized_end = 862
+    _LISTOFFLAPCOUNTERREPLY._serialized_start = 864
+    _LISTOFFLAPCOUNTERREPLY._serialized_end = 960
+    _DUALTORMGMTSERVICE._serialized_start = 963
+    _DUALTORMGMTSERVICE._serialized_end = 1503
 # @@protoc_insertion_point(module_scope)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2_grpc.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_mgmt_service_pb2_grpc.py
@@ -35,10 +35,20 @@ class DualTorMgmtServiceStub(object):
                 response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.FromString,
                 )
         self.SetNicServerAdminState = channel.unary_unary(
-                '/DualTorMgmtService/SetNicServerAdminState',
-                request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.SerializeToString,
-                response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.FromString,
-                )
+            '/DualTorMgmtService/SetNicServerAdminState',
+            request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.SerializeToString,                                         # noqa E501
+            response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.FromString,
+        )
+        self.QueryFlapCounter = channel.unary_unary(
+            '/DualTorMgmtService/QueryFlapCounter',
+            request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.SerializeToString,
+            response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.FromString,
+        )
+        self.ResetFlapCounter = channel.unary_unary(
+            '/DualTorMgmtService/ResetFlapCounter',
+            request_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.SerializeToString,
+            response_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.FromString,
+        )
 
 
 class DualTorMgmtServiceServicer(object):
@@ -74,34 +84,56 @@ class DualTorMgmtServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def QueryFlapCounter(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def ResetFlapCounter(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DualTorMgmtServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'QueryAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryAdminForwardingPortState,
-                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.FromString,
-                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.SerializeToString,
-            ),
-            'SetAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.SetAdminForwardingPortState,
-                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.FromString,
-                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.SerializeToString,
-            ),
-            'QueryOperationPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryOperationPortState,
-                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.FromString,
-                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.SerializeToString,
-            ),
-            'SetDrop': grpc.unary_unary_rpc_method_handler(
-                    servicer.SetDrop,
-                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.FromString,
-                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.SerializeToString,
-            ),
-            'SetNicServerAdminState': grpc.unary_unary_rpc_method_handler(
-                    servicer.SetNicServerAdminState,
-                    request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.FromString,
-                    response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.SerializeToString,
-            ),
+        'QueryAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryAdminForwardingPortState,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.SerializeToString,
+        ),
+        'SetAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.SetAdminForwardingPortState,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.SerializeToString,
+        ),
+        'QueryOperationPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryOperationPortState,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.SerializeToString,
+        ),
+        'SetDrop': grpc.unary_unary_rpc_method_handler(
+            servicer.SetDrop,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.SerializeToString,
+        ),
+        'SetNicServerAdminState': grpc.unary_unary_rpc_method_handler(
+            servicer.SetNicServerAdminState,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.SerializeToString,                                          # noqa E501
+        ),
+        'QueryFlapCounter': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryFlapCounter,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.SerializeToString,
+        ),
+        'ResetFlapCounter': grpc.unary_unary_rpc_method_handler(
+            servicer.ResetFlapCounter,
+            request_deserializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.FromString,
+            response_serializer=nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.SerializeToString,
+        ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
             'DualTorMgmtService', rpc_method_handlers)
@@ -114,85 +146,119 @@ class DualTorMgmtService(object):
 
     @staticmethod
     def QueryAdminForwardingPortState(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
+                                      target,
+                                      options=(),
+                                      channel_credentials=None,
+                                      call_credentials=None,
+                                      insecure=False,
+                                      compression=None,
+                                      wait_for_ready=None,
+                                      timeout=None,
+                                      metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/QueryAdminForwardingPortState',
-            nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.SerializeToString,
-            nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.SerializeToString,                                         # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def SetAdminForwardingPortState(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
+                                    target,
+                                    options=(),
+                                    channel_credentials=None,
+                                    call_credentials=None,
+                                    insecure=False,
+                                    compression=None,
+                                    wait_for_ready=None,
+                                    timeout=None,
+                                    metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/SetAdminForwardingPortState',
-            nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.SerializeToString,
-            nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfAdminRequest.SerializeToString,                                         # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfAdminReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def QueryOperationPortState(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
+                                target,
+                                options=(),
+                                channel_credentials=None,
+                                call_credentials=None,
+                                insecure=False,
+                                compression=None,
+                                wait_for_ready=None,
+                                timeout=None,
+                                metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/QueryOperationPortState',
-            nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.SerializeToString,
-            nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfOperationRequest.SerializeToString,                                     # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfOperationReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def SetDrop(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
+                target,
+                options=(),
+                channel_credentials=None,
+                call_credentials=None,
+                insecure=False,
+                compression=None,
+                wait_for_ready=None,
+                timeout=None,
+                metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/SetDrop',
-            nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.SerializeToString,
-            nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfDropRequest.SerializeToString,                                          # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfDropReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def SetNicServerAdminState(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
+                               target,
+                               options=(),
+                               channel_credentials=None,
+                               call_credentials=None,
+                               insecure=False,
+                               compression=None,
+                               wait_for_ready=None,
+                               timeout=None,
+                               metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/SetNicServerAdminState',
-            nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.SerializeToString,
-            nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateRequest.SerializeToString,                           # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfNiCServerAdminStateReply.FromString,                                    # noqa E501
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def QueryFlapCounter(request,
+                         target,
+                         options=(),
+                         channel_credentials=None,
+                         call_credentials=None,
+                         insecure=False,
+                         compression=None,
+                         wait_for_ready=None,
+                         timeout=None,
+                         metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/QueryFlapCounter',
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.SerializeToString,                                   # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ResetFlapCounter(request,
+                         target,
+                         options=(),
+                         channel_credentials=None,
+                         call_credentials=None,
+                         insecure=False,
+                         compression=None,
+                         wait_for_ready=None,
+                         timeout=None,
+                         metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualTorMgmtService/ResetFlapCounter',
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterRequest.SerializeToString,                                   # noqa E501
+                                             nic__simulator__grpc__mgmt__service__pb2.ListOfFlapCounterReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service.proto
@@ -11,7 +11,11 @@ service DualToRActive {
 
   rpc QueryServerVersion(ServerVersionRequest) returns (ServerVersionReply) {}
 
-  rpc SetDrop(DropRequest) returns (DropReply) {}
+  rpc SetDrop(DropRequest) returns(DropReply) {}
+
+  rpc QueryFlapCounter(FlapCounterRequest) returns(FlapCounterReply) {}
+
+  rpc ResetFlapCounter(FlapCounterRequest) returns(FlapCounterReply) {}
 }
 
 message AdminRequest {
@@ -59,4 +63,13 @@ message DropRequest {
 message DropReply {
   repeated int32 portid = 1;
   repeated bool success = 2;
+}
+
+message FlapCounterRequest {
+    repeated int32 portid = 1;
+}
+
+message FlapCounterReply {
+    repeated int32 portid = 1;
+    repeated int32 flaps = 2;
 }

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2.py
@@ -12,10 +12,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n nic_simulator_grpc_service.proto\"-\n\x0c\x41\x64minRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"+\n\nAdminReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10OperationRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eOperationReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10LinkStateRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eLinkStateReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\'\n\x14ServerVersionRequest\x12\x0f\n\x07version\x18\x01 \x01(\t\"%\n\x12ServerVersionReply\x12\x0f\n\x07version\x18\x01 \x01(\t\"A\n\x0b\x44ropRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x11\n\tdirection\x18\x02 \x03(\x05\x12\x0f\n\x07recover\x18\x03 \x01(\x08\",\n\tDropReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x0f\n\x07success\x18\x02 \x03(\x08\x32\xef\x02\n\rDualToRActive\x12=\n\x1dQueryAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12;\n\x1bSetAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12?\n\x17QueryOperationPortState\x12\x11.OperationRequest\x1a\x0f.OperationReply\"\x00\x12\x36\n\x0eQueryLinkState\x12\x11.LinkStateRequest\x1a\x0f.LinkStateReply\"\x00\x12\x42\n\x12QueryServerVersion\x12\x15.ServerVersionRequest\x1a\x13.ServerVersionReply\"\x00\x12%\n\x07SetDrop\x12\x0c.DropRequest\x1a\n.DropReply\"\x00\x62\x06proto3')
-
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n nic_simulator_grpc_service.proto\"-\n\x0c\x41\x64minRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"+\n\nAdminReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10OperationRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eOperationReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\"\n\x10LinkStateRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"/\n\x0eLinkStateReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05state\x18\x02 \x03(\x08\"\'\n\x14ServerVersionRequest\x12\x0f\n\x07version\x18\x01 \x01(\t\"%\n\x12ServerVersionReply\x12\x0f\n\x07version\x18\x01 \x01(\t\"A\n\x0b\x44ropRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x11\n\tdirection\x18\x02 \x03(\x05\x12\x0f\n\x07recover\x18\x03 \x01(\x08\",\n\tDropReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\x0f\n\x07success\x18\x02 \x03(\x08\"$\n\x12\x46lapCounterRequest\x12\x0e\n\x06portid\x18\x01 \x03(\x05\"1\n\x10\x46lapCounterReply\x12\x0e\n\x06portid\x18\x01 \x03(\x05\x12\r\n\x05\x66laps\x18\x02 \x03(\x05\x32\xeb\x03\n\rDualToRActive\x12=\n\x1dQueryAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12;\n\x1bSetAdminForwardingPortState\x12\r.AdminRequest\x1a\x0b.AdminReply\"\x00\x12?\n\x17QueryOperationPortState\x12\x11.OperationRequest\x1a\x0f.OperationReply\"\x00\x12\x36\n\x0eQueryLinkState\x12\x11.LinkStateRequest\x1a\x0f.LinkStateReply\"\x00\x12\x42\n\x12QueryServerVersion\x12\x15.ServerVersionRequest\x1a\x13.ServerVersionReply\"\x00\x12%\n\x07SetDrop\x12\x0c.DropRequest\x1a\n.DropReply\"\x00\x12<\n\x10QueryFlapCounter\x12\x13.FlapCounterRequest\x1a\x11.FlapCounterReply\"\x00\x12<\n\x10ResetFlapCounter\x12\x13.FlapCounterRequest\x1a\x11.FlapCounterReply\"\x00\x62\x06proto3')           # noqa E501
 
 
 _ADMINREQUEST = DESCRIPTOR.message_types_by_name['AdminRequest']
@@ -28,6 +25,8 @@ _SERVERVERSIONREQUEST = DESCRIPTOR.message_types_by_name['ServerVersionRequest']
 _SERVERVERSIONREPLY = DESCRIPTOR.message_types_by_name['ServerVersionReply']
 _DROPREQUEST = DESCRIPTOR.message_types_by_name['DropRequest']
 _DROPREPLY = DESCRIPTOR.message_types_by_name['DropReply']
+_FLAPCOUNTERREQUEST = DESCRIPTOR.message_types_by_name['FlapCounterRequest']
+_FLAPCOUNTERREPLY = DESCRIPTOR.message_types_by_name['FlapCounterReply']
 AdminRequest = _reflection.GeneratedProtocolMessageType('AdminRequest', (_message.Message,), {
   'DESCRIPTOR' : _ADMINREQUEST,
   '__module__' : 'nic_simulator_grpc_service_pb2'
@@ -98,30 +97,48 @@ DropReply = _reflection.GeneratedProtocolMessageType('DropReply', (_message.Mess
   })
 _sym_db.RegisterMessage(DropReply)
 
-_DUALTORACTIVE = DESCRIPTOR.services_by_name['DualToRActive']
-if _descriptor._USE_C_DESCRIPTORS == False:
+FlapCounterRequest = _reflection.GeneratedProtocolMessageType('FlapCounterRequest', (_message.Message,), {
+    'DESCRIPTOR': _FLAPCOUNTERREQUEST,
+    '__module__': 'nic_simulator_grpc_service_pb2'
+    # @@protoc_insertion_point(class_scope:FlapCounterRequest)
+})
+_sym_db.RegisterMessage(FlapCounterRequest)
 
-  DESCRIPTOR._options = None
-  _ADMINREQUEST._serialized_start=36
-  _ADMINREQUEST._serialized_end=81
-  _ADMINREPLY._serialized_start=83
-  _ADMINREPLY._serialized_end=126
-  _OPERATIONREQUEST._serialized_start=128
-  _OPERATIONREQUEST._serialized_end=162
-  _OPERATIONREPLY._serialized_start=164
-  _OPERATIONREPLY._serialized_end=211
-  _LINKSTATEREQUEST._serialized_start=213
-  _LINKSTATEREQUEST._serialized_end=247
-  _LINKSTATEREPLY._serialized_start=249
-  _LINKSTATEREPLY._serialized_end=296
-  _SERVERVERSIONREQUEST._serialized_start=298
-  _SERVERVERSIONREQUEST._serialized_end=337
-  _SERVERVERSIONREPLY._serialized_start=339
-  _SERVERVERSIONREPLY._serialized_end=376
-  _DROPREQUEST._serialized_start=378
-  _DROPREQUEST._serialized_end=443
-  _DROPREPLY._serialized_start=445
-  _DROPREPLY._serialized_end=489
-  _DUALTORACTIVE._serialized_start=492
-  _DUALTORACTIVE._serialized_end=859
+FlapCounterReply = _reflection.GeneratedProtocolMessageType('FlapCounterReply', (_message.Message,), {
+    'DESCRIPTOR': _FLAPCOUNTERREPLY,
+    '__module__': 'nic_simulator_grpc_service_pb2'
+    # @@protoc_insertion_point(class_scope:FlapCounterReply)
+})
+_sym_db.RegisterMessage(FlapCounterReply)
+
+_DUALTORACTIVE = DESCRIPTOR.services_by_name['DualToRActive']
+if _descriptor._USE_C_DESCRIPTORS == False:                                         # noqa E712
+
+    DESCRIPTOR._options = None
+    _ADMINREQUEST._serialized_start = 36
+    _ADMINREQUEST._serialized_end = 81
+    _ADMINREPLY._serialized_start = 83
+    _ADMINREPLY._serialized_end = 126
+    _OPERATIONREQUEST._serialized_start = 128
+    _OPERATIONREQUEST._serialized_end = 162
+    _OPERATIONREPLY._serialized_start = 164
+    _OPERATIONREPLY._serialized_end = 211
+    _LINKSTATEREQUEST._serialized_start = 213
+    _LINKSTATEREQUEST._serialized_end = 247
+    _LINKSTATEREPLY._serialized_start = 249
+    _LINKSTATEREPLY._serialized_end = 296
+    _SERVERVERSIONREQUEST._serialized_start = 298
+    _SERVERVERSIONREQUEST._serialized_end = 337
+    _SERVERVERSIONREPLY._serialized_start = 339
+    _SERVERVERSIONREPLY._serialized_end = 376
+    _DROPREQUEST._serialized_start = 378
+    _DROPREQUEST._serialized_end = 443
+    _DROPREPLY._serialized_start = 445
+    _DROPREPLY._serialized_end = 489
+    _FLAPCOUNTERREQUEST._serialized_start = 491
+    _FLAPCOUNTERREQUEST._serialized_end = 527
+    _FLAPCOUNTERREPLY._serialized_start = 529
+    _FLAPCOUNTERREPLY._serialized_end = 578
+    _DUALTORACTIVE._serialized_start = 581
+    _DUALTORACTIVE._serialized_end = 1072
 # @@protoc_insertion_point(module_scope)

--- a/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2_grpc.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator_grpc_service_pb2_grpc.py
@@ -40,10 +40,20 @@ class DualToRActiveStub(object):
                 response_deserializer=nic__simulator__grpc__service__pb2.ServerVersionReply.FromString,
                 )
         self.SetDrop = channel.unary_unary(
-                '/DualToRActive/SetDrop',
-                request_serializer=nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
-                response_deserializer=nic__simulator__grpc__service__pb2.DropReply.FromString,
-                )
+            '/DualToRActive/SetDrop',
+            request_serializer=nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
+            response_deserializer=nic__simulator__grpc__service__pb2.DropReply.FromString,
+        )
+        self.QueryFlapCounter = channel.unary_unary(
+            '/DualToRActive/QueryFlapCounter',
+            request_serializer=nic__simulator__grpc__service__pb2.FlapCounterRequest.SerializeToString,
+            response_deserializer=nic__simulator__grpc__service__pb2.FlapCounterReply.FromString,
+        )
+        self.ResetFlapCounter = channel.unary_unary(
+            '/DualToRActive/ResetFlapCounter',
+            request_serializer=nic__simulator__grpc__service__pb2.FlapCounterRequest.SerializeToString,
+            response_deserializer=nic__simulator__grpc__service__pb2.FlapCounterReply.FromString,
+        )
 
 
 class DualToRActiveServicer(object):
@@ -85,46 +95,69 @@ class DualToRActiveServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def QueryFlapCounter(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def ResetFlapCounter(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DualToRActiveServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'QueryAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryAdminForwardingPortState,
-                    request_deserializer=nic__simulator__grpc__service__pb2.AdminRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.AdminReply.SerializeToString,
-            ),
-            'SetAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.SetAdminForwardingPortState,
-                    request_deserializer=nic__simulator__grpc__service__pb2.AdminRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.AdminReply.SerializeToString,
-            ),
-            'QueryOperationPortState': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryOperationPortState,
-                    request_deserializer=nic__simulator__grpc__service__pb2.OperationRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.OperationReply.SerializeToString,
-            ),
-            'QueryLinkState': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryLinkState,
-                    request_deserializer=nic__simulator__grpc__service__pb2.LinkStateRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.LinkStateReply.SerializeToString,
-            ),
-            'QueryServerVersion': grpc.unary_unary_rpc_method_handler(
-                    servicer.QueryServerVersion,
-                    request_deserializer=nic__simulator__grpc__service__pb2.ServerVersionRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.ServerVersionReply.SerializeToString,
-            ),
-            'SetDrop': grpc.unary_unary_rpc_method_handler(
-                    servicer.SetDrop,
-                    request_deserializer=nic__simulator__grpc__service__pb2.DropRequest.FromString,
-                    response_serializer=nic__simulator__grpc__service__pb2.DropReply.SerializeToString,
-            ),
+        'QueryAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryAdminForwardingPortState,
+            request_deserializer=nic__simulator__grpc__service__pb2.AdminRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.AdminReply.SerializeToString,
+        ),
+        'SetAdminForwardingPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.SetAdminForwardingPortState,
+            request_deserializer=nic__simulator__grpc__service__pb2.AdminRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.AdminReply.SerializeToString,
+        ),
+        'QueryOperationPortState': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryOperationPortState,
+            request_deserializer=nic__simulator__grpc__service__pb2.OperationRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.OperationReply.SerializeToString,
+        ),
+        'QueryLinkState': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryLinkState,
+            request_deserializer=nic__simulator__grpc__service__pb2.LinkStateRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.LinkStateReply.SerializeToString,
+        ),
+        'QueryServerVersion': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryServerVersion,
+            request_deserializer=nic__simulator__grpc__service__pb2.ServerVersionRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.ServerVersionReply.SerializeToString,
+        ),
+        'SetDrop': grpc.unary_unary_rpc_method_handler(
+            servicer.SetDrop,
+            request_deserializer=nic__simulator__grpc__service__pb2.DropRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.DropReply.SerializeToString,
+        ),
+        'QueryFlapCounter': grpc.unary_unary_rpc_method_handler(
+            servicer.QueryFlapCounter,
+            request_deserializer=nic__simulator__grpc__service__pb2.FlapCounterRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.FlapCounterReply.SerializeToString,
+        ),
+        'ResetFlapCounter': grpc.unary_unary_rpc_method_handler(
+            servicer.ResetFlapCounter,
+            request_deserializer=nic__simulator__grpc__service__pb2.FlapCounterRequest.FromString,
+            response_serializer=nic__simulator__grpc__service__pb2.FlapCounterReply.SerializeToString,
+        ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
             'DualToRActive', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
+# This class is part of an EXPERIMENTAL API.
 
- # This class is part of an EXPERIMENTAL API.
+
 class DualToRActive(object):
     """Missing associated documentation comment in .proto file."""
 
@@ -140,10 +173,10 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryAdminForwardingPortState',
-            nic__simulator__grpc__service__pb2.AdminRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.AdminReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.AdminRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.AdminReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def SetAdminForwardingPortState(request,
@@ -157,10 +190,10 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/SetAdminForwardingPortState',
-            nic__simulator__grpc__service__pb2.AdminRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.AdminReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.AdminRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.AdminReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def QueryOperationPortState(request,
@@ -174,10 +207,10 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryOperationPortState',
-            nic__simulator__grpc__service__pb2.OperationRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.OperationReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.OperationRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.OperationReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def QueryLinkState(request,
@@ -191,10 +224,10 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryLinkState',
-            nic__simulator__grpc__service__pb2.LinkStateRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.LinkStateReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.LinkStateRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.LinkStateReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def QueryServerVersion(request,
@@ -208,10 +241,10 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryServerVersion',
-            nic__simulator__grpc__service__pb2.ServerVersionRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.ServerVersionReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.ServerVersionRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.ServerVersionReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def SetDrop(request,
@@ -225,7 +258,41 @@ class DualToRActive(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/DualToRActive/SetDrop',
-            nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
-            nic__simulator__grpc__service__pb2.DropReply.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+                                             nic__simulator__grpc__service__pb2.DropRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.DropReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def QueryFlapCounter(request,
+                         target,
+                         options=(),
+                         channel_credentials=None,
+                         call_credentials=None,
+                         insecure=False,
+                         compression=None,
+                         wait_for_ready=None,
+                         timeout=None,
+                         metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualToRActive/QueryFlapCounter',
+                                             nic__simulator__grpc__service__pb2.FlapCounterRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.FlapCounterReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ResetFlapCounter(request,
+                         target,
+                         options=(),
+                         channel_credentials=None,
+                         call_credentials=None,
+                         insecure=False,
+                         compression=None,
+                         wait_for_ready=None,
+                         timeout=None,
+                         metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/DualToRActive/ResetFlapCounter',
+                                             nic__simulator__grpc__service__pb2.FlapCounterRequest.SerializeToString,
+                                             nic__simulator__grpc__service__pb2.FlapCounterReply.FromString,
+                                             options, channel_credentials,
+                                             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -10,6 +10,9 @@ import os
 import ptf
 import re
 import string
+import sys
+import six
+import tabulate
 
 from collections import defaultdict
 from datetime import datetime
@@ -26,6 +29,9 @@ from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                            # noqa F401
+from tests.common.dualtor.nic_simulator_control import nic_simulator_flap_counter                       # noqa F401
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter                           # noqa F401
+from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_common import cable_type                                                     # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import active_standby_ports                                           # lgtm[py/unused-import]
@@ -1546,3 +1552,96 @@ def config_active_active_dualtor_active_standby(
 
         for duthost in duthosts:
             duthost.shell_cmds(cmds=restore_cmds)
+
+
+@pytest.fixture(autouse=True)
+def check_simulator_flap_counter(
+    nic_simulator_flap_counter, simulator_flap_counter, active_active_ports, active_standby_ports, cable_type   # noqa F811
+):
+    """Check the flap count for mux ports."""
+
+    def set_expected_counter_diff(diff):
+        """Set expected counter difference."""
+        if isinstance(diff, list) or isinstance(diff, tuple):
+            expected_diff.extend(diff)
+        else:
+            expected_diff.append(diff)
+
+    def check_nic_simulator_flaps_helper(mux_ports):
+        logging.info("Check active-active mux port flap counters: %s", mux_ports)
+        result = nic_simulator_flap_counter(mux_ports)
+        mux_port_flaps = {}
+        for mux_port, flaps in zip(mux_ports, result):
+            mux_port_flaps[mux_port] = {
+                UPPER_TOR: flaps[ActiveActivePortID.UPPER_TOR],
+                LOWER_TOR: flaps[ActiveActivePortID.LOWER_TOR]
+            }
+        return mux_port_flaps
+
+    def check_mux_simulator_flaps_helper(mux_ports):
+        logging.info("Check active-standby mux port flap counters: %s", mux_ports)
+        mux_port_flaps = {}
+        for mux_port in mux_ports:
+            flaps = simulator_flap_counter(mux_port)
+            mux_port_flaps[mux_port] = {
+                UPPER_TOR: flaps,
+                LOWER_TOR: flaps
+            }
+        return mux_port_flaps
+
+    def check_flaps_diff_active_active(expected_diff, counter_diffs):
+        unexpected_flap_mux_ports = []
+        for mux_port, counter_diff in counter_diffs.items():
+            if (counter_diff[UPPER_TOR] != expected_diff[ActiveActivePortID.UPPER_TOR] or
+                    counter_diff[LOWER_TOR] != expected_diff[ActiveActivePortID.LOWER_TOR]):
+                unexpected_flap_mux_ports.append(mux_port)
+        return unexpected_flap_mux_ports
+
+    def check_flaps_diff_active_standby(expected_diff, counter_diffs):
+        unexpected_flap_mux_ports = []
+        for mux_port, counter_diff in counter_diffs.items():
+            if counter_diff[UPPER_TOR] != expected_diff[-1] or counter_diff[LOWER_TOR] != expected_diff[-1]:
+                unexpected_flap_mux_ports.append(mux_port)
+        return unexpected_flap_mux_ports
+
+    def log_flap_counter(flap_counters):
+        for mux_port, flaps in flap_counters.items():
+            logging.debug("Mux port %s flap counter: %s", mux_port, flaps)
+
+    expected_diff = []
+    if cable_type == CableType.active_active:
+        mux_ports = [str(_) for _ in active_active_ports]
+        check_flap_func = check_nic_simulator_flaps_helper
+        check_flap_diff_func = check_flaps_diff_active_active
+    elif cable_type == CableType.active_standby:
+        mux_ports = [str(_) for _ in active_standby_ports]
+        check_flap_func = check_mux_simulator_flaps_helper
+        check_flap_diff_func = check_flaps_diff_active_standby
+    else:
+        raise ValueError
+
+    counters_before = check_flap_func(mux_ports)
+    log_flap_counter(counters_before)
+    yield set_expected_counter_diff
+    counters_after = check_flap_func(mux_ports)
+    log_flap_counter(counters_after)
+
+    counter_diffs = {}
+    for mux_port in mux_ports:
+        counter_diffs[mux_port] = {
+            UPPER_TOR: counters_after[mux_port][UPPER_TOR] - counters_before[mux_port][UPPER_TOR],
+            LOWER_TOR: counters_after[mux_port][LOWER_TOR] - counters_before[mux_port][LOWER_TOR]
+        }
+    logging.info(
+        "\n%s\n",
+        tabulate.tabulate(
+            [[mux_port, flaps[UPPER_TOR], flaps[LOWER_TOR]] for mux_port, flaps in counter_diffs.items()],
+            headers=["port", "upper ToR flaps", "lower ToR flaps"]
+        )
+    )
+    if expected_diff:
+        unexpected_flap_mux_ports = check_flap_diff_func(expected_diff, counter_diffs)
+        error_str = json.dumps(unexpected_flap_mux_ports, indent=4)
+        if unexpected_flap_mux_ports:
+            logging.error(error_str)
+            raise ValueError(error_str)

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -36,6 +36,7 @@ __all__ = [
     'toggle_all_simulator_ports',
     'check_mux_status',
     'validate_check_result',
+    'simulator_flap_counter',
     ]
 
 logger = logging.getLogger(__name__)

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -33,7 +33,8 @@ __all__ = [
     "ForwardingState",
     "toggle_active_active_simulator_ports",
     "stop_nic_grpc_server",
-    "simulator_server_down_active_active"
+    "simulator_server_down_active_active",
+    "nic_simulator_flap_counter"
 ]
 
 logger = logging.getLogger(__name__)
@@ -414,3 +415,33 @@ def simulator_server_down_active_active(active_active_ports, set_drop_active_act
         )
 
     return _simulate_server_down
+
+
+@pytest.fixture
+def nic_simulator_flap_counter(mux_config, nic_simulator_client):   # noqa F811
+    """Return a helper function to retrieve flap counter for active-active ports."""
+
+    def _call_query_flap_counter_nic_simulator(nic_addresses):
+        request = nic_simulator_grpc_mgmt_service_pb2.ListOfFlapCounterRequest(
+            nic_addresses=list(nic_addresses),
+            flap_counter_requests=[
+                nic_simulator_grpc_service_pb2.FlapCounterRequest(portid=[0, 1]) for _ in nic_addresses
+            ]
+        )
+        client_stub = nic_simulator_client()
+        response = call_grpc(client_stub.QueryFlapCounter, args=(request,))
+        logging.debug("Query flap counter response:\n%s", response)
+        return response
+
+    def _get_nic_simulator_flap_counter(mux_ports):
+        """Get the flap counter for mux ports."""
+        nic_addresses = []
+        for mux_port in mux_ports:
+            nic_address = mux_config[mux_port]["SERVER"]["soc_ipv4"].split("/")[0]
+            nic_addresses.append(nic_address)
+
+        response = _call_query_flap_counter_nic_simulator(nic_addresses)
+        flap_counter_replies = response.flap_counter_replies
+        return [dict(zip(_.portid, _.flaps)) for _ in flap_counter_replies]
+
+    return _get_nic_simulator_flap_counter

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def pytest_configure(config):
 
     config.addinivalue_line(
@@ -7,3 +10,20 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "skip_active_standby: mark test to skip running with 'active_standby' ports"
     )
+
+    config.addinivalue_line(
+        "markers", "last: mark fixture to run last"
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_generate_tests(metafunc):
+    yield
+    # HACK: this is to ensure the fixture check_simulator_flap is the
+    # one runs last, so the flaps it retrieved reflects the test
+    # operations.
+    for fixturedef in metafunc._arg2fixturedefs.values():
+        fixturedef = fixturedef[0]
+        if fixturedef.argname == "check_simulator_flap_counter":
+            metafunc.fixturenames.remove(fixturedef.argname)
+            metafunc.fixturenames.append(fixturedef.argname)

--- a/tests/dualtor_io/test_grpc_server_failure.py
+++ b/tests/dualtor_io/test_grpc_server_failure.py
@@ -14,6 +14,7 @@ from tests.common.dualtor.dual_tor_common import cable_type                     
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.nic_simulator_control import stop_nic_grpc_server         # noqa F401
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator        # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter        # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -3,11 +3,14 @@ import random
 import pytest
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
-from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                                                                       # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, \
+                                                  send_server_to_t1_with_action                 # noqa F401
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                    # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
+from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                       # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
+                                                copy_ptftests_directory, change_mac_addresses   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type 
 from tests.common.dualtor.dual_tor_common import CableType

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -1,19 +1,19 @@
 import logging
-import json
 import pytest
-import tabulate
 import time
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # lgtm[py/unused-import]
-from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action                 # lgtm[py/unused-import]
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action                 # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import set_drop                                 # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import set_drop_all                             # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import set_output                               # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import simulator_flap_counter                   # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
-from tests.common.dualtor.nic_simulator_control import set_drop_active_active                   # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                    # noqa F401
+from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action                 # noqa F401
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action                 # noqa F401
+from tests.common.dualtor.mux_simulator_control import set_drop                                 # noqa F401
+from tests.common.dualtor.mux_simulator_control import set_drop_all                             # noqa F401
+from tests.common.dualtor.mux_simulator_control import set_output                               # noqa F401
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter                   # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
+from tests.common.dualtor.nic_simulator_control import nic_simulator_flap_counter               # noqa F401
+from tests.common.dualtor.nic_simulator_control import set_drop_active_active                   # noqa F401
 from tests.common.dualtor.nic_simulator_control import TrafficDirection
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service            # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # lgtm[py/unused-import]
@@ -89,41 +89,6 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
         set_drop_active_active(active_active_ports, portids, directions)
 
     return _drop_flow_upper_tor_active_active
-
-
-@pytest.fixture(scope="function")
-def check_simulator_flap_counter(
-    simulator_flap_counter,
-    toggle_all_simulator_ports_to_upper_tor,
-    active_standby_ports
-):
-    """Check the flap count for each server-facing interfaces."""
-    def set_expected_counter_diff(diff):
-        """Set expected counter difference."""
-        expected_diff.append(diff)
-
-    expected_diff = []
-    tor_mux_intfs = [str(_) for _ in active_standby_ports]
-    counters_before = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}
-    yield set_expected_counter_diff
-    counters_after = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}
-    logging.info(
-        "\n%s\n",
-        tabulate.tabulate(
-            [[intf, counters_before[intf], counters_after[intf]] for intf in tor_mux_intfs],
-            headers=["port", "flap counter before", "flap counter after"]
-        )
-    )
-    counter_diffs = {intf: counters_after[intf] - counters_before[intf] for intf in tor_mux_intfs}
-    if expected_diff:
-        not_expected_counter_diffs = [
-            intf for intf, counter_diff in counter_diffs.items() if counter_diff != expected_diff[-1]
-        ]
-
-        error_str = json.dumps(not_expected_counter_diffs, indent=4)
-        if not_expected_counter_diffs:
-            logging.error(error_str)
-            raise ValueError(error_str)
 
 
 @pytest.mark.enable_active_active
@@ -246,11 +211,8 @@ def test_active_link_drop_downstream_standby(
 
 
 def test_standby_link_drop_upstream(
-    upper_tor_host,
-    lower_tor_host,
-    send_server_to_t1_with_action,
-    check_simulator_flap_counter,
-    drop_flow_lower_tor_all
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
+    check_simulator_flap_counter, drop_flow_lower_tor_all               # noqa F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the standby ToR.
@@ -272,11 +234,8 @@ def test_standby_link_drop_upstream(
 
 
 def test_standby_link_drop_downstream_active(
-    upper_tor_host,
-    lower_tor_host,
-    send_t1_to_server_with_action,
-    check_simulator_flap_counter,
-    drop_flow_lower_tor_all
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
+    check_simulator_flap_counter, drop_flow_lower_tor_all               # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -299,11 +258,8 @@ def test_standby_link_drop_downstream_active(
 
 
 def test_standby_link_drop_downstream_standby(
-    upper_tor_host,
-    lower_tor_host,
-    send_t1_to_server_with_action,
-    check_simulator_flap_counter,
-    drop_flow_lower_tor_all
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
+    check_simulator_flap_counter, drop_flow_lower_tor_all               # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the standby Tor and remove the flow between the

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -3,10 +3,13 @@ import pytest
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action, send_soc_to_t1_with_action, send_t1_to_soc_with_action                                  # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, shutdown_fanout_upper_tor_intfs, \
-                                                shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts, \
-                                                shutdown_upper_tor_downlink_intfs, shutdown_lower_tor_downlink_intfs                   # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+                                                shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, \
+                                                lower_tor_fanouthosts, shutdown_upper_tor_downlink_intfs, \
+                                                shutdown_lower_tor_downlink_intfs                   # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
+                                                copy_ptftests_directory, change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -7,9 +7,12 @@ from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action,
                                                   send_server_to_server_with_action                 # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, force_active_tor, force_standby_tor
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, \
+                                                force_active_tor, force_standby_tor                 # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
+                                                copy_ptftests_directory, change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 
 

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -1,11 +1,13 @@
 import pytest
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
-from tests.common.dualtor.tor_failure_utils import kill_bgpd                                                                                    # lgtm[py/unused-import]
-from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions                                                                        # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, \
+                                                  send_server_to_t1_with_action                     # noqa F401
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                      # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
+from tests.common.dualtor.tor_failure_utils import kill_bgpd                                        # noqa F401
+from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions                            # noqa F401
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions_on_duthost
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -5,6 +5,7 @@ import time
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action      # noqa F401
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                      # noqa F401
+from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                                        # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                      # noqa F401
 from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable     # noqa F401
 from tests.common.dualtor.tor_failure_utils import wait_for_mux_container                                           # noqa F401


### PR DESCRIPTION
Approach
What is the motivation for this PR?
Cherry-pick PR https://github.com/sonic-net/sonic-mgmt/pull/9568 into 202205
For dualtor-io tests, log the mux port flaps to better help debug.

Signed-off-by: Longxiang Lyu lolv@microsoft.com

How did you do it?
Add fixture check_simulator_flap_counter to show/check mux port flaps during test execution, and enable it for all dualtor-io testcases.

How did you verify/test it?
Run dualtor-io tests on both active-standby and active-active testbed.

Any platform specific information?
Supported testbed topology if it's a new test case?

