### PR TITLE
[202205] Add missing imports exposed after ansible upgrade

### DIFF
--- a/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
+++ b/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
@@ -1,5 +1,6 @@
 # Packet Test Framework imports
 import logging
+import os
 
 import ptf
 import ptf.testutils as testutils

--- a/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
+++ b/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
@@ -1,5 +1,6 @@
 # Packet Test Framework imports
 import logging
+import os
 
 import ptf
 import ptf.testutils as testutils
@@ -155,7 +156,7 @@ class RadvUnSolicitedRATest(DataplaneBaseTest):
 
     def runTest(self):
         self.verify_periodic_router_advertisement_with_m_flag()
-        
+
 
 """
 @summary: This test validates the solicited router advertisement sent on the VLAN network of the ToR
@@ -232,7 +233,7 @@ class RadvSolicitedRATest(DataplaneBaseTest):
         logging.info("Received solicited RA from:%s on PTF eth%d having M=1",
                      self.downlink_vlan_ip6,
                      self.ptf_port_index)
-        
+
     def runTest(self):
         count = 5
         while count > 0:

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import ipaddr
+import ipaddress
 import pytest
 
 import ptf.testutils as testutils

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -490,7 +490,7 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost, pkt_fields
         src_mac = "00:00:00:00:00:11"
         # Prepare openflow rule
         fanouthost.prepare_drop_counter_config(
-            fanout_graph_facts=fanout_graph_facts, match_mac=src_mac, set_mac=ports_info["dst_mac"], eth_field="eth_src")
+            fanout_graph_facts=enum_fanout_graph_facts, match_mac=src_mac, set_mac=ports_info["dst_mac"], eth_field="eth_src")
 
     pkt = testutils.simple_tcp_packet(
         eth_dst=ports_info["dst_mac"],  # DUT port

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -505,7 +505,7 @@ def _generate_vlan_servers(vlan_network, vlan_ports):
     # - IP addresses are randomly selected from the given VLAN network
     # - "Hosts" (IP/MAC pairs) are distributed evenly amongst the ports in the VLAN
     addr_list = list(IPNetwork(vlan_network))
-    for counter, i in enumerate(xrange(2, VLAN_HOSTS + 2)):
+    for counter, i in enumerate(range(2, VLAN_HOSTS + 2)):
         mac = VLAN_BASE_MAC_PATTERN.format(counter)
         port = vlan_ports[i % len(vlan_ports)]
         addr = random.choice(addr_list)

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -4,6 +4,8 @@ import time
 import logging
 import ipaddress
 import json
+from collections import defaultdict
+
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
@@ -299,7 +301,7 @@ def fg_ecmp(ptfhost, duthost, router_mac, net_ports, port_list, ip_to_port, bank
     flows_per_nh = NUM_FLOWS/len(port_list)
     for port in port_list:
         exp_flow_count[port] = flows_per_nh
-        
+
     flows_to_redist = exp_flow_count[shutdown_link]
     for port in bank_0_port:
         if port != shutdown_link:
@@ -403,7 +405,7 @@ def fg_ecmp(ptfhost, duthost, router_mac, net_ports, port_list, ip_to_port, bank
         if port != withdraw_nh_port:
             exp_flow_count[port] = flows_for_withdrawn_nh_bank
 
-    partial_ptf_runner(ptfhost, 'add_nh', dst_ip, exp_flow_count, add_nh_port=shutdown_link) 
+    partial_ptf_runner(ptfhost, 'add_nh', dst_ip, exp_flow_count, add_nh_port=shutdown_link)
 
 
     ### Send the same flows again, but enable the next-hop which was down previously
@@ -423,7 +425,7 @@ def fg_ecmp(ptfhost, duthost, router_mac, net_ports, port_list, ip_to_port, bank
     for port in port_list:
         exp_flow_count[port] = flows_per_nh
 
-    partial_ptf_runner(ptfhost, 'add_nh', dst_ip, exp_flow_count, add_nh_port=withdraw_nh_port) 
+    partial_ptf_runner(ptfhost, 'add_nh', dst_ip, exp_flow_count, add_nh_port=withdraw_nh_port)
 
 
     ### Simulate route and link flap conditions by toggling the route
@@ -468,10 +470,10 @@ def fg_ecmp(ptfhost, duthost, router_mac, net_ports, port_list, ip_to_port, bank
     for port in bank_1_port:
         exp_flow_count[port] = flows_per_nh
 
-    partial_ptf_runner(ptfhost, 'withdraw_bank', dst_ip, exp_flow_count, withdraw_nh_bank=withdraw_nh_bank) 
+    partial_ptf_runner(ptfhost, 'withdraw_bank', dst_ip, exp_flow_count, withdraw_nh_bank=withdraw_nh_bank)
 
 
-    ### Send the same flows again, but enable 1 next-hop in a previously down bank to check 
+    ### Send the same flows again, but enable 1 next-hop in a previously down bank to check
     ### if flows redistribute back to previously down bank
     logger.info("Send the same flows again, but enable 1 next-hop in a previously down bank to check "
                 "if flows redistribute back to previously down bank")
@@ -598,7 +600,7 @@ def common_setup_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
         if USE_INNER_HASHING is True:
             configure_switch_vxlan_cfg(duthost)
 
-        yield duthost, cfg_facts, router_mac, net_ports 
+        yield duthost, cfg_facts, router_mac, net_ports
 
     finally:
         cleanup(duthost, ptfhost)

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -1,4 +1,5 @@
 """Test cases to support the Everflow IPv6 Mirroring feature in SONiC."""
+import time
 import pytest
 import ptf.testutils as testutils
 
@@ -43,13 +44,13 @@ class EverflowIPv6Tests(BaseEverflowTest):
             tx_port = setup_info[UP_STREAM]["dest_port"][0]
             dest_port_ptf_id_list = [setup_info[UP_STREAM]["dest_port_ptf_id"][0]]
             remote_dut = setup_info[UP_STREAM]['remote_dut']
-            rx_port_id =  setup_info[UP_STREAM]["src_port_ptf_id"] 
+            rx_port_id =  setup_info[UP_STREAM]["src_port_ptf_id"]
         else:
             namespace = setup_info[DOWN_STREAM]['remote_namespace']
             tx_port = setup_info[DOWN_STREAM]["dest_port"][0]
             dest_port_ptf_id_list = [setup_info[DOWN_STREAM]["dest_port_ptf_id"][0]]
             remote_dut = setup_info[DOWN_STREAM]['remote_dut']
-            rx_port_id =  setup_info[DOWN_STREAM]["src_port_ptf_id"] 
+            rx_port_id =  setup_info[DOWN_STREAM]["src_port_ptf_id"]
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace("vtysh -c \"config\" -c \"router bgp\" -c \"address-family ipv4\" -c \"redistribute static\"", namespace))
         peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo)
         everflow_utils.add_route(remote_dut, setup_mirror_session["session_prefixes"][0], peer_ip, namespace)
@@ -61,7 +62,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
         everflow_utils.remove_route(remote_dut, setup_mirror_session["session_prefixes"][0], peer_ip, namespace)
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace("vtysh -c \"config\" -c \"router bgp\" -c \"address-family ipv4\" -c \"no redistribute static\"", namespace))
-    
+
     @pytest.fixture(scope='class')
     def everflow_dut(self, setup_info):
         if setup_info['topo'] in ['t0', 'm0_vlan']:
@@ -85,7 +86,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on Source IPv6 addresses."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0002"
@@ -95,12 +96,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match on Destination IPv6 addresses."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0003"
@@ -110,7 +111,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -121,7 +122,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -132,7 +133,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -143,7 +144,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -154,7 +155,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -165,7 +166,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -176,7 +177,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -187,12 +188,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0004",
@@ -205,10 +206,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0005",
@@ -221,12 +222,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match a SYN -> SYN-ACK pattern."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0006",
@@ -238,10 +239,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0007",
@@ -253,12 +254,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match a TCP handshake between a client and server."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0008",
@@ -272,10 +273,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0009",
@@ -289,12 +290,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match UDP traffic between a client and server application."""
-        test_packet = self._base_udpv6_packet(everflow_direction, 
+        test_packet = self._base_udpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000a",
@@ -308,9 +309,9 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
-        test_packet = self._base_udpv6_packet(everflow_direction, 
+        test_packet = self._base_udpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000b",
@@ -324,12 +325,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
@@ -340,10 +341,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_udpv6_packet(everflow_direction, 
+        test_packet = self._base_udpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
@@ -354,10 +355,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_udpv6_packet(everflow_direction, 
+        test_packet = self._base_udpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
@@ -369,12 +370,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:001c",
@@ -387,10 +388,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
-        test_packet = self._base_udpv6_packet(everflow_direction, 
+        test_packet = self._base_udpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:001c",
@@ -403,7 +404,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
@@ -417,7 +418,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with a Source IPv6 Subnet."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:b000:0000:0000:0000:0010",
@@ -430,12 +431,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with a Destination IPv6 Subnet."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0010",
@@ -448,12 +449,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with both source and destination subnets."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:c000:0000:0000:0000:0010",
@@ -466,12 +467,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut, everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):
         """Verify that we can match packets with non-standard subnet sizes."""
-        test_packet = self._base_tcpv6_packet(everflow_direction, 
+        test_packet = self._base_tcpv6_packet(everflow_direction,
             ptfadapter,
             setup_info,
             src_ip="2002:0225:7c6b:e000:0000:0000:0000:0010",
@@ -484,7 +485,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            everflow_dut,
-                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,  
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
                                            dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def _base_tcpv6_packet(self,
@@ -559,7 +560,7 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
         else:
             everflow_dut = setup_info[DOWN_STREAM]['everflow_dut']
             remote_dut = setup_info[DOWN_STREAM]['remote_dut']
- 
+
         table_name = self._get_table_name(everflow_dut)
         temporary_table = False
 

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -1,5 +1,6 @@
 """Test cases to support the Everflow Mirroring feature in SONiC."""
 import logging
+import os
 import time
 import pytest
 

--- a/tests/mpls/conftest.py
+++ b/tests/mpls/conftest.py
@@ -1,6 +1,8 @@
 import logging
+import os
 import pytest
 import pprint
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -49,20 +51,20 @@ def setup(duthost, tbinfo, ptfadapter):
             tor_addr[k]=v['ipv4']
             tor_peer_addr[k]=v['peer_ipv4']
         elif 'T2' in v['bgp_neighbor']:
-            spine_ports.append(k) 
-            spine_addr[k]=v['ipv4']    
-            spine_peer_addr[k]=v['peer_ipv4']           
-    
+            spine_ports.append(k)
+            spine_addr[k]=v['ipv4']
+            spine_peer_addr[k]=v['peer_ipv4']
+
     logger.info('tor_ports: {}'.format(tor_ports))
-    logger.info('spine_ports: {}'.format(spine_ports))    
-    logger.info('tor_addr: {}'.format(tor_addr)) 
-  
+    logger.info('spine_ports: {}'.format(spine_ports))
+    logger.info('tor_addr: {}'.format(tor_addr))
+
     for dut_port in tor_ports:
         port_id=mg_facts['minigraph_port_indices'][dut_port]
         tor_ports_ids[dut_port]=port_id
         ansible_port='ansible_'+dut_port
         tor_mac[dut_port]=host_facts[ansible_port]['macaddress']
-    
+
     for dut_port in spine_ports:
         port_id=mg_facts['minigraph_port_indices'][dut_port]
         spine_ports_ids[dut_port]=port_id

--- a/tests/nat/nat_helpers.py
+++ b/tests/nat/nat_helpers.py
@@ -1,3 +1,4 @@
+import copy
 import re
 import os
 import time
@@ -1111,7 +1112,7 @@ def get_redis_val(duthost, db, key):
         try:
             output = exec_command(duthost, ["redis-dump -d {} --pretty -k *{}*".format(db, key)])
             if output["rc"]:
-                raise Exception('Return code is {} not 0'.format(output_cli["rc"]))
+                raise Exception('Return code is {} not 0'.format(output["rc"]))
             redis_dict = json.loads(output['stdout'])
             for table in redis_dict:
                 if 'expireat' in redis_dict[table]:

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -1,6 +1,7 @@
 import copy
 import time
 import json
+import re
 
 import pytest
 

--- a/tests/passw_hardening/passw_hardening_utils.py
+++ b/tests/passw_hardening/passw_hardening_utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import difflib
+import operator
 from tests.common.helpers.assertions import pytest_assert
 
 CURR_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -104,7 +105,7 @@ def config_and_review_policies(duthost, passw_hardening_ob, pam_file_expected):
     exp_show_policies = dict((k.replace('-', ' '), v) for k, v in passw_hardening_ob.policies.items())
 
     # ~~ test passw policies in show CLI ~~
-    cli_passw_policies_cmp = cmp(exp_show_policies, curr_show_policies)
+    cli_passw_policies_cmp = operator.eq(exp_show_policies, curr_show_policies)
     pytest_assert(cli_passw_policies_cmp == 0, "Fail: exp_show_policies='{}',not equal to curr_show_policies='{}'"
                   .format(exp_show_policies, curr_show_policies))
 

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -266,12 +266,12 @@ class TestPfcwdAllTimer(object):
         self.all_dut_detect_restore_time = list()
         try:
             if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
-                for i in xrange(1, 11):
+                for i in range(1, 11):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers_t2()
             else:
-                for i in xrange(1, 20):
+                for i in range(1, 20):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
                     self.run_test()
                 self.verify_pfcwd_timers()

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -18,6 +18,8 @@ from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import list_dut_fanout_connections
 from tests.common.utilities import skip_release
 from tests.common.platform.interface_utils import get_physical_port_indices
+from tests.common.mellanox_data import is_mellanox_device
+
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -35,7 +37,7 @@ SINGLE_PORT_WAIT_TIME = 90
 PORT_STATUS_CHECK_INTERVAL = 10
 
 # To avoid getting candidate test ports again and again, use a global variable
-# to save all candidate test ports. 
+# to save all candidate test ports.
 # Key: dut host name, value: a dictionary of candidate ports tuple with dut port name as key
 all_ports_by_dut = {}
 fanout_original_port_states = {}
@@ -67,7 +69,7 @@ def save_fanout_port_state(enum_dut_portname_module_fixture):
 @pytest.fixture(scope='module', autouse=True)
 def recover_ports(duthosts, fanouthosts):
     """Module level fixture that automatically do following job:
-        1. Build global candidate test ports 
+        1. Build global candidate test ports
         2. Save fanout port state before the test
         3. Restore fanout and DUT after test
 
@@ -105,7 +107,7 @@ def recover_ports(duthosts, fanouthosts):
 
 
 def get_supported_speeds_for_port(duthost, dut_port_name, fanout, fanout_port_name):
-    """Get supported speeds list for a given port. The supported speeds list is 
+    """Get supported speeds list for a given port. The supported speeds list is
        a intersection of DUT port supported speeds, fanout port supported speeds,
        and cable supported speeds.
 
@@ -141,13 +143,13 @@ def get_supported_speeds_for_port(duthost, dut_port_name, fanout, fanout_port_na
         # Since the port link is up before the test, we should not hit this branch
         # However, in case we hit here, we use current actual speed as supported speed
         return [duthost.get_speed(dut_port_name)]
-    
+
     return natsorted(supported_speeds)
 
 
 def get_cable_supported_speeds(duthost, dut_port_name):
     """Get cable supported speeds. As there is no SONiC CLI to get supported speeds for
-       a given cable, this function depends on vendor implementation. 
+       a given cable, this function depends on vendor implementation.
        A sample: MlnxCableSupportedSpeedsHelper.
 
     Args:
@@ -214,7 +216,7 @@ def dut_all_supported_speeds(request):
             port_speeds[dut_port] = get_speeds_func(duthost, dut_port)
         res[dutname] = port_speeds
     return res
-    
+
 def test_auto_negotiation_advertised_speeds_all(enum_dut_portname_module_fixture):
     """Test all candidate ports to advertised all supported speeds and verify:
         1. All ports are up after auto negotiation
@@ -243,11 +245,11 @@ def test_auto_negotiation_advertised_speeds_all(enum_dut_portname_module_fixture
         duthost.shell('config interface autoneg {} enabled'.format(dut_port))
         duthost.shell('config interface advertised-speeds {} {}'.format(dut_port, all_speeds))
     logger.info('Wait until all ports are up')
-    wait_result = wait_until(ALL_PORT_WAIT_TIME, 
-                                PORT_STATUS_CHECK_INTERVAL, 
-                                0, 
-                                check_ports_up, 
-                                duthost, 
+    wait_result = wait_until(ALL_PORT_WAIT_TIME,
+                                PORT_STATUS_CHECK_INTERVAL,
+                                0,
+                                check_ports_up,
+                                duthost,
                                 [portname])
     pytest_assert(wait_result, 'Some ports are still down')
 
@@ -289,12 +291,12 @@ def test_auto_negotiation_dut_advertises_each_speed(enum_dut_portname_module_fix
     for speed in supported_speeds:
         duthost.shell('config interface advertised-speeds {} {}'.format(dut_port, speed))
         logger.info('Wait until the port status is up, expected speed: {}'.format(speed))
-        wait_result = wait_until(SINGLE_PORT_WAIT_TIME, 
-                                PORT_STATUS_CHECK_INTERVAL, 
-                                0, 
-                                check_ports_up, 
-                                duthost, 
-                                [dut_port], 
+        wait_result = wait_until(SINGLE_PORT_WAIT_TIME,
+                                PORT_STATUS_CHECK_INTERVAL,
+                                0,
+                                check_ports_up,
+                                duthost,
+                                [dut_port],
                                 speed)
         pytest_assert(wait_result, '{} are still down'.format(dut_port))
         fanout_actual_speed = fanout.get_speed(fanout_port)
@@ -322,18 +324,18 @@ def test_auto_negotiation_fanout_advertises_each_speed(enum_dut_portname_module_
         logger.info('Run test based on supported speeds: {}'.format(supported_speeds))
         success = fanout.set_auto_negotiation_mode(fanout_port, True)
         pytest_require(success, 'Failed to set port autoneg on fanout port {}'.format(fanout_port))
-    
+
     for speed in supported_speeds:
         success = fanout.set_speed(fanout_port, speed)
         pytest_require(success, 'Failed to advertised speeds on fanout port {}, speed {}'.format(fanout_port, speed))
 
         logger.info('Wait until the port status is up, expected speed: {}'.format(speed))
-        wait_result = wait_until(SINGLE_PORT_WAIT_TIME, 
-                                PORT_STATUS_CHECK_INTERVAL, 
-                                0, 
-                                check_ports_up, 
-                                duthost, 
-                                [dut_port], 
+        wait_result = wait_until(SINGLE_PORT_WAIT_TIME,
+                                PORT_STATUS_CHECK_INTERVAL,
+                                0,
+                                check_ports_up,
+                                duthost,
+                                [dut_port],
                                 speed)
 
         pytest_assert(wait_result, '{} are still down. Advertised speeds: DUT = {}, fanout = {}'
@@ -366,11 +368,11 @@ def test_force_speed(enum_dut_portname_module_fixture):
 
         duthost.shell('config interface speed {} {}'.format(dut_port, speed))
         logger.info('Wait until the port status is up, expected speed: {}'.format(speed))
-        wait_result = wait_until(SINGLE_PORT_WAIT_TIME, 
-                                PORT_STATUS_CHECK_INTERVAL, 
-                                0, 
-                                check_ports_up, 
-                                duthost, 
+        wait_result = wait_until(SINGLE_PORT_WAIT_TIME,
+                                PORT_STATUS_CHECK_INTERVAL,
+                                0,
+                                check_ports_up,
+                                duthost,
                                 [dut_port],
                                 speed)
         pytest_assert(wait_result, '{} are still down'.format(dut_port))

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -305,7 +305,7 @@ def start_thermal_control_daemon(dut):
         dut.start_pmon_daemon(daemon_name)
         wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_running_status)
     running_daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
-    assert running_daemon_status == expected_running_status, "Run command '{}' failed after starting of thermalctld on {}".format(start_pmon_daemon, dut.hostname)
+    assert running_daemon_status == expected_running_status, "Run command '{}' failed after starting of thermalctld on {}".format("start_pmon_daemon", dut.hostname)
     logging.info("thermalctld processes started successfully on {}".format(dut.hostname))
 
 def stop_thermal_control_daemon(dut):
@@ -314,9 +314,9 @@ def stop_thermal_control_daemon(dut):
         dut.stop_pmon_daemon(daemon_name)
         wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_stopped_status)
     stopped_daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
-    assert stopped_daemon_status == expected_stopped_status, "Run command '{}' failed after stopping of thermalctld on {}".format(stop_pmon_daemon, dut.hostname)
+    assert stopped_daemon_status == expected_stopped_status, "Run command '{}' failed after stopping of thermalctld on {}".format("stop_pmon_daemon", dut.hostname)
     logging.info("thermalctld processes stopped successfully on {}".format(dut.hostname))
-                                                                
+
 class ThermalPolicyFileContext:
     """
     Context class to help replace thermal control policy file and restore it automatically.

--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -88,7 +88,7 @@ def nearbySourcePorts(duthost, mg_facts, singleMemberPort):
         lanes = duthost.shell(
             'sonic-db-cli {} CONFIG_DB hget "PORT|{}" lanes'.format(
                 ns_spec, intf))['stdout'].split(',')
-        assert len(lanes) > 0, "Lanes not found for port {}".format(port)
+        assert len(lanes) > 0, "Lanes not found for port {}".format(intf)
         slc = int(lanes[0]) >> 9
         if single_slc == None:
             single_slc = slc

--- a/tests/qos/test_buffer_traditional.py
+++ b/tests/qos/test_buffer_traditional.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 

--- a/tests/qos/test_qos_masic.py
+++ b/tests/qos/test_qos_masic.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import pytest
+import time
 
 from tests.common.utilities import wait_until
 
@@ -258,7 +259,7 @@ class QosSaiBaseMasic:
            .
            .
         }
-        """ 
+        """
 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index="all")

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import logging
+import re
 import time
 from datetime import datetime
 from tests.common.utilities import wait_until
@@ -232,13 +233,13 @@ def test_perf_add_remove_routes(tbinfo, duthosts, enum_rand_one_per_hwsku_fronte
     # Generate interfaces and neighbors
     NUM_NEIGHS = 50 # Update max num neighbors for multi-asic
     intf_neighs, str_intf_nexthop = generate_intf_neigh(asichost, NUM_NEIGHS, ip_versions)
-   
+
     route_tag = "ipv{}_route".format(ip_versions)
     used_routes_count = asichost.count_crm_resources("main_resources", route_tag, "used")
     avail_routes_count = asichost.count_crm_resources("main_resources", route_tag, "available")
     pytest_assert(avail_routes_count, "CRM main_resources data is not ready within adjusted CRM polling time {}s".\
             format(CRM_POLL_INTERVAL))
-    
+
     num_routes = min(avail_routes_count, set_num_routes)
     logger.info("IP route utilization before test start: Used: {}, Available: {}, Test count: {}"\
         .format(used_routes_count, avail_routes_count, num_routes))

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -1,11 +1,13 @@
 import os
 import pprint
 import pytest
+import re
 import time
 import logging
 import tech_support_cmds as cmds
 
 from random import randint
+from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until

--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -144,6 +144,9 @@ def test_snmp_swap(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
     total_swap = duthost.shell("grep SwapTotal /proc/meminfo | awk '{print $2}'")['stdout']
     free_swap = duthost.shell("grep SwapFree /proc/meminfo | awk '{print $2}'")['stdout']
 
+    mem_total = duthost.shell("grep MemTotal /proc/meminfo | awk '{print $2}'")['stdout']
+    percentage = get_percentage_threshold(int(mem_total))
+
     if total_swap == "0":
         pytest.skip("Swap is not on for this device, snmp does not support swap related queries when swap isn't on")
 
@@ -154,8 +157,8 @@ def test_snmp_swap(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
 
     logging.info("total_swap {}, free_swap {}, snmp_total_swap {}, snmp_free_swap {}".format(total_swap, free_swap, snmp_total_swap, snmp_free_swap))
 
-    pytest_assert(CALC_DIFF(snmp_total_swap, total_swap) < percent,
-                  "sysTotalSwap differs by more than {}: expect {} received {}".format(percent, total_swap, snmp_total_swap))
+    pytest_assert(CALC_DIFF(snmp_total_swap, total_swap) < percentage,
+                  "sysTotalSwap differs by more than {}: expect {} received {}".format(percentage, total_swap, snmp_total_swap))
 
     if snmp_free_swap == 0 or snmp_total_swap / snmp_free_swap >= 2:
         """
@@ -163,9 +166,9 @@ def test_snmp_swap(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
         The comparison could get inaccurate if the number to compare is close to 0,
         so we test only one of used/free swap space.
         """
-        pytest_assert(CALC_DIFF(snmp_total_swap - snmp_free_swap, int(total_swap) - int(free_swap)) < percent,
+        pytest_assert(CALC_DIFF(snmp_total_swap - snmp_free_swap, int(total_swap) - int(free_swap)) < percentage,
                       "Used Swap (calculated using sysTotalFreeSwap) differs by more than {}: expect {} received {}".format(
-                          percent, snmp_total_swap - snmp_free_swap, int(total_swap) - int(free_swap)))
+                          percentage, snmp_total_swap - snmp_free_swap, int(total_swap) - int(free_swap)))
     else:
-        pytest_assert(CALC_DIFF(snmp_free_swap, free_swap) < percent,
-                      "sysTotalFreeSwap differs by more than {}: expect {} received {}".format(percent, snmp_free_swap, free_swap))
+        pytest_assert(CALC_DIFF(snmp_free_swap, free_swap) < percentage,
+                      "sysTotalFreeSwap differs by more than {}: expect {} received {}".format(percentage, snmp_free_swap, free_swap))

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from tests.common.utilities import wait_until
 from utils import get_crm_resources, check_queue_status, sleep_to_wait

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,4 +1,6 @@
 import re
+import time
+
 
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
 SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1150,7 +1150,7 @@ class TestVrfCapacity():
     def random_vrf_list(self, vrf_count, request):
         test_count = request.config.option.vrf_test_count or self.TEST_COUNT  # get cmd line option value, use default if none
 
-        return sorted(random.sample(xrange(1, vrf_count+1), min(test_count, vrf_count)))
+        return sorted(random.sample(range(1, vrf_count+1), min(test_count, vrf_count)))
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_vrf_capacity(self, duthosts, rand_one_dut_hostname, ptfhost, localhost, cfg_facts, vrf_count, random_vrf_list, request):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
After ansible version of sonic-mgmt docker image is upgraded to 6.7, some scripts failed with errors like:
    global name 'os' is not defined

I don't know the reason why these issues are exposed after ansible upgrade. Anyway, these scripts are using modules before import them and need fix.

#### How did you do it?
This change added missing imports for the modules. What's more, this change also fixed some other undefined name issue.
This change is only for 202205 branch. The master and 202305 branch are protected by pre-commit and do not have this issue.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
