### PR TITLE
ipinip delay merge conflict 202205

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -195,16 +195,21 @@ def setup_uplink(rand_selected_dut, tbinfo):
     # Update the LAG if it has more than one member
     pc_members = mg_facts['minigraph_portchannels'][up_portchannel]['members']
     if len(pc_members) > 1:
-        cmds = [
-            "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 1".format(up_portchannel), # Update min_links
-            "config portchannel member del {} {}".format(up_portchannel, pc_members[len(pc_members) - 1]),         # Remove 1 portchannel member
-            "systemctl unmask teamd",                                                            # Unmask the service
-            "systemctl restart teamd"                                                            # Resart teamd
-        ]
+        # Update min_links
+        min_link_cmd = "sonic-db-cli CONFIG_DB hset 'PORTCHANNEL|{}' 'min_links' 1".format(up_portchannel)
+        rand_selected_dut.shell(min_link_cmd)
+        # Delete to min_links
+        cmds = "config portchannel member del {} {}".format(up_portchannel, pc_members[len(pc_members) - 1])
         rand_selected_dut.shell_cmds(cmds=cmds)
+        # Ensure delete to complete before restarting service
+        time.sleep(5)
+        # Unmask the service
+        rand_selected_dut.shell_cmds(cmds="systemctl unmask teamd")
+        # Restart teamd
+        rand_selected_dut.shell_cmds(cmds="systemctl restart teamd")
         _wait_portchannel_up(rand_selected_dut, up_portchannel)
     up_member = pc_members[0]
-    
+
     yield mg_facts['minigraph_ptf_indices'][up_member]
 
     # Startup the uplinks that were shutdown
@@ -245,7 +250,7 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, p
     """
     A test case to verify the bounced back packet from Standby ToR to T1 doesn't have an unexpected vlan id (4095)
     The issue can happen if the bounced back packets egressed from the monitor port of mirror session
-    Find more details in CSP CS00012263713. 
+    Find more details in CSP CS00012263713.
     """
     # Since we have only 1 uplink, the source port is also the dest port
     src_port_id = setup_mirror_session
@@ -261,4 +266,4 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface, p
     inner_packet[IP].ttl -= 1
     with tunnel_traffic_monitor(rand_selected_dut, inner_packet=inner_packet, check_items=()):
         testutils.send(ptfadapter, src_port_id, pkt_to_server)
-       
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Port channel fails to come up after the above test. Port channel which
were UP, before the test. The script changes the minimum link from 2 to 1. Then performs
restarts the teamd and all is performed via a single command is likely causing this issue.
All the commands are issued via shell_cmds. Here it executes multiple commands
sequentially. However since multiple command were issued, the previous command may not have completed before
the new command could be executed. This is likely reason for the failure.
**Below is the original PR:**
https://github.com/sonic-net/sonic-mgmt/pull/8417

Summary:
I see this could be timing issue. Failure are seen sometime only. Could not repro the issues. But, looking at the PASS logs, I see messages for min link changes are still running while the next command of teamd restart is triggered. This could lead to failure, when the second command finishes ahead of first.
I could not get a FAIL even after running 20 runs, with all of them PASS.
hence based on analysis the conclusion is that,
It is a timing issue, where min link changes command failure to complete before the second
teamd restart command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
