### PR TITLE
Allow 150 seconds of LACP downtime for warm reboot with vSONiC neighbors

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1387,7 +1387,7 @@ class ReloadTest(BaseTest):
         for neigh in self.ssh_targets:
             flap_cnt = None
             if self.test_params['neighbor_type'] == "sonic":
-                flap_cnt = self.cli_info[neigh][1]
+                flap_cnt = self.cli_info[neigh]['po'][1]
             else:
                 self.test_params['port_channel_intf_idx'] = [x['ptf_ports'][0] for x in self.vm_dut_map.values()
                                                              if x['mgmt_addr'] == neigh]
@@ -1624,6 +1624,9 @@ class ReloadTest(BaseTest):
 
         # in the list of all LACPDUs received by T1, find the largest time gap between two consecutive LACPDUs
         max_lacp_session_wait = None
+        max_allowed_lacp_session_wait = 90
+        if self.test_params['neighbor_type'] == "sonic":
+            max_allowed_lacp_session_wait = 150
         if lacp_pdu_all_times and len(lacp_pdu_all_times) > 1:
             lacp_pdu_all_times.sort()
             max_lacp_session_wait = 0
@@ -1635,7 +1638,7 @@ class ReloadTest(BaseTest):
                 prev_time = new_time
 
         if 'warm-reboot' in self.reboot_type:
-            if max_lacp_session_wait and max_lacp_session_wait >= 90 and not self.kvm_test:
+            if max_lacp_session_wait and max_lacp_session_wait >= max_allowed_lacp_session_wait and not self.kvm_test:
                 self.fails['dut'].add("LACP session likely terminated by neighbor ({})".format(ip) +
                                       " post-reboot lacpdu came after {}s of lacpdu pre-boot"
                                       .format(max_lacp_session_wait))

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1387,7 +1387,7 @@ class ReloadTest(BaseTest):
         for neigh in self.ssh_targets:
             flap_cnt = None
             if self.test_params['neighbor_type'] == "sonic":
-                flap_cnt = self.cli_info[neigh]['po'][1]
+                flap_cnt = self.cli_info[neigh][1]
             else:
                 self.test_params['port_channel_intf_idx'] = [x['ptf_ports'][0] for x in self.vm_dut_map.values()
                                                              if x['mgmt_addr'] == neigh]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

When doing a warm reboot with SONiC neighbors, assuming all images involved support the teamd retry count feature, up to 150 seconds of LACP downtime is allowed. Therefore, bump up the limit to 150 seconds before logging a failure.

#### How did you do it?

#### How did you verify/test it?

Verified in manual runs with this change that >90 of LACP downtime didn't cause a failure.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
