### PR TITLE
Add retries to validate PSU status after shutdown

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -311,14 +311,16 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
         pytest_assert(psu_test_results[psu],
                       "Test psu status of PSU %s failed" % psu)
 
+
 def validate_psu_status(duthost, psu_line_pattern, psu_under_test):
     cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
     for line in cli_psu_status["stdout_lines"][2:]:
         psu_match = psu_line_pattern.match(line)
         pytest_assert(psu_match, "Unexpected PSU status output")
         if psu_match.group(1) == psu_under_test:
-            pytest_assert(psu_match.group(2) == "OK","Unexpected PSU status after turned it on")
+            pytest_assert(psu_match.group(2) == "OK", "Unexpected PSU status after turned it on")
         check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
+
 
 @pytest.mark.disable_loganalyzer
 def test_show_platform_fanstatus_mocked(duthosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -304,7 +304,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
         pdu_ctrl.turn_on_outlet(outlet)
         time.sleep(5)
 
-        retry_call(validate_psu_status, fargs=[duthost, psu_line_pattern, psu_under_test], tries=3, delay=5)
+        retry_call(validate_psu_status, fargs=[duthost, psu_line_pattern, psu_under_test], tries=3, delay=10)
         psu_test_results[psu_under_test] = True
 
     for psu in psu_test_results:

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -302,9 +302,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn on outlet {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
-        time.sleep(5)
 
-        retry_call(validate_psu_status, fargs=[duthost, psu_line_pattern, psu_under_test], tries=3, delay=10)
+        retry_call(validate_psu_status, fargs=[duthost, psu_line_pattern, psu_under_test], tries=3, delay=5)
         psu_test_results[psu_under_test] = True
 
     for psu in psu_test_results:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
To overcome a stability issue in the test on some platforms after upgrade to debian 12, it is recommended to check up to 3 times every 10 seconds the main reason in that strict value of  which PSU daemon itself has a period of 3 sec. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
The test is failing with a relatively high probability on some platforms.

#### How did you do it?
Added a function for PSU status validation with retries 

#### How did you verify/test it?
Added retries and run the test

#### Any platform specific information?
Any. In Mellanox it was seen on several types following new kernel version as part of debian 12


