### PR TITLE
Dynamic PORT selection for PFC storm testing

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -2,6 +2,9 @@
 
 import logging
 import time
+import random
+import re
+random.seed(10)
 
 from run_events_test import run_test
 
@@ -31,8 +34,12 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
 def shutdown_interface(duthost):
     logger.info("Shutting down interface")
     interfaces = duthost.get_interfaces_status()
-    if_state_test_port = next((interface for interface, status in interfaces.items()
-                               if status["oper"] == "up" and status["admin"] == "up"), None)
+    pattern = re.compile(r'^Ethernet[0-9]{1,2}$')
+    interface_list = []
+    for interface, status in interfaces.items():
+        if pattern.match(interface) and status["oper"] == "up" and status["admin"] == "up":
+            interface_list.append(interface)
+    if_state_test_port = random.choice(interface_list)
     assert if_state_test_port is not None, "Unable to find valid interface for test"
 
     ret = duthost.shell("config interface shutdown {}".format(if_state_test_port))
@@ -45,8 +52,12 @@ def shutdown_interface(duthost):
 def generate_pfc_storm(duthost):
     logger.info("Generating pfc storm")
     interfaces = duthost.get_interfaces_status()
-    PFC_STORM_TEST_PORT = next((interface for interface, status in interfaces.items()
-                               if status["oper"] == "up" and status["admin"] == "up"), None)
+    pattern = re.compile(r'^Ethernet[0-9]{1,2}$')
+    interface_list = []
+    for interface, status in interfaces.items():
+        if pattern.match(interface) and status["oper"] == "up" and status["admin"] == "up":
+            interface_list.append(interface)
+    PFC_STORM_TEST_PORT = random.choice(interface_list)
     assert PFC_STORM_TEST_PORT is not None, "Unable to find valid interface for test"
 
     queue_oid = duthost.get_queue_oid(PFC_STORM_TEST_PORT, PFC_STORM_TEST_QUEUE)

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -4,10 +4,10 @@ import logging
 import time
 import random
 import re
-random.seed(10)
 
 from run_events_test import run_test
 
+random.seed(10)
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

In the test file : telemetry/events/swss_events.py
in the function generate_pfc_storm, in the line
queue_oid = duthost.get_queue_oid(PFC_STORM_TEST_PORT, PFC_STORM_TEST_QUEUE)
The PFC_STORM_TEST_PORT - the port chosen to test the PFC storm on - is assigned a fixed value of “Ethernet4”, whereas, some DUTs don't have a port Ethernet4 associated with it’s ASIC instance. Therefore this test is passing when assigning a value of Ethernet8 or Ethernet16 which are valid ports.

Changing fixed assigned value, replacing it with a dynamically selected port from the list of ports that have both open and admin status as "UP"


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Want to ensure that telemetry/test_events.py test case passes - and that when selecting a port to do a PFC storm on, we are chasing a valid port, instead of a fixed one. 

#### How did you do it?

#### How did you verify/test it?
Successfully ran telemetry/test_events.py

#### Any platform specific information?

#### Supported testbed topology if it's
 a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Logs: 
[test_events.log](https://github.com/sonic-net/sonic-mgmt/files/13635360/test_events.log)
[test_events_master.log](https://github.com/sonic-net/sonic-mgmt/files/14642407/test_events_master.log)