### PR TITLE
[202205] Use golden config to recover testbed when sanity check failed

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -160,7 +160,7 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
         method = constants.RECOVER_METHODS[outstanding_action]
         wait_time = method['recover_wait']
         if method["reload"]:
-            config_reload(dut, safe_reload=True, check_intf_up_ports=True)
+            config_reload(dut, config_source='running_golden_config', safe_reload=True, check_intf_up_ports=True)
         elif method["reboot"]:
             reboot_dut(dut, localhost, method["cmd"])
         else:
@@ -174,7 +174,7 @@ def recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, recove
     if method["adaptive"]:
         adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, wait_time)
     elif method["reload"]:
-        config_reload(dut, safe_reload=True, check_intf_up_ports=True)
+        config_reload(dut, config_source='running_golden_config', safe_reload=True, check_intf_up_ports=True)
     elif method["reboot"]:
         reboot_dut(dut, localhost, method["cmd"])
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Currently, sanity check recover would use config db to do config reload, but there could be a risk if config db was changed and saved by previous test
PR in master: https://github.com/sonic-net/sonic-mgmt/pull/10608
#### How did you do it?
Use golden config to do config reload
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
