### PR TITLE
[SNMP]: Skip test_snmp_link_local testcase

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1068,11 +1068,10 @@ show_techsupport/test_techsupport.py::test_techsupport:
 #######################################
 snmp/test_snmp_link_local.py:
   skip:
-    reason: "SNMP over IPv6 support not present in release branches."
+    reason: "SNMP over link local IPv6 not supported in all scenarios."
     conditions:
-      - https://github.com/sonic-net/sonic-buildimage/issues/6108
+      - https://github.com/sonic-net/sonic-mgmt/pull/10244/files
       - "is_multi_asic==False"
-      - "release in ['202205', '202211', '202305']"
 
 snmp/test_snmp_pfc_counters.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1071,7 +1071,6 @@ snmp/test_snmp_link_local.py:
     reason: "SNMP over link local IPv6 not supported in all scenarios."
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/pull/10244/files
-      - "is_multi_asic==False"
 
 snmp/test_snmp_pfc_counters.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-buildimage/pull/17045 changes the approach taken to update snmp and the test case has to be modified to work with latest changes. Details added in https://github.com/sonic-net/sonic-mgmt/issues/10766
#### How did you do it?
skip test_snmp_link_local test case for all branches.
#### How did you verify/test it?
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_link_local.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -e "--mark-conditions-files common/plugins/conditional_mark/tests_mark_conditions.yaml" -u -e "--rootdir /data/sonic-mgmt/tests"
=== Running tests in groups ===
Running: python2 -m pytest snmp/test_snmp_link_local.py --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --skip_sanity --disable_loganalyzer --mark-conditions-files common/plugins/conditional_mark/tests_mark_conditions.yaml --rootdir /data/sonic-mgmt/tests
                                                                                                                     

snmp/test_snmp_link_local.py::test_snmp_link_local_ip[vlab-01] SKIPPED                                                                                        [100%]

========================================================================= warnings summary ==========================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:335
  /usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:335: PytestUnknownMarkWarning: Unknown pytest.mark.bsl - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------ generated xml file: /data/sonic-mgmt/tests/logs/tr.xml -------------------------------------------------------
====================================================================== short test summary info ======================================================================
SKIPPED [1] snmp/test_snmp_link_local.py:20: SNMP over link local IPv6 not supported in all scenarios.
=============================================================== 1 skipped, 1 warnings in 6.91 seconds ===============================================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
