### PR TITLE
[Mellanox|202205] Fix testQosSaiDwrr issue

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -177,9 +177,10 @@ class ThriftInterface(BaseTest):
 
         return stdOut, stdErr, retValue
 
-    def sai_thrift_port_tx_enable(self, client, asic_type, port_list, target='dst', last_port=True):
+    def sai_thrift_port_tx_enable(
+            self, client, asic_type, port_list, target='dst', last_port=True, enable_port_by_unblock_queue=True):
         count = 0
-        if asic_type == 'mellanox':
+        if asic_type == 'mellanox' and enable_port_by_unblock_queue:
             self.enable_mellanox_egress_data_plane(port_list)
         else:
             sai_thrift_port_tx_enable(client, asic_type, port_list, target=target)
@@ -205,7 +206,7 @@ class ThriftInterface(BaseTest):
             assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0,\
                 "enable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
 
-    def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst'):
+    def sai_thrift_port_tx_disable(self, client, asic_type, port_list, target='dst', disable_port_by_block_queue=True):
         count = 0
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             # need to enable watchdog on the source asic using cint script
@@ -229,7 +230,7 @@ class ThriftInterface(BaseTest):
             assert 'Success rv = 0' in stdOut[1] if stdOut else retValue == 0, \
                 "disable wd failed '{}' on asic '{}' on '{}'".format(cmd, self.src_asic_index, self.src_server_ip)
                         
-        if asic_type == 'mellanox':
+        if asic_type == 'mellanox' and disable_port_by_block_queue:
             self.disable_mellanox_egress_data_plane(port_list)
         else:
             sai_thrift_port_tx_disable(client, asic_type, port_list, target=target)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3118,7 +3118,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         )
         print("actual dst_port_id: {}".format(dst_port_id), file=sys.stderr)
 
-        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id], disable_port_by_block_queue=False)
 
         send_packet(self, src_port_id, pkt, pkts_num_leak_out)
 
@@ -3144,7 +3144,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
 
         # Release port
-        self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+        self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id], enable_port_by_unblock_queue=False)
 
         cnt = 0
         pkts = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix issue: https://github.com/sonic-net/sonic-mgmt/issues/10299
Because the method to generate congestion for Mellanox device is changed from disabling the whole port to disabling the queue one by one, and when we recover the port, we also enable the queue one by one. So, it will cause testQosSaiDwrr to fail. testQosSaiDwrr is to test the function of scheduling queue to send packets, the pre-condition is that all queues should be at the same enabled state, but currently, they are enabled back one by one, so the order to send packets is the same as the order to enable the queue not depending on the scheduling algorithm. So, for this case, we still use the original method to generate congestion.



Summary:
Fixes # (issue)https://github.com/sonic-net/sonic-mgmt/issues/10299

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Fix issue : https://github.com/sonic-net/sonic-mgmt/issues/10299

#### How did you do it?
For this case, we still use the original method to generate congestion.

#### How did you verify/test it?
Run testQosSaiDwrr  on Mellanox device

#### Any platform specific information?
Mellonax device

#### Supported testbed topology if it's a new test case?
T0

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
