### PR TITLE
Fix tunnel dscp to pg mapping test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1050,8 +1050,8 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     standby_tor_mac=standby_tor_mac,
                     active_tor_ip=active_tor_ip,
                     standby_tor_ip=standby_tor_ip,
-                    inner_dscp=dscp,
-                    outer_dscp=0,
+                    inner_dscp=inner_dscp,
+                    outer_dscp=outer_dscp,
                     dst_ip=dst_port_ip,
                     packet_size=packet_size
                 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The issue was introduced by PR https://github.com/sonic-net/sonic-mgmt/pull/8149 .
The wrong variables are used for building testing packet, that results in test failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix code bug in ```TunnelDscpToPgMapping```. The test is consistently failing because incorrect DSCP values are used for creating packets.

#### How did you do it?
Fix the code issue.

#### How did you verify/test it?
The change is verified on a dualtor testbed.
```
collected 1 item                                                                                                                                                                                      

qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_pg_mapping  ^H ^HPASSED                                                                                                                       [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
