### PR TITLE
 [Mellanox] Add topology marker for test_vxlan_crm script

### DIFF
--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -12,6 +12,11 @@ from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401
     fixture_setUp,
     fixture_encap_type)
 
+
+pytestmark = [
+    pytest.mark.topology("t1")
+]
+
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 


### PR DESCRIPTION
Add topology marker for test_vxlan_crm script



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
There is no topology marker in the script of test_vxlan_crm 

Summary:
Fixes # (issue)
Lack of topology marker in script of test_vxlan_crm

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
There is no topology marker in the script of test_vxlan_crm 
#### How did you do it?
Add a topologu marker
#### How did you verify/test it?
Run automation test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
