### PR TITLE
[202012][BUGFIX] Fix the wait time for config_reload function

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -88,7 +88,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         duthost.shell(cmd, executable="/bin/bash")
 
     modular_chassis = duthost.get_facts().get("modular_chassis")
-    wait = max(wait, 240) if modular_chassis else wait
+    wait = max(wait, 240) if modular_chassis.lower() == 'true' else wait
 
     if safe_reload:
         # The wait time passed in might not be guaranteed to cover the actual


### PR DESCRIPTION
Backport #10539 

What is the motivation for this PR?
Fix the wait time for config_reload function.

How did you do it?
Repair the expression in if statement.

How did you verify/test it?
Verified by running testcases.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
