### PR TITLE
Don't look for /proc/sched_debug for Bookworm

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -25,7 +25,6 @@ copy_proc_files = [
     "/proc/self/net",
     "/proc/pagetypeinfo",
     "/proc/partitions",
-    "/proc/sched_debug",
     "/proc/slabinfo",
     "/proc/softirqs",
     "/proc/stat",

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -11,6 +11,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 from log_messages import LOG_EXPECT_ACL_RULE_CREATE_RE, LOG_EXPECT_ACL_RULE_REMOVE_RE, LOG_EXCEPT_MIRROR_SESSION_REMOVE
+from pkg_resources import parse_version
 
 logger = logging.getLogger(__name__)
 
@@ -412,6 +413,12 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             "docker_cmds":
                 add_asic_arg("{}", docker_cmds, num)}
     )
+
+    # /proc/sched_debug has been moved to debugfs starting with 5.13.0, and is
+    # currently collected only on the older kernel versions
+    if parse_version(duthost.kernel_version) < parse_version('5.13.0'):
+        cmds.copy_proc_files.append("/proc/sched_debug")
+
     if duthost.facts["asic_type"] == "broadcom":
         if duthost.facts.get("platform_asic") == "broadcom-dnx":
             asic_cmds = cmds.broadcom_cmd_bcmcmd_dnx


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes sonic-net/sonic-buildimage#17064

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In the Bookworm kernel, /proc/sched_debug has been moved to debugfs. For now, don't collect this file. If this file is needed, and debugfs collection code gets added to techsupport, then this can be updated.

#### How did you do it?

If the device is running on a kernel older than 5.13.0, then look for `/proc/sched_debug` to be present; otherwise, don't look for it.

#### How did you verify/test it?

Tested on a Bookworm KVM device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
