### PR TITLE
[dualtor] fix command to get dualtor_ports

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -723,7 +723,7 @@ class MultiAsicSonicHost(object):
         This will work for both single/multi-asic.
         Note that for multi-asic, it will run on specific asic given, or asic0
         """
-        self.asic_instance(asic_index).run_redis_cmd(argv)
+        return self.asic_instance(asic_index).run_redis_cmd(argv)
 
     def docker_cmds_on_all_asics(self, cmd, container_name):
         """This function iterate for ALL asics and execute cmds"""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
https://github.com/sonic-net/sonic-mgmt/pull/10234 introduced a wrapper function `def run_redis_cmd` to call redis command on asic in multi_asic.py, but it does not return the stdout value. This causes failure on some dualtors and the T1 that connects to dualtor.

This PR adds a return in wrapper function that returns the result['stdout'] here: https://github.com/sonic-net/sonic-mgmt/blob/635d4b15979195de92f149319570e17ad27dca14/tests/common/devices/sonic_asic.py#L435


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
before:
```
dual_tor_utils.dualtor_ports             L1493 INFO   | Finish fetching dual ToR info set()
```

after:
```
 dual_tor_utils.dualtor_ports             L1417 INFO   | Finish fetching dual ToR info set([u'Ethernet152', u'Ethernet180', u'Ethernet200', u'Ethernet168', u'Ethernet156', u'Ethernet148', u'Ethernet232', u'Ethernet220', u'Ethernet144', u'Ethernet208', u'Ethernet216', ...'])
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
