### PR TITLE
Add an event to block power on action until power off finished.

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -239,7 +239,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
 
     # Release event to proceed poweron for PDU.
     power_on_event.set()
-    
+
     # if wait_for_ssh flag is False, do not wait for dut to boot up
     if not wait_for_ssh:
         return

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -15,6 +15,9 @@ from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 logger = logging.getLogger(__name__)
 
+# Create the waiting power on event
+power_on_event = threading.Event()
+
 # SSH defines
 SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
@@ -174,7 +177,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
 
     def execute_reboot_helper():
         logger.info('rebooting {} with helper "{}"'.format(hostname, reboot_helper))
-        return reboot_helper(reboot_kwargs)
+        return reboot_helper(reboot_kwargs, power_on_event)
 
     dut_datetime = duthost.get_now_time(utc_timezone=True)
     DUT_ACTIVE.clear()
@@ -185,7 +188,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     if reboot_type != REBOOT_TYPE_POWEROFF:
         reboot_res = pool.apply_async(execute_reboot_command)
     else:
-        assert reboot_helper is not None, "A reboot function must be provided for power off reboot"
+        assert reboot_helper is not None, "A reboot function must be provided for power off/on reboot"
         reboot_res = pool.apply_async(execute_reboot_helper)
     return [reboot_res, dut_datetime]
 
@@ -233,6 +236,10 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
+
+    # Release event to proceed poweron for PDU.
+    power_on_event.set()
+    
     # if wait_for_ssh flag is False, do not wait for dut to boot up
     if not wait_for_ssh:
         return

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import time
+import threading
 
 from tests.common.reboot import wait_for_startup, REBOOT_TYPE_POWEROFF
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
@@ -40,7 +41,7 @@ def teardown_module(duthosts, enum_supervisor_dut_hostname, conn_graph_facts, xc
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list, INTERFACE_WAIT_TIME)
 
 
-def _power_off_reboot_helper(kwargs):
+def _power_off_reboot_helper(kwargs, power_on_event=None):
     """
     @summary: used to parametrized test cases on power_off_delay
     @param kwargs: the delay time between turning off and on the PSU
@@ -48,16 +49,26 @@ def _power_off_reboot_helper(kwargs):
     pdu_ctrl = kwargs["pdu_ctrl"]
     all_outlets = kwargs["all_outlets"]
     power_on_seq = kwargs["power_on_seq"]
-    delay_time = kwargs["delay_time"]
-
     for outlet in all_outlets:
         logging.debug("turning off {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)
-    time.sleep(delay_time)
+
+    # Wait for wait_for_shutdown assertion finished.
+    power_on_event.wait()
+    logging.debug("Turning off all_outlets finished.")
+
+    # Check outlets status?
+    outlet_status = pdu_ctrl.get_outlet_status()
+    for outlet in outlet_status:       
+        logging.debug("After turn off outlet, its status is {}".format(outlet))
+
     logging.info("Power on {}".format(power_on_seq))
     for outlet in power_on_seq:
         logging.debug("turning on {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
+
+    # Clean the flag to let next run still blocking power on action.
+    power_on_event.clear()
 
 
 def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, conn_graph_facts,

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -1,7 +1,5 @@
 import logging
 import pytest
-import time
-import threading
 
 from tests.common.reboot import wait_for_startup, REBOOT_TYPE_POWEROFF
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -57,7 +57,7 @@ def _power_off_reboot_helper(kwargs, power_on_event=None):
 
     # Check outlets status?
     outlet_status = pdu_ctrl.get_outlet_status()
-    for outlet in outlet_status:       
+    for outlet in outlet_status:
         logging.debug("After turn off outlet, its status is {}".format(outlet))
 
     logging.info("Power on {}".format(power_on_seq))


### PR DESCRIPTION
**Summary**
This PR improves the test_power_off_reboot test case's heler `_power_off_reboot_helper` that can help avoid the timing issue during the power off and power on procedure.

**Type of change**
 - [ ] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [x] Test case(new/improvement)
 
**Approach**
Use threading.Event() instead of sleep delay to avoid race condition.

**What is the motivation for this PR?**
There was nightly test failed due to power off took a while that exceed given delay time. To increase test reliability, we use semaphore way to ensure the time sequence.

**How did you do it?**
Introducing threading.Event(), when we finished shutdown assertion, then can let semaphore release the flag, then power off helper will proceed the power on action as expected.

**How did you verify/test it?**
Put the change into lab device, then inspect the testlog.

**Any platform specific information?**
This is common test issue.

Signed-off-by: Xincun Li [xincun.li@microsoft.com](mailto:xincun.li@microsoft.com)