### PR TITLE
Add double check for port oper and admin down status

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2294,14 +2294,11 @@ Totals               6450                 6449
             output_port = output_line.strip().split(' ')[0]
             # Only care about port that connect to current DUT
             if output_port in ports:
-                # Either oper or admin status 'down' means link down
-                # for SONiC OS, oper/admin status could only be up/down, so only 2 conditions here
-                if 'down' in output_line:
-                    logging.info("Interface {} is down on {}".format(output_port, self.hostname))
-                    continue
-                else:
-                    logging.info("Interface {} is up on {}".format(output_port, self.hostname))
+                # Here only check the oper and admin both down status
+                if 'up' in output_line:
+                    logging.info("Interface {} is either oper or admin up on {}".format(output_port, self.hostname))
                     return False
+                logging.info("Interface {} is both oper and admin down on {}".format(output_port, self.hostname))
         return True
 
     def links_status_up(self, ports):


### PR DESCRIPTION
Add double check for port oper and admin down status If a port keeps oper down and admin up, lpmode test result would be affected.

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In low power mode test, after multiple shutdown ports, there would be a check to make sure port down. But sometimes, some ports would stay in oper down and admin up states for seconds.
This modification is just to make sure the ports are really down, which means both oper and admin down.
Fixes # (issue)
Configure lpmode when ports are not really down, which would cause wrong lpmode states. 
Such as - "Transceiver x expected low-power state enable is not aligned with the real state"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Configure lpmode when ports are not really down, which would cause wrong lpmode states. 
Such as - "Transceiver x expected low-power state enable is not aligned with the real state"
#### How did you do it?
Double check oper and admin down status
#### How did you verify/test it?
Verified the modification by run it over community setups.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
