### PR TITLE
Enhance restore_bgp_suppress_fib to check status first

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -101,13 +101,26 @@ def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganaly
 @pytest.fixture(scope="function")
 def restore_bgp_suppress_fib(duthost):
     """
+    Record the configuration before test only restore bgp suppress fib
+    if it is not enabled before test
+    """
+    suppress_fib = False
+    rets = duthost.shell('show suppress-fib-pending')
+    if rets['rc'] != 0:
+        logger.info("Failed to get suppress-fib-pending configuration")
+    else:
+        logger.info("Get suppress-fib-pending configuration: {}".format(rets['stdout']))
+        if rets['stdout'] == 'Enabled':
+            suppress_fib = True
+
+    """
     Restore bgp suppress fib pending function
     """
     yield
-
-    config_bgp_suppress_fib(duthost, False)
-    logger.info("Save configuration")
-    duthost.shell('sudo config save -y')
+    if not suppress_fib:
+        config_bgp_suppress_fib(duthost, False)
+        logger.info("Save configuration")
+        duthost.shell('sudo config save -y')
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
ADO: 25564723

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
In current test, it will set the bgp suppress to disabled no matter what's the value in the config_db. If it is enabled before the test, it should honor it,  and don't change it after the test. 
In this PR, will add a check logic to restore only it is needed.

#### How did you do it?
To read back the config db before test, then do the restore when it is needed.

#### How did you verify/test it?
1. enable the fib suppress.
2. run bgp suppress fib test. 
3. check the config, if it is same as before. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
