### PR TITLE
Fix an error in parsing the neighbor analysis for SONiC neighbors

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1387,7 +1387,7 @@ class ReloadTest(BaseTest):
         for neigh in self.ssh_targets:
             flap_cnt = None
             if self.test_params['neighbor_type'] == "sonic":
-                flap_cnt = self.cli_info[neigh][1]
+                flap_cnt = self.cli_info[neigh]['po'][1]
             else:
                 self.test_params['port_channel_intf_idx'] = [x['ptf_ports'][0] for x in self.vm_dut_map.values()
                                                              if x['mgmt_addr'] == neigh]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In #10107, when doing a warm reboot with SONiC neighbors, instead of going to the neighbor device to get the LAG flap information, the code was changed to reuse information that was already collected and returned. However, the code to access that information is wrong, and needs to access the `po` key first.

#### How did you do it?

Fix this error by updating the code.

#### How did you verify/test it?

Verfied by doing a warm upgrade from sonic-mgmt with SONiC neighbros and making sure that it succeeded and the LAG flap information was correctly read.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
