### PR TITLE
skip warm reboot related cases on 202305 branch for 7060

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -56,9 +56,9 @@ arp/test_wr_arp.py:
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-buildimage/issues/16502
   xfail:
-    reason: "Warm reboot has a known issue on 7050cx3"
+    reason: "Warm reboot has a known issue on 202305 branch"
     conditions:
-      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and release in ['202305', 'master']"
+      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32'] and release in ['202305']"
       - https://github.com/sonic-net/sonic-mgmt/issues/10077
 
 #######################################
@@ -809,9 +809,9 @@ pfcwd/test_pfcwd_warm_reboot.py:
      conditions:
         - "'t2' in topo_name"
    xfail:
-     reason: "Warm Reboot is not supported in dualtor."
+     reason: "Warm Reboot is not supported in dualtor and has a known issue on 202305 branch"
      conditions:
-        - "('dualtor' in topo_name) or (hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and release in ['202305', 'master'])"
+        - "('dualtor' in topo_name) or (hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32'] and release in ['202305'])"
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
 #######################################
@@ -871,8 +871,8 @@ platform_tests/test_auto_negotiation.py:
 
 platform_tests/test_cont_warm_reboot.py:
   xfail:
-    reason: "warm reboot has a known issue on 7050cx3"
-    conditions: "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and release in ['202305', 'master']"
+    reason: "warm reboot has a known issue on 202305 branch"
+    conditions: "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32'] and release in ['202305']"
 
 #######################################
 #####           qos               #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
there is a warm reboot related known issue on the 202305 branch.

#### How did you do it?
xfail the warm reboot related cases on 202305 branch for 7060
remove xfail on master branch, only xfail it on feature branch
platform_tests/test_cont_warm_reboot.py
arp/test_wr_arp.py
pfcwd/test_pfcwd_warm_reboot.py

#### How did you verify/test it?
=================================================================================================================== short test summary info ====================================================================================================================
XFAIL pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm-str3-7060-acs-1]
  Warm Reboot is not supported in dualtor and has a known issue on 202305 branch
XFAIL pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm-str3-7060-acs-1]
  Warm Reboot is not supported in dualtor and has a known issue on 202305 branch
XFAIL pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm-str3-7060-acs-1]
  Warm Reboot is not supported in dualtor and has a known issue on 202305 branch
========================================================================================================== 3 xfailed, 1 warning in 474.44s (0:07:54) ===========================================================================================================

#### Any platform specific information?
7060

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
