### PR TITLE
Skip test_get_transceiver_threshold_info testcase if transceiver vend…

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -462,6 +462,10 @@ class TestSfpApi(PlatformApiTestBase):
                     if info_dict["type_abbrv_name"] == "QSFP-DD":
                         expected_keys += self.QSFPDD_EXPECTED_XCVR_THRESHOLD_INFO_KEYS
                         if 'ZR' in info_dict["media_interface_code"]:
+                            if 'INPHI CORP' in info_dict['manufacturer']:
+                                logger.info("INPHI CORP Transceiver is not populating the associated threshold fields \
+                                             in redis TRANSCEIVER_DOM_THRESHOLD table. Skipping this transceiver")
+                                continue
                             expected_keys += self.QSFPZR_EXPECTED_XCVR_THRESHOLD_INFO_KEYS
 
                     missing_keys = set(expected_keys) - set(actual_keys)

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -462,7 +462,7 @@ class TestSfpApi(PlatformApiTestBase):
                     if info_dict["type_abbrv_name"] == "QSFP-DD":
                         expected_keys += self.QSFPDD_EXPECTED_XCVR_THRESHOLD_INFO_KEYS
                         if 'ZR' in info_dict["media_interface_code"]:
-                            if 'INPHI CORP' in info_dict['manufacturer']:
+                            if 'INPHI CORP' in info_dict['manufacturer'] and 'IN-Q3JZ1-TC' in info_dict['model']:
                                 logger.info("INPHI CORP Transceiver is not populating the associated threshold fields \
                                              in redis TRANSCEIVER_DOM_THRESHOLD table. Skipping this transceiver")
                                 continue


### PR DESCRIPTION
### Description of PR
test_get_transceiver_threshold_info testcase fails if transceiver is INPHI CORP

Transceiver test failure is ZR related and is due to the fact that Inphi ZR optic has default values of 0 for a variety 
of threshold fields that are optional as per the spec.  
Thus, xcvrd (via optoe) is not populating the associated threshold fields in redis TRANSCEIVER_DOM_THRESHOLD 
table (those fields are missing).  
Meanwhile, the test is failing when those optional fields are missing from the database.   
Acacia ZR optics have these threshold values populated such that the database fields do indeed get populated 
and then the same test passes for them.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
To skip test_get_transceiver_threshold_info testcase if transceiver vendor is INPHI CORP.
Thus, xcvrd (via optoe) is not populating the associated threshold fields in redis TRANSCEIVER_DOM_THRESHOLD 
table (those fields are missing).

#### How did you do it?
Check the vendor and skip the testcase if the vendor is INPHI CORP.

#### How did you verify/test it?
Ran the OC testcase against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
