### PR TITLE
Add docker0's IPv6 address since it was removed when disabling IPv6

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1666,7 +1666,8 @@ class QosSaiBase(QosBase):
     def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host): # noqa F811
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             docker0_ipv6_addr = \
-            duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")["stdout_lines"][0]
+                duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")[
+                    "stdout_lines"][0]
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
         yield
@@ -1675,7 +1676,7 @@ class QosSaiBase(QosBase):
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
             logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
             duthost.shell("ip -6 addr add {} dev docker0".format(docker0_ipv6_addr))
-            config_reload(duthost, config_source='config_db')
+            config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -24,6 +24,7 @@ from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.common.system_utils import docker  # noqa F401
 from tests.common.errors import RunAnsibleModuleFail
+from tests.common import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -1670,6 +1671,9 @@ class QosSaiBase(QosBase):
 
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
+            logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
+            duthost.shell("ip -6 addr add fd00::1/80 dev docker0")
+            config_reload(duthost, config_source='config_db')
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1665,6 +1665,8 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class', autouse=True)
     def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host): # noqa F811
         for duthost in get_src_dst_asic_and_duts['all_duts']:
+            docker0_ipv6_addr = \
+            duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")["stdout_lines"][0]
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
         yield
@@ -1672,7 +1674,7 @@ class QosSaiBase(QosBase):
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
             logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
-            duthost.shell("ip -6 addr add fd00::1/80 dev docker0")
+            duthost.shell("ip -6 addr add {} dev docker0".format(docker0_ipv6_addr))
             config_reload(duthost, config_source='config_db')
 
     @pytest.fixture(scope='class', autouse=True)


### PR DESCRIPTION
### Description of PR
IPv6 address is removed from docker0 when disabling IPv6 and this causes test_snmp_loopback testcase to fail

ARISTA06T1#bash snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0 (FC00:11::1 is the ipv6 address of the LC's loopback0)
Timeout: No Response from FC00:11::1.
% 'snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0' returned error code: 1
bash snmpget -v2c -c public FC00:11::1 .1.3.6.1.2.1.1.1.0 AssertionError: Sysdescr not found in SNMP result from IP FC00:11::1/128)

After enabling IPv6, an IPv6 address should be added to docker0 and a config reload is required.  

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
To restore the docker0's IPv6 address which is removed when IPv6 is disabled

#### How did you do it?
Add IPv6 address do docker0.
Do a config reload

#### How did you verify/test it?
Tested qos and snmp suites against a multi Asics line card on a T2 chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
