### PR TITLE
test_snmp_link_local_ip : wait for interfaces to be up after config reload 

### DIFF
--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -13,7 +13,7 @@ def config_reload_after_test(duthosts,
                              enum_rand_one_per_hwsku_frontend_hostname):
     yield
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    config_reload(duthost, config_source='config_db')
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
 
 @pytest.mark.bsl


### PR DESCRIPTION

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/10344)


### Approach
#### What is the motivation for this PR?
test_snmp_link_local_ip : wait for interfaces to be up after config reload 

This issue is in test_snmp_loopback which follows this test test_snmp_link_local_ip in a pipeline run. Since we don't wait for interfaces to be up after a config reload the following tests randomly fail.

#### How did you do it?
Added the additional parameters in config_reload call 

#### How did you verify/test it?
Verified the interfaces come up before starting next test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
