### PR TITLE
[sFlow] testDelAgentfix

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -109,6 +109,28 @@ def config_dut_ports(duthost, ports, vlan):
     config_reload(duthost, config_source='config_db', wait=120)
     time.sleep(5)
 
+# ----------------------------------------------------------------------------------$
+
+
+def get_default_agent(duthost):
+    # get_default_agent function is used to get the agentip selected by the hsflowd dameon.
+    # hsflowd.auto is the auto generated file by hsflowd daemon
+    hsflowd_autogen_file = '/etc/hsflowd.auto'
+    result = duthost.shell(
+                        r"docker exec -i sflow sh -c 'test -f {} && echo exist'".format(hsflowd_autogen_file),
+                        module_ignore_errors=True)['stdout'].strip()
+    if result != 'exist':
+        pytest.fail("{} file doesnot exist.".format(hsflowd_autogen_file))
+
+    selected_agent = duthost.shell(
+            "docker exec sflow grep -w 'agentIP' {} | cut -d '=' -f 2".format(hsflowd_autogen_file))['stdout'].strip()
+    if not selected_agent:
+        pytest.fail('agent variable not found in the hsflowd.auto file')
+    else:
+        logger.info('Selected hsflowd agent is : {}'.format(selected_agent))
+
+    return selected_agent
+
 # ----------------------------------------------------------------------------------
 
 
@@ -471,10 +493,11 @@ class TestAgentId():
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost, status='up', agent_id='default')
         time.sleep(5)
+        agent_ip = get_default_agent(duthost)
         # Verify  whether the samples are received with previously configured agent ip
         partial_ptf_runner(
             polling_int=20,
-            agent_id=var['mgmt_ip'],
+            agent_id=agent_ip,
             active_collectors="['collector0','collector1']")
 
     def testAddAgent(self, duthost, partial_ptf_runner):

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -113,14 +113,14 @@ def config_dut_ports(duthost, ports, vlan):
 
 
 def get_default_agent(duthost):
-    # get_default_agent function is used to get the agentip selected by the hsflowd dameon.
+    # get_default_agent function is used to get the agentip selected by the hsflowd daemon.
     # hsflowd.auto is the auto generated file by hsflowd daemon
     hsflowd_autogen_file = '/etc/hsflowd.auto'
     result = duthost.shell(
                         r"docker exec -i sflow sh -c 'test -f {} && echo exist'".format(hsflowd_autogen_file),
                         module_ignore_errors=True)['stdout'].strip()
     if result != 'exist':
-        pytest.fail("{} file doesnot exist.".format(hsflowd_autogen_file))
+        pytest.fail("{} file does not exist.".format(hsflowd_autogen_file))
 
     selected_agent = duthost.shell(
             "docker exec sflow grep -w 'agentIP' {} | cut -d '=' -f 2".format(hsflowd_autogen_file))['stdout'].strip()


### PR DESCRIPTION
Signed-off-by: mohanapriya-meganathan <mohanapriya.m1@dell.com>
Co-authored-by: Gokulnath-Raja <gokulnath_r@dell.com>

### Description of PR
   This PR is raised to fix for the following issue. 
https://github.com/sonic-net/sonic-mgmt/issues/10291

Here is the default agent-id selection logic in hsflowd:

If the agentip or agentname is configured in the settings or hardcoded in the configuration file, agent-ip will be choosen from that settings or configuration file.

If it is not falls under 1st condition, we will try to get all(ipv4 and ipv6) the ip interfaces configured and match ipPriority(EnumIPSelectionPriority) appropriate for the interface.

https://github.com/sflow/host-sflow/blob/6296a172c2c3879126298dc66994d38e68956185/src/Linux/hsflowconfig.c#L1019

typedef enum { IPSP_NONE=0,
	 IPSP_CLASS_E,
	 IPSP_MULTICAST,
	 IPSP_LOOPBACK6,
	 IPSP_LOOPBACK4,
	 IPSP_SELFASSIGNED4,
	 IPSP_IP6_SCOPE_LINK,
	 IPSP_VLAN6,
	 IPSP_VLAN4,
	 IPSP_IP6_SCOPE_UNIQUE,
	 IPSP_IP6_SCOPE_GLOBAL,
	 IPSP_IP4_RFC1918,
	 IPSP_IP4,
	 IPSP_NUM_PRIORITIES,
} EnumIPSelectionPriority;

Based on the Selection Priority, ip interface having higher priority will be selected as agent-id.
https://github.com/sflow/host-sflow/blob/6296a172c2c3879126298dc66994d38e68956185/src/Linux/hsflowconfig.c#L1112,
If two interfaces having same selectionpriority, then we need to get the interface index and adaptor selection priority for the particular interface.
If interface index is same, then first discovered ip is choosen to be the agent-id.
If interface index is different, then the adaptor having lower selection priority is choosen to be the agent-id.
If adaptor priority is same, then interface having lower interface index is choosen to be agent-id.

The chosen agent-id is updated in hsflowd.auto file. From the test script, we are accessing /etc/hsflowd.auto file to find the selected hsflowd agent. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

#### How did you verify/test it?
[test_sflow.log](https://github.com/sonic-net/sonic-mgmt/files/13346820/test_sflow.log)

