### PR TITLE
[Mellanox] Fix test_incremental_qos_config_updates issue

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -11,6 +11,7 @@ from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.generic_config_updater.gu_utils import is_valid_platform_and_version
+from tests.common.mellanox_data import is_mellanox_device
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -210,6 +211,14 @@ def ensure_application_of_updated_config(duthost, configdb_field, value):
     )
 
 
+@pytest.fixture(scope='module', autouse=True)
+def skip_when_buffer_is_dynamic_model(duthost):
+    buffer_model = duthost.shell(
+        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
+    if buffer_model == 'dynamic':
+        pytest.skip("Skip the test, because dynamic buffer config cannot be updated")
+
+
 @pytest.mark.parametrize("configdb_field", ["ingress_lossless_pool/xoff",
                                             "ingress_lossless_pool/size", "egress_lossy_pool/size"])
 @pytest.mark.parametrize("op", ["add", "replace", "remove"])
@@ -221,6 +230,8 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
     field_value = duthost.shell('sonic-db-cli CONFIG_DB hget "BUFFER_POOL|{}" {}'
                                 .format(configdb_field.split("/")[0], configdb_field.split("/")[1]))['stdout']
     if op == "remove":
+        if is_mellanox_device(duthost):
+            pytest.skip("Skip remove test, because the mellanox device doesn't support removing qos config fields")
         value = ""
     else:
         value = calculate_field_value(duthost, tbinfo, configdb_field)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/10354
1. For mellanox device, it doesn't support removing qos config fields
2. When buffer model is the dynamic model, skip the test. Because for dynamic model, the qos config will be generated automatically and cannot be updated manually.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/10354

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/10354

#### How did you do it?
1. For mellanox device, it doesn't support removing qos config fields
2. When buffer model is the dynamic model, skip the test. Because for dynamic model, the qos config will be generated automatically and cannot be updated manually.

#### How did you verify/test it?
Run test_incremental_qos_config_updates on the mellanox device

#### Any platform specific information?
Mellanox

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
