### PR TITLE
[sanity check] Fix list clear attribute error

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -530,8 +530,8 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
     def _check_mux_status_helper():
         run_result.clear()
         duts_parsed_mux_status.clear()
-        err_msg_from_mux_status.clear()
-        dut_wrong_mux_status_ports.clear()
+        err_msg_from_mux_status[:] = []
+        dut_wrong_mux_status_ports[:] = []
         run_result.update(
             **parallel_run(_verify_show_mux_status, (), kwargs, duthosts, timeout=600, init_result=init_result)
         )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the sanity check failure observed in 202305 branch nightly:
```
    def _check_mux_status_helper():
        run_result.clear()
        duts_parsed_mux_status.clear()
>       err_msg_from_mux_status.clear()
E       AttributeError: 'list' object has no attribute 'clear'
```

#### How did you do it?
Use assignment to empty list to clear.

#### How did you verify/test it?
Run `test_bgp_fact` with sanity check on 202305.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
