### PR TITLE
Increase check bgp session timeout; handle failed tcp connection

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -439,7 +439,8 @@ def start_peer_ipv4_bgp_session(
     )
 
     # check exabgp http_api port is ready
-    return wait_tcp_connection(localhost, ptfhost.mgmt_ip, port)
+    if not wait_tcp_connection(localhost, ptfhost.mgmt_ip, port, timeout_s=60):
+        pytest.fail(f"exabgp http_api {ptfhost.mgmt_ip} port {port} is not ready")
 
 
 def verify_bgp_session(duthost, bgp_neighbor):

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -169,7 +169,7 @@ def wait_tcp_connection(client, server_hostname, listening_port, timeout_s=30):
                           state='started',
                           timeout=timeout_s,
                           module_ignore_errors=True)
-    if 'exception' in res:
+    if 'exception' in res or res.get('failed') is True:
         logger.warn("Failed to establish TCP connection to %s:%d, timeout=%d" %
                     (str(server_hostname), listening_port, timeout_s))
         return False


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: increase check bgp session timeout; handle failed tcp connection

Previously we used the default value for the timeout equal to 30s. While running this test I faced errors because of small timeout occurs rarely, so it was decided to double it(30s -> 60s).
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
To handle failed TCP connections and adjust bgp session timeout
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
