### PR TITLE
[BUGFIX] Fix the wait time for `config_reload` function

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -133,7 +133,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         sonic_host.shell(cmd, executable="/bin/bash")
 
     modular_chassis = sonic_host.get_facts().get("modular_chassis")
-    wait = max(wait, 240) if modular_chassis else wait
+    wait = max(wait, 240) if modular_chassis.lower() == 'true' else wait
 
     if safe_reload:
         # The wait time passed in might not be guaranteed to cover the actual


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the common function `config_reload`, variable `modular_chassis` at Line 135 is a **string** `False` instead of a boolean. It's treated as `True` in the `if` statement at Line 136 and can never hit the `else` section. So the `config_reload` function **always wait at least 4 minutes**.

```
> /home/zhijianli/mgmt/sonic-mgmt-int/tests/common/config_reload.py(136)config_reload()
-> wait = max(wait, 240) if modular_chassis else wait
(Pdb) l
130             cmd = 'config reload -y -l /etc/sonic/running_golden_config.json &>/dev/null'
131             if config_force_option_supported(sonic_host):
132                 cmd = 'config reload -y -f -l /etc/sonic/running_golden_config.json &>/dev/null'
133             sonic_host.shell(cmd, executable="/bin/bash")
134         import pdb; pdb.set_trace()
135         modular_chassis = sonic_host.get_facts().get("modular_chassis")
136  ->     wait = max(wait, 240) if modular_chassis else wait
137
138         if safe_reload:
139             # The wait time passed in might not be guaranteed to cover the actual
140             # time it takes for containers to come back up. Therefore, add 5
(Pdb) modular_chassis
'False'
(Pdb) type(modular_chassis)
<class 'ansible.utils.unsafe_proxy.AnsibleUnsafeText'>
(Pdb)
```

This PR is to fix the bug by comparing the string value.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the wait time for `config_reload` function.

#### How did you do it?
Repair the expression in `if` statement.

#### How did you verify/test it?
Verified by running testcases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
