### PR TITLE
[test_qos_sai] Fix toggle failures on dualtor testbed

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -412,12 +412,55 @@ def _toggle_all_simulator_ports(mux_server_url, side, tbinfo):
 
 
 @pytest.fixture(scope='module')
-def toggle_all_simulator_ports(mux_server_url, tbinfo):
+def toggle_all_simulator_ports(mux_server_url, tbinfo, duthosts):
     """
     A module level fixture to toggle all ports to specified side.
     """
-    def _toggle(side):
-        _toggle_all_simulator_ports(mux_server_url, side, tbinfo)
+
+    def _check_toggle_and_probe(duthosts, active_side):
+        """Check if toggle success and probe those inconsistent mux ports if any."""
+        if active_side == UPPER_TOR:
+            active_duthost, standby_duthost = duthosts[0], duthosts[1]
+        elif active_side == LOWER_TOR:
+            standby_duthost, active_duthost = duthosts[0], duthosts[1]
+        else:
+            raise ValueError("Unsupported side %s" % active_side)
+
+        standby_ports_on_active_side = _get_mux_ports(active_duthost, exclude_status="active")
+        active_ports_on_standby_side = _get_mux_ports(standby_duthost, exclude_status="standby")
+        logging.debug("standby mux ports on the active side %s:\n%s",
+                      active_duthost, json.dumps(list(standby_ports_on_active_side.keys())))
+        logging.debug("active mux ports on the standby side %s:\n%s",
+                      standby_duthost, json.dumps(list(active_ports_on_standby_side.keys())))
+        if (not standby_ports_on_active_side) and (not active_ports_on_standby_side):
+            return True
+
+        # probe those inconsistent mux ports
+        _probe_mux_ports([active_duthost], list(standby_ports_on_active_side.keys()))
+        _probe_mux_ports([standby_duthost], list(active_ports_on_standby_side.keys()))
+        return False
+
+    def _toggle(active_side, retries=0):
+        _toggle_all_simulator_ports(mux_server_url, active_side, tbinfo)
+
+        if retries <= 0:
+            return
+
+        time.sleep(10)
+        if _check_toggle_and_probe(duthosts, active_side):
+            return
+
+        for retry in range(retries):
+            logging.info("Retry=%d, toggle all mux cables to %s", retry + 1, active_side)
+            _toggle_all_simulator_ports(mux_server_url, active_side, tbinfo)
+
+            time.sleep(10)
+            if _check_toggle_and_probe(duthosts, active_side):
+                return
+
+        pytest_assert(utilities.wait_until(120, 10, 0, _check_toggle_and_probe, duthosts, active_side),
+                      "Failed to toggle all mux cables to %s" % active_side)
+
     return _toggle
 
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1179,7 +1179,7 @@ class QosSaiBase(QosBase):
         if 'dualtor' in tbinfo['topo']['name']:
             file = "/usr/local/bin/write_standby.py"
             backup_file = "/usr/local/bin/write_standby.py.bkup"
-            toggle_all_simulator_ports(LOWER_TOR)
+            toggle_all_simulator_ports(LOWER_TOR, retries=3)
             check_result = wait_until(
                 120, 10, 10, check_mux_status, duthosts, LOWER_TOR)
             validate_check_result(check_result, duthosts, get_mux_status)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The toggle to the lower ToR in the `test_qos_sai` setup failed recently.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Improve the toggle fixture `toggle_all_simulator_ports`:
1. add retry logic.
2. probe those inconsistent mux ports.

#### How did you verify/test it?
Run on dualtor testbed:
```
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED                                                                                                                                                                                   [100%]


===================================================================================================================== warnings summary =====================================================================================================================
../../../../../../usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18
  /usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18: DeprecationWarning: The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 1 passed, 1 warning in 781.55s (0:13:01) =========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
