### PR TITLE
Update GCU loganalyzer list for Bookworm

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -127,6 +127,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     if loganalyzer:
         ignoreRegex = [
             ".*ERR sonic_yang.*",
+            ".*ERR.*Failed to start dhcp_relay.service - dhcp_relay container.*",  # Valid test_dhcp_relay for Bookworm
             ".*ERR.*Failed to start dhcp_relay container.*",  # Valid test_dhcp_relay
             # Valid test_dhcp_relay test_syslog
             ".*ERR GenericConfigUpdater: Service Validator: Service has been reset.*",


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

Bookworm's systemd changes the syntax for services being stopped. Update GCU's ignore list for the dhcp_relay error logs.

#### How did you do it?

#### How did you verify/test it?

Tested on KVM with Bookworm base image. Original failure message (with the new syntax):

```
E               Match Messages:
E               Oct 11 05:05:04.713125 vlab-01 ERR systemd[1]: Failed to start dhcp_relay.service - dhcp_relay container.
E               
E               Oct 11 05:05:43.599634 vlab-01 ERR systemd[1]: Failed to start dhcp_relay.service - dhcp_relay container.
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
