### PR TITLE
[202305] Support share image for gnmi and telemetry

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -27,6 +27,7 @@ r, ".* INFO kernel:.*"
 r, ".* INFO systemd.*"
 r, ".* ERR kernel:.* Module gpio_ich is blacklisted.*"
 r, ".* skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID.*"
+r, ".* ERR monit.*Expected containers not running: telemetry.*"
 
 # White list below messages found on KVM for now. Need to address them later.
 r, ".* ERR macsec#wpa_supplicant.*l2_packet_send.*Network is down.*"

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -1,0 +1,53 @@
+from functools import lru_cache
+import pytest
+
+
+@lru_cache(maxsize=None)
+class GNMIEnvironment(object):
+    TELEMETRY_MODE = 0
+    GNMI_MODE = 1
+
+    def __init__(self, duthost, mode):
+        if mode == self.TELEMETRY_MODE:
+            ret = self.generate_telemetry_config(duthost)
+            if ret:
+                return
+            ret = self.generate_gnmi_config(duthost)
+            if ret:
+                return
+        elif mode == self.GNMI_MODE:
+            ret = self.generate_gnmi_config(duthost)
+            if ret:
+                return
+            ret = self.generate_telemetry_config(duthost)
+            if ret:
+                return
+        pytest.fail("Can't generate GNMI/TELEMETRY configuration, mode %d" % mode)
+
+    def generate_gnmi_config(self, duthost):
+        cmd = "docker images | grep -w sonic-gnmi"
+        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+            cmd = "docker ps | grep -w gnmi"
+            if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+                self.gnmi_config_table = "GNMI"
+                self.gnmi_container = "gnmi"
+                self.gnmi_program = "gnmi-native"
+                self.gnmi_port = 50052
+                return True
+            else:
+                pytest.fail("GNMI is not running")
+        return False
+
+    def generate_telemetry_config(self, duthost):
+        cmd = "docker images | grep -w sonic-telemety"
+        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+            cmd = "docker ps | grep -w telemety"
+            if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+                self.gnmi_config_table = "TELEMETRY"
+                self.gnmi_container = "telemetry"
+                self.gnmi_program = "telemetry"
+                self.gnmi_port = 50051
+                return True
+            else:
+                pytest.fail("Telemetry is not running")
+        return False

--- a/tests/minigraph/test_masked_services.py
+++ b/tests/minigraph/test_masked_services.py
@@ -41,19 +41,36 @@ def change_service_state(duthost, service, enable):
 @pytest.mark.disable_loganalyzer
 def test_masked_services(duthosts, rand_one_dut_hostname):
     """
-    @summary: This test case will mask telemetry service, then test load_minigraph and check its success
+    @summary: This test case will mask telemetry/gnmi service, then test load_minigraph and check its success
     """
     duthost = duthosts[rand_one_dut_hostname]
-    test_service = "telemetry"
-    logging.info("Bringing down telemetry service")
-    service_status = duthost.critical_process_status("telemetry")
+    cmd = "docker images | grep -w sonic-telemetry"
+    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+        cmd = "docker ps | grep -w telemetry"
+        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+            test_service = "telemetry"
+        else:
+            pytest.fail("Telemetry is not running")
+    else:
+        cmd = "docker images | grep -w sonic-gnmi"
+        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+            cmd = "docker ps | grep -w gnmi"
+            if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+                test_service = "gnmi"
+            else:
+                pytest.fail("GNMI is not running")
+        else:
+            pytest.fail("Can't find telemetry and gnmi image")
+    logging.info("Bringing down {} service".format(test_service))
+    service_status = duthost.critical_process_status(test_service)
 
     if not service_status:
-        pytest.fail("Make sure telemetry is up and running before calling this test")
+        pytest.fail("Make sure {} is up and running before calling this test".format(test_service))
 
     change_service_state(duthost, test_service, False)
     logging.info("Wait until service is masked and inactive")
-    pytest_assert(not wait_until(30, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY still running")
+    pytest_assert(not wait_until(30, 10, 0, duthost.is_service_fully_started, test_service),
+                  "{} still running".format(test_service))
 
     logging.info("Check service status")
     assert not is_service_loaded(duthost, test_service)
@@ -66,7 +83,8 @@ def test_masked_services(duthosts, rand_one_dut_hostname):
         logging.info("Bring back service if not up")
         change_service_state(duthost, test_service, True)
         logging.info("Wait until service is unmasked and active")
-        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started")
+        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, test_service),
+                      "{} not started".format(test_service))
 
         if load_minigraph_error_code:
             pytest.fail("Test failed as load_minigraph was not successful")

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -7,10 +7,9 @@ import re
 
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
-
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
 logger = logging.getLogger(__name__)
 
-TELEMETRY_PORT = 50051
 METHOD_GET = "get"
 METHOD_SUBSCRIBE = "subscribe"
 SUBSCRIBE_MODE_STREAM = 0
@@ -55,20 +54,24 @@ def setup_telemetry_forpyclient(duthost):
     """ Set client_auth=false. This is needed for pyclient to successfully set up channel with gnmi server.
         Restart telemetry process
     """
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "%s|gnmi" "client_auth"' % (env.gnmi_config_table),
                                     module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     return client_auth
 
 
 def restore_telemetry_forpyclient(duthost, default_client_auth):
-    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"',
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "%s|gnmi" "client_auth"' % (env.gnmi_config_table),
                                     module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth != default_client_auth:
-        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" {}'.format(default_client_auth),
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "%s|gnmi" "client_auth" %s'
+                      % (env.gnmi_config_table, default_client_auth),
                       module_ignore_errors=False)
-        duthost.service(name="telemetry", state="restarted")
+        duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
+        duthost.service(name=env.gnmi_container, state="restarted")
 
 
 def listen_for_event(ptfhost, cmd, results):
@@ -105,8 +108,9 @@ def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/E
                         intervalms=0, update_count=3, create_connections=1, filter_event_regex=""):
     """ Generate the py_gnmicli command line based on the given params.
     """
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
-    cmd = cmdFormat.format(duthost.mgmt_ip, TELEMETRY_PORT, method, xpath, target, "ndastreamingservertest")
+    cmd = cmdFormat.format(duthost.mgmt_ip, env.gnmi_port, method, xpath, target, "ndastreamingservertest")
 
     if method == METHOD_SUBSCRIBE:
         cmd += " --subscribe_mode {0} --submode {1} --interval {2} --update_count {3} --create_connections {4}".format(

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -5,7 +5,9 @@ import re
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older, generate_client_cli
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older
+from telemetry_utils import generate_client_cli
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -13,7 +15,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-TELEMETRY_PORT = 50051
 METHOD_SUBSCRIBE = "subscribe"
 METHOD_GET = "get"
 MEMORY_CHECKER_WAIT = 1
@@ -24,21 +25,22 @@ def test_config_db_parameters(duthosts, enum_rand_one_per_hwsku_hostname):
     """Verifies required telemetry parameters from config_db.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
 
-    gnmi = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "TELEMETRY|gnmi"',
+    gnmi = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "%s|gnmi"' % (env.gnmi_config_table),
                          module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None,
-                  "TELEMETRY|gnmi does not exist in config_db")
+                  "%s|gnmi does not exist in config_db" % (env.gnmi_config_table))
 
-    certs = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "TELEMETRY|certs"',
+    certs = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "%s|certs"' % (env.gnmi_config_table),
                           module_ignore_errors=False)['stdout_lines']
     pytest_assert(certs is not None,
-                  "TELEMETRY|certs does not exist in config_db")
+                  "%s|certs does not exist in config_db" % (env.gnmi_config_table))
 
     d = get_dict_stdout(gnmi, certs)
     for key, value in list(d.items()):
         if str(key) == "port":
-            port_expected = str(TELEMETRY_PORT)
+            port_expected = str(env.gnmi_port)
             pytest_assert(str(value) == port_expected,
                           "'port' value is not '{}'".format(port_expected))
         if str(key) == "ca_crt":
@@ -59,8 +61,9 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
     """Verify telemetry should be enabled by default
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
 
-    status = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "FEATURE|telemetry"',
+    status = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "FEATURE|%s"' % (env.gnmi_container),
                            module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     # Elements in list alternate between key and value. Separate them and combine into a dict.
@@ -79,13 +82,14 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     if duthost.is_supervisor_node():
         pytest.skip(
             "Skipping test as no Ethernet0 frontpanel port on supervisor")
     logger.info('start telemetry output testing')
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt COUNTERS_DB \
-           -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT)
+           -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     logger.info("GNMI Server output")
     logger.info(show_gnmi_out)
@@ -119,10 +123,11 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhos
     """
     logger.info("start test the dataset 'system uptime'")
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     skip_201911_and_older(duthost)
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x proc/uptime -xt OTHERS \
-           -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT)
+           -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
     found_system_uptime_field = False
@@ -194,6 +199,7 @@ def test_mem_spike(duthosts, rand_one_dut_hostname, ptfhost, gnxi_path):
     logger.info("Starting to test the memory spike issue of telemetry container")
 
     duthost = duthosts[rand_one_dut_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
 
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               xpath="DOCKER_STATS", target="STATE_DB", update_count=1, create_connections=2000)
@@ -201,7 +207,8 @@ def test_mem_spike(duthosts, rand_one_dut_hostname, ptfhost, gnxi_path):
     client_thread.start()
 
     for i in range(MEMORY_CHECKER_CYCLES):
-        ret = duthost.shell("python3 /usr/bin/memory_checker telemetry 419430400", module_ignore_errors=True)
+        ret = duthost.shell("python3 /usr/bin/memory_checker %s 419430400" % (env.gnmi_container),
+                            module_ignore_errors=True)
         assert ret["rc"] == 0, "Memory utilization has exceeded threshold"
         time.sleep(MEMORY_CHECKER_WAIT)
 

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -59,4 +59,9 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     for feature_name, state in list(features_dict.items()):
         if 'enabled' not in state:
             continue
+        if feature_name == "telemetry":
+            # Skip telemetry if there's no docker image
+            output = duthost.shell("docker images", module_ignore_errors=True)['stdout']
+            if "sonic-telemetry" not in output:
+                continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='enable')

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -169,6 +169,11 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
         # Skip dhcp_relay check if dhcp_server is enabled
         if is_dhcp_server_enable is not None and "enabled" in is_dhcp_server_enable and feature_name == "dhcp_relay":
             continue
+        if feature_name == "telemetry":
+            # Skip telemetry if there's no docker image
+            output = duthost.shell("docker images", module_ignore_errors=True)['stdout']
+            if "sonic-telemetry" not in output:
+                continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support share image for gnmi and telemetry
Backport https://github.com/sonic-net/sonic-mgmt/pull/10348
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
We will share docker image to support gnmi and telemetry.
So we need to update minigraph, gnmi and telemetry test to support this change.

#### How did you do it?
For telemetry test, check telemetry container at first, if there's no telemetry container, use gnmi container.
For gnmi test, check gnmi container at first, if there's no gnmi container, use telemetry container.
For minigraph test, check feature status to choose service.

#### How did you verify/test it?
Run minigraph, gnmi and telemetry end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
