### PR TITLE
[Mellanox] Fix qos sai issues on dualtor setup

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -8,7 +8,7 @@ MELLANOX_QOS_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__
 class QosParamMellanox(object):
     def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile,
                  ingressLossyProfile, egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
-                 dualTor, src_dut_index, src_asic_index, dst_asic_index, dst_dut_index):
+                 dualTor, src_dut_index, src_asic_index, dst_dut_index, dst_asic_index):
         self.asic_param_dic = {
             'spc1': {
                 'cell_size': 96,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1407,7 +1407,8 @@ class QosSaiBase(QosBase):
             if sub_folder_dir not in sys.path:
                 sys.path.append(sub_folder_dir)
             import qos_param_generator
-            qpm = qos_param_generator.QosParamMellanox(qosConfigs['qos_params']['mellanox'][dutTopo], dutAsic,
+            dut_top = dutTopo if dutTopo in qosConfigs['qos_params']['mellanox'] else "topo-any"
+            qpm = qos_param_generator.QosParamMellanox(qosConfigs['qos_params']['mellanox'][dut_top], dutAsic,
                                                        portSpeedCableLength,
                                                        dutConfig,
                                                        ingressLosslessProfile,

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -27,7 +27,7 @@ import json
 import re
 from tabulate import tabulate
 
-from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts     # noqa F401
+from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts, get_graph_facts    # noqa F401
 from tests.common.fixtures.duthost_utils import dut_qos_maps, \
     separated_dscp_to_tc_map_on_uplink, load_dscp_to_pg_map                                 # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                     # noqa F401
@@ -278,7 +278,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testPfcStormWithSharedHeadroomOccupancy(
         self, xonProfile, ptfhost, fanouthosts, conn_graph_facts,  fanout_graph_facts,              # noqa F811
-        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile
+        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile, localhost
     ):
         """
             Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link.
@@ -356,12 +356,12 @@ class TestQosSai(QosSaiBase):
         fanout_neighbors = conn_graph_facts["device_conn"][duthost.hostname]
         peerdevice = fanout_neighbors[pfcwd_test_port]["peerdevice"]
         peerport = fanout_neighbors[pfcwd_test_port]["peerport"]
+        peerdevice_hwsku = get_graph_facts(duthost, localhost, peerdevice)["device_info"][peerdevice]["HwSku"]
         peer_info = {
             'peerdevice': peerdevice,
-            'hwsku': fanout_graph_facts[peerdevice]["device_info"]["HwSku"],
+            'hwsku': peerdevice_hwsku,
             'pfc_fanout_interface': peerport
         }
-
         queue_index = qosConfig[xonProfile]["pg"]
         frames_number = 100000000
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/10526
1. When calling QosParamMellanox(), the argument dst_dut_index, dst_asic_index oder is not correct. we should exchange them.
2. The Fanout device doesn't match the duthost
3. When topo is not defined in qos_param['mellanox'], we should use the default one


Summary:
Fixes # (issue)https://github.com/sonic-net/sonic-mgmt/issues/10526

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix https://github.com/sonic-net/sonic-mgmt/issues/10526. ,make QoS sai test running on dualtor setup with Mellanox device

#### How did you do it?
1.  Exchange dst_dut_index, dst_asic_index oder in QosParamMellanox
2. Use duthost to get the peer device_info
3. When topo is not defined in qos_param['mellanox'], we should use the default one

#### How did you verify/test it?
Run qos sai tests on dualtor setup with Mellanox device

#### Any platform specific information?
Mellanox device

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
