### PR TITLE
[TACACS] Add debug info to RO disk UT. 

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -219,7 +219,6 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
                   os.path.join(LOG_DIR, "syslog")]:
             fetch_into_file(localhost, dutip, rw_user, rw_pass, f,
                             os.path.join(DATA_DIR, os.path.basename(f)))
-        assert res, "Failed to ssh as ro user"
 
     finally:
         logger.debug("START: reboot {} to restore disk RW state".
@@ -227,3 +226,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         do_reboot(duthost, localhost, duthosts)
         logger.debug("  END: reboot {} to restore disk RW state".
                      format(enum_rand_one_per_hwsku_hostname))
+
+        # Fetch disk_check log for debug info
+        res = duthost.shell("sudo cat /var/log/syslog | grep disk_check", module_ignore_errors=True)
+        logger.debug("disk_check log:{}".format(res))

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -219,6 +219,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
                   os.path.join(LOG_DIR, "syslog")]:
             fetch_into_file(localhost, dutip, rw_user, rw_pass, f,
                             os.path.join(DATA_DIR, os.path.basename(f)))
+        assert res, "Failed to ssh as ro user"
 
     finally:
         logger.debug("START: reboot {} to restore disk RW state".


### PR DESCRIPTION
[TACACS] Add debug info to RO disk UT. 

### Description of PR
[TACACS] Add debug info to RO disk UT. 

##### Work item tracking
- Microsoft ADO: 25165957

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
RO disk UT randomly failed, and there is not enough information to debug.

#### How did you do it?
Add code to fetch disk_checker log and output to test log.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
