### PR TITLE
Fix voq test for py3

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/voq.py
+++ b/ansible/roles/test/files/ptftests/py3/voq.py
@@ -347,12 +347,11 @@ class MtuTest(BaseTest):
 
             masked_exp_pkt = Mask(exp_pkt)
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "tc")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "fl")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "plen")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.ICMPv6Unknown, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.ICMPv6Unknown, "cksum")
 
         src_port = self.src_ptf_port_list[0]
         send_packet(self, src_port, pkt)


### PR DESCRIPTION
Do not set_do_not_care for `id` field because IPv6 header does not have this field. 
```
(Pdb) fields_desc
[<BitField (IPv6,IPerror6).version>, <BitField (IPv6,IPerror6).tc>, <BitField (IPv6,IPerror6).fl>, <ShortField (IPv6,IPerror6).plen>, <ByteEnumField (IPv6,IPerror6).nh>, <ByteField (IPv6,IPerror6).hlim>, <SourceIP6Field (IPv6,IPerror6).src>, <DestIP6Field (IPv6,IPerror6).dst>]
(Pdb) 
```

Fix the name of checksum field, which should be `cksum`, not `chksum`.
```
(Pdb) fields_desc
[<ByteEnumField (ICMPv6Unknown).type>, <ByteField (ICMPv6Unknown).code>, <XShortField (ICMPv6Unknown).cksum>, <StrField (ICMPv6Unknown).msgbody>]
(Pdb) 
```

These issues were there before py3 migration.  But py2 ptf implementation of `set_do_not_care_scapy` does not raise exception for wrong field name. So these issues were not uncovered until now.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/9719

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ x] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
