### PR TITLE
Avoid running command in exited ptf docker container

### DIFF
--- a/ansible/roles/vm_set/library/ptf_control.py
+++ b/ansible/roles/vm_set/library/ptf_control.py
@@ -61,10 +61,12 @@ class PtfControl(object):
         cli = docker.from_env()
         try:
             ctn = cli.containers.get(ctn_name)
-        except Exception:
-            return None
+            if ctn.status == 'running':
+                return ctn.attrs['State']['Pid']
+        except Exception as e:
+            logging.debug("Failed to get pid for container %s: %s" % (ctn_name, str(e)))
 
-        return ctn.attrs['State']['Pid']
+        return None
 
     def get_process_pids(self, process):
         cmd = 'docker exec -t {} bash -c "pgrep -f \'{}\'"'.format(self.ctn_name, process)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
While stopping PTF container, "ptf_control" module is executed to kill all processes in the PTF container.
The original code checks if the PTF container's Pid exists before running command in the PTF container. Unfortunately, this check is not enough. PTF docker container in exited status still has Pid.

#### How did you do it?
This change improved the code for getting PTF container's Pid. When PTF container is not in "running" status, always return None for PTF container's Pid.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
