### PR TITLE
Fix the portchannel_on_asic() method to handle asic with no portchannels

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -562,7 +562,7 @@ class SonicAsic(object):
         # Wrapping shell cmd in try block to account for that case
         pcs = None
         try:
-            pcs =  self.shell(cmd)["stdout_lines"][0].decode("utf-8")
+            pcs = self.shell(cmd)["stdout_lines"][0]
         except RunAnsibleModuleFail as e:
             if "stderr_lines" in e.results and "\'PORTCHANNEL\' is undefined" in e.results["stderr_lines"][-1]:
                 return False

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -558,7 +558,16 @@ class SonicAsic(object):
         # And cannot do 'if portchannel in pcs', reason is that string/unicode comparison could be misleading
         # e.g. 'Portchanne101 in ['portchannel1011']' -> returns True
         # By split() function we are converting 'pcs' to list, and can do one by one comparison
-        pcs = self.shell(cmd)["stdout_lines"][0]
+        # sonic-cfggen returns "'PORTCHANNEL' is undefined" error if no portchannels are defined in config
+        # Wrapping shell cmd in try block to account for that case
+        pcs = None
+        try:
+            pcs =  self.shell(cmd)["stdout_lines"][0].decode("utf-8")
+        except RunAnsibleModuleFail as e:
+            if "stderr_lines" in e.results and "\'PORTCHANNEL\' is undefined" in e.results["stderr_lines"][-1]:
+                return False
+            else:
+                raise
         if pcs is not None:
             pcs_list = pcs.split("'")
             for pc in pcs_list:


### PR DESCRIPTION
Summary:
As describe in issue https://github.com/sonic-net/sonic-mgmt/issues/10399, the `sonic-cfggen` call from the portchannel_on_asic() method in `tests/common/devices/sonic_asic.py` fails when run on an asic that has no portchannels.  

This PR updates portchannel_on_asic() to handle the error returned by `sonic-cfggen` in this case.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
