### PR TITLE
For NTPsec, ignore error about statistics directory not existing

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -186,3 +186,6 @@ r, ".* ERR syncd\d*#syncd.*SAI_API_UNSPECIFIED:sai_bulk_object_get_stats.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/25018599
 r, ".* ERROR: Failed to parse lldp age.*"
+
+# NTPsec always expects the statistics directory to be available, but for now, we don't need NTP stats to be logged
+r, ".* ERR ntpd.*: statistics directory .* does not exist or is unwriteable, error No such file or directory"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

NTPsec by default wants to log statistics to a file (or at least check to see that the statistics directory exists, even if no logging is enabled). To match the behavior we had with NTP where no logging is enabled, don't configure the statistics directory for NTPsec, and ignore any errors about it not existing.

#### How did you do it?

#### How did you verify/test it?

Tested on Bookworm image by running `generic_config_updater/test_aaa.py` test suite. This suite was previously failing with loganalyzer errors from ntpd.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
