### PR TITLE
Ignore NTP exiting "error" message

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -189,3 +189,6 @@ r, ".* ERROR: Failed to parse lldp age.*"
 
 # NTPsec always expects the statistics directory to be available, but for now, we don't need NTP stats to be logged
 r, ".* ERR ntpd.*: statistics directory .* does not exist or is unwriteable, error No such file or directory"
+
+# NTPsec logs a message with ERR in it at NOTICE level when exiting gracefully, ignore it
+r, ".* NOTICE ntpd.*: ERR: ntpd exiting on signal 15.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes sonic-net/sonic-buildimage#17034

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

When exiting, ntpd from NTPsec logs a message containing ERR at NOTICE level saying that it is exiting because of a signal. This causes loganalyzer to flag the message because ERR is present. This log message happens during graceful termination (such as when systemd is restarting the service). Therefore, ignore it.

This is applicable only to a Bookworm base image.

#### How did you do it?

Add the log message regex (but looking only for signal 15) to the loganalyzer ignore list. If other exits with other signals pop up on loganalyzer, they can be handled or added as needed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
