### PR TITLE
[override_config] Remove skip for override config tests in tests_mark_conditions.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -711,21 +711,6 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
-#####     override_config_table   #####
-#######################################
-override_config_table/test_override_config_table.py:
-  skip:
-    reason: "Skip override-config-table testing on multi-asic platforms, test provided golden config format is not compatible with multi-asics"
-    conditions:
-      - is_multi_asic == True
-
-override_config_table/test_override_config_table_masic.py:
-  skip:
-    reason: "Skip override-config-table-masic testing on single-asic platforms, test provided golden config format is not compatible with single-asics"
-    conditions:
-      - is_multi_asic == False
-
-#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Original test_override_config_table_masic.py is added on multi-asic platform in https://github.com/sonic-net/sonic-mgmt/pull/9923. 
But fixture `setup` is still getting called on single-asic and had issue with config db backup for single-asic, because of config_db naming.

https://github.com/sonic-net/sonic-mgmt/pull/10363 add skip for whole test if:
```
conditions:
      - is_multi_asic == True
```
This condition is always true for chassis. Because if any sup/card is multi-asic, it returns true.

https://github.com/sonic-net/sonic-mgmt/pull/10522 later handles backup of config db in test_override_config_table_masic.py  on when asic exists, in that case backup of single-asic won't happen. 

This PR is to revert the skips added in https://github.com/sonic-net/sonic-mgmt/pull/10363. With the presence of https://github.com/sonic-net/sonic-mgmt/pull/10522 the skip is not needed.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
