### PR TITLE
Update the copp test rate limits for queue4_group3

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -332,6 +332,9 @@ class DHCPTopoT1Test(PolicyTest):
 class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        self.PPS_LIMIT = 300
+        self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
+        self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 
     def runTest(self):
         self.log("DHCPTest")
@@ -366,6 +369,9 @@ class DHCPTest(PolicyTest):
 class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        self.PPS_LIMIT = 300
+        self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
+        self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 
     def runTest(self):
         self.log("DHCP6Test")
@@ -419,6 +425,9 @@ class DHCP6TopoT1Test(PolicyTest):
 class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        self.PPS_LIMIT = 300
+        self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
+        self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 
     def runTest(self):
         self.log("LLDPTest")
@@ -440,6 +449,9 @@ class LLDPTest(PolicyTest):
 class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        self.PPS_LIMIT = 300
+        self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
+        self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.3
 
     def runTest(self):
         self.log("UDLDTest")

--- a/tests/copp/scripts/update_copp_config.py
+++ b/tests/copp/scripts/update_copp_config.py
@@ -75,13 +75,18 @@ def generate_limited_pps_config(pps_limit, input_config_file, output_config_file
         raise ValueError("Invalid config format specified")
 
     for trap_group in trap_groups:
-        for _, group_config in list(trap_group.items()):
+        for group, group_config in list(trap_group.items()):
             # Notes:
             # CIR (committed information rate) - bandwidth limit set by the policer
             # CBS (committed burst size) - largest burst of packets allowed by the policer
             #
             # Setting these two values to pps_limit restricts the policer to allowing exactly
             # that number of packets per second, which is what we want for our tests.
+            # For queue4_group3, use the default value in copp configuration as this is lower
+            # than 600 PPS
+
+            if group == "queue4_group3":
+                continue
 
             if "cir" in group_config:
                 group_config["cir"] = pps_limit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
 * Do not update default sonic config for queue4_group3 in scripts/update_copp_config.py as the new rate-limit for this copp group is lower than the default value of 600 PPS used by copp tests

 * Change constraint checks to reflect a rate-limit of 300 PPS for queue4_group3 in ansible/roles/test/files/ptftests/py3/copp_tests.py

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
