### PR TITLE
[Drop_counter] Set the ignore field of header based on the IP header type

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -231,8 +231,18 @@ def expected_packet_mask(pkt):
     exp_pkt = mask.Mask(exp_pkt)
     exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
     exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
-    exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
-    exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
+
+    if packet.IP not in exp_pkt.exp_pkt and packet.IPv6 not in exp_pkt.exp_pkt:
+        # When exp_pkt doesn't include IPv4 or IPv6 header, return the exp_pkt directly
+        return exp_pkt
+    elif packet.IPv6 in exp_pkt.exp_pkt:
+        # For Ipv6 header, hlim is same to ttl of Ipv4, and ipv6 has no chksum
+        exp_pkt.set_do_not_care_scapy(packet.IPv6, 'hlim')
+    else:
+        # For Ipv4 header, need to ignore ttl and chksum
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
+
     return exp_pkt
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/10391
 1. When exp_pkt doesn't include IPv4 or IPv6 header, we don't need to ignore the ttl, chksum or hlim
 2. For Ipv6 header, hlim is same as ttl of Ipv4, and ipv6 has no chksum
 3. For Ipv4 header, need to ignore ttl and chksum

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/10391

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix issue https://github.com/sonic-net/sonic-mgmt/issues/10391

#### How did you do it?
1. When exp_pkt doesn't include IPv4 or IPv6 header, we don't need to ignore the ttl, chksum or hlim
 2. For Ipv6 header, hlim is same as ttl of Ipv4, and ipv6 has no chksum
 3. For Ipv4 header, need to ignore ttl and chksum

#### How did you verify/test it?
Run test_drop_counters.py

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
