### PR TITLE
[warmboot][teardown] force reset warmboot system flag after warmboot tests

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -831,7 +831,7 @@ class AdvancedReboot:
         """
         logger.info('Running test tear down')
         if 'warm-reboot' in self.rebootType:
-            if not wait_until(300, 10, 0, self.checkWarmbootFlag, self.duthost):
+            if not wait_until(300, 10, 0, self.__checkWarmbootFlag, self.duthost):
                 logger.info('Setting warm-reboot system flag to false')
                 self.duthost.shell(cmd='sonic-db-cli STATE_DB hset "WARM_RESTART_ENABLE_TABLE|system" enable false')
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -20,6 +20,7 @@ from tests.common.utilities import InterruptableThread
 from tests.common.dualtor.data_plane_utils import get_peerhost
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.fixtures.duthost_utils import check_bgp_router_id
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -815,11 +816,25 @@ class AdvancedReboot:
             wait=300
         )
 
+    def __checkWarmbootFlag(self, duthost):
+        """
+            Checks if warm-reboot system flag is set to false.
+        """
+        warmbootFlag = duthost.shell(
+            cmd='sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable')['stdout']
+        logger.info("warmbootFlag: " + warmbootFlag)
+        return warmbootFlag != 'true'
+
     def tearDown(self):
         """
         Tears down test case. It also verifies that config_db.json exists.
         """
         logger.info('Running test tear down')
+        if 'warm-reboot' in self.rebootType:
+            if not wait_until(300, 10, 0, self.checkWarmbootFlag, self.duthost):
+                logger.info('Setting warm-reboot system flag to false')
+                self.duthost.shell(cmd='sonic-db-cli STATE_DB hset "WARM_RESTART_ENABLE_TABLE|system" enable false')
+
         if 'warm-reboot' in self.rebootType and self.newSonicImage is not None:
             logger.info('Save configuration after warm rebooting into new image')
             self.duthost.shell('config save -y')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to force reset warmboot system flag back to `false` as a cleanup step after warmboot tests.

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Add an extra step in `AdvanceReboot` teardown function. 

#### How did you verify/test it?
Ran test on a lab device: 
```
01:04:51 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture get_advanced_reboot teardown starts --------------------
01:04:51 advanced_reboot.tearDown                 L0836 INFO   | Running test tear down
01:04:51 advanced_reboot.__checkWarmbootFlag      L0829 INFO   | warmbootFlag: false
01:04:52 advanced_reboot.__runScript              L0301 INFO   | Running script remove_ip.sh on vms28-10
01:04:52 advanced_reboot.tearDown                 L0864 INFO   | Stay in new image
01:04:52 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture get_advanced_reboot teardown ends --------------------
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
