### PR TITLE
[dualtor-io] Remove mux flap check for grpc server failure tests

### DIFF
--- a/tests/dualtor_io/test_grpc_server_failure.py
+++ b/tests/dualtor_io/test_grpc_server_failure.py
@@ -14,7 +14,6 @@ from tests.common.dualtor.dual_tor_common import cable_type                     
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.nic_simulator_control import stop_nic_grpc_server         # noqa F401
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator        # noqa F401
-from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter        # noqa F401
 
 
 pytestmark = [


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
As the grpc server failure tests disable the grpc server, the mux flap
check will have grpc unavailable issue.

So let's remove the mux flap check.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
```
dualtor_io/test_grpc_server_failure.py::test_grpc_server_failure_config_standby_config_auto_upstream_active[active-standby] SKIPPED [ 25%]
dualtor_io/test_grpc_server_failure.py::test_grpc_server_failure_config_standby_config_auto_upstream_active[active-active] PASSED [ 50%]
dualtor_io/test_grpc_server_failure.py::test_grpc_server_failure_config_standby_config_auto_downstream_standby[active-standby] SKIPPED [ 75%]
dualtor_io/test_grpc_server_failure.py::test_grpc_server_failure_config_standby_config_auto_downstream_standby[active-active] PASSED [100%]

======================================== 2 passed, 2 skipped in 823.63 seconds =========================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
