### PR TITLE
Adding skip for test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset] for cisco-8111 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -252,9 +252,9 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
   skip:
-    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release and innovium"
+    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release and innovium and cisco-8111 platform"
     conditions:
-      - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or asic_type in ['innovium']"
+      - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or asic_type in ['innovium'] or platform in ['x86_64-8111_32eh_o-r0']"
 
 decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=disable]:
   skip:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding skip for test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset] for cisco-8111 platform

#### What is the motivation for this PR?
Adding skip for test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset] for cisco-8111 platform

#### How did you verify/test it?
Verified the change on cisco-8111 platform
