### PR TITLE
Select only ports belonging to same asic - chassis-packet

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -213,6 +213,8 @@ class FibTest(BaseTest):
                 # Because the MACsec is session based channel but the injected ports are stateless ports
                 if src_port in macsec.MACSEC_INFOS.keys():
                     continue
+                if self.switch_type == "chassis-packet":
+                    exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
                 logging.info('src_port={}, exp_port_lists={}, active_dut_indexes={}'.format(
                     src_port, exp_port_lists, active_dut_indexes))
                 break
@@ -284,7 +286,7 @@ class FibTest(BaseTest):
                 for next_hop in next_hops:
                     # only check balance on a DUT
                     self.check_hit_count_map(
-                        next_hop.get_next_hop(), hit_count_map)
+                        next_hop.get_next_hop(), hit_count_map, src_port)
                     self.balancing_test_count += 1
                 if self.balancing_test_count >= self.balancing_test_number:
                     break
@@ -508,7 +510,34 @@ class FibTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    def check_hit_count_map(self, dest_port_list, port_hit_cnt):
+    def check_same_asic(self, src_port, exp_port_list):
+        updated_exp_port_list = list()
+        for port in exp_port_list:
+            if type(port) == list:
+                per_port_list = list()
+                for per_port in port:
+                    if self.ptf_test_port_map[str(per_port)]['target_dut'] \
+                            != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                            return exp_port_list
+                    else:
+                        if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
+                                == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                            per_port_list.append(per_port)
+                if per_port_list:
+                    updated_exp_port_list.append(per_port_list)
+            else:
+                if self.ptf_test_port_map[str(port)]['target_dut'] \
+                        != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                        return exp_port_list
+                else:
+                    if self.ptf_test_port_map[str(port)]['asic_idx'] \
+                            == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                        updated_exp_port_list.append(port)
+        if updated_exp_port_list:
+            exp_port_list = updated_exp_port_list
+        return exp_port_list
+
+    def check_hit_count_map(self, dest_port_list, port_hit_cnt, src_port):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
@@ -518,6 +547,9 @@ class FibTest(BaseTest):
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" %
                      ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
+
+        if self.switch_type == "chassis-packet":
+            dest_port_list = self.check_same_asic(src_port, dest_port_list)
 
         asic_list = defaultdict(list)
         if self.switch_type == "voq":

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -518,7 +518,7 @@ class FibTest(BaseTest):
                 for per_port in port:
                     if self.ptf_test_port_map[str(per_port)]['target_dut'] \
                             != self.ptf_test_port_map[str(src_port)]['target_dut']:
-                            return exp_port_list
+                        return exp_port_list
                     else:
                         if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
                                 == self.ptf_test_port_map[str(src_port)]['asic_idx']:
@@ -528,7 +528,7 @@ class FibTest(BaseTest):
             else:
                 if self.ptf_test_port_map[str(port)]['target_dut'] \
                         != self.ptf_test_port_map[str(src_port)]['target_dut']:
-                        return exp_port_list
+                    return exp_port_list
                 else:
                     if self.ptf_test_port_map[str(port)]['asic_idx'] \
                             == self.ptf_test_port_map[str(src_port)]['asic_idx']:

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -453,7 +453,7 @@ class HashTest(BaseTest):
                 for per_port in port:
                     if self.ptf_test_port_map[str(per_port)]['target_dut'] \
                             != self.ptf_test_port_map[str(src_port)]['target_dut']:
-                            return exp_port_list
+                        return exp_port_list
                     else:
                         if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
                                 == self.ptf_test_port_map[str(src_port)]['asic_idx']:
@@ -463,7 +463,7 @@ class HashTest(BaseTest):
             else:
                 if self.ptf_test_port_map[str(port)]['target_dut'] \
                         != self.ptf_test_port_map[str(src_port)]['target_dut']:
-                        return exp_port_list
+                    return exp_port_list
                 else:
                     if self.ptf_test_port_map[str(port)]['asic_idx'] \
                             == self.ptf_test_port_map[str(src_port)]['asic_idx']:

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -471,7 +471,7 @@ class HashTest(BaseTest):
         if updated_exp_port_list:
             exp_port_list = updated_exp_port_list
         return exp_port_list
-    
+
     def check_balancing(self, dest_port_list, port_hit_cnt, src_port):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -162,6 +162,8 @@ class HashTest(BaseTest):
         dst_ip = self.dst_ip_interval.get_random_ip()
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
         logging.info("dst_ip={}, src_port={}, exp_port_lists={}".format(
             dst_ip, src_port, exp_port_lists))
         for exp_port_list in exp_port_lists:
@@ -201,7 +203,7 @@ class HashTest(BaseTest):
                 hash_key, hit_count_map))
 
             for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
 
     def check_ip_route(self, hash_key, src_port, dst_ip, dst_port_lists):
         if ip_network(six.text_type(dst_ip)).version == 4:
@@ -443,7 +445,34 @@ class HashTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    def check_balancing(self, dest_port_list, port_hit_cnt):
+    def check_same_asic(self, src_port, exp_port_list):
+        updated_exp_port_list = list()
+        for port in exp_port_list:
+            if type(port) == list:
+                per_port_list = list()
+                for per_port in port:
+                    if self.ptf_test_port_map[str(per_port)]['target_dut'] \
+                            != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                            return exp_port_list
+                    else:
+                        if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
+                                == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                            per_port_list.append(per_port)
+                if per_port_list:
+                    updated_exp_port_list.append(per_port_list)
+            else:
+                if self.ptf_test_port_map[str(port)]['target_dut'] \
+                        != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                        return exp_port_list
+                else:
+                    if self.ptf_test_port_map[str(port)]['asic_idx'] \
+                            == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                        updated_exp_port_list.append(port)
+        if updated_exp_port_list:
+            exp_port_list = updated_exp_port_list
+        return exp_port_list
+    
+    def check_balancing(self, dest_port_list, port_hit_cnt, src_port):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
@@ -454,6 +483,8 @@ class HashTest(BaseTest):
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" %
                      ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
+        if self.switch_type == "chassis-packet":
+            dest_port_list = self.check_same_asic(src_port, dest_port_list)
 
         asic_list = defaultdict(list)
         if self.switch_type == "voq":
@@ -743,6 +774,8 @@ class IPinIPHashTest(HashTest):
         outer_dst_ip = '80.1.0.32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
 
         logging.info("outer_src_ip={}, outer_dst_ip={}, src_port={}, exp_port_lists={}".format(
             outer_src_ip, outer_dst_ip, src_port, exp_port_lists))
@@ -791,7 +824,7 @@ class IPinIPHashTest(HashTest):
                 hash_key, hit_count_map))
 
             for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
 
     def runTest(self):
         """


### PR DESCRIPTION
### Description of PR
In case of chassis-packet switch type, when src port of the traffic is on the same DUT and same asic as destination port, it sends out traffic only on the ports that belong to the same asic. Currently both fib_test and hash_test was set to send out on ports that belonged to different asic causing the balancing test to fail. THis change pertains only to chassis-packet switch type 

Summary:
Fixes # (issue)

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?
Fix balancing test for chassis packet switch type

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
