### PR TITLE
skip box tb in setup of test_override_config_table_masic

### DIFF
--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -48,6 +48,8 @@ def setup_env(duthost, tbinfo):
         original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "disable")
     # Backup configDB
     for asic_id in duthost.get_asic_ids():
+        if asic_id is None:
+            continue
         config = "/etc/sonic/config_db{}.json".format(asic_id)
         config_backup = "/etc/sonic/config_db{}.json_before_override".format(asic_id)
         backup_config(duthost, config, config_backup)
@@ -66,6 +68,8 @@ def setup_env(duthost, tbinfo):
         update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", original_pfcwd_value)
     # Restore configDB after test.
     for asic_id in duthost.get_asic_ids():
+        if asic_id is None:
+            continue
         config = "/etc/sonic/config_db{}.json".format(asic_id)
         config_backup = "/etc/sonic/config_db{}.json_before_override".format(asic_id)
         restore_config(duthost, config, config_backup)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

test_override_config_table_masic failed for box testbed
```
{"changed": true, "cmd": "cp /etc/sonic/config_dbNone.json /etc/sonic/config_dbNone.json_before_override",
"delta": "0:00:00.004615",
"end": "2023-10-29 21:47:30.281705",
"failed": true, "msg": "non-zero return code",
"rc": 1, "start": "2023-10-29 21:47:30.277090",
"stderr": "cp: cannot stat '/etc/sonic/config_dbNone.json': No such file or directory",
"stderr_lines": ["cp: cannot stat '/etc/sonic/config_dbNone.json': No such file or directory"], "stdout": "",
"stdout_lines": []}
```

RCA:
need to skip chassis's config backup and restore behavior when asic_id is None

#### How did you do it?

skip chassis's config backup and restore behavior

#### How did you verify/test it?

pass local test

```
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/override_config_table/test_override_config_table_masic.py::test_load_minigraph_with_golden_config.xml -
=========================== short test summary info ============================
SKIPPED [1] /var/src/sonic-mgmt-int/tests/override_config_table/test_override_config_table_masic.py:235: Skip override-config-table multi-asic testing on single-asic platforms,                    test provided golden config format is not compatible with single-asics
========================= 1 skipped in 488.74 seconds ==========================
xuchen3@xuchen3-env-c:/var/src/sonic-mgmt-int/tests$ git diff
diff --git a/tests/override_config_table/test_override_config_table_masic.py b/tests/override_config_table/test_override_config_table_masic.py
index 90f30b978..8543a10fc 100644
--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -48,6 +48,8 @@ def setup_env(duthost, tbinfo):
         original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "disable")
     # Backup configDB
     for asic_id in duthost.get_asic_ids():
+        if asic_id is None:
+            continue
         config = "/etc/sonic/config_db{}.json".format(asic_id)
         config_backup = "/etc/sonic/config_db{}.json_before_override".format(asic_id)
         backup_config(duthost, config, config_backup)
@@ -66,6 +68,8 @@ def setup_env(duthost, tbinfo):
         update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", original_pfcwd_value)
     # Restore configDB after test.
     for asic_id in duthost.get_asic_ids():
+        if asic_id is None:
+            continue
         config = "/etc/sonic/config_db{}.json".format(asic_id)
         config_backup = "/etc/sonic/config_db{}.json_before_override".format(asic_id)
         restore_config(duthost, config, config_backup)
xuchen3@xuchen3-env-c:/var/src/sonic-mgmt-int/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
