### PR TITLE
[202205][dualtor-io] Remove `test_normal_op_server_to_server`

### DIFF
--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -141,28 +141,6 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
     # TODO: Add per-port db check
 
 
-@pytest.mark.enable_active_active
-def test_normal_op_server_to_server(upper_tor_host, lower_tor_host,             # noqa F811
-                                    send_server_to_server_with_action,          # noqa F811
-                                    toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                                    cable_type):                                # noqa F811
-    """
-    Send server to server traffic and confirm no disruption or switchover occurs.
-    """
-    if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
-        verify_tor_states(expected_active_host=upper_tor_host,
-                          expected_standby_host=lower_tor_host,
-                          skip_tunnel_route=False)
-
-    if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
-        verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
-                          expected_standby_host=None,
-                          cable_type=cable_type,
-                          skip_tunnel_route=False)
-
-
 @pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Remove testcase `test_normal_op_server_to_server` as it is replaced by
`test_normal_op_active_server_to_active_server`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
