### PR TITLE
Update NTP longjump test for Bookworm

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -17,14 +17,19 @@ TIME_FORWARD = 3600
 
 def config_long_jump(duthost, enable=False):
     """change ntpd option to enable or disable long jump"""
+    ntpsec_conf_stat = duthost.stat(path="/etc/ntpsec/ntp.conf")
+    using_ntpsec = ntpsec_conf_stat["stat"]["exists"]
     if enable:
         logger.info("enable ntp long jump")
-        regex = "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
+        regex = "s/NTPD_OPTS=\\\"-x -N\\\"/NTPD_OPTS=\\\"-g -N\\\"/" if using_ntpsec else "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
     else:
         logger.info("disable ntp long jump")
-        regex = "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
+        regex = "s/NTPD_OPTS=\\\"-g -N\\\"/NTPD_OPTS=\\\"-x -N\\\"/" if using_ntpsec else "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
 
-    duthost.command("sed -i %s /etc/default/ntp" % regex)
+    if using_ntpsec:
+        duthost.command("sed -i '%s' /etc/default/ntpsec" % regex)
+    else:
+        duthost.command("sed -i %s /etc/default/ntp" % regex)
     duthost.service(name='ntp', state='restarted')
 
 
@@ -74,6 +79,8 @@ def setup_long_jump_config(duthosts, rand_one_dut_hostname):
     # collect long jump state
     long_jump_enable = False
     if not duthost.shell("grep -q \"NTPD_OPTS='-g'\" /etc/default/ntp", module_ignore_errors=True)['rc']:
+        long_jump_enable = True
+    if not duthost.shell("grep -q \"NTPD_OPTS=\\\"-g -N\\\"\" /etc/default/ntpsec", module_ignore_errors=True)['rc']:
         long_jump_enable = True
 
     # get time before set time

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -21,10 +21,16 @@ def config_long_jump(duthost, enable=False):
     using_ntpsec = ntpsec_conf_stat["stat"]["exists"]
     if enable:
         logger.info("enable ntp long jump")
-        regex = "s/NTPD_OPTS=\\\"-x -N\\\"/NTPD_OPTS=\\\"-g -N\\\"/" if using_ntpsec else "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
+        if using_ntpsec:
+            regex = "s/NTPD_OPTS=\\\"-x -N\\\"/NTPD_OPTS=\\\"-g -N\\\"/"
+        else:
+            regex = "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
     else:
         logger.info("disable ntp long jump")
-        regex = "s/NTPD_OPTS=\\\"-g -N\\\"/NTPD_OPTS=\\\"-x -N\\\"/" if using_ntpsec else "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
+        if using_ntpsec:
+            regex = "s/NTPD_OPTS=\\\"-g -N\\\"/NTPD_OPTS=\\\"-x -N\\\"/"
+        else:
+            regex = "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
 
     if using_ntpsec:
         duthost.command("sed -i '%s' /etc/default/ntpsec" % regex)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

Bookworm uses NTPsec instead of NTP, and so the file paths have changed slightly. Update the test case for that.

#### How did you do it?

#### How did you verify/test it?

Tested on Bookworm VS image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
