### PR TITLE
Fix test_fabric_reach.py to run on t2 min topology.

### DIFF
--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -12,6 +12,7 @@ pytestmark = [
 localModule = 0
 supervisorAsicBase = 1
 supReferenceData = {}
+linecardModule = []
 
 
 # Try to get the reference data, and if the reference data files
@@ -87,6 +88,7 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
     global localModule
     global supervisorAsicBase
     global supReferenceData
+    global linecardModule
 
     if not supReferenceData:
         supRefData(duthosts)
@@ -127,8 +129,7 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
 
             # tokens: [localPort, remoteModule, remotLink, localLinkStatus]
             # Example output: ['0', '304', '171', 'up']
-            localPortName = tokens[0]
-            referencePortData = asicReferenceData[localPortName]
+            localPortName = int(tokens[0])
             remoteModule = tokens[1]
             remotePort = tokens[2]
             pytest_assert(localPortName in asicReferenceData,
@@ -150,6 +151,8 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
             # build reference data for sup: supReferenceData
             fabricAsic = 'asic' + str(remoteMod - supervisorAsicBase)
             lkData = {'peer slot': slot, 'peer lk': localPortName, 'peer asic': asic, 'peer mod': localModule}
+            if localModule not in linecardModule:
+                linecardModule.append(localModule)
             supReferenceData[fabricAsic].update({referenceRemotePort: lkData})
         # the module number increased by number of asics per slot.
         localModule += asicPerSlot
@@ -189,6 +192,9 @@ def test_fabric_reach_supervisor(duthosts, enum_supervisor_dut_hostname, refData
             localPortName = tokens[0]
             remoteModule = int(tokens[1])
             remotePort = int(tokens[2])
+            if remoteModule not in linecardModule:
+                logger.info("The linecard is not inserted or down.")
+                continue
             pytest_assert(localPortName in asicReferenceData,
                           "Reference port data for {} not found!".format(localPortName))
             referencePortData = asicReferenceData[localPortName]


### PR DESCRIPTION
Fix test_fabric_reach.py to run on t2 min topology.

manually run the test on a t2 min topo, and it passed.  
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
