### PR TITLE
[202205][dualtor-io] Add server to server testcases (#10292)

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -154,7 +154,7 @@ def verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruptio
 
 
 def run_test(
-    duthosts, activehost, ptfhost, ptfadapter, action,
+    duthosts, activehost, ptfhost, ptfadapter, vmhost, action,
     tbinfo, tor_vlan_port, send_interval, traffic_direction,
     stop_after, cable_type=CableType.active_standby
 ):
@@ -162,7 +162,7 @@ def run_test(
 
     peerhost = get_peerhost(duthosts, activehost)
     tor_IO = DualTorIO(
-        activehost, peerhost, ptfhost, ptfadapter, tbinfo,
+        activehost, peerhost, ptfhost, ptfadapter, vmhost, tbinfo,
         io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type
     )
     tor_IO.generate_traffic(traffic_direction)
@@ -211,7 +211,7 @@ def cleanup(ptfadapter, duthosts_list):
 
 
 @pytest.fixture
-def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type):
+def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost):       # noqa F811
     """
     Starts IO test from T1 router to server.
     As part of IO test the background thread sends and sniffs packets.
@@ -258,10 +258,10 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
             data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
 
-        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
-                        action, tbinfo, tor_vlan_port, send_interval,
-                        traffic_direction="t1_to_server", stop_after=stop_after,
-                        cable_type=cable_type)
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
+                          action, tbinfo, tor_vlan_port, send_interval,
+                          traffic_direction="t1_to_server", stop_after=stop_after,
+                          cable_type=cable_type)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption
@@ -276,7 +276,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
 
 @pytest.fixture
-def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type):
+def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost):   # noqa F811
     """
     Starts IO test from server to T1 router.
     As part of IO test the background thread sends and sniffs packets.
@@ -323,10 +323,10 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
             data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
 
-        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
-                        action, tbinfo, tor_vlan_port, send_interval,
-                        traffic_direction="server_to_t1", stop_after=stop_after,
-                        cable_type=cable_type)
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
+                          action, tbinfo, tor_vlan_port, send_interval,
+                          traffic_direction="server_to_t1", stop_after=stop_after,
+                          cable_type=cable_type)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption
@@ -341,7 +341,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
 
 @pytest.fixture
-def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type):
+def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost):      # noqa F811
 
     arp_setup(ptfhost)
 
@@ -349,7 +349,7 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
                              stop_after=None):
 
-        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
                           traffic_direction="soc_to_t1", stop_after=stop_after,
                           cable_type=cable_type)
@@ -365,7 +365,7 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
 
 
 @pytest.fixture
-def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type):
+def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost):      # noqa F811
 
     arp_setup(ptfhost)
 
@@ -373,7 +373,7 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
                              stop_after=None):
 
-        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
                           traffic_direction="t1_to_soc", stop_after=stop_after,
                           cable_type=cable_type)
@@ -391,22 +391,31 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
 
 
 @pytest.fixture
-def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type,        # noqa F811
-                                      active_active_ports, active_standby_ports):               # noqa F811
+def select_test_mux_ports(active_active_ports, active_standby_ports):                               # noqa F811
+    """Return helper function to select test mux ports based on cable_type"""
+
+    def _select_test_mux_ports(cable_type, count):                                                  # noqa F811
+        if cable_type == CableType.active_active:
+            test_mux_ports = random.sample(active_active_ports, count)
+        elif cable_type == CableType.active_standby:
+            test_mux_ports = random.sample(active_standby_ports, count)
+        else:
+            raise ValueError("Unsupported cable type %s" % cable_type)
+        return test_mux_ports
+
+    return _select_test_mux_ports
+
+
+@pytest.fixture
+def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost):   # noqa F811
 
     arp_setup(ptfhost)
 
-    if cable_type == CableType.active_active:
-        tor_vlan_port = random.sample(active_active_ports, 2)
-    elif cable_type == CableType.active_standby:
-        tor_vlan_port = random.sample(active_standby_ports, 2)
-    else:
-        raise ValueError("Unsupported cable type %s" % cable_type)
-
-    def server_to_server_io_test(activehost, delay=0, allowed_disruption=0, action=None,
+    def server_to_server_io_test(activehost, test_mux_ports, delay=0,
+                                 allowed_disruption=0, action=None,
                                  verify=False, send_interval=0.01, stop_after=None):
-        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter,
-                          action, tbinfo, tor_vlan_port, send_interval,
+        tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
+                          action, tbinfo, test_mux_ports, send_interval,
                           traffic_direction="server_to_server", stop_after=stop_after,
                           cable_type=cable_type)
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -37,18 +37,20 @@ logger = logging.getLogger(__name__)
 class DualTorIO:
     """Class to conduct IO over ports in `active-standby` mode."""
 
-    def __init__(self, activehost, standbyhost, ptfhost, ptfadapter, tbinfo,
-                io_ready, tor_vlan_port=None, send_interval=0.01, cable_type=CableType.active_standby):
+    def __init__(self, activehost, standbyhost, ptfhost, ptfadapter, vmhost, tbinfo,
+                 io_ready, tor_vlan_port=None, send_interval=0.01, cable_type=CableType.active_standby):
         self.tor_pc_intf = None
         self.tor_vlan_intf = tor_vlan_port
         self.duthost = activehost
         self.ptfadapter = ptfadapter
         self.ptfhost = ptfhost
+        self.vmhost = vmhost
         self.tbinfo = tbinfo
         self.io_ready_event = io_ready
         self.dut_mac = self.duthost.facts["router_mac"]
         self.active_mac = self.dut_mac
         self.standby_mac = standbyhost.facts["router_mac"]
+        self.tcp_sport = 1234
 
         self.cable_type = cable_type
 
@@ -167,7 +169,7 @@ class DualTorIO:
         for intf in natsorted(self.test_interfaces):
             ptf_intf = self.tor_to_ptf_intf_map[intf]
             server_ip = str(self.mux_cable_table[intf]['server_ipv4'].split("/")[0])
-            ptf_to_server_map[ptf_intf] = [server_ip]
+            ptf_to_server_map[ptf_intf] = server_ip
 
         logger.debug('VLAN intf to server IP map: {}'.format(json.dumps(ptf_to_server_map, indent=4, sort_keys=True)))
         return ptf_to_server_map
@@ -189,7 +191,7 @@ class DualTorIO:
         for intf in natsorted(self.test_interfaces):
             ptf_intf = self.tor_to_ptf_intf_map[intf]
             soc_ip = str(self.mux_cable_table[intf]['soc_ipv4'].split('/')[0])
-            ptf_to_soc_map[ptf_intf] = [soc_ip]
+            ptf_to_soc_map[ptf_intf] = soc_ip
 
         logger.debug('VLAN intf to soc IP map: {}'.format(json.dumps(ptf_to_soc_map, indent=4, sort_keys=True)))
         return ptf_to_soc_map
@@ -208,8 +210,8 @@ class DualTorIO:
         Copy this configuration to PTF and restart arp_responder
         """
         arp_responder_conf = {}
-        for intf, ip in self.ptf_intf_to_server_ip_map.items():
-            arp_responder_conf['eth{}'.format(intf)] = ip
+        for intf, ip in list(self.ptf_intf_to_server_ip_map.items()):
+            arp_responder_conf['eth{}'.format(intf)] = [ip]
         with open("/tmp/from_t1.json", "w") as fp:
             json.dump(arp_responder_conf, fp, indent=4, sort_keys=True)
         self.ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
@@ -296,7 +298,8 @@ class DualTorIO:
             eth_dst=eth_dst,
             eth_src=eth_src,
             ip_ttl=ip_ttl,
-            tcp_dport=TCP_DST_PORT
+            tcp_dport=TCP_DST_PORT,
+            tcp_sport=self.tcp_sport
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
         payload_suffix = "X" * 60
@@ -356,7 +359,7 @@ class DualTorIO:
                 'random', src_ip
             )
         )
-        logger.info("TCP port: dst: {} src: 1234".format(TCP_DST_PORT))
+        logger.info("TCP port: dst: {} src: {}".format(TCP_DST_PORT, self.tcp_sport))
         logger.info("DUT ToR MAC: {}, PEER ToR MAC: {}".format(self.active_mac, self.standby_mac))
         logger.info("VLAN MAC: {}".format(self.vlan_mac))
         logger.info("-"*50)
@@ -370,7 +373,8 @@ class DualTorIO:
         # server/soc #2, etc.
         tcp_tx_packet_orig = testutils.simple_tcp_packet(
             eth_dst=self.vlan_mac,
-            tcp_dport=TCP_DST_PORT
+            tcp_dport=TCP_DST_PORT,
+            tcp_sport=self.tcp_sport
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
         payload_suffix = "X" * 60
@@ -395,6 +399,66 @@ class DualTorIO:
         self.sent_pkt_dst_mac = self.vlan_mac
         self.received_pkt_src_mac = [self.active_mac, self.standby_mac]
 
+    def _generate_upstream_packet_to_target_duthost(self, vlan_src_intf, tcp_packet):
+        """Generate a packet to the target duthost."""
+        packet = tcp_packet.copy()
+        if self.cable_type == CableType.active_active:
+            # for active-active, the upstream packet is ECMPed. So let's increase
+            # the tcp source port till we get one packet that is determined to be
+            # forwarded to the target duthost
+            src_ptf_port_index = self.tor_to_ptf_intf_map[vlan_src_intf]
+
+            # get the bridge that the vlan source interface is connected to
+            active_active_vmhost_bridge = "baa-%s-%d" % (self.tbinfo["group-name"], src_ptf_port_index)
+
+            # get the ptf port that is connected to the bridge
+            active_active_vmhost_ptf_port = "iaa-%s-%d" % (self.tbinfo["group-name"], src_ptf_port_index)
+
+            # get the dut ports that is connected to the bridge
+            list_ports_res = self.vmhost.shell("ovs-vsctl list-ports %s" % active_active_vmhost_bridge)
+            active_active_vmhost_dut_ports = [port for port in list_ports_res["stdout_lines"] if "." in port]
+
+            # NOTE: Let's assume that the upper ToR's port is always ending with
+            # smaller vlan suffix, so active_active_vmhost_dut_ports[0] is connected
+            # to the upper ToR and active_active_vmhost_dut_ports[1] is connected
+            # to the lower ToR.
+            active_active_vmhost_dut_ports.sort()
+            for dut, vmhost_dut_port in zip(self.tbinfo["duts"], active_active_vmhost_dut_ports):
+                if self.duthost.hostname == dut:
+                    vmhost_target_dut_port = vmhost_dut_port
+                    break
+            else:
+                raise ValueError(
+                    "Failed to find the port connected to DUT %s in bridge %s" %
+                    (self.duthost.hostname, active_active_vmhost_bridge)
+                )
+
+            get_ovs_port_no_res = self.vmhost.shell("ovs-vsctl get Interface %s ofport" % vmhost_target_dut_port)
+            vmhost_target_dut_port_no = get_ovs_port_no_res["stdout"].strip()
+
+            trace_command = ("ovs-appctl ofproto/trace {bridge} in_port={port},tcp,"
+                             "eth_src={eth_src},eth_dst={eth_dst},ip_src={ip_src},"
+                             "ip_dst={ip_dst},tp_src={{tp_src}},tp_dst={tp_dst}").format(
+                                 bridge=active_active_vmhost_bridge,
+                                 port=active_active_vmhost_ptf_port,
+                                 eth_src=packet[scapyall.Ether].src,
+                                 eth_dst=packet[scapyall.Ether].dst,
+                                 ip_src=packet[scapyall.IP].src,
+                                 ip_dst=packet[scapyall.IP].dst,
+                                 tp_dst=packet[scapyall.TCP].dport)
+            for tcp_sport in range(tcp_packet[scapyall.TCP].sport, 65535):
+                trace_res = self.vmhost.shell(trace_command.format(tp_src=tcp_sport))
+                if "output:%s" % vmhost_target_dut_port_no in trace_res["stdout"]:
+                    packet[scapyall.TCP].sport = tcp_sport
+                    self.tcp_sport = tcp_sport
+                    packet[scapyall.TCP].chksum = None
+                    packet[scapyall.IP].chksum = None
+                    break
+            else:
+                raise ValueError("Failed to generate packet destinated to target DUT %s" % self.duthost.hostname)
+
+        return packet
+
     def generate_server_to_server_traffic(self):
         """
         @summary: Generate (not send) the packets to be sent from server to server
@@ -414,7 +478,7 @@ class DualTorIO:
         dst_ip = ptf_intf_to_ip_map[dst_ptf_port]
         logger.info("Ethernet address: dst: {} src: {}".format(self.vlan_mac, src_mac))
         logger.info("IP address: dst: {} src: {}".format(dst_ip, src_ip))
-        logger.info("TCP port: dst: {} src: 1234".format(TCP_DST_PORT))
+        logger.info("TCP port: dst: {} src: {}".format(TCP_DST_PORT, self.tcp_sport))
         logger.info("DUT ToR MAC: {}, PEER ToR MAC: {}".format(self.active_mac, self.standby_mac))
         logger.info("VLAN MAC: {}".format(self.vlan_mac))
         logger.info("-"*50)
@@ -422,16 +486,19 @@ class DualTorIO:
         self.packets_list = []
         tcp_tx_packet_orig = testutils.simple_tcp_packet(
             eth_dst=self.vlan_mac,
-            tcp_dport=TCP_DST_PORT
+            tcp_dport=TCP_DST_PORT,
+            tcp_sport=self.tcp_sport
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
+        tcp_tx_packet_orig[scapyall.Ether].src = src_mac
+        tcp_tx_packet_orig[scapyall.IP].src = src_ip
+        tcp_tx_packet_orig[scapyall.IP].dst = dst_ip
+        tcp_tx_packet_orig = self._generate_upstream_packet_to_target_duthost(vlan_src_intf, tcp_tx_packet_orig)
+
         payload_suffix = "X" * 60
         for i in range(self.packets_per_server):
             payload = str(i) + payload_suffix
             packet = tcp_tx_packet_orig.copy()
-            packet[scapyall.Ether].src = src_mac
-            packet[scapyall.IP].src = src_ip
-            packet[scapyall.IP].dst = dst_ip
             packet.load = payload
             packet[scapyall.TCP].chksum = None
             packet[scapyall.IP].chksum = None
@@ -497,8 +564,8 @@ class DualTorIO:
         self.sniff_timeout = self.time_to_listen + self.sniff_time_incr
         self.sniffer_start = datetime.datetime.now()
         logger.info("Sniffer started at {}".format(str(self.sniffer_start)))
-        self.sniff_filter = "tcp and tcp dst port {} and tcp src port 1234 and not icmp".\
-            format(TCP_DST_PORT)
+        self.sniff_filter = "tcp and tcp dst port {} and tcp src port {} and not icmp".\
+            format(TCP_DST_PORT, self.tcp_sport)
 
         # We run a PTF script on PTF to sniff traffic. The PTF script calls
         # scapy.sniff which by default capture the backplane interface for
@@ -611,21 +678,19 @@ class DualTorIO:
             return None
 
         # Filter out packets:
-        filtered_packets = [ pkt for pkt in self.all_packets if
-            scapyall.TCP in pkt and
-            not scapyall.ICMP in pkt and
-            pkt[scapyall.TCP].sport == 1234 and
-            pkt[scapyall.TCP].dport == TCP_DST_PORT and
-            self.check_tcp_payload(pkt) and
-            (
-                pkt[scapyall.Ether].dst == self.sent_pkt_dst_mac or
-                pkt[scapyall.Ether].src in self.received_pkt_src_mac
-            )
-        ]
+        filtered_packets = [pkt for pkt in self.all_packets if
+                            scapyall.TCP in pkt and
+                            scapyall.ICMP not in pkt and
+                            pkt[scapyall.TCP].sport == self.tcp_sport and
+                            pkt[scapyall.TCP].dport == TCP_DST_PORT and
+                            self.check_tcp_payload(pkt) and
+                            (
+                                pkt[scapyall.Ether].dst == self.sent_pkt_dst_mac or
+                                pkt[scapyall.Ether].src in self.received_pkt_src_mac
+                            )]
         logger.info("Number of filtered packets captured: {}".format(len(filtered_packets)))
         if not filtered_packets or len(filtered_packets) == 0:
             logger.error("Sniffer failed to capture any traffic")
-            return
 
         server_to_packet_map = defaultdict(list)
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -4,16 +4,19 @@ from tests.common.config_reload import config_reload
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action, \
                                                   send_soc_to_t1_with_action, send_t1_to_soc_with_action, \
-                                                  send_server_to_server_with_action                 # noqa F401
+                                                  send_server_to_server_with_action, select_test_mux_ports  # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, \
                                                 force_active_tor, force_standby_tor                 # noqa F401
+from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
@@ -79,8 +82,63 @@ def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
-                            expected_standby_host=None,
-                            cable_type=cable_type)
+                          expected_standby_host=None,
+                          cable_type=cable_type)
+
+
+@pytest.mark.enable_active_active
+def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host,               # noqa F811
+                                                  send_server_to_server_with_action,            # noqa F811
+                                                  toggle_all_simulator_ports_to_upper_tor,      # noqa F811
+                                                  cable_type,                                   # noqa F811
+                                                  select_test_mux_ports):                       # noqa F811
+    """
+    Send server to server traffic in active-active setup and confirm no disruption or switchover occurs.
+    """
+
+    test_mux_ports = select_test_mux_ports(cable_type, 2)
+
+    if cable_type == CableType.active_standby:
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=upper_tor_host,
+                          expected_standby_host=lower_tor_host,
+                          skip_tunnel_route=False)
+
+    if cable_type == CableType.active_active:
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
+                          expected_standby_host=None,
+                          cable_type=cable_type,
+                          skip_tunnel_route=False)
+
+
+@pytest.mark.enable_active_active
+def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_host,                  # noqa F811
+                                                   send_server_to_server_with_action,               # noqa F811
+                                                   toggle_all_simulator_ports_to_upper_tor,         # noqa F811
+                                                   cable_type, force_standby_tor,                   # noqa F811
+                                                   select_test_mux_ports):                          # noqa F811
+    """
+    Send server to server traffic in active-standby setup and confirm no disruption or switchover occurs.
+    """
+
+    def _is_mux_port_standby(duthost, mux_port):
+        return show_muxcable_status(duthost)[mux_port]["status"] == "standby"
+
+    test_mux_ports = select_test_mux_ports(cable_type, 2)
+
+    tx_mux_port = test_mux_ports[1]
+    force_standby_tor(upper_tor_host, [tx_mux_port])
+    pytest_assert(wait_until(10, 2, 0, _is_mux_port_standby, upper_tor_host, tx_mux_port),
+                  "failed to toggle mux port %s to standby on DUT %s" % (tx_mux_port, upper_tor_host.hostname))
+
+    if cable_type == CableType.active_standby:
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+
+    if cable_type == CableType.active_active:
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+
+    # TODO: Add per-port db check
 
 
 @pytest.mark.enable_active_active
@@ -272,9 +330,73 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,
 
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
-def test_normal_op_upstream_soc(upper_tor_host, lower_tor_host,
-                            send_soc_to_t1_with_action,
-                            cable_type):
+def test_mux_port_switch_active_server_to_active_server(upper_tor_host, lower_tor_host,                 # noqa F811
+                                                        send_server_to_server_with_action,              # noqa F811
+                                                        cable_type, force_standby_tor,                  # noqa F811
+                                                        select_test_mux_ports):                         # noqa F811
+    """
+    Send server to server traffic in active-active setup and config the tx mux port to standby.
+    Confirm switchover occurs and no disruption.
+    """
+
+    def _is_mux_port_standby(duthost, mux_port):
+        return show_muxcable_status(duthost)[mux_port]["status"] == "standby"
+
+    if cable_type == CableType.active_active:
+        test_mux_ports = select_test_mux_ports(cable_type, 2)
+        tx_mux_port = test_mux_ports[1]
+
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          action=lambda: force_standby_tor(upper_tor_host, [tx_mux_port]),
+                                          send_interval=0.0035,
+                                          stop_after=60)
+
+        pytest_assert(_is_mux_port_standby(upper_tor_host, tx_mux_port),
+                      "mux port %s on DUT %s failed to toggle to standby" % (upper_tor_host.hostname, tx_mux_port))
+
+        # TODO: Add per-port db check
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_mux_port_switch_active_server_to_standby_server(upper_tor_host, lower_tor_host,                 # noqa F811
+                                                         send_server_to_server_with_action,              # noqa F811
+                                                         cable_type, force_standby_tor,                  # noqa F811
+                                                         force_active_tor,                              # noqa F811
+                                                         select_test_mux_ports):                         # noqa F811
+    """
+    Send server to server traffic in active-standby setup and config the tx mux port to auto.
+    Confirm switchover occurs and no disruption.
+    """
+
+    def _is_mux_port_standby(duthost, mux_port):
+        return show_muxcable_status(duthost)[mux_port]["status"] == "standby"
+
+    def _is_mux_port_active(duthost, mux_port):
+        return show_muxcable_status(duthost)[mux_port]["status"] == "active"
+
+    if cable_type == CableType.active_active:
+        test_mux_ports = select_test_mux_ports(cable_type, 2)
+        tx_mux_port = test_mux_ports[1]
+        force_standby_tor(upper_tor_host, [tx_mux_port])
+        pytest_assert(wait_until(10, 2, 0, _is_mux_port_standby, upper_tor_host, tx_mux_port),
+                      "failed to toggle mux port %s to standby on DUT %s" % (tx_mux_port, upper_tor_host.hostname))
+
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          action=lambda: force_active_tor(upper_tor_host, [tx_mux_port]),
+                                          send_interval=0.0035,
+                                          stop_after=60)
+
+        pytest_assert(_is_mux_port_active(upper_tor_host, tx_mux_port),
+                      "mux port %s on DUT %s failed to toggle back to active" % (upper_tor_host.hostname, tx_mux_port))
+
+        # TODO: Add per-port db check
+
+
+@pytest.mark.enable_active_active
+@pytest.mark.skip_active_standby
+def test_normal_op_upstream_soc(upper_tor_host, lower_tor_host,             # noqa F811
+                                send_soc_to_t1_with_action, cable_type):    # noqa F811
     """Send upstream traffic and confirm no disruption or switchover occurs"""
     if cable_type == CableType.active_active:
         send_soc_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)


### PR DESCRIPTION
Approach
What is the motivation for this PR?
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/10292 into 202205

Add three testcases to cover three scenario:

1. active server to standby server
2. active server to active server, then config mux standby
3. active server to standby server, then config mux auto

Signed-off-by: Longxiang Lyu lolv@microsoft.com

How did you do it?
for class DualTorIO, add method _generate_upstream_packet_to_target_duthost to guarantee that all the server-to-server packets are forwarded to the specified test target DUT. So test user could have the knowledge of which ToR receives the packet. _generate_upstream_packet_to_target_duthost basically increments the source port one by one till finding one packet that is hashed to the port that is connected to the specified test target DUT. 

How did you verify/test it?


