### PR TITLE
Use xunit1 as default junit family version

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+junit_family=xunit1
 markers:
     acl: ACL tests
     bsl: BSL tests


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
When we use python3 env to run tests, it would use latest pytest by default, with junit_family=xunit2, which would not generate "file" and "line" field in test result xml file
#### How did you do it?
Use junit_family=xunit1 by default in pytest.ini file
#### How did you verify/test it?
Run test in python2 and python3 env, difference is only "file" and "line" fields in xml file
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
