### PR TITLE
Fix python3 errors in pfcwd test suite

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -250,7 +250,7 @@ class Connection(ConnectionBase):
             self._display.vvv('> %s' % (cmd), host=self.host)
             client.sendline(cmd)
             client.expect(prompts)
-            before = self._remove_unprintable(client.before.decode())
+            before = self._remove_unprintable(client.before.decode('utf-8'))
             stdout += before
             self._display.vvv('< %s' % (before), host=self.host)
 

--- a/tests/scripts/exec_template.yml
+++ b/tests/scripts/exec_template.yml
@@ -12,3 +12,5 @@
       args:
         login: "{{ switch_login[hwsku_map[peer_hwsku]] }}"
       connection: switch
+      vars:
+        ansible_connection: switch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When run pfcwd test suite using python3 following error appears: 
`TypeError: exec_command() got an unexpected keyword argument 'template' 
           fatal: [XX]: FAILED! => { 
               "msg": "Unexpected failure during module execution.", 
               "stdout": "" 
           } `

And when fix provided exec_template.yml:
`             Traceback (most recent call last):  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/task_executor.py", line 145, in run
                 res = self._execute()
                File "/usr/local/lib/python2.7/dist-packages/ansible/executor/task_executor.py", line 664, in _execute
                  result = self._handler.run(task_vars=variables)
              File "/root/mars/workspace/sonic-mgmt/ansible/plugins/action/apswitch.py", line 71, in run
                   os_name=_os_name)
                 File "/root/mars/workspace/sonic-mgmt/ansible/plugins/connection/switch.py", line 253, in exec_command
                   before = self._remove_unprintable(client.before.decode())
              UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 47: ordinal not in range(128)` 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Run pfcwd TC using python3
#### How did you do it?
Add fix in swith.py and exec_tamplate.yml
#### How did you verify/test it?
Run pfcwd TC: `/env-python3/bin/python3 -m pytest pfcwd/ --inventory="../ansible/inventory,../ansible/veos" --host-pattern  --module-path                ../ansible/library/ --testbed  --testbed_file ../ansible/testbed.csv                --allow_recover --assert plain --log-cli-level debug --show-capture=no -ra --showlocals -v \ --topology t0,any,util `

All TC passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
