### PR TITLE
[dualtor_io] wait for `pmon` docker before verification in ToR failure cases 

### DIFF
--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -8,7 +8,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                                        # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                      # noqa F401
 from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable     # noqa F401
-from tests.common.dualtor.tor_failure_utils import wait_for_mux_container                                           # noqa F401
+from tests.common.dualtor.tor_failure_utils import wait_for_mux_container, wait_for_pmon_container                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, change_mac_addresses          # noqa F401
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                                # noqa F401
 from tests.common.dualtor.nic_simulator_control import ForwardingState
@@ -60,7 +60,8 @@ def toggle_lower_tor_pdu(lower_tor_host, get_pdu_controller):       # noqa F811
 def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
-    wait_for_device_reachable, wait_for_mux_container, cable_type       # noqa F811
+    wait_for_device_reachable, wait_for_mux_container, cable_type,      # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
@@ -72,6 +73,7 @@ def test_active_tor_reboot_upstream(
     )
     wait_for_device_reachable(upper_tor_host)
     wait_for_mux_container(upper_tor_host)
+    wait_for_pmon_container(upper_tor_host)
 
     if cable_type == CableType.active_standby:
         verify_tor_states(
@@ -91,7 +93,8 @@ def test_active_tor_reboot_upstream(
 def test_active_tor_reboot_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
-    wait_for_device_reachable, wait_for_mux_container                   # noqa F811
+    wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send downstream traffic to the standby ToR and reboot the active ToR.
@@ -103,6 +106,7 @@ def test_active_tor_reboot_downstream_standby(
     )
     wait_for_device_reachable(upper_tor_host)
     wait_for_mux_container(upper_tor_host)
+    wait_for_pmon_container(upper_tor_host)
     verify_tor_states(
         expected_active_host=lower_tor_host,
         expected_standby_host=upper_tor_host
@@ -113,7 +117,8 @@ def test_active_tor_reboot_downstream_standby(
 def test_standby_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
-    wait_for_device_reachable, wait_for_mux_container                   # noqa F811
+    wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
@@ -125,6 +130,7 @@ def test_standby_tor_reboot_upstream(
     )
     wait_for_device_reachable(lower_tor_host)
     wait_for_mux_container(lower_tor_host)
+    wait_for_pmon_container(lower_tor_host)
     verify_tor_states(
         expected_active_host=upper_tor_host,
         expected_standby_host=lower_tor_host
@@ -135,7 +141,8 @@ def test_standby_tor_reboot_upstream(
 def test_standby_tor_reboot_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
-    wait_for_device_reachable, wait_for_mux_container                   # noqa F811
+    wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send downstream traffic to the active ToR and reboot the standby ToR.
@@ -147,6 +154,7 @@ def test_standby_tor_reboot_downstream_active(
     )
     wait_for_device_reachable(lower_tor_host)
     wait_for_mux_container(lower_tor_host)
+    wait_for_pmon_container(lower_tor_host)
     verify_tor_states(
         expected_active_host=upper_tor_host,
         expected_standby_host=lower_tor_host
@@ -160,7 +168,7 @@ def test_active_tor_reboot_downstream(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_upper_tor_pdu, wait_for_device_reachable, cable_type,        # noqa F811
     tunnel_traffic_monitor, mux_status_from_nic_simulator,              # noqa F811
-    wait_for_mux_container                                              # noqa F811
+    wait_for_mux_container,wait_for_pmon_container                      # noqa F811
 ):
     def check_forwarding_state(upper_tor_forwarding_state, lower_tor_forwarding_state):
         mux_status = mux_status_from_nic_simulator()
@@ -197,6 +205,7 @@ def test_active_tor_reboot_downstream(
         # verify the upper ToR changes back to active after the upper comes back from reboot
         wait_for_device_reachable(upper_tor_host)
         wait_for_mux_container(upper_tor_host)
+        wait_for_pmon_container(upper_tor_host)
         pytest_assert(
             wait_until(180, 5, 60, check_forwarding_state, ForwardingState.ACTIVE, ForwardingState.ACTIVE),
             "Forwarding state check failed after the upper ToR comes back from reboot."


### PR DESCRIPTION
ADO#: 25587797
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Wait for `pmon` docker to start before verifying `show mux status` output in ToR failure cases. Otherwise, `show mux status` might return error. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Fix flaky tests. 

#### How did you do it?
Added a `wait_until` checker. 

#### How did you verify/test it?
Ran `test_active_tor_reboot_downstream_standby`, you can tell pmon was up 3 seconds after mux was up. 
```
01:15:49 tor_failure_utils.wait_for_device_reacha L0130 INFO   | Waiting for ssh to startup on str2-7050cx3-acs-08
01:15:59 tor_failure_utils.wait_for_device_reacha L0142 INFO   | SSH started on str2-7050cx3-acs-08
01:16:01 tor_failure_utils.wait_for_mux_container L0182 INFO   | Waiting for mux container to start on str2-7050cx3-acs-08
01:16:02 tor_failure_utils.wait_for_pmon_containe L0203 INFO   | Waiting for pmon container to start on str2-7050cx3-acs-08
01:16:05 control_plane_utils.get_mismatched_ports L0144 INFO   | Verifying APP_DB values on <MultiAsicSonicHost str2-7050cx3-acs-09>: expected state = active, expected health = healthy
``` 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
