### PR TITLE
Update GCU's NTP test case for Bookworm

### DIFF
--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -34,6 +34,11 @@ def setup_env(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     create_checkpoint(duthost)
 
+    ntpsec_conf_stat = duthost.stat(path="/etc/ntpsec/ntp.conf")
+    if ntpsec_conf_stat["stat"]["exists"]:
+        global NTP_CONF
+        NTP_CONF = "/etc/ntpsec/ntp.conf"
+
     init_ntp_servers = running_ntp_servers(duthost)
 
     yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In Bookworm, NTP has been replaced with NTPsec. Add a check to see if NTPsec's config file is present, then use that config file instead of /etc/ntp.conf.

#### How did you do it?

#### How did you verify/test it?

Tested on Bookworm image by manually running `generic_config_updater/test_ntp.py` test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
