### PR TITLE
[dualtor-io] Ignore BGPMON errors in bgp failure tests

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -62,7 +62,8 @@ def temp_enable_bgp_autorestart(duthosts):
 def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
-        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'"
+        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'",
+        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: \['vtysh', '-c', 'show bgp summary json'\]"
     ]
 
     if loganalyzer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Ignore the `bgpmon` syslog error:
```
Oct 22 15:35:20.469660 lab-dev-01 ERR bgp#bgpmon: *ERROR* Failed with rc:1 when execute: ['vtysh', '-c', 'show bgp summary json']
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Add the the error string pattern to `loganalyzer` ignore list.

#### How did you verify/test it?
```
dualtor_io/test_tor_bgp_failure.py::test_active_tor_kill_bgpd_upstream[active-standby] PASSED                                                                                                                                                        [ 50%]
dualtor_io/test_tor_bgp_failure.py::test_active_tor_kill_bgpd_upstream[active-active] SKIPPED                                                                                                                                                        [100%]

========================================================================================================== 1 passed, 1 skipped in 661.67 seconds ===========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
