### PR TITLE
[202205] Move install_mergecap_on_ptf to pre_test script

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,17 +196,6 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def install_mergecap_on_ptf(ptfhost):
-    """
-    Temporary fixture which will install "wireshark-common" package on PTF host which has "mergecap" application inside
-    """
-    try:
-        ptfhost.shell("export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install wireshark-common -y")
-    except Exception as err:
-        logger.warning('Unable to install "wireshark-common" on PTF host. Got error: {}'.format(err))
-
-
-@pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):
     """
     This fixture is to enhance the capability of parsing the value of pytest cli argument '--inventory'.

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -335,6 +335,7 @@ def prepare_autonegtest_params(duthosts, fanouthosts):
     except IOError as e:
         logger.warning('Unable to create a datafile for autoneg tests: {}. Err: {}'.format(filepath, e))
 
+
 def test_generate_running_golden_config(duthosts):
     """
     Generate running golden config after pre test.
@@ -346,3 +347,13 @@ def test_generate_running_golden_config(duthosts):
                 asic_ns = 'asic{}'.format(asic_index)
                 duthost.shell("sonic-cfggen -n {} -d --print-data > /etc/sonic/running_golden_config{}.json".
                               format(asic_ns, asic_index))
+
+
+def test_install_mergecap_on_ptf(ptfhost):
+    """
+    Temporary fixture which will install "wireshark-common" package on PTF host which has "mergecap" application inside
+    """
+    try:
+        ptfhost.shell("export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install wireshark-common -y")
+    except Exception as err:
+        logger.warning('Unable to install "wireshark-common" on PTF host. Got error: {}'.format(err))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to move a session level auto-used fixture `install_mergecap_on_ptf` to [tests/test_pretest.py](https://github.com/sonic-net/sonic-mgmt/compare/202205...bingwang-ms:mv_install_mergecap_on_ptf_to_pre_test?expand=1#diff-cfd8216a00a276591d127aca331535e2e9fbf3fc444f51528c4ddfc99cfbf106).
We need to do this change because nightly test is running each test module in a single session. There is no need to install the package for each run. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
This PR is to move a session level auto-used fixture `install_mergecap_on_ptf` to tests/test_pretest.py.

#### How did you do it?
Move the auto-used fixture to pretest and change it to a utility test case.

#### How did you verify/test it?
Verified on a physical testbed
```
collected 1 item                                                                                                                                                                                      

test_pretest.py::test_install_mergecap_on_ptf PASSED                                                                                                                                            [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
