### PR TITLE
enlarge sleep time in test_pfcwd_timer_accuracy

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -166,14 +166,14 @@ class TestPfcwdAllTimer(object):
             self.dut.shell("logrotate -f /etc/logrotate.conf")
         self.storm_handle.start_storm()
         logger.info("Wait for queue to recover from PFC storm")
-        time.sleep(8)
+        time.sleep(16)
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         else:
             storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         logger.info("Wait for PFC storm end marker to appear in logs")
-        time.sleep(8)
+        time.sleep(16)
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
         else:
@@ -284,10 +284,28 @@ class TestPfcwdAllTimer(object):
             else:
                 for i in range(1, 20):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
+
+                    cmd = "show pfc counters"
+                    pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+                    logger.debug("loop {} cmd {} rsp {}".format(i, cmd, pfcwd_cmd_response.get('stdout', None)))
+
+                    cmd = "show pfcwd stats"
+                    pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+                    logger.debug("loop {} cmd {} rsp {}".format(i, cmd, pfcwd_cmd_response.get('stdout', None)))
+
                     self.run_test()
                 self.verify_pfcwd_timers()
 
         except Exception as e:
+            logger.info("exception: ")
+            cmd = "show pfc counters"
+            pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+            logger.info("pfcwd_cmd {} response: {}".format(cmd, pfcwd_cmd_response.get('stdout', None)))
+
+            cmd = "show pfcwd stats"
+            pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+            logger.info("pfcwd_cmd {} response: {}".format(cmd, pfcwd_cmd_response.get('stdout', None)))
+
             pytest.fail(str(e))
 
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
25074148

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The case failure on some devices.

#### How did you do it?
Enlarge the sleep time in case test_pfcwd_timer_accuracy

#### How did you verify/test it?
Verified locally
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[str3-7060-acs-3] PASSED  

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
