### PR TITLE
Fix `Unknown header type` in drop counter test

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -224,14 +224,17 @@ def pkt_fields(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     return test_pkt_data
 
 
-def expected_packet_mask(pkt):
+def expected_packet_mask(pkt, ip_ver):
     """ Return mask for sniffing packet """
     exp_pkt = pkt.copy()
     exp_pkt = mask.Mask(exp_pkt)
     exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
     exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
-    exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
-    exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
+    if ip_ver == "ipv4" and pkt.haslayer(packet.IP):
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
+        exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
+    elif ip_ver == "ipv6" and pkt.haslayer(packet.IPv6):
+        exp_pkt.set_do_not_care_scapy(packet.IPv6, 'hlim')
     return exp_pkt
 
 
@@ -760,7 +763,7 @@ def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_
                    ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, ip_ver=ip_addr)
 
 
 def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
@@ -838,7 +841,8 @@ def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, a
     if setup.get("platform_asic") == "broadcom-dnx" and addr_direction == "src":
         pytest.skip("Src IP zero packets are not dropped on Broadcom DNX platform currently")
 
-    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports,
+            ip_ver=addr_type)
 
 
 def test_dst_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -253,7 +253,7 @@ def check_if_skip():
 @pytest.fixture(scope='module')
 def do_test(duthosts):
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa F811
-                         comparable_pkt=None, skip_counter_check=False, drop_information=None):
+                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
         @param discard_group: Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -262,6 +262,7 @@ def do_test(duthosts):
         @param duthost: fixture
         @param dut_iface: DUT interface name expected to receive packets from PTF
         @param sniff_ports: DUT ports to check that packets were not egressed from
+        @param ip_ver: A string, ipv4 or ipv6
         """
         check_if_skip()
         asic_index = ports_info["asic_index"]
@@ -270,7 +271,7 @@ def do_test(duthosts):
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
-            exp_pkt = expected_packet_mask(pkt)
+            exp_pkt = expected_packet_mask(pkt, ip_ver=ip_ver)
             testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=sniff_ports)
 
     return do_counters_test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix error in `test_drop_counter`.
```
drop_packets/drop_packets.py:763: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
drop_packets/test_drop_counters.py:273: in do_counters_test
    exp_pkt = expected_packet_mask(pkt)
drop_packets/drop_packets.py:233: in expected_packet_mask
    exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
/var/AzDevOps/env-python3/lib/python3.8/site-packages/ptf/mask.py:74: in set_do_not_care_scapy
    self.set_do_not_care_packet(hdr_type, field_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ptf.mask.Mask object at 0x7fd6b9fd5670>, hdr_type = <class 'scapy.layers.inet.IP'>, field_name = 'ttl'

    def set_do_not_care_packet(self, hdr_type, field_name):
        if hdr_type not in self.exp_pkt:
            self.valid = False
>           raise MaskException("Unknown header type")
E           ptf.mask.MaskException: Unknown header type
```

For IPv6 test, the `ttl` and `chksum` fields are not available. 
```
    exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
    exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix `Unknown header type` in drop counter test.

#### How did you do it?
Check IPv4 or IPv6 in function `expected_packet_mask`

#### How did you verify/test it?
The change is verified on Mellanox T0 testbed.
```
collected 102 items                                                                                                                                                                                                           

drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                                 [  0%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                                         [  1%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                            [  2%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                                  [  3%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                                          [  4%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                             [  5%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Currently not supported on Mellanox platform)                         [  6%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Currently not supported on Mellanox platform)                                 [  7%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                      [  8%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                            [  9%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                    [ 10%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                         [ 11%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                            [ 12%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                    [ 13%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                         [ 14%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                      [ 15%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                              [ 16%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                                   [ 17%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-str-msn2700-22-ipv4] <- drop_packets/drop_packets.py PASSED                                                                      [ 18%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-str-msn2700-22-ipv6] <- drop_packets/drop_packets.py PASSED                                                                      [ 19%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-str-msn2700-22-ipv4] <- drop_packets/drop_packets.py PASSED                                                                              [ 20%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-str-msn2700-22-ipv6] <- drop_packets/drop_packets.py PASSED                                                                              [ 21%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-str-msn2700-22-ipv4] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                   [ 22%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-str-msn2700-22-ipv6] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                   [ 23%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                  [ 24%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py  ^HPASSED                                                                                          [ 25%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                               [ 26%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str-msn2700-22-ipv4-src] <- drop_packets/drop_packets.py PASSED                                                                           [ 27%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str-msn2700-22-ipv6-src] <- drop_packets/drop_packets.py PASSED                                                                           [ 28%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str-msn2700-22-ipv4-dst] <- drop_packets/drop_packets.py PASSED                                                                           [ 29%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str-msn2700-22-ipv6-dst] <- drop_packets/drop_packets.py PASSED                                                                           [ 30%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str-msn2700-22-ipv4-src] <- drop_packets/drop_packets.py PASSED                                                                                   [ 31%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str-msn2700-22-ipv6-src] <- drop_packets/drop_packets.py PASSED                                                                                   [ 32%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str-msn2700-22-ipv4-dst] <- drop_packets/drop_packets.py PASSED                                                                                   [ 33%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str-msn2700-22-ipv6-dst] <- drop_packets/drop_packets.py PASSED                                                                                   [ 34%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str-msn2700-22-ipv4-src] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                        [ 35%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str-msn2700-22-ipv6-src] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                        [ 36%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str-msn2700-22-ipv4-dst] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                        [ 37%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str-msn2700-22-ipv6-dst] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                        [ 38%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                  [ 39%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                          [ 40%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                               [ 41%]
drop_packets/test_drop_counters.py::test_loopback_filter[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (SONiC can't enable loop-back filter feature)                                     [ 42%]
drop_packets/test_drop_counters.py::test_loopback_filter[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (SONiC can't enable loop-back filter feature)                                             [ 43%]
drop_packets/test_drop_counters.py::test_loopback_filter[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (SONiC can't enable loop-back filter feature)                                              [ 44%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Not supported on Mellanox devices)                                       [ 45%] ^H
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (Not supported on Mellanox devices)                                               [ 46%]

drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                         [ 47%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str-msn2700-22-version-1] <- drop_packets/drop_packets.py PASSED                                                                         [ 48%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str-msn2700-22-chksum-10] <- drop_packets/drop_packets.py PASSED                                                                         [ 49%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str-msn2700-22-ihl-1] <- drop_packets/drop_packets.py PASSED                                                                             [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str-msn2700-22-version-1] <- drop_packets/drop_packets.py PASSED                                                                                 [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str-msn2700-22-chksum-10] <- drop_packets/drop_packets.py PASSED                                                                                 [ 51%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str-msn2700-22-ihl-1] <- drop_packets/drop_packets.py PASSED                                                                                     [ 52%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str-msn2700-22-version-1] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                      [ 53%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str-msn2700-22-chksum-10] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                      [ 54%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str-msn2700-22-ihl-1] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                          [ 55%]
drop_packets/test_drop_counters.py::test_absent_ip_header[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                   [ 56%]
drop_packets/test_drop_counters.py::test_absent_ip_header[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                           [ 57%]
drop_packets/test_drop_counters.py::test_absent_ip_header[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                                [ 58%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-str-msn2700-22-01:00:5e:00:01:02] <- drop_packets/drop_packets.py PASSED                                                     [ 59%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-str-msn2700-22-ff:ff:ff:ff:ff:ff] <- drop_packets/drop_packets.py PASSED                                                     [ 60%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-str-msn2700-22-01:00:5e:00:01:02] <- drop_packets/drop_packets.py SKIPPED (Test case is not supported on VLAN interface)             [ 61%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-str-msn2700-22-ff:ff:ff:ff:ff:ff] <- drop_packets/drop_packets.py SKIPPED (Test case is not supported on VLAN interface)             [ 62%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-str-msn2700-22-01:00:5e:00:01:02] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                  [ 63%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-str-msn2700-22-ff:ff:ff:ff:ff:ff] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                  [ 64%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v1-general_query] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)              [ 65%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v3-general_query] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)              [ 66%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v1-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)          [ 67%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v2-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)          [ 68%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v3-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)          [ 69%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str-msn2700-22-v2-leave_group] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                [ 70%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v1-general_query] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                      [ 71%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v3-general_query] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                      [ 72%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v1-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                  [ 73%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v2-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                  [ 74%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v3-membership_report] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                  [ 75%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str-msn2700-22-v2-leave_group] <- drop_packets/drop_packets.py SKIPPED (Test case requires explicit fanout support)                        [ 76%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v1-general_query] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                         [ 77%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v3-general_query] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                         [ 78%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v1-membership_report] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                     [ 79%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v2-membership_report] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                     [ 80%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v3-membership_report] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                     [ 81%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str-msn2700-22-v2-leave_group] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                           [ 82%]
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py  ^HPASSED                                                                                           [ 83%]
drop_packets/test_drop_counters.py::test_acl_drop[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (RX DUT port absent in 'DATAACL' table)                                                          [ 84%]
drop_packets/test_drop_counters.py::test_acl_drop[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                                        [ 85%]
drop_packets/test_drop_counters.py::test_acl_egress_drop[port_channel_members-str-msn2700-22] <- drop_packets/drop_packets.py PASSED                                                                                    [ 86%]
drop_packets/test_drop_counters.py::test_acl_egress_drop[vlan_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (RX DUT port absent in 'DATAACL' table)                                                   [ 87%] ^H
drop_packets/test_drop_counters.py::test_acl_egress_drop[rif_members-str-msn2700-22] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                                                                 [ 88%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[port_channel_members-str-msn2700-22] SKIPPED (Test case requires explicit fanout support)                                                                   [ 89%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[vlan_members-str-msn2700-22] SKIPPED (Test case requires explicit fanout support)                                                                           [ 90%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[rif_members-str-msn2700-22] SKIPPED (No rif_members available)                                                                                              [ 91%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[port_channel_members-str-msn2700-22] SKIPPED (RIF interface is absent)                                                                             [ 92%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[vlan_members-str-msn2700-22] SKIPPED (RIF interface is absent)                                                                                     [ 93%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[rif_members-str-msn2700-22] SKIPPED (No rif_members available)                                                                                     [ 94%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[port_channel_members-str-msn2700-22] PASSED                                                                                                                  [ 95%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[vlan_members-str-msn2700-22] PASSED                                                                                                                          [ 96%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[rif_members-str-msn2700-22] SKIPPED (No rif_members available)                                                          
```
#### Any platform specific information?
Mellanox specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
