### PR TITLE
Skip queue watermark and wm_pg_shared_lossy for Q100

### DIFF
--- a/tests/qos/files/qos_params.pac.yaml
+++ b/tests/qos/files/qos_params.pac.yaml
@@ -10,15 +10,6 @@ qos_params:
                 pkts_num_margin: 4
                 packet_size: 1350
                 cell_size: 384
-            wm_pg_shared_lossy:
-                dscp: 8
-                ecn: 1
-                pg: 0
-                pkts_num_trig_egr_drp: 5121
-                pkts_num_fill_min: 0
-                pkts_num_margin: 4
-                packet_size: 8156
-                cell_size: 8192
             wm_buf_pool_lossy:
                 dscp: 8
                 ecn: 1
@@ -168,15 +159,6 @@ qos_params:
                     cell_size: 384
                     packet_size: 1350
         topo-t2:
-            wm_pg_shared_lossy:
-                dscp: 8
-                ecn: 1
-                pg: 0
-                pkts_num_trig_egr_drp: 5121
-                pkts_num_fill_min: 0
-                pkts_num_margin: 4
-                packet_size: 8156
-                cell_size: 8192
             wm_buf_pool_lossy:
                 dscp: 8
                 ecn: 1

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2088,3 +2088,11 @@ class QosSaiBase(QosBase):
                 "This test is skipped since asic types of ingress and egress are different.")
         yield
         return
+
+    @pytest.fixture(scope="function", autouse=False)
+    def skip_pacific_dst_asic(self, dutConfig):
+        if dutConfig['dstDutAsic'] == "pac":
+            pytest.skip(
+                "This test is skipped since egress asic is cisco-8000 Q100.")
+        yield
+        return

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1428,6 +1428,10 @@ class TestQosSai(QosSaiBase):
         if "wm_pg_shared_lossless" in pgProfile:
             pktsNumFillShared = qosConfig[pgProfile]["pkts_num_trig_pfc"]
         elif "wm_pg_shared_lossy" in pgProfile:
+            if dutConfig['dstDutAsic'] == "pac":
+                pytest.skip(
+                    "PGSharedWatermark: Lossy test is not applicable in "
+                    "cisco-8000 Q100 platform.")
             pktsNumFillShared = int(
                 qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
@@ -1595,7 +1599,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, _skip_watermark_multi_DUT
+        resetWatermark, _skip_watermark_multi_DUT, skip_pacific_dst_asic
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -1919,7 +1923,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_wm_all_ports"])
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, _skip_watermark_multi_DUT
+        resetWatermark, _skip_watermark_multi_DUT, skip_pacific_dst_asic
     ):
         """
             Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, Skip queue watermark cases. Q100 does not support congestion level and thus no queue watermarks.
2, Skip wm_pg_shared_lossy. After eviction to hbm, the sq counter is 0 on Q100 hardware.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
