### PR TITLE
Add wait until in stress acl test

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 LOOP_TIMES_LEVEL_MAP = {
     'debug': 10,
     'basic': 50,
-    'confident': 200
+    'confident': 100
 }
 
 # Template json file used to test scale rules
@@ -130,7 +130,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
     if normalized_level is None:
         normalized_level = 'basic'
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
-    wait_time = 2
+    wait_time = 10
 
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -5,7 +5,7 @@ import ptf.testutils as testutils
 from ptf import mask, packet
 from collections import defaultdict
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
-from tests.common.utilities import wait
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "m0", "mx"),
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 LOOP_TIMES_LEVEL_MAP = {
     'debug': 10,
     'basic': 50,
-    'confident': 100
+    'confident': 200
 }
 
 # Template json file used to test scale rules
@@ -115,6 +115,17 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port,
             testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
 
 
+def acl_rule_loaded(rand_selected_dut, acl_rule_list):
+    acl_rule_infos = rand_selected_dut.show_and_parse("show acl rule")
+    acl_id_list = []
+    for acl_info in acl_rule_infos:
+        acl_id = int(acl_info['rule'][len('RULE_'):])
+        acl_id_list.append(acl_id)
+    if sorted(acl_id_list) != sorted(acl_rule_list):
+        return False
+    return True
+
+
 def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_file,
                             prepare_test_port, get_function_conpleteness_level,
                             toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
@@ -130,7 +141,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
     if normalized_level is None:
         normalized_level = 'basic'
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
-    wait_time = 10
+    wait_time = 15
 
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
@@ -150,15 +161,16 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
                                         .format(readd_id, ip_addr2, ip_addr1, readd_id))
                 acl_rule_list.append(readd_id)
 
-            wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
+            wait_until(wait_time, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "drop")
 
             del_rule_id = random.choice(acl_rule_list)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
-            wait(wait_time, "Waiting {} sec acl rules to be loaded".format(wait_time))
+            acl_rule_list.remove(del_rule_id)
+
+            wait_until(wait_time, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
                              acl_rule_list, del_rule_id, "drop")
-            acl_rule_list.remove(del_rule_id)
 
             loops += 1
     finally:

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -141,7 +141,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
     if normalized_level is None:
         normalized_level = 'basic'
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
-    wait_time = 15
+    wait_timeout = 15
 
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
@@ -161,14 +161,14 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
                                         .format(readd_id, ip_addr2, ip_addr1, readd_id))
                 acl_rule_list.append(readd_id)
 
-            wait_until(wait_time, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
+            wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "drop")
 
             del_rule_id = random.choice(acl_rule_list)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
             acl_rule_list.remove(del_rule_id)
 
-            wait_until(wait_time, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
+            wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
                              acl_rule_list, del_rule_id, "drop")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The stress ACL test has a relatively low probability of failing during execution. The reason could be that the add and delete of ACLs require some time, and occasionally, the short time frame may cause the add and delete operations to not occur promptly, resulting in test case failure.
#### How did you do it?
Add wait_until to check if acl rule added/deleted in state db.
#### How did you verify/test it?
Run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
