### PR TITLE
[chassis] [voq] convert strings to lowercases before comparison in voq_helpers.py

### DIFF
--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -362,7 +362,7 @@ def check_rif_on_sup(systemintftable, slot, asic, port):
         asic_str = asic
 
     key = "SYSTEM_INTERFACE|{}|{}|{}".format(slot_str, asic_str, port)
-    lower_systemintftable = dict((k.lower(), v) for k,v in systemintftable.iteritems())
+    lower_systemintftable = dict((k.lower(), v) for k, v in systemintftable.iteritems())
     if key.lower() in lower_systemintftable.keys():
         logger.info("Found key {} on chassisdb on supervisor card".format(key))
     else:
@@ -393,7 +393,7 @@ def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac)
     logger.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
     pytest_assert("|%s|" % slot.lower() in lower_neigh_key,
                   "Slot for %s does not match %s" % (lower_neigh_key, slot.lower()))
-    pytest_assert("|%s|" % port.lower() in lower_neigh_key \
+    pytest_assert("|%s|" % port.lower() in lower_neigh_key
                   or "|%s|" % port.lower() in lower_neigh_key,
                   "Port for %s does not match %s" % (lower_neigh_key, port.lower()))
     pytest_assert("|%s|" % asic.lower() in lower_neigh_key,

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -386,7 +386,11 @@ def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac)
 
     """
     voqdb = VoqDbCli(sup)
-    neigh_key = voqdb.get_neighbor_key_by_ip(neighbor)
+    # Convert string to lowercases for furthur comparison
+    neigh_key = voqdb.get_neighbor_key_by_ip(neighbor).lower()
+    slot = slot.lower()
+    port = port.lower()
+    asic = asic.lower()
     logger.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
     pytest_assert("|%s|" % slot in neigh_key,
                   "Slot for %s does not match %s" % (neigh_key, slot))
@@ -779,21 +783,22 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
         # supervisor checks
         for entry in voq_dump:
             if entry.endswith('|%s' % neighbor) or entry.endswith(':%s' % neighbor):
-
+                # Convert strings to lowercases for furthur comparison
+                lower_entry = entry.lower()
                 if "portchannel" in local_port.lower():
-                    slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname']
-                    asicname = cfg_facts['DEVICE_METADATA']['localhost']['asic_name']
+                    slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname'].lower()
+                    asicname = cfg_facts['DEVICE_METADATA']['localhost']['asic_name'].lower()
                 else:
-                    slotname = sysport_info['slot']
-                    asicname = sysport_info['asic']
+                    slotname = sysport_info['slot'].lower()
+                    asicname = sysport_info['asic'].lower()
 
-                logger.debug("Neigh key: %s, slotnum: %s", entry, slotname)
-                pytest_assert("|%s|" % slotname in entry,
-                              "Slot for %s does not match %s" % (entry, slotname))
-                pytest_assert("|%s:" % local_port in entry or "|%s|" % local_port in entry,
-                              "Port for %s does not match %s" % (entry, local_port))
-                pytest_assert("|%s|" % asicname in entry,
-                              "Asic for %s does not match %s" % (entry, asicname))
+                logger.debug("Neigh key: %s, slotnum: %s", lower_entry, slotname)
+                pytest_assert("|%s|" % slotname in lower_entry,
+                              "Slot for %s does not match %s" % (lower_entry, slotname))
+                pytest_assert("|%s:" % local_port in lower_entry or "|%s|" % local_port in lower_entry,
+                              "Port for %s does not match %s" % (lower_entry, local_port))
+                pytest_assert("|%s|" % asicname in lower_entry,
+                              "Asic for %s does not match %s" % (lower_entry, asicname))
 
                 pytest_assert(voq_dump[entry]['value']['neigh'].lower() == neigh_mac.lower(),
                               "Voq: neighbor: %s mac does not match: %s" %

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -362,7 +362,8 @@ def check_rif_on_sup(systemintftable, slot, asic, port):
         asic_str = asic
 
     key = "SYSTEM_INTERFACE|{}|{}|{}".format(slot_str, asic_str, port)
-    if key in systemintftable:
+    lower_systemintftable = dict((k.lower(), v) for k,v in systemintftable.iteritems())
+    if key.lower() in lower_systemintftable.keys():
         logger.info("Found key {} on chassisdb on supervisor card".format(key))
     else:
         raise SonicDbKeyNotFound("No keys for %s found in chassisdb SYSTEM_INTERFACE table" % key)
@@ -387,17 +388,16 @@ def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac)
     """
     voqdb = VoqDbCli(sup)
     # Convert string to lowercases for furthur comparison
-    neigh_key = voqdb.get_neighbor_key_by_ip(neighbor).lower()
-    slot = slot.lower()
-    port = port.lower()
-    asic = asic.lower()
+    neigh_key = voqdb.get_neighbor_key_by_ip(neighbor)
+    lower_neigh_key = neigh_key.lower()
     logger.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
-    pytest_assert("|%s|" % slot in neigh_key,
-                  "Slot for %s does not match %s" % (neigh_key, slot))
-    pytest_assert("|%s:" % port in neigh_key or "|%s|" % port in neigh_key,
-                  "Port for %s does not match %s" % (neigh_key, port))
-    pytest_assert("|%s|" % asic in neigh_key,
-                  "Asic for %s does not match %s" % (neigh_key, asic))
+    pytest_assert("|%s|" % slot.lower() in lower_neigh_key,
+                  "Slot for %s does not match %s" % (lower_neigh_key, slot.lower()))
+    pytest_assert("|%s|" % port.lower() in lower_neigh_key \
+                  or "|%s|" % port.lower() in lower_neigh_key,
+                  "Port for %s does not match %s" % (lower_neigh_key, port.lower()))
+    pytest_assert("|%s|" % asic.lower() in lower_neigh_key,
+                  "Asic for %s does not match %s" % (lower_neigh_key, asic.lower()))
 
     voqdb.get_and_check_key_value(neigh_key, mac, field="neigh")
     voqdb.get_and_check_key_value(neigh_key, encap_index, field="encap_index")

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -393,7 +393,7 @@ def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac)
     logger.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
     pytest_assert("|%s|" % slot.lower() in lower_neigh_key,
                   "Slot for %s does not match %s" % (lower_neigh_key, slot.lower()))
-    pytest_assert("|%s|" % port.lower() in lower_neigh_key
+    pytest_assert("|%s:" % port.lower() in lower_neigh_key
                   or "|%s|" % port.lower() in lower_neigh_key,
                   "Port for %s does not match %s" % (lower_neigh_key, port.lower()))
     pytest_assert("|%s|" % asic.lower() in lower_neigh_key,
@@ -793,10 +793,11 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                     asicname = sysport_info['asic'].lower()
 
                 logger.debug("Neigh key: %s, slotnum: %s", lower_entry, slotname)
+                lower_port = local_port.lower()
                 pytest_assert("|%s|" % slotname in lower_entry,
                               "Slot for %s does not match %s" % (lower_entry, slotname))
-                pytest_assert("|%s:" % local_port in lower_entry or "|%s|" % local_port in lower_entry,
-                              "Port for %s does not match %s" % (lower_entry, local_port))
+                pytest_assert("|%s:" % lower_port in lower_entry or "|%s|" % lower_port in lower_entry,
+                              "Port for %s does not match %s" % (lower_entry, lower_port))
                 pytest_assert("|%s|" % asicname in lower_entry,
                               "Asic for %s does not match %s" % (lower_entry, asicname))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There are failures in function check_voq_neighbor_on_sup and check_all_neighbors_present_local that on some voq chassis, config facts had entries like: `SYSTEM_NEIGH|xxx-lc3-1|Asic0|Ethernet72|fc00::ca` while we are trying to find asicname that is `ASIC0` in the previous string, which causes lots of failures in voq testing.

in some other cases on the same chassis dut, the uppercase/lowercase is not consistent, so we have to check by ignoring upper/lowercases.
```
79) "SYSTEM_INTERFACE|lc7-1|Asic0|Ethernet80"
80) "SYSTEM_INTERFACE|lc3-1|ASIC0|PortChannel1015"
```

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/10473

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
run test_voq_init and test_voq_disrupts on chassis, only failure is because of TB issue(/etc/sonic/chassisdb.conf" not present on dut)

```
ERROR voq/test_voq_init.py::test_voq_neighbor_create[lc5-1-0] - Fai...
ERROR voq/test_voq_init.py::test_voq_neighbor_create[lc5-1-1] - Fai...
FAILED voq/test_voq_init.py::test_voq_interface_create[lc5-1-0] - R...
FAILED voq/test_voq_init.py::test_voq_interface_create[lc5-1-1] - R...
================ 2 failed, 8 passed, 2 error in 344.93 seconds =================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
