### PR TITLE
[sanity-check][dualtor] Retrieve the mux status in each retry

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -527,6 +527,17 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
         err_msg_from_mux_status.append("")
         return True
 
+    def _check_mux_status_helper():
+        run_result.clear()
+        duts_parsed_mux_status.clear()
+        err_msg_from_mux_status.clear()
+        dut_wrong_mux_status_ports.clear()
+        run_result.update(**parallel_run(_verify_show_mux_status, (), kwargs, duthosts, timeout=600, init_result=init_result))
+        duts_parsed_mux_status[dut_upper_tor.hostname] = run_result[dut_upper_tor.hostname]["parsed_mux_status"]
+        duts_parsed_mux_status[dut_lower_tor.hostname] = run_result[dut_lower_tor.hostname]["parsed_mux_status"]
+        return (all(result['failed'] is False for result in run_result.values()) and
+                _verify_inconsistent_mux_status(duts_parsed_mux_status, dut_upper_tor, dut_lower_tor))
+
     dut_upper_tor = duthosts[0]
     dut_lower_tor = duthosts[1]
 
@@ -563,21 +574,21 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
     dut_wrong_mux_status_ports = []
 
     init_result = {"failed": False, "check_item": "check_mux_simulator"}
-    run_result = parallel_run(_verify_show_mux_status, (), kwargs, duthosts, timeout=600, init_result=init_result)
+    run_result = {}
+
+    check_success = _check_mux_status_helper()
 
     for result in run_result.values():
         if result['failed'] is True:
             err_msg = result["error_msg"][-1]
             return False, err_msg, {}
 
-    duts_parsed_mux_status[dut_upper_tor.hostname] = run_result[dut_upper_tor.hostname]["parsed_mux_status"]
-    duts_parsed_mux_status[dut_lower_tor.hostname] = run_result[dut_lower_tor.hostname]["parsed_mux_status"]
-
-    if not _verify_inconsistent_mux_status(duts_parsed_mux_status, dut_upper_tor, dut_lower_tor):
-        if len(dut_wrong_mux_status_ports) != 0:
+    if not check_success:
+        if len(dut_wrong_mux_status_ports) == 0:
+            # NOTE: Let's probe here to see if those inconsistent mux ports could be
+            # restored before using the recovery method.
             _probe_mux_ports(duthosts, dut_wrong_mux_status_ports)
-        if not wait_until(30, 5, 0, _verify_inconsistent_mux_status,
-                          duts_parsed_mux_status, dut_upper_tor, dut_lower_tor):
+        if not wait_until(60, 10, 0, _check_mux_status_helper):
             if err_msg_from_mux_status:
                 err_msg = err_msg_from_mux_status[-1]
             else:

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -532,7 +532,9 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
         duts_parsed_mux_status.clear()
         err_msg_from_mux_status.clear()
         dut_wrong_mux_status_ports.clear()
-        run_result.update(**parallel_run(_verify_show_mux_status, (), kwargs, duthosts, timeout=600, init_result=init_result))
+        run_result.update(
+            **parallel_run(_verify_show_mux_status, (), kwargs, duthosts, timeout=600, init_result=init_result)
+        )
         duts_parsed_mux_status[dut_upper_tor.hostname] = run_result[dut_upper_tor.hostname]["parsed_mux_status"]
         duts_parsed_mux_status[dut_lower_tor.hostname] = run_result[dut_lower_tor.hostname]["parsed_mux_status"]
         return (all(result['failed'] is False for result in run_result.values()) and


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
There is an issue that the mux status is retrieved only once, the retry
of mux check `_verify_inconsistent_mux_status` is using the result
instead of retrieving the mux status.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. retrieve the mux status in each retry.
2. wait longer for 60s instead of 30s.

#### How did you verify/test it?
Run dualtor-io tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
