### PR TITLE
Ignore orchagent stuck error log in route perf test

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -80,7 +80,11 @@ def ignore_expected_loganalyzer_exceptions(
         duthost: DUT fixture
         loganalyzer: Loganalyzer utility fixture
     """
-    ignoreRegex = [".*ERR route_check.py:.*", ".*ERR.* 'routeCheck' status failed.*"]
+    ignoreRegex = [
+        ".*ERR route_check.py:.*",
+        ".*ERR.* 'routeCheck' status failed.*",
+        ".*Process \'orchagent\' is stuck in namespace \'host\'.*"
+        ]
     if loganalyzer:
         # Skip if loganalyzer is disabled
         loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to ignore error log.
```
ERR swss#supervisor-proc-exit-listener: Process 'orchagent' is stuck in namespace 'host' (1.0 minutes).
```
The log is expected during the route performance test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
This PR is to ignore orchagent stuck error log in route perf test.

#### How did you do it?
Add the log pattern into ignore list.

#### How did you verify/test it?
Verified on a SN2700 testbed.
```
collected 2 items                                                                                                                                                                                     

route/test_route_perf.py::test_perf_add_remove_routes[4-str-msn2700-06-None] ^[[C ^HPASSED                                                                                                             [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6-str-msn2700-06-None]  ^HPASSED                                                                                                             [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
