### PR TITLE
Always define shared res size test_qos_sai.py test params

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -60,9 +60,12 @@ class QosParamCisco(object):
         Each function takes common parameters and outputs to the relevant section of the
         self.qos_params structure.
         '''
+        # Always define shared reservation size test params, parameter generation is
+        # required on all platforms.
+        self.__define_shared_reservation_size()
+        # Skip all other tests if basic autogen variables aren't defined.
         if not self.supports_autogen:
             return self.qos_params
-        self.__define_shared_reservation_size()
         self.__define_pfc_xoff_limit()
         self.__define_pfc_xon_limit()
         self.__define_pg_shared_watermark()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes T2 issue. 
Shared res size parameters always need to be defined, they don't need more advanced asic-specific parameters like other tests do. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Specific to Cisco-8000 QOS yaml parameter generator.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
