### PR TITLE
Fix Python3 syntax issue in test_custom_acl_table.py

### DIFF
--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -230,7 +230,7 @@ def test_custom_acl(rand_selected_dut, tbinfo, ptfadapter,
     """
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     if "dualtor" in tbinfo["topo"]["name"]:
-        vlan_name = mg_facts['minigraph_vlans'].keys()[0]
+        vlan_name = list(mg_facts['minigraph_vlans'].keys())[0]
         # Use VLAN MAC as router MAC on dual-tor testbed
         router_mac = rand_selected_dut.get_dut_iface_mac(vlan_name)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix Python3 syntax issue in test_custom_acl_table.py.
The error message is
```
if "dualtor" in tbinfo["topo"]["name"]:
>           vlan_name = mg_facts['minigraph_vlans'].keys()[0]
E           TypeError: 'dict_keys' object is not subscriptable
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix Python3 syntax issue in test_custom_acl_table.py.

#### How did you do it?
Convert the keys to list explicitly.

#### How did you verify/test it?
Verified by syntax check.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
This change is dualtor specific.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
