### PR TITLE
[202205] Improve the stability of fib/decap test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -349,7 +349,7 @@ class FibTest(BaseTest):
 
         dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self,masked_exp_pkt, dst_ports)
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports, timeout=1)
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))
@@ -438,7 +438,7 @@ class FibTest(BaseTest):
 
         dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports)
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports, timeout=1)
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -414,7 +414,7 @@ class DecapPacketTest(BaseTest):
                              str(expected_ports)))
 
         matched, received = verify_packet_any_port(
-            self, masked_exp_pkt, expected_ports)
+            self, masked_exp_pkt, expected_ports, timeout=1)
         logging.info('Received expected packet on interface {}'.format(
             str(expected_ports[matched])))
         return matched, received

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -36,7 +36,7 @@ class HashTest(BaseTest):
     # Class variables
     #---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
-    BALANCING_TEST_TIMES = 625
+    BALANCING_TEST_TIMES = 250
     DEFAULT_SWITCH_TYPE = 'voq'
 
     _required_params = [
@@ -284,7 +284,7 @@ class HashTest(BaseTest):
                     dport))
 
         dst_ports = list(itertools.chain(*dst_port_lists))
-        rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports)
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports, timeout=1)
         rcvd_port = dst_ports[rcvd_port_index]
 
         exp_src_mac = None
@@ -375,7 +375,7 @@ class HashTest(BaseTest):
                     dport))
 
         dst_ports = list(itertools.chain(*dst_port_lists))
-        rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports)
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports, timeout=1)
         rcvd_port = dst_ports[rcvd_port_index]
 
         exp_src_mac = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
**This is the manual cherry-pick of PR #10415 for conflict resolving.**

The fib/decap tests occasionally fail on or testbeds due to some random packet is not received by the ptf. After the debugging we found that there may be a big delay(max 0.3s observed on our testbed) between the packet is send by the ptf src port and received by the ptf dst port.
We suspect it could be introduced by the lag on the server side, because we see this failure mostly on the t1-lag/t1-lag-64 topologies.
And in the fib hash test, it looks like sometimes the packet is totally lost on the server(we have checked that there was no packet loss on the dut and fanout).
We have found a way to prevent this failure by:
1. Add a timeout in the ptf verify_packet_any_port method, with the timeout, the ptf adapter will constantly poll in the dataplane until the timeout elapse.
2. Decrease the BALANCING_TEST_TIMES in the fib_hash test, with this change, we no longer see the packet loss at all in the hash test. And 250 times is enough for the test. (Without this, even if the timeout was set to 5s, we still observed packet loss)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
To fix that occasional packet loss failure in fib/decap tests.
#### How did you do it?
Check the summary.
#### How did you verify/test it?
We have run the regression with this fix for one week, the failure is no longer seen.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
