### PR TITLE
Fix for test_crm_acl_entry test and py3 fix for API: port_on_asic()

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import socket
+import re
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE, NAMESPACE_PREFIX
@@ -548,7 +549,12 @@ class SonicAsic(object):
     def port_on_asic(self, portname):
         cmd = 'sudo sonic-cfggen {} -v "PORT.keys()" -d'.format(self.cli_ns_option)
         ports = self.shell(cmd)["stdout_lines"][0]
-        if ports is not None and portname in ports:
+        # The variable 'ports' is a string in format below
+        # u"dict_keys(['Ethernet144', 'Ethernet152', 'Ethernet160', 'Ethernet280'])"
+        # doing a regex match for '<interface_name>'' to get the **exact** port.
+        # Without which a check like --> ('Ethernet16' in ports) returns true, because
+        # Ethernet16 matches as a substring to Ethernet160 which is present in 'ports'
+        if ports is not None and re.search(r"'{}'".format(portname), ports):
             return True
         return False
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -945,6 +945,9 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
         # PCs are a single bind point
         portToLag = {}
         for lag, lagData in mg_facts["minigraph_portchannels"].items():
+            # Check if Portchannel belongs to this namespace
+            if lagData['namespace'] != asichost.namespace:
+                continue
             for member in lagData['members']:
                 portToLag[member] = lag
         aclBindings = mg_facts["minigraph_acls"]["DataAcl"]


### PR DESCRIPTION
Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/10341)

### Type of change
Added following checks 
1. Check if the portchannel is part of asic before adding to porthannel list
2. Fix the py3 conversion issue with the common API port_on_asic()


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

```
crm/test_crm.py::test_crm_route[svcstr-xxxx-lc1-1-0-ipv4] PASSED                                                                                                                                                                                         [  4%]
crm/test_crm.py::test_crm_route[svcstr-xxxx-lc1-1-0-ipv6] PASSED                                                                                                                                                                                         [  9%]
crm/test_crm.py::test_crm_nexthop[svcstr-xxxx-lc1-1-0-4-2.2.2.2] PASSED                                                                                                                                                                                  [ 13%]
crm/test_crm.py::test_crm_nexthop[svcstr-xxxx-lc1-1-0-6-2001::1] PASSED                                                                                                                                                                                  [ 18%]
crm/test_crm.py::test_crm_neighbor[svcstr-xxxx-lc1-1-0-4-2.2.2.2-2.2.2.1/8] PASSED                                                                                                                                                                       [ 22%]
crm/test_crm.py::test_crm_neighbor[svcstr-xxxx-lc1-1-0-6-2001::1-2001::2/64] PASSED                                                                                                                                                                      [ 27%]
crm/test_crm.py::test_crm_nexthop_group[svcstr-xxxx-lc1-1-0-False-2.2.2.0/24] PASSED                                                                                                                                                                     [ 31%]
crm/test_crm.py::test_crm_nexthop_group[svcstr-xxxx-lc1-1-0-True-2.2.2.0/24] PASSED                                                                                                                                                                      [ 36%]
crm/test_crm.py::test_acl_entry[svcstr-xxxx-lc1-1-0] PASSED                                                                                                                                                                                              [ 40%]
crm/test_crm.py::test_acl_counter[svcstr-xxxx-lc1-1-0] PASSED                                                                                                                                                                                            [ 45%]
crm/test_crm.py::test_crm_fdb_entry[svcstr-xxxx-lc1-1-0] SKIPPED                                                                                                                                                                                         [ 50%]
crm/test_crm.py::test_crm_route[svcstr-xxxx-lc1-1-1-ipv4] PASSED                                                                                                                                                                                         [ 54%]
crm/test_crm.py::test_crm_route[svcstr-xxxx-lc1-1-1-ipv6] PASSED                                                                                                                                                                                         [ 59%]
crm/test_crm.py::test_crm_nexthop[svcstr-xxxx-lc1-1-1-4-2.2.2.2] PASSED                                                                                                                                                                                  [ 63%]
crm/test_crm.py::test_crm_nexthop[svcstr-xxxx-lc1-1-1-6-2001::1] PASSED                                                                                                                                                                                  [ 68%]
crm/test_crm.py::test_crm_neighbor[svcstr-xxxx-lc1-1-1-4-2.2.2.2-2.2.2.1/8] PASSED                                                                                                                                                                       [ 72%]
crm/test_crm.py::test_crm_neighbor[svcstr-xxxx-lc1-1-1-6-2001::1-2001::2/64] PASSED                                                                                                                                                                      [ 77%]
crm/test_crm.py::test_crm_nexthop_group[svcstr-xxxx-lc1-1-1-False-2.2.2.0/24] PASSED                                                                                                                                                                     [ 81%]
crm/test_crm.py::test_crm_nexthop_group[svcstr-xxxx-lc1-1-1-True-2.2.2.0/24] PASSED                                                                                                                                                                      [ 86%]
crm/test_crm.py::test_acl_entry[svcstr-xxxx-lc1-1-1] PASSED                                                                                                                                                                                              [ 90%]
crm/test_crm.py::test_acl_counter[svcstr-xxxx-lc1-1-1] PASSED                                                                                                                                                                                            [ 95%]
crm/test_crm.py::test_crm_fdb_entry[svcstr-xxxx-lc1-1-1] SKIPPED                                                                                                                                                                                         [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [2] crm/test_crm.py:1121: Unsupported topology, expected to run only on 'T0*' or 'M0/MX' topology
=========================================================================================================== 20 passed, 2 skipped in 6126.68 seconds ============================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
