### PR TITLE
fix dutConfig error on T0/T1

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -999,7 +999,7 @@ class QosSaiBase(QosBase):
         pytest_assert(dutAsic, "Cannot identify DUT ASIC type")
 
         # Get dst_dut asic type
-        if dst_asic != src_asic:
+        if dst_dut != src_dut:
             vendor = dst_dut.facts["asic_type"]
             hostvars = dst_dut.host.options['variable_manager']._hostvars[dst_dut.hostname]
             dstDutAsic = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
dutConfig run to error on T0/T1:
```
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
-------------------------------- live log setup --------------------------------
08:43:01 __init__._fixture_generator_decorator    L0088 ERROR  |
UnboundLocalError("local variable 'dst_asic' referenced before assignment")
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_vms2-t1-7260-7_646f1406735219c3e54440f7/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_vms2-t1-7260-7_646f1406735219c3e54440f7/tests/qos/qos_sai_base.py", line 1002, in dutConfig
    if dst_asic != src_asic:
UnboundLocalError: local variable 'dst_asic' referenced before assignment
ERROR    
```

Summary:
Issue was introduced by https://github.com/sonic-net/sonic-mgmt/pull/10300
dst_asic is not defined if T0/T1, change to use dst_dut.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
T1 passed:
multi-dut and single_dut_multi_asic skipped, single_asic passed.
```
--------------------------------------- generated xml file: /data/tests/logs/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue_2023-10-25-18-02-36.xml ----------------------------------------
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
18:20:31 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
SKIPPED [1] /data/tests/qos/qos_sai_base.py:550: multi-dut is not supported on T1 topologies
SKIPPED [1] /data/tests/qos/qos_sai_base.py:544: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
==================== 1 passed, 2 skipped in 1073.89 seconds ====================
INFO:root:Can not get Allure report URL. Please check logs
root@99027110b121:/data/tests# cat /data/tests/logs/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue_2023-10-25-18-02-36.xml
<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="99027110b121" name="pytest" skipped="2" tests="3" time="1073.905" timestamp="2023-10-25T18:02:37.708031"><properties><property name="topology" value="t1-64-lag"/><property name="testbed" value="ucs-m5-2"/><property name="timestamp" value="2023-10-25 18:08:41.631072"/><property name="host" value="mth64-m5-2"/><property name="asic" value="cisco-8000"/><property name="platform" value="x86_64-8102_64h_o-r0"/><property name="hwsku" value="Cisco-8102-C64"/><property name="os_version" value="azure_cisco_msft_202205.6877-dirty-20231011.143014"/></properties><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1005" name="testQosSaiLossyQueue[single_asic]" time="728.200"><properties><property name="start" value="2023-10-25 18:02:48.437674"/><property name="end" value="2023-10-25 18:14:56.641397"/></properties></testcase><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1005" name="testQosSaiLossyQueue[single_dut_multi_asic]" time="331.316"><properties><property name="start" value="2023-10-25 18:14:56.647067"/><property name="end" value="2023-10-25 18:20:27.966446"/></properties><skipped message="Did not find any frontend node that is multi-asic - so can&apos;t run single_dut_multi_asic tests" type="pytest.skip">/data/tests/qos/qos_sai_base.py:543: Did not find any frontend node that is multi-asic - so can&apos;t run single_dut_multi_asic tests</skipped></testcase><testcase classname="qos.test_qos_sai.TestQosSai" file="qos/test_qos_sai.py" line="1005" name="testQosSaiLossyQueue[multi_dut]" time="3.636"><properties><property name="start" value="2023-10-25 18:20:27.968804"/><property name="end" value="2023-10-25 18:20:31.605726"/></properties><skipped message="multi-dut is not supported on T1 topologies" type="pytest.skip">/data/tests/qos/qos_sai_base.py:549: multi-dut is not supported on T1 topologies</skipped></testcase></testsuite></testsuites>root@99027110b121:/data/tests# 
```

T2 skipped when src and dst's asic types are different
```
------------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue.xml --------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
18:41:54 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
SKIPPED [1] /data/tests/qos/qos_sai_base.py:2166: This test is skipped since asic types of ingress and egress are different.
=================================================================================== 1 skipped in 563.92 seconds ===================================================================================
```
T2 passed when src and dst's asic types are the same
multi_dut passed.
```
============================================================================================= PASSES ==============================================================================================
___________________________________________________________________________ TestQosSai.testQosSaiLossyQueue[multi_dut] ____________________________________________________________________________
------------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue.xml --------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
18:56:42 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[multi_dut]
=================================================================================== 1 passed in 516.97 seconds ====================================================================================
```
single_dut_multi_asic passed.
```
============================================================================================= PASSES ==============================================================================================
_____________________________________________________________________ TestQosSai.testQosSaiLossyQueue[single_dut_multi_asic] ______________________________________________________________________
------------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue.xml --------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
20:10:18 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_dut_multi_asic]
=================================================================================== 1 passed in 513.09 seconds ====================================================================================
```
single_asic passed.
```
============================================================================================= PASSES ==============================================================================================
__________________________________________________________________________ TestQosSai.testQosSaiLossyQueue[single_asic] ___________________________________________________________________________
------------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue.xml --------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
20:19:00 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic]
=================================================================================== 1 passed in 383.86 seconds ====================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
