### PR TITLE
[202205][dualtor-io] Change the health expectation for bgp shutdown case (#9980)

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -182,12 +182,21 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
             action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
 
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host,
-        expected_standby_health="unhealthy",
-        cable_type=cable_type
-    )
+    if cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host,
+            expected_standby_health="unhealthy",
+            cable_type=cable_type
+        )
 
 
 @pytest.mark.enable_active_active


### PR DESCRIPTION
Approach
What is the motivation for this PR?
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/9980 into 202205

When BGP is shutdown, default route n/a, linkmgrd will write unhealthy. So let's change the expected health for the standby to unhealthy.

Signed-off-by: Longxiang Lyu lolv@microsoft.com

How did you do it?
How did you verify/test it?

