### PR TITLE
Add multi-asic support to bgp-queue test case

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -11,6 +11,7 @@ pytestmark = [
 
 NAMESPACE_PREFIX = "sudo ip netns exec {} "
 
+
 def clear_queue_counters(duthost, namespace):
     CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
     duthost.shell(CMD_PREFIX + "sonic-clear queuecounters")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- This PR fixes test failures and adds support to '_test_bgp_queue_' test case for T2 multi-asic chassis.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
- For T2 multi-asic chassis, 'test_bgp_queue' tests fail with the following error.

`E           RunAnsibleModuleFail: run module command failed, Ansible Results =>
E           {"changed": true, "cmd": ["show", "arp"], "delta": "0:01:04.005088", "end": "2023-11-11 14:41:44.351253", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2023-11-11 14:40:40.346165", "stderr": "", "stderr_lines": [], "stdout": "Key '{COUNTERS_PORT_NAME_MAP}' unavailable in database '{COUNTERS_DB}'", "stdout_lines": ["Key '{COUNTERS_PORT_NAME_MAP}' unavailable in database '{COUNTERS_DB}'"]}
`

#### How did you do it?
- If the duthost is multi-asic, used asic aware namespace commands to fetch the details on the DUT.

#### How did you verify/test it?

- Ran the '_test_bgp_queue_' test cases against a multi-asic line card in a T2 chassis.

![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/301f4cd5-f735-48e8-b751-7e93147d064f)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
