### PR TITLE
vSONiC: Specify minimum number of links for portchannels

### DIFF
--- a/ansible/roles/sonic/templates/configdb.j2
+++ b/ansible/roles/sonic/templates/configdb.j2
@@ -1,5 +1,20 @@
 {% set host = configuration[hostname] %}
 {
+{% set lag_member_count = dict() %}
+    "PORTCHANNEL_MEMBER": {
+{% set separator = joiner(",") %}
+{% for name, iface in host['interfaces'].items() %}
+{% if iface['lacp'] is defined %}
+{{ separator() }}
+{% if iface['lacp'] in lag_member_count %}
+{% set _dummy = lag_member_count.update({ iface['lacp']: lag_member_count[iface['lacp']] + 1 }) %}
+{% else %}
+{% set _dummy = lag_member_count.update({ iface['lacp']: 1 }) %}
+{% endif %}
+        "PortChannel{{ iface['lacp'] }}|{{ name }}": {}
+{% endif %}
+{% endfor %}
+    },
     "PORTCHANNEL": {
 {% set separator = joiner(",") %}
 {% for name, iface in host['interfaces'].items() %}
@@ -7,6 +22,7 @@
 {{ separator() }}
         "{{ name | replace("-", "") }}": {
             "admin_status": "up",
+            "min_links": {{ (lag_member_count[name | replace("Port-Channel", "") | int] * 0.75) | round(0, 'ceil') | int }},
             "mtu": "9100"
         }
 {% endif %}
@@ -108,9 +124,8 @@
         }
 {% endfor %}
     },
-{% set separator = joiner(",") %}
-{% set first_in_loop = true %}
     "PORTCHANNEL_INTERFACE": {
+{% set separator = joiner(",") %}
 {% for name, iface in host['interfaces'].items() %}
 {% if name.startswith('Port-Channel') %}
 {{ separator() }}
@@ -126,18 +141,8 @@
 {% endif %}
 {% endfor %}
     },
-{% set separator = joiner(",") %}
-    "PORTCHANNEL_MEMBER": {
-{% for name, iface in host['interfaces'].items() %}
-{% if iface['lacp'] is defined %}
-{{ separator() }}
-{% set index = name | replace("Ethernet", "") | int - 1 %}
-        "PortChannel{{ iface['lacp'] }}|{{ name }}": {}
-{% endif %}
-{% endfor %}
-    },
-{% set separator = joiner(",") %}
     "LOOPBACK_INTERFACE": {
+{% set separator = joiner(",") %}
 {% for name, iface in host['interfaces'].items() %}
 {% if name.startswith('Loopback') %}
 {{ separator() }}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

When bringing up a topology with SONiC neighbors, specify the minimum number of links that must be up for a portchannel to be up. This matches the behavior on cEOS neighbors, specifically on topo configurations with portchannels having 2 or more member links.

#### How did you do it?

#### How did you verify/test it?

Tested on t0-64-32 topo, where port channel links have 2 members.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
