### PR TITLE
Fix failure case number in test result summary incorrect issue

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -390,7 +390,7 @@ def _extract_test_summary(test_cases):
             # The result field is unique per test case, either error or failure.
             # xfails is the counter for all kinds of xfail results (include success/failure/error/skipped)
             test_result_summary["tests"] += 1
-            test_result_summary["failures"] += case["result"] == "failure" or case["result"] == "error"
+            test_result_summary["failures"] += case["result"] == "failure"
             test_result_summary["skipped"] += case["result"] == "skipped"
             test_result_summary["errors"] += case["error"]
             test_result_summary["time"] += float(case["time"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
In test summary, failures += failure + error, but in fact, if a testcase failed with both failure and error, the count of failure and error would both +1, so it's unnecessary to calculate in that way
#### How did you do it?
Let failures += failure
#### How did you verify/test it?
Run a test with both failure and error, and check the test result xml file
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
