### PR TITLE
[202205] [cherry-pick] Fix TypeError in check_sysfs

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -145,7 +145,7 @@ def check_sysfs(dut):
 
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in sysfs_facts['sfp_info'].items():
-        assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % sfp_id
+        assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % int(sfp_id)
         sfp_temp = float(sfp_info['temp']) if sfp_info['temp'] != '0' else 0
         sfp_temp_crit = float(sfp_info['crit_temp']) if sfp_info['crit_temp'] != '0' else 0
         sfp_temp_emergency = float(sfp_info['emergency_temp']) if sfp_info['emergency_temp'] != '0' else 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix `TypeError` in `check_sysfs`. The error message is as below.
```
  File "/var/src/sonic-mgmt_vms2-4-t0-2700_646f1405735219c3e54440f2/tests/platform_tests/test_reboot.py", line 167, in test_cold_reboot
    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
  File "/var/src/sonic-mgmt_vms2-4-t0-2700_646f1405735219c3e54440f2/tests/platform_tests/test_reboot.py", line 91, in reboot_and_check
    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
  File "/var/src/sonic-mgmt_vms2-4-t0-2700_646f1405735219c3e54440f2/tests/platform_tests/test_reboot.py", line 140, in check_interfaces_and_services
    check_sysfs(dut)
  File "/var/src/sonic-mgmt_vms2-4-t0-2700_646f1405735219c3e54440f2/tests/platform_tests/mellanox/check_sysfs.py", line 165, in check_sysfs
    assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % sfp_id
TypeError: %d format: a number is required, not AnsibleUnsafeText
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR is to fix `TypeError` in `check_sysfs`. The error message is as below.

#### How did you do it?
Convert `sfp_id` into `int` explicitly.

#### How did you verify/test it?
The change is verified by running `test_cold_reboot` on a Mellanox platform.

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
