### PR TITLE
[Python3 migration] Fix test_vrf failure in python3

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -274,8 +274,8 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     # get members from Vlan1000, and move half of them to Vlan2000 in vrf basic cfg
     ports = get_vlan_members('Vlan1000', cfg_facts)
 
-    vlan_ports = {'Vlan1000': ports[:len(ports)/2],
-                  'Vlan2000': ports[len(ports)/2:]}
+    vlan_ports = {'Vlan1000': ports[:int(len(ports)/2)],
+                  'Vlan2000': ports[int(len(ports)/2):]}
 
     extra_vars = {'cfg_t0': cfg_t0,
                   'vlan_ports': vlan_ports}


### PR DESCRIPTION
What is the motivation for this PR?
In python3, / operator performs true division, which means it returns a float even if the operands are integers. but in test_vrf test, only allow slice indices must be integers or None or have an __index__ method.

How did you do it?
Add (int) before (/)

Signed-off-by: meinh@supermicro.com.tw

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes Python3 migration issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ x] 202305

### Approach
#### What is the motivation for this PR?
In python3, / operator performs "true" division, which means it returns a float even if the operands are integers.
but in test_vrf test, only allow slice indices must be integers or None or have an __index__ method.

#### How did you do it?
Add (int) before ("/")

#### How did you verify/test it?

run t0 test and pass
vrf/test_vrf.py::TestVrfCreateAndBind::test_vrf_in_kernel PASSED

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
