### PR TITLE
Closes #9879 Andubela/migsoftwar 9879 test_snmp_fdb_dmac_nmatch

### DIFF
--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -104,7 +104,7 @@ def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,      
     # Flush dataplane
     ptfadapter.dataplane.flush()
 
-    time.sleep(10)
+    time.sleep(20)
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
     snmp_facts = get_snmp_facts(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Logs: /auto/sonic-logs/crocodile-T0/6266/t0_croc_6266_nightly/snmp
name="test_snmp_fdb_send_tagged"
failure message="AssertionError: Dummy MAC count does not match"

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The Test sonic-mgmt/tests/snmp/test_snmp_fdb.py performs below operations.
     * Send tagged packets from each port.
     * Verify SNMP FDB entry

While verification we found that the Flush dataplane was not flushing all the data. 
     ptfadapter.dataplane.flush()
 
So, we have added extra 10Sec time to it.
     time.sleep(20)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
