### PR TITLE
Ignore kdump-tools log message from loganalyzer

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -213,3 +213,6 @@ r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*\] \[Type:.* sx_bridge_id.*"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
+
+# https://github.com/sonic-net/sonic-mgmt/issues/10384
+r, ".*kdump-tools\[[0-9]+\]: no crashkernel= parameter in the kernel cmdline.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- During multiple tests teardown, seen the following LogAnalyzer match for kdump related messages being reported as errors.
- Issues seen in tests running on chassis with topo t2_2lc_36-masic.
- And also observed similar errors seen during dut reboot and config reload as well.

The issue is reported as #10384 

Example error message,
`Oct 15 08:06:10.491683 ixre-egl-board28 INFO kdump-tools[873]: no crashkernel= parameter in the kernel cmdline ...`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
- During multiple tests teardown, seen the following LogAnalyzer match for kdump related messages being reported as errors.
- Issues seen in tests running on chassis with topo t2_2lc_36-masic.

#### How did you do it?
- Since these messages are not errors but pointing to missing info when loading kdump config on DUT which is not supporting kdump.
- Added expected ERROR messages to the regex list in loganalyzer_common_ignore.txt.

#### How did you verify/test it?
- Ran all the tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
