### PR TITLE
[dualtor] Add `mux` to the critical service list to enable sanity check

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -75,10 +75,12 @@ class MultiAsicSonicHost(object):
 
         config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
         # NOTE: Add mux to critical services for dualtor
-        if ("DEVICE_METADATA" in config_facts and
+        if (
+            "DEVICE_METADATA" in config_facts and
             "localhost" in config_facts["DEVICE_METADATA"] and
             "subtype" in config_facts["DEVICE_METADATA"]["localhost"] and
-            config_facts["DEVICE_METADATA"]["localhost"]["subtype"] == "DualToR"):
+                config_facts["DEVICE_METADATA"]["localhost"]["subtype"] == "DualToR"
+        ):
             service_list.append("mux")
 
         if self.get_facts().get("modular_chassis"):

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -72,9 +72,17 @@ class MultiAsicSonicHost(object):
                 a_asic_instance = self.asic_instance_from_namespace(namespace=a_asic_name)
                 active_asics.append(a_asic_instance)
         service_list += self._DEFAULT_SERVICES
+
+        config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
+        # NOTE: Add mux to critical services for dualtor
+        if ("DEVICE_METADATA" in config_facts and
+            "localhost" in config_facts["DEVICE_METADATA"] and
+            "subtype" in config_facts["DEVICE_METADATA"]["localhost"] and
+            config_facts["DEVICE_METADATA"]["localhost"]["subtype"] == "DualToR"):
+            service_list.append("mux")
+
         if self.get_facts().get("modular_chassis"):
             # Update the asic service based on feature table state and asic flag
-            config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
             for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
                 if service == 'teamd' and config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu':
                     logger.info("Removing teamd from default services for switch_type DPU")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
`mux` is not verified in `sanity_check` critical process check.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add `mux` to the critical service list if it is a dualtor device.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
