### PR TITLE
Skip bgp notification event test for 202211

### DIFF
--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -4,14 +4,16 @@ import logging
 import time
 
 from run_events_test import run_test
+from telemetry.utils import isMasterImage
 
 logger = logging.getLogger(__name__)
 tag = "sonic-events-bgp"
 
 
 def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
-    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, drop_tcp_packets,
-             "bgp_notification.json", "sonic-events-bgp:notification", tag)
+    if not isMasterImage(duthost):
+        run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, drop_tcp_packets,
+                 "bgp_notification.json", "sonic-events-bgp:notification", tag)
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, shutdown_bgp_neighbors,
              "bgp_state.json", "sonic-events-bgp:bgp-state", tag)
 

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -52,6 +52,11 @@ def skip_201911_and_older(duthost):
         pytest.skip("Test not supported for 201911 images. Skipping the test")
 
 
+def isMasterImage(duthost):
+    os_version = duthost.os_version
+    return "master" in os_version or "internal" in os_version
+
+
 def setup_telemetry_forpyclient(duthost):
     """ Set client_auth=false. This is needed for pyclient to successfully set up channel with gnmi server.
         Restart telemetry process


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

BGP holdtimer expiry event test only will work on latest branch/image. Skip older version for now

#### How did you do it?

Avoid running test unless master branch or internal is in os version

#### How did you verify/test it?

Pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
