### PR TITLE
[lag] Fix `test_lag_2` route_check failures

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -13,6 +13,7 @@ from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.helpers.dut_ports import get_duthost_with_name
 from tests.common.config_reload import config_reload
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
+from tests.common.helpers.parallel import parallel_run_threaded
 
 logger = logging.getLogger(__name__)
 
@@ -28,13 +29,17 @@ TEST_DIR = "/tmp/acstests/"
 def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""
     if loganalyzer:
-        loganalyzer[rand_one_dut_hostname].ignore_regex.extend([".*missed_ROUTE_TABLE_routes.*"])
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(
+            [
+                r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
+            ]
+        )
 
     return
 
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(ptfhost):
+def common_setup_teardown(ptfhost, duthosts):
     logger.info("########### Setup for lag testing ###########")
 
     ptfhost.shell("mkdir -p {}".format(TEST_DIR))
@@ -48,6 +53,14 @@ def common_setup_teardown(ptfhost):
     yield ptfhost
 
     ptfhost.file(path=TEST_DIR, state="absent")
+    # NOTE: As test_lag always causes the route_check to fail and route_check
+    # takes more than 3 cycles(15mins) to alert, the testcase in the nightly after
+    # the test_lag will suffer from the monit alert, so let's config reload the
+    # device here to reduce any potential impact.
+    parallel_run_threaded(
+        target_functions=[lambda duthost=_: config_reload(duthost) for _ in duthosts],
+        timeout=300
+    )
 
 
 def is_vtestbed(duthost):


### PR DESCRIPTION


So, two improvements here:
1. Ignore any error messages from `route_check`
2. Config reload the devices after `test_lag_2` finishes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
`test_lag_2` operations always cause `route_check` to fail. And monit
check will become failed in 15 minutes later(3 check cycles), the
testcases after `test_lag_2` will suffer from sanity check failure due
to this.

So, two improvements here:
1. Ignore any error messages from `route_check`
2. Config reload the devices after `test_lag_2` finishes.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
Run `test_lag_2`, verify no `loganalyzer` error, and `monit` status is good.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
