### PR TITLE
[T2]:Porting 9713 to 202205: Enable qos-sai for 8800-LC-48H-C48

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -26,9 +26,10 @@ barefoot_hwskus: [ "montara", "mavericks", "Arista-7170-64C", "newport", "Arista
 marvell_hwskus: [ "et6448m" ]
 innovium_tl7_hwskus: ["Wistron_sw_to3200k_32x100" , "Wistron_sw_to3200k"]
 
-cisco_hwskus: ["Cisco-8102-C64", "Cisco-8111-O32", "Cisco-8111-O64"]
+cisco_hwskus: ["Cisco-8102-C64", "Cisco-8111-O32", "Cisco-8111-O64", "Cisco-8800-LC-48H-C48"]
 cisco-8000_gb_hwskus: ["Cisco-8102-C64"]
 cisco-8000_gr_hwskus: ["Cisco-8111-O32", "Cisco-8111-O64"]
+cisco-8000_pac_hwskus: ["Cisco-8800-LC-48H-C48"]
 ## Note:
 ## Docker volumes should be list instead of dict. However, if we want to keep code DRY, we
 ## need to merge dictionaries, and convert them to list

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -36,7 +36,8 @@ class QosBase:
                           "t0-120", "t0-80", "t0-backend"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
-    SUPPORTED_ASIC_LIST = ["gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3", "j2c+", "jr2"]
+    SUPPORTED_ASIC_LIST = ["pac", gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3",
+                           "j2c+", "jr2"]
 
     TARGET_QUEUE_WRED = 3
     TARGET_LOSSY_QUEUE_SCHED = 0

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -36,7 +36,7 @@ class QosBase:
                           "t0-120", "t0-80", "t0-backend"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
-    SUPPORTED_ASIC_LIST = ["pac", gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3",
+    SUPPORTED_ASIC_LIST = ["pac", "gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3",
                            "j2c+", "jr2"]
 
     TARGET_QUEUE_WRED = 3


### PR DESCRIPTION
Porting the PR: #9713 to 202205, since there is a conflict in cherrypicking.
Description of PR
enable qos-sai scripts for cisco 8800-LC-48H-C48 platform

Summary:
Enables support for a new asic and new card using that asic

Type of change
 Bug fix
 Testbed and Framework(new/improvement)
 Test case(new/improvement)
Back port request
 201911
 202012
 202205
Approach
What is the motivation for this PR?
enable qos-sai scripts for cisco 8800-LC-48H-C48 platform

How did you do it?
How did you verify/test it?
On local system, patched the change and tested with test qos sai XOFF test

