### PR TITLE
ignore DEBUG systemd message in show_techsupport case module

### DIFF
--- a/tests/show_techsupport/conftest.py
+++ b/tests/show_techsupport/conftest.py
@@ -20,7 +20,8 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
         ".*ERR kernel:.*Fails to read module eeprom.*",
         ".*ERR kernel:.*Fails to access.*module eeprom.*",
         ".*ERR kernel:.*Fails to get module type.*",
-        ".*ERR pmon#xcvrd:.*Failed to read sfp.*"
+        ".*ERR pmon#xcvrd:.*Failed to read sfp.*",
+        ".*DEBUG systemd.*"
     ]
     for dut in duthosts:
         if loganalyzer and loganalyzer[dut.hostname]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
25424807

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The case failed due to the below error message.
E               Match Messages:
E               Oct 18 21:49:42.847851 str-a7060cx-acs-1 DEBUG systemd[1]: Got message type=method_call sender=n/a destination=org.freedesktop.systemd1 path=/org/freedesktop/systemd1/unit/dev_2ddisk_2dby_5cx2dlabel_2deos_5fcrash_2edevice interface=org.freedesktop.DBus.Properties member=GetAll cookie=187 reply_cookie=0 signature=s error-name=n/a error-message=n/a

#### How did you do it?
The failure message should be the debug level message, should be a false alarm.
Ignore it

#### How did you verify/test it?
case pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
