### PR TITLE
Add speed check lower then 1G

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -155,7 +155,10 @@ def check_ports_up(duthost, dut_ports, expect_speed=None):
         if expect_speed:
             int_status = show_interface_output['int_status']
             for dut_port in dut_ports:
-                actual_speed = int_status[dut_port]['speed'][:-1] + '000'
+                if int_status[dut_port]['speed'][-1] == 'G':
+                    actual_speed = int_status[dut_port]['speed'][:-1] + '000'
+                else:
+                    actual_speed = int_status[dut_port]['speed'][:-1]
                 if actual_speed != expect_speed:
                     return False
         return True
@@ -217,7 +220,10 @@ def test_auto_negotiation_advertised_speeds_all(enum_dut_portname_module_fixture
     int_status = duthost.show_interface(command="status")["ansible_facts"]['int_status']
     common_supported_speeds = enum_dut_portname_module_fixture['speeds']
     highest_speed = max([int(p) for p in common_supported_speeds])
-    actual_speed = int(int_status[dut_port]['speed'][:-1] + '000')
+    if int_status[dut_port]['speed'][-1] == 'G':
+        actual_speed = int_status[dut_port]['speed'][:-1] + '000'
+    else:
+        actual_speed = int_status[dut_port]['speed'][:-1]
     pytest_assert(actual_speed == highest_speed, 'Actual speed is not the highest speed')
 
 

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -221,9 +221,9 @@ def test_auto_negotiation_advertised_speeds_all(enum_dut_portname_module_fixture
     common_supported_speeds = enum_dut_portname_module_fixture['speeds']
     highest_speed = max([int(p) for p in common_supported_speeds])
     if int_status[dut_port]['speed'][-1] == 'G':
-        actual_speed = int_status[dut_port]['speed'][:-1] + '000'
+        actual_speed = int(int_status[dut_port]['speed'][:-1] + '000')
     else:
-        actual_speed = int_status[dut_port]['speed'][:-1]
+        actual_speed = int(int_status[dut_port]['speed'][:-1])
     pytest_assert(actual_speed == highest_speed, 'Actual speed is not the highest speed')
 
 


### PR DESCRIPTION
Summary: Add speed check lower then 1G

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?

Original test_auto_negotiation.py only check speed more than 1G. Add check for 100M, 10M and 1M.

#### How did you do it?

Modify tests/platform_tests/test_auto_negotiation.py
Add speed check lower than 1G.

#### How did you verify/test it?

Test case: 
tests/platform_tests/test_auto_negotiation.py
Verify Interface speed lower than 1G.

#### Any platform specific information?

Any

#### Supported testbed topology if it's a new test case?

Any

