### PR TITLE
[202205] Fix test issues of drop counters test

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -9,7 +9,7 @@ import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
 
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts  # lgtm[py/unused-import]
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # lgtm[py/unused-import]
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.platform.device_utils import fanout_switch_port_lookup
@@ -126,12 +126,11 @@ def is_mellanox_fanout(duthost, localhost):
     return True
 
 def get_fanout_obj(conn_graph_facts, duthost, fanouthosts):
-    fanout_obj = None
     for fanout_name, fanout_obj in fanouthosts.items():
         for interface, interface_info in conn_graph_facts['device_conn'][duthost.hostname].items():
             if fanout_name == interface_info.get('peerdevice'):
-                break
-    return fanout_obj
+                return fanout_obj
+    pytest_assert(False, "Failed to get the fanout for dut {}".format(duthost.hostname))
 
 
 @pytest.fixture(scope="module")
@@ -476,7 +475,7 @@ def send_packets(pkt, ptfadapter, ptf_tx_port_id, num_packets=1):
     testutils.send(ptfadapter, ptf_tx_port_id, pkt, count=num_packets)
     time.sleep(1)
 
-def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields, ports_info, fanout_graph_facts):
+def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields, ports_info, enum_fanout_graph_facts):
     """
     @summary: Create a packet with equal SMAC and DMAC.
     """
@@ -514,7 +513,7 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields
     group = "L2"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
 
-def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields, ports_info, fanout_graph_facts):
+def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields, ports_info, enum_fanout_graph_facts):
     """
     @summary: Create a packet with multicast SMAC.
     """
@@ -531,7 +530,7 @@ def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields,
         src_mac = "00:00:00:00:00:11"
         # Prepare openflow rule
         fanouthost.prepare_drop_counter_config(
-            fanout_graph_facts=fanout_graph_facts, match_mac=src_mac, set_mac=multicast_smac, eth_field="eth_src")
+            fanout_graph_facts=enum_fanout_graph_facts, match_mac=src_mac, set_mac=multicast_smac, eth_field="eth_src")
 
     pkt = testutils.simple_tcp_packet(
         eth_dst=ports_info["dst_mac"],  # DUT port

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -15,6 +15,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.drop_counters.drop_counters import verify_drop_counters, ensure_no_l3_drops, ensure_no_l2_drops
 from .drop_packets import *  # FIXME
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is to cherry-pick PR https://github.com/sonic-net/sonic-mgmt/pull/10308 to 202205 for conflict resolving.

Two issues to be fixed:

1. The logic for choosing the fanout in drop counters test is wrong, it always returns the last fanout in the list, which causes the test to fail on dualtor testbed if the lower tor is selected as the dut.
```
def get_fanout_obj(conn_graph_facts, duthost, fanouthosts):
    fanout_obj = None
    for fanout_name, fanout_obj in list(fanouthosts.items()):
        for interface, interface_info in list(conn_graph_facts['device_conn'][duthost.hostname].items()):
            if fanout_name == interface_info.get('peerdevice'):
                break   - This only breaks the inner loop, the outer loop will continue even when the correct fanout is found.
    return fanout_obj
```

2. There are 2 test cases in drop_packets.py uses fanout_graph_facts to get the fanout facts. But the duthost in fanout_graph_facts could be different than the one selected in the test case, which is selected by enum_rand_one_per_hwsku_frontend_hostname. Used enum_fanout_graph_facts instead.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix test issues of drop counters test
#### How did you do it?
Please check the summary.
#### How did you verify/test it?
Run the test on single tor and dualtor testbeds, no test issues found.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
