### PR TITLE
[dualtor-io] cleanup and collect pcap file

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -585,6 +585,11 @@ class DualTorIO:
         self.capture_pcap = '/tmp/capture.pcap'
         self.capture_log = '/tmp/capture.log'
 
+        # Do some cleanup first
+        self.ptfhost.file(path=self.capture_pcap, state="absent")
+        if os.path.exists(self.capture_pcap):
+            os.unlink(self.capture_pcap)
+
         self.setup_ptf_sniffer()
         self.start_ptf_sniffer()
 

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.common.dualtor.data_plane_utils import save_pcap                 # noqa F401
+
 
 def pytest_configure(config):
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
1. Cleanup any pcap files before the sniffer starts.
2. Save the pcap file to the log directory so it could be collected by the nightly for further analysis.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As in the motivation.

#### How did you verify/test it?
Run dualtor-io testcase

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
