### PR TITLE
enhance test_max_numbers_of_sub_ports for python3

### DIFF
--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -467,10 +467,10 @@ class TestSubPortStress(object):
         """
         sub_ports_new = dict()
         sub_ports = apply_config_on_the_dut['sub_ports']
-        sub_ports_new[sub_ports.keys()[0]] = sub_ports[sub_ports.keys()[0]]
-        sub_ports_new[sub_ports.keys()[-1]] = sub_ports[sub_ports.keys()[-1]]
+        sub_ports_new[list(sub_ports.keys())[0]] = sub_ports[list(sub_ports.keys())[0]]
+        sub_ports_new[list(sub_ports.keys())[-1]] = sub_ports[list(sub_ports.keys())[-1]]
 
-        rand_sub_ports = sub_ports.keys()[random.randint(1, len(sub_ports)-1)]
+        rand_sub_ports = list(sub_ports.keys())[random.randint(1, len(sub_ports)-1)]
         sub_ports_new[rand_sub_ports] = sub_ports[rand_sub_ports]
 
         for sub_port, value in sub_ports_new.items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
25745148

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
case sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortStress::test_max_numbers_of_sub_ports failure on internal 

#### How did you do it?
enhance the case for python3

#### How did you verify/test it?
collected 2 items                                                                                                                                                                                                                                                                                                                                                   it is now deprecated in cryptography, and will be removed in the next release.

sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortStress::test_max_numbers_of_sub_ports[port] PASSED                                                                    it is now deprecated in cryptography, and will be removed in the next release.                                                                       [ 50%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortStress::test_max_numbers_of_sub_ports[port_in_lag] PASSED                                                             it is now deprecated in cryptography, and will be removed in the next release.                                                                       [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
