### PR TITLE
Fixing warmboot finalizer and reachability watcher sync

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1081,8 +1081,8 @@ class ReloadTest(BaseTest):
                 self.warmboot_finalizer_thread.is_alive():
             time.sleep(0.5)
         if self.warmboot_finalizer_thread.is_alive():
-            self.fails['dut'].add(f"Warmboot Finalizer hasn't finished for {total_timeout} seconds. "
-                                  f"Finalizer state: {self.get_warmboot_finalizer_state()}")
+            self.fails['dut'].add("Warmboot Finalizer hasn't finished for {} seconds. Finalizer state: {}"
+                                  .format(total_timeout, self.get_warmboot_finalizer_state()))
 
         # Stop watching DUT
         self.watching = False


### PR DESCRIPTION
Change-Id: I13c1c9bf835bfafb924bbddab0acd50a8e045318

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This fix ensures that in cases of warm or fast reboot, the reachability watcher will not stop until the reboot is completed. The warmboot finalizer is the thread that is responsible for indicating when the reboot is completed.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311 

### Approach
#### What is the motivation for this PR?
The motivation for this PR is to prevent such kind of situation when the reachability watcher exits too early before the control plane is up status reported.

#### How did you do it?
Moved _waiting for finalizer to be done or exit by timeout_ code block to stand before stopping reachability watcher

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
