### PR TITLE
Fix test_bgpmon_v6 to use asic router_mac

### DIFF
--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -149,7 +149,7 @@ def test_bgpmon_v6(dut_with_default_route, localhost, enum_rand_one_frontend_asi
                    local_asn=asn,
                    peer_asn=asn,
                    port=BGP_MONITOR_PORT, passive=True)
-    ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
+    ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, asichost.get_router_mac(), ptf_interface))
     ptfhost.shell("ip -6 route add %s dev %s" % (local_addr + "/128", ptf_interface))
     try:
         pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
test_bgpmon_v6 is failing on packet chassis with the below error:
```
pytest_assert(wait_until(MAX_TIME_FOR_BGPMON, 5, 0, bgpmon_peer_connected, duthost, peer_addr),
>                         "BGPMon Peer connection not established")
E                         Failed: BGPMon Peer connection not established
```

#### How did you do it?
Modify test case to use asic router_mac instead of duthost router_mac.
Because the packet was not using the right mac, packet was not coming into the expected interface on the Linecard and the BGP connection was not getting established.
#### How did you verify/test it?
Verified on packet and voq chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
