### PR TITLE
[TACACS] Remove 'show feature status telemetry' command test because telemetry feature removed

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -185,7 +185,6 @@ def test_authorization_tacacs_only(
         "show interfaces counters -a -p 3",
         "show ip bgp neighbor",
         "show ipv6 bgp neighbor",
-        "show feature status telemetry",
         "touch testfile",
         "chmod +w testfile",
         "echo \"test\" > testfile",


### PR DESCRIPTION
[TACACS] Remove 'show feature status telemetry' command test because telemetry feature removed

### Description of PR
[TACACS] Remove 'show feature status telemetry' command test because telemetry feature removed


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Remove 'show feature status telemetry' command test because telemetry feature removed

#### How did you do it?
Remove 'show feature status telemetry' command

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
