### PR TITLE
[Nvidia] [DualTor] Skip dscp 2 and 6 in test case test_tunnel_decap_dscp_to_queue_mapping

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -210,6 +210,9 @@ def test_tunnel_decap_dscp_to_queue_mapping(ptfhost, rand_selected_dut, rand_uns
     try:
         # Walk through all DSCP values
         for inner_dscp in range(0, 64):
+            # For Nvidia platforms, the inner dscp 2 and 6 are considered invalid use cases, skip the test
+            if 'mellanox' == rand_selected_dut.facts["asic_type"] and inner_dscp in [2, 6]:
+                continue
             outer_dscp = tunnel_qos_maps['inner_dscp_to_outer_dscp_map'][inner_dscp]
             _, exp_packet = build_testing_packet(src_ip=DUMMY_IP,
                                                  dst_ip=dualtor_meta['target_server_ip'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For Nvidia platforms, the inner dscp 2 and 6 are considered invalid use cases, skip the test. 
The dscp 2 and 6 are reserved only for the outer dscp after the remapping and encapsulation.
We have another similar issue fixed by PR #9625.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the test failure of test_tunnel_decap_dscp_to_queue_mapping on Nvidia platforms.
#### How did you do it?
 Skip the test for dscp 2 and 6
#### How did you verify/test it?
Run the test case on 4600c dualtor testbed, passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
