### PR TITLE
Fix key Error in get_queue_scheduler_name

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -103,6 +103,9 @@ class ThriftInterface(BaseTest):
                     continue
                 interface_front_pair = line.split("@")
                 interface_to_front_mapping['src'][interface_front_pair[0]] = interface_front_pair[1].strip()
+                # src = dst on single ASIC device.
+                # Copy the src to dst cause some function will read this key
+                interface_to_front_mapping['dst'] = interface_to_front_mapping['src']
             f.close()
         else:
             exit("No ptf interface<-> switch front port mapping, please specify as parameter or in external file")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix KeyError in `get_queue_scheduler_name`
```
======================================================================
ERROR: sai_qos_tests.PCBBPFCTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 4779, in runTest
    self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
  File \"saitests/py3/sai_base_test.py\", line 230, in sai_thrift_port_tx_disable
    self.disable_mellanox_egress_data_plane(port_list)
  File \"saitests/py3/sai_base_test.py\", line 235, in disable_mellanox_egress_data_plane
    self.original_dut_port_queue_scheduler_map = self.get_queue_scheduler_name(ptf_port_list)
  File \"saitests/py3/sai_base_test.py\", line 253, in get_queue_scheduler_name
    dut_port = interface_to_front_mapping['dst'][str(ptf_port)]
KeyError: 'dst'
```

The error is fixed by copying interface_to_front_mapping['src'] to interface_to_front_mapping['dst'] as the src and dst are the same on single ASIC device.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix KeyError in `get_queue_scheduler_name`

#### How did you do it?
The error is fixed by copying interface_to_front_mapping['src'] to interface_to_front_mapping['dst'] .

#### How did you verify/test it?
Verified on a Mellanox dualtor testbed.
```
collected 4 items                                                                                                                                                                                                             

qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1] PASSED                                                                                                                                                    [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2]  ^HPASSED                                                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED                                                                                                                                                    [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_4] PASSED                                                                                                                                                    [100%]
```
#### Any platform specific information?
Mellanox specific change.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
