### PR TITLE
[202012] Remove scapy mask on chksum for IPv6 Header

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -325,7 +325,6 @@ class DecapPacketTest(BaseTest):
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             else:
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
 
         inner_pkt_type = 'ipv4' if ipaddress.ip_address(unicode(dst_ip)).version == 4 else 'ipv6'
 

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -359,7 +359,6 @@ class FibTest(BaseTest):
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
 
         send_packet(self, src_port, pkt)

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -315,7 +315,6 @@ class HashTest(BaseTest):
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
@@ -533,7 +532,6 @@ class IPinIPHashTest(HashTest):
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         
         send_packet(self, src_port, ipinip_pkt)

--- a/ansible/roles/test/files/ptftests/voq.py
+++ b/ansible/roles/test/files/ptftests/voq.py
@@ -340,7 +340,6 @@ class MtuTest(BaseTest):
             masked_exp_pkt = Mask(exp_pkt)
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "id")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "tc")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "fl")
@@ -409,7 +408,6 @@ class MtuTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
             if self.ignore_ttl:
                 masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
 
         src_port = self.src_ptf_port_list[0]
         send_packet(self, src_port, pkt)

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -4,6 +4,7 @@ Test the feature of container_checker
 import logging
 
 import pytest
+import time
 
 from pkg_resources import parse_version
 from tests.common import config_reload

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -128,7 +128,6 @@ def generate_and_verify_traffic(
     exp_pkt.set_do_not_care_scapy(packet.Ether, "src")
     if ipv6:
         exp_pkt.set_do_not_care_scapy(packet.IPv6, "hlim")
-        exp_pkt.set_do_not_care_scapy(packet.IPv6, "chksum")
     else:
         exp_pkt.set_do_not_care_scapy(packet.IP, "ttl")
         exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
IPv6 header do not have field 'checksum', if set do not care 'checksum' would cause failure "MaskException: Field chksum does not exist in frame"
ref PR: https://github.com/sonic-net/sonic-mgmt/pull/6407
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
