### PR TITLE
add lossy_queue_voq_2 in qos_param_generator.py

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -261,6 +261,16 @@ class QosParamCisco(object):
                       "packet_size": 64,
                       "cell_size": self.buffer_size}
             self.write_params("lossy_queue_voq_1", params)
+        if self.should_autogen(["lossy_queue_voq_2"]):
+            params = {"dscp": 8,
+                      "ecn": 1,
+                      "pg": 0,
+                      "flow_config": "shared",
+                      "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size,
+                      "pkts_num_margin": 4,
+                      "packet_size": 64,
+                      "cell_size": self.buffer_size}
+            self.write_params("lossy_queue_voq_2", params)
 
     def __define_lossy_queue(self):
         if self.should_autogen(["lossy_queue_1"]):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Q200 Lancer case lossy_queue_voq_2 failed since lack of qos params. Added it in qos_param_generator.py to auto generate the qos params.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
