### PR TITLE
Remove the skip for underlay route in dash vnet test

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -95,8 +95,6 @@ def get_intf_from_ip(local_ip, config_facts):
 
 @pytest.fixture(params=["no-underlay-route", "with-underlay-route"])
 def use_underlay_route(request):
-    if request.param == "with-underlay-route":
-        pytest.skip("Underlay route not supported yet")
     return request.param == "with-underlay-route"
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test is supported by SONiC now. Enable it by removing the skip.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Enable the dash vnet underlay route test cases.
#### How did you do it?
Remove the skip in dash/conftest.py
#### How did you verify/test it?
Run test cases on Bluefield3 testbed, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
