### PR TITLE
[Python3 migration] test_sub_port_interfaces fail with 'dict_keys' object is not subscriptable

### DIFF
--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -467,10 +467,10 @@ class TestSubPortStress(object):
         """
         sub_ports_new = dict()
         sub_ports = apply_config_on_the_dut['sub_ports']
-        sub_ports_new[sub_ports.keys()[0]] = sub_ports[sub_ports.keys()[0]]
-        sub_ports_new[sub_ports.keys()[-1]] = sub_ports[sub_ports.keys()[-1]]
+        sub_ports_new[list(sub_ports.keys())[0]] = sub_ports[list(sub_ports.keys())[0]]
+        sub_ports_new[list(sub_ports.keys())[-1]] = sub_ports[list(sub_ports.keys())[-1]]
 
-        rand_sub_ports = sub_ports.keys()[random.randint(1, len(sub_ports)-1)]
+        rand_sub_ports = list(sub_ports.keys())[random.randint(1, len(sub_ports)-1)]
         sub_ports_new[rand_sub_ports] = sub_ports[rand_sub_ports]
 
         for sub_port, value in sub_ports_new.items():

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -274,8 +274,8 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     # get members from Vlan1000, and move half of them to Vlan2000 in vrf basic cfg
     ports = get_vlan_members('Vlan1000', cfg_facts)
 
-    vlan_ports = {'Vlan1000': ports[:len(ports)/2],
-                  'Vlan2000': ports[len(ports)/2:]}
+    vlan_ports = {'Vlan1000': ports[:int(len(ports)/2)],
+                  'Vlan2000': ports[int(len(ports)/2):]}
 
     extra_vars = {'cfg_t0': cfg_t0,
                   'vlan_ports': vlan_ports}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
test_sub_port_interfaces fail with 'dict_keys' object is not subscriptable
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Summary:
Fixes Python3 migration issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
In Python 3, dict_keys is a view object that provides a dynamic view of the keys in a dictionary.
However, it does not support direct indexing because it is not a list or tuple.

TestSubPortStress in test_sub_port_interfaces.py test failure with following error:
>       sub_ports_new[sub_ports.keys()[0]] = sub_ports[sub_ports.keys()[0]]
E       TypeError: 'dict_keys' object is not subscriptable

#### How did you do it?
convert it into a list. like this list(sub_ports.keys())[0]

#### How did you verify/test it?
run t0 test and pass
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortStress::test_max_numbers_of_sub_ports[port] PASSED

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
