### PR TITLE
Enable counterpoll watermark and counterpoll queue after being disabled

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1962,6 +1962,13 @@ class QosSaiBase(QosBase):
             dut_asic.command("counterpoll watermark disable")
             dut_asic.command("counterpoll queue disable")
 
+        yield
+
+        for dut_asic in get_src_dst_asic_and_duts['all_asics']:
+            dut_asic.command("counterpoll watermark enable")
+            dut_asic.command("counterpoll queue enable")
+            dut_asic.command("config save -y")
+
     @pytest.fixture(scope='class')
     def dualtor_ports_for_duts(request, get_src_dst_asic_and_duts):
         # Fetch dual ToR ports


### PR DESCRIPTION
### Description of PR
In /tests/qos/qos_sai_base.py/resetWatermark definition counterpoll watermark and counterpoll queue are being disabled but they are not being enabled back.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
counterpoll watermark and counterpoll queue are being enabled in resetWatermark definition.
Then they are being disabled.
When these entries are disabled, the testcase snmp/test_snmp_queue.py::test_snmp_queues which runs after qos fails with the message "Failed: port Ethernetx/x does not have queue counters"
These entries need to be enabled not to cause issues when running other testcases.

#### How did you do it?
Added codes to enable both counterpoll watermark and counterpoll queue in teardown.

#### How did you verify/test it?
Ran OC testcases against a multi-asic line card in a T2 chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
