### PR TITLE
202205:Select only ports belonging to same asic - chassis-packet

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -197,6 +197,8 @@ class FibTest(BaseTest):
                 # Because the MACsec is session based channel but the injected ports are stateless ports
                 if src_port in macsec.MACSEC_INFOS.keys():
                     continue
+                if self.switch_type == "chassis-packet":
+                    exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
                 logging.info('src_port={}, exp_port_lists={}, active_dut_indexes={}'.format(src_port, exp_port_lists, active_dut_indexes))
                 break
         return src_port, exp_port_lists, next_hops
@@ -260,7 +262,7 @@ class FibTest(BaseTest):
                     hit_count_map[matched_port] = hit_count_map.get(matched_port, 0) + 1
                 for next_hop in next_hops:
                     # only check balance on a DUT
-                    self.check_hit_count_map(next_hop.get_next_hop(), hit_count_map)
+                    self.check_hit_count_map(next_hop.get_next_hop(), hit_count_map, src_port)
                     self.balancing_test_count += 1
                 if self.balancing_test_count >= self.balancing_test_number:
                     break
@@ -472,7 +474,34 @@ class FibTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    def check_hit_count_map(self, dest_port_list, port_hit_cnt):
+    def check_same_asic(self, src_port, exp_port_list):
+        updated_exp_port_list = list()
+        for port in exp_port_list:
+            if type(port) == list:
+                per_port_list = list()
+                for per_port in port:
+                    if self.ptf_test_port_map[str(per_port)]['target_dut'] \
+                            != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                        return exp_port_list
+                    else:
+                        if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
+                                == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                            per_port_list.append(per_port)
+                if per_port_list:
+                    updated_exp_port_list.append(per_port_list)
+            else:
+                if self.ptf_test_port_map[str(port)]['target_dut'] \
+                        != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                    return exp_port_list
+                else:
+                    if self.ptf_test_port_map[str(port)]['asic_idx'] \
+                            == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                        updated_exp_port_list.append(port)
+        if updated_exp_port_list:
+            exp_port_list = updated_exp_port_list
+        return exp_port_list
+
+    def check_hit_count_map(self, dest_port_list, port_hit_cnt, src_port):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
@@ -481,6 +510,8 @@ class FibTest(BaseTest):
         '''
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" % ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
+        if self.switch_type == "chassis-packet":
+            dest_port_list = self.check_same_asic(src_port, dest_port_list)
 
         asic_list = defaultdict(list)
         if self.switch_type == "voq":
@@ -508,7 +539,7 @@ class FibTest(BaseTest):
         for ecmp_entry in dest_port_list:
             for member in ecmp_entry:
                 total_hit_cnt += port_hit_cnt.get(member, 0)
-        
+
         total_hit_cnt = total_hit_cnt//len(asic_list.keys())
 
         for asic_member in asic_list.values():

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -145,6 +145,8 @@ class HashTest(BaseTest):
     def check_hash(self, hash_key):
         dst_ip = self.dst_ip_interval.get_random_ip()
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
         logging.info("dst_ip={}, src_port={}, exp_port_lists={}".format(dst_ip, src_port, exp_port_lists))
         for exp_port_list in exp_port_lists:
             if len(exp_port_list) <= 1:
@@ -176,7 +178,7 @@ class HashTest(BaseTest):
             logging.info("hash_key={}, hit count map: {}".format(hash_key, hit_count_map))
 
             for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
 
     def check_ip_route(self, hash_key, src_port, dst_ip, dst_port_lists):
         if ip_network(six.text_type(dst_ip)).version == 4:
@@ -405,7 +407,34 @@ class HashTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    def check_balancing(self, dest_port_list, port_hit_cnt):
+    def check_same_asic(self, src_port, exp_port_list):
+        updated_exp_port_list = list()
+        for port in exp_port_list:
+            if type(port) == list:
+                per_port_list = list()
+                for per_port in port:
+                    if self.ptf_test_port_map[str(per_port)]['target_dut'] \
+                            != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                        return exp_port_list
+                    else:
+                        if self.ptf_test_port_map[str(per_port)]['asic_idx'] \
+                                == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                            per_port_list.append(per_port)
+                if per_port_list:
+                    updated_exp_port_list.append(per_port_list)
+            else:
+                if self.ptf_test_port_map[str(port)]['target_dut'] \
+                        != self.ptf_test_port_map[str(src_port)]['target_dut']:
+                    return exp_port_list
+                else:
+                    if self.ptf_test_port_map[str(port)]['asic_idx'] \
+                            == self.ptf_test_port_map[str(src_port)]['asic_idx']:
+                        updated_exp_port_list.append(port)
+        if updated_exp_port_list:
+            exp_port_list = updated_exp_port_list
+        return exp_port_list
+
+    def check_balancing(self, dest_port_list, port_hit_cnt, src_port):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
@@ -415,6 +444,8 @@ class HashTest(BaseTest):
 
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" % ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
+        if self.switch_type == "chassis-packet":
+            dest_port_list = self.check_same_asic(src_port, dest_port_list)
 
         asic_list = defaultdict(list)
         if self.switch_type == "voq":
@@ -442,7 +473,7 @@ class HashTest(BaseTest):
         for ecmp_entry in dest_port_list:
             for member in ecmp_entry:
                 total_hit_cnt += port_hit_cnt.get(member, 0)
-        
+
         total_hit_cnt = total_hit_cnt//len(asic_list.keys())
 
         for asic_member in asic_list.values():
@@ -513,7 +544,7 @@ class IPinIPHashTest(HashTest):
                             tcp_sport=sport,
                             tcp_dport=dport,
                             ip_ttl=64)
-        
+
         ipinip_pkt = simple_ipv4ip_packet(
                             eth_dst=router_mac,
                             eth_src=src_mac,
@@ -535,7 +566,7 @@ class IPinIPHashTest(HashTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
-       
+
         send_packet(self, src_port, ipinip_pkt)
         logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'\
             .format(ipinip_pkt.src,
@@ -568,7 +599,7 @@ class IPinIPHashTest(HashTest):
                             "but the src mac doesn't match, expected {}, got {}".
                             format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
         return (rcvd_port, rcvd_pkt)
-    
+
     def check_ipv6_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip):
         '''
         @summary: Check IPv6 route works.
@@ -609,7 +640,7 @@ class IPinIPHashTest(HashTest):
                                 ip_src=outer_src_ip,
                                 ip_dst=outer_dst_ip,
                                 inner_frame=pkt['IPv6'])
-        
+
         exp_pkt = ipinip_pkt.copy()
         exp_pkt['IP'].ttl -= 1
 
@@ -624,7 +655,7 @@ class IPinIPHashTest(HashTest):
         if self.ignore_ttl:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
-        
+
         send_packet(self, src_port, ipinip_pkt)
         logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'\
             .format(ipinip_pkt.src,
@@ -659,7 +690,7 @@ class IPinIPHashTest(HashTest):
                             "but the src mac doesn't match, expected {}, got {}".
                             format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
         return (rcvd_port, rcvd_pkt)
-    
+
     def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip):
         if self.ipver == 'ipv4':
             (matched_port, received) = self.check_ipv4_route(hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip)
@@ -672,7 +703,7 @@ class IPinIPHashTest(HashTest):
         time.sleep(0.02)
 
         return (matched_port, received)
-    
+
     def check_hash(self, hash_key):
         # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
         # We don't care the actually value as long as the outer_dst_ip is routed by default routed
@@ -680,6 +711,8 @@ class IPinIPHashTest(HashTest):
         outer_src_ip = '80.1.0.31'
         outer_dst_ip = '80.1.0.32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(outer_dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
 
         logging.info("outer_src_ip={}, outer_dst_ip={}, src_port={}, exp_port_lists={}".format(outer_src_ip, outer_dst_ip, src_port, exp_port_lists))
         for exp_port_list in exp_port_lists:
@@ -719,7 +752,7 @@ class IPinIPHashTest(HashTest):
             logging.info("hash_key={}, hit count map: {}".format(hash_key, hit_count_map))
 
             for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
 
     def runTest(self):
         """


### PR DESCRIPTION
Since Cherry-picking to 202205 failed from master for PR#10365. Opening this PR just for 202205 branch

Description of PR
In case of chassis-packet switch type, when src port of the traffic is on the same DUT and same asic as destination port, it sends out traffic only on the ports that belong to the same asic. Currently both fib_test and hash_test was set to send out on ports that belonged to different asic causing the balancing test to fail. THis change pertains only to chassis-packet switch type

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Fix balancing test for chassis packet switch type


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
