### PR TITLE
Skip queue watermark and wm_pg_shared_lossy for Q100

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2067,3 +2067,19 @@ class QosSaiBase(QosBase):
                 max_port_num = len(port_list)
         logger.info("Test ports ids is{}".format(test_port_ids))
         return test_port_ids
+
+    def is_pacific(self, dut_asic):
+        pacific_platforms = ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']
+        if 'platform' in dut_asic.sonichost.facts and \
+                dut_asic.sonichost.facts['platform'] in pacific_platforms:
+            return True
+        return False
+
+    @pytest.fixture(scope="function", autouse=False)
+    def skip_pacific_dst_asic(self, get_src_dst_asic_and_duts):
+        dst_asic = get_src_dst_asic_and_duts['dst_asic']
+        if self.is_pacific(dst_asic):
+            pytest.skip(
+                "This test is skipped since egress asic is cisco-8000 Q100.")
+        yield
+        return

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1423,6 +1423,10 @@ class TestQosSai(QosSaiBase):
                 pytest.skip(
                     "PGSharedWatermark: Lossy test is not applicable in "
                     "multiple ASIC case in cisco-8000 platform.")
+            if dutTestParams['hwsku'] in ['Cisco-8800-LC-48H-C48']:
+                pytest.skip(
+                    "PGSharedWatermark: Lossy test is not applicable in "
+                    "cisco-8000 Q100 platform.")
 
             pktsNumFillShared = int(qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
@@ -1581,7 +1585,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark
+        resetWatermark, skip_pacific_dst_asic
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -1838,7 +1842,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, get_src_dst_asic_and_duts, dut_qos_maps
+        resetWatermark, get_src_dst_asic_and_duts, dut_qos_maps, skip_pacific_dst_asic
     ):
         """
             Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, Skip queue watermark cases. Q100 does not support congestion level and thus no queue watermarks.
2, Skip wm_pg_shared_lossy. After eviction to hbm, the sq counter is 0 on Q100 hardware.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
