### PR TITLE
Bug fix for nonetype error for get_egress_queue_pkt_count

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1063,7 +1063,9 @@ def get_egress_queue_pkt_count_all_prio(duthost, port):
     queue_stats = []
 
     for prio in range(8):
-        total_pkts_str = intf_queue_stats.get("UC{}".format(prio)).get("totalpacket")
+        total_pkts_prio_str = intf_queue_stats.get("UC{}".format(prio)) if intf_queue_stats.get("UC{}".format(prio)) \
+            is not None else {"totalpacket": "0"}
+        total_pkts_str = total_pkts_prio_str.get("totalpacket")
         if total_pkts_str == "N/A" or total_pkts_str is None:
             total_pkts_str = "0"
         queue_stats.append(int(total_pkts_str.replace(',', '')))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The first get command may result in a `NoneType` error if there are not that many traffic classes on the switch. Hence, we split the get commands and check for a `None` return type at each step to prevent this error. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
