### PR TITLE
Fix the ansible timeout issue in the add-topo step

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -51,7 +51,7 @@ sudo_exe = sudo
 #sudo_flags = -H
 
 # SSH timeout
-timeout = 30
+timeout = 60
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -72,6 +72,11 @@
         - net-tools
         - bridge-utils
         - util-linux
+
+    - name: Install necessary packages
+      apt: pkg={{ item }} update_cache=yes cache_valid_time=86400
+      become: yes
+      with_items:
         - iproute2
         - vlan
         - apt-transport-https


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We suffer from the ansible ssh timeout issue in the add-topo step from time to time:
```
TASK [vm_set : Add docker official GPG key] ************************************
task path: /root/mars/workspace/sonic-mgmt/ansible/roles/vm_set/tasks/docker.yml:1
Wednesday 12 July 2023  19:07:15 +0300 (0:00:00.053)       0:00:38.860 ******** 
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/packaging/os/apt_key.py
Pipelining is enabled.
<mtvr-r640-02> ESTABLISH SSH CONNECTION FOR USER: svc-nbu-sws-sonic
<mtvr-r640-02> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)(-o)(StrictHostKeyChecking=no)
<mtvr-r640-02> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
<mtvr-r640-02> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User="svc-nbu-sws-sonic")
<mtvr-r640-02> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
<mtvr-r640-02> SSH: PlayContext set ssh_common_args: ()
<mtvr-r640-02> SSH: PlayContext set ssh_extra_args: ()
<mtvr-r640-02> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/00f288ced3)
<mtvr-r640-02> SSH: EXEC sshpass -d8 ssh -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o StrictHostKeyChecking=no -o 'User="svc-nbu-sws-sonic"' -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/00f288ced3 mtvr-r640-02 '/bin/sh -c '"'"'sudo -H -S  -p "[sudo via ansible, key=svzxhjvljfuttszilkmijphdriytunoh] password:" -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-svzxhjvljfuttszilkmijphdriytunoh ; /usr/bin/python'"'"'"'"'"'"'"'"' && sleep 0'"'"''
fatal: [MTVR-R640-02]: FAILED! => {
    "msg": "Timeout (32s) waiting for privilege escalation prompt: "
}
```
Mostly it happens in the task "vm_set : Add docker official GPG key" and "vm_set : Install necessary packages", I have searched the Internet and found 2 possible solutions:
1. Increase the ssh timeout to 60 in ansible.cfg
2. Divide the "Install necessary packages" into two to has less packages installed in a single task.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the ansible timeout issue in the add-topo step
#### How did you do it?
1. Increase the ssh timeout to 60 in ansible.cfg
2. Divide the "Install necessary packages" into two to has less packages installed in a single task.
#### How did you verify/test it?
Run regression with this fix for a few weeks, the timeout failure was not observed again.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
