### PR TITLE
Add orchagent heartbeat during warm-reboot UT

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -612,7 +612,8 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
 
 
 def get_latest_stuck_message(duthost):
-    res = duthost.command(r"sudo sed -n 's/.*\(Process '\''orchagent'\'' is stuck in namespace\).*/\0/p'  /var/log/syslog")
+    query_command = r"sudo sed -n 's/.*\(Process '\''orchagent'\'' is stuck in namespace\).*/\0/p'  /var/log/syslog"
+    res = duthost.command(query_command)
     if len(res["stdout_lines"]) == 0:
         return ""
 
@@ -649,4 +650,4 @@ def test_orchagent_heartbeat(duthosts, rand_one_dut_hostname, tbinfo, skip_vendo
     logger.info("Executing the config reload was done!")
 
     # assert after config reload, make sure orchange recovered after test
-    pytest_assert(orchagent_stuck == False, "Orchagent not stuck after frozen for warm-reboot.")
+    pytest_assert(not orchagent_stuck, "Orchagent not stuck after frozen for warm-reboot.")

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -16,6 +16,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.helpers.dut_utils import get_group_program_info
+from tests.common.helpers.dut_utils import is_container_running
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 
@@ -624,6 +625,12 @@ def test_orchagent_heartbeat(duthosts, rand_one_dut_hostname, tbinfo, skip_vendo
     """Tests orchagent heartbeat after warm-restart
     """
     duthost = duthosts[rand_one_dut_hostname]
+
+    # t1 lag does not have swss container
+    swss_running = is_container_running(duthost, 'swss')
+    if not swss_running:
+        logger.info("swss container not running.")
+        return
 
     # get last stuck message
     last_stuck = get_latest_stuck_message(duthost)


### PR DESCRIPTION
Add orchagent heartbeat during warm-reboot UT

### Description of PR
Add orchagent heartbeat during warm-reboot UT

##### Work item tracking
- Microsoft ADO: 25295846

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix orchagent stuck error during warm-reboot:
https://github.com/sonic-net/sonic-buildimage/issues/16686

#### How did you do it?
Add new UT, freeze orchanget for warm-reboot then check the process listener not send alert.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
