### PR TITLE
Enhance PFC watchdog log analyzer to check debug information on a per-vendor basis

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -359,7 +359,7 @@ def fetch_vendor_specific_diagnosis_re(duthost):
     Args:
         duthost: The duthost object
     """
-    unsupported_branches = ['202211']
+    unsupported_branches = ['202012', '202205', '202211']
     if duthost.os_version in unsupported_branches or duthost.sonic_release in unsupported_branches:
         return ""
 

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -8,6 +8,15 @@ from tests.common import constants
 if sys.version_info[0] >= 3:
     unicode = str
 
+EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
+VENDOR_SPEC_ADDITIONAL_INFO_RE = {
+    "mellanox":
+        r"additional info: occupancy:[0-9]+\|packets:[0-9]+\|packets_last:[0-9]+\|pfc_rx_packets:[0-9]+\|"
+        r"pfc_rx_packets_last:[0-9]+\|pfc_duration:[0-9]+\|pfc_duration_last:[0-9]+\|timestamp:[0-9]+\.[0-9]+\|"
+        r"timestamp_last:[0-9]+\.[0-9]+\|real_poll_time:[0-9]+"
+    }
+EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
+
 
 class TrafficPorts(object):
     """ Generate a list of ports needed for the PFC Watchdog test"""
@@ -342,3 +351,16 @@ def start_wd_on_ports(duthost, port, restore_time, detect_time, action="drop"):
     """
     duthost.command("pfcwd start --action {} --restoration-time {} {} {}"
                     .format(action, restore_time, port, detect_time))
+
+
+def fetch_vendor_specific_diagnosis_re(duthost):
+    """
+    Fetch regular expression of vendor specific diagnosis information
+    Args:
+        duthost: The duthost object
+    """
+    unsupported_branches = ['202211']
+    if duthost.os_version in unsupported_branches or duthost.sonic_release in unsupported_branches:
+        return ""
+
+    return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -7,10 +7,9 @@ from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      
 from tests.common.helpers.pfc_storm import PFCMultiStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from .files.pfcwd_helper import start_wd_on_ports
+from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, fetch_vendor_specific_diagnosis_re
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
-EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
-EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -157,7 +156,10 @@ class TestPfcwdAllPortStorm(object):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         storm_hndle = storm_test_setup_restore
         logger.info("--- Testing if PFC storm is detected on all ports ---")
-        self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_DETECT_RE], syslog_marker="all_port_storm",
+        self.run_test(duthost,
+                      storm_hndle,
+                      expect_regex=[EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(duthost)],
+                      syslog_marker="all_port_storm",
                       action="storm")
 
         logger.info("--- Testing if PFC storm is restored on all ports ---")

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -10,6 +10,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from .files.pfcwd_helper import start_wd_on_ports
+from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, fetch_vendor_specific_diagnosis_re
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 from tests.common import constants
@@ -20,8 +21,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
-EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
-EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
 WD_ACTION_MSG_PFX = {"dontcare": "Verify PFCWD detection when queue buffer is not empty "
                      "and proper function of pfcwd drop action",
                      "drop": "Verify proper function of pfcwd drop action",
@@ -671,7 +670,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
         loganalyzer.ignore_regex.extend(reg_exp)
         loganalyzer.expect_regex = []
-        loganalyzer.expect_regex.extend([EXPECT_PFC_WD_DETECT_RE])
+        loganalyzer.expect_regex.extend([EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(dut)])
         loganalyzer.match_regex = []
 
         if action != "dontcare":
@@ -1067,7 +1066,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
                 loganalyzer.ignore_regex.extend(reg_exp)
                 loganalyzer.expect_regex = []
-                loganalyzer.expect_regex.extend([EXPECT_PFC_WD_DETECT_RE])
+                loganalyzer.expect_regex.extend([EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(duthost)])
                 loganalyzer.match_regex = []
 
                 port_toggle(self.dut, tbinfo, ports=[port])

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -16,10 +16,9 @@ from tests.common.reboot import DUT_ACTIVE
 from tests.common.utilities import InterruptableThread
 from tests.common.utilities import join_all
 from tests.ptf_runner import ptf_runner
+from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
-EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
-EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
 TESTCASE_INFO = {'no_storm': {'test_sequence': ["detect", "restore", "warm-reboot", "detect", "restore"],
                               'desc': "Test PFC storm detect/restore before and after warm boot"},
                  'storm': {'test_sequence': ["detect", "warm-reboot", "detect", "restore"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhance PFC watchdog diagnosis information checking.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Recently, more diagnosis information has been introduced when PFC watchdog is triggered for some vendors.
This is to verify whether the diagnosis information is reported in the syslog.

#### How did you do it?

1. Check diagnosis information in PFC watchdog detection message on a per-vendor basis
2. Move the expected log message pattern to a common file 
3. In warm reboot scenario, the PFC watchdog can be reported based on APPL_DB content instead of counters. In this case, no additional information can be provided. So, do not check  diagnosis information in this case.
4. Do not check it on the branches that it is not supported, like 202211.

#### How did you verify/test it?

Run regression test PFC watchdog

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
