### PR TITLE
[memory_checker/test_memory_checker] - Increase timeout for memory checker test 

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -528,7 +528,7 @@ def consumes_memory_and_checks_container_restart(duthost, container):
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     with loganalyzer:
-        timeout_monit_fail = 80  # fails happens after 10 cycles of 1 second
+        timeout_monit_fail = 180  # fails happens after 10 cycles of 1 second
         container.start_consume_memory()
         container.wait_monit_mem_failed(timeout_monit_fail)
         logger.info("Container %s should now be restarting", container.name)


### PR DESCRIPTION

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The test case test_memory_checker consumes a large amount of memory on the telemetry docker and waits for monit to detect the failure. The testcase waits for 80 seconds currently to see if monit fails. This timeout is not enough. In the testcase monit runs every second and since there are an increased number of checks in monit currently, the cpu does not have enough idle cycles for the monit to detect the failure. Therefore, increasing the timeout to 150 seconds.
#### How did you do it?
Increased the monit fail timeout to 150 seconds
#### How did you verify/test it?
Ran the test multiple times to see if the testcase passes.
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA