### PR TITLE
[tests/stress]: Increase sleep time before checking for crm resources

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -61,7 +61,7 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
         announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 120)
 
     ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
     ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 Some platforms take a little more time to program routes in HW during this
 stress test, so CRM checks may fail. The change here is to give it more time
 before checking for CRM counters. With this change, the test seems to pass
 consistently on dualtor testbeds with internal image.

Summary:
Fixes # 24468219

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Some platforms might need more time for route programming as done in this stress test.
#### How did you do it?
By increasing the sleep time before checking for crm resources
#### How did you verify/test it?
By running this sonic-mgmt tests multiple times on dualtor testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
