### PR TITLE
Skip test_pktgen.py in non-Cisco platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -800,6 +800,15 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
 #######################################
+#####         pktgen              #####
+#######################################
+test_pktgen.py
+   skip:
+     reason: "Only supported in cisco-8000"
+     conditions:
+        - "asic_type not in ['cisco-8000']"
+
+#######################################
 #####         platform_tests      #####
 #######################################
 platform_tests/api/test_sfp.py::TestSfpApi::test_reset:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -802,9 +802,9 @@ pfcwd/test_pfcwd_warm_reboot.py:
 #######################################
 #####         pktgen              #####
 #######################################
-test_pktgen.py
+test_pktgen.py:
    skip:
-     reason: "Only supported in cisco-8000"
+     reason: "Currently only supported in cisco-8000"
      conditions:
         - "asic_type not in ['cisco-8000']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -800,15 +800,6 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
 #######################################
-#####         pktgen              #####
-#######################################
-test_pktgen.py:
-   skip:
-     reason: "Currently only supported in cisco-8000"
-     conditions:
-        - "asic_type not in ['cisco-8000']"
-
-#######################################
 #####         platform_tests      #####
 #######################################
 platform_tests/api/test_sfp.py::TestSfpApi::test_reset:
@@ -1190,6 +1181,15 @@ telemetry/test_telemetry.py:
     reason: "Skip telemetry test for 201911 and older branches"
     conditions:
       - "(is_multi_asic==True) and (release in ['201811', '201911'])"
+
+#######################################
+#####         pktgen              #####
+#######################################
+test_pktgen.py:
+   skip:
+     reason: "Currently only supported in cisco-8000"
+     conditions:
+        - "asic_type not in ['cisco-8000']"
 
 #######################################
 #####            vlan             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip test_pktgen.py in non-Cisco platform
This case was introduced in: #10164

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This testcase failed in non-Cisco platform.

#### How did you do it?
Skip test_pktgen.py in non-Cisco platform

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
