### PR TITLE
restart docker service after disable/enable IPv6

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1669,6 +1669,9 @@ class QosSaiBase(QosBase):
 
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
+            duthost.shell("systemctl restart docker.service")
+            pytest_assert(wait_until(420, 20, 0, duthost.critical_services_fully_started),
+                          "All critical services should be fully started!")
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(


### PR DESCRIPTION
### Description of PR
IPv6 address is removed from docker0 when disabling IPv6 and this causes test_snmp_loopback testcase to fail:

ARISTA06T1#bash snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0 (FC00:11::1 is the ipv6 address of the LC's loopback0)
Timeout: No Response from FC00:11::1.
% 'snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0' returned error code: 1
	bash snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0 AssertionError: Sysdescr not found in SNMP result from IP FC00:11::1/128)

To restore the docker0's IPv6 address either a LC reboot or a restart of docker services is required.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
To restore the docker0's IPv6 address which is removed when IPv6 is disabled.

#### How did you do it?
1. Disable IPv6 on the dut (sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1).  This will cause IPv6 address of docker0 to be removed.
2. Enable IPv6 (sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0).   Still no ipv6 address on docker0 
3. Restart the docker service (systemctl restart docker.service)
4. Ensure all critical services are fully started

#### How did you verify/test it?
Tested qos and snmp suites against a multi Asics line card on a T2 chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
