### PR TITLE
Modifying sonic db cli command namespace parameter

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -57,10 +57,11 @@ def enable_counters(duthosts):
 
         namespace_list = duthost.get_asic_namespace_list() if duthost.is_multi_asic else ['']
         for namespace in namespace_list:
-            cmd_get_cnt_status = "sonic-db-cli -n '{}' CONFIG_DB HGET \"FLEX_COUNTER_TABLE|{}\" FLEX_COUNTER_STATUS"
+            namespace_param = NAMESPACE_SUFFIX.format(namespace) if duthost.is_multi_asic else ''
+            cmd_get_cnt_status = "sonic-db-cli {} CONFIG_DB HGET \"FLEX_COUNTER_TABLE|{}\" FLEX_COUNTER_STATUS"
             previous_cnt_status[duthost][namespace] = {
                 item: duthost.command(
-                    cmd_get_cnt_status.format(namespace, item.upper()))["stdout"] for item in ["port", "rif"]}
+                    cmd_get_cnt_status.format(namespace_param, item.upper()))["stdout"] for item in ["port", "rif"]}
 
             ns_cmd_list = []
             CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
@@ -193,7 +194,8 @@ def mtu_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         @classmethod
         def set_mtu(cls, mtu, iface, asic_index):
             duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-            namespace = duthost.get_namespace_from_asic_id(asic_index) if duthost.is_multi_asic else ''
+            namespace_param = NAMESPACE_SUFFIX.format(
+                duthost.get_namespace_from_asic_id(asic_index)) if duthost.is_multi_asic else ''
             if "PortChannel" in iface:
                 cls.key = "PORTCHANNEL"
             elif "Ethernet" in iface:
@@ -202,8 +204,8 @@ def mtu_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                 raise Exception("Unsupported interface parameter - {}".format(iface))
 
             cls.mtu = duthost.command(
-                "sonic-db-cli -n '{}' CONFIG_DB hget \"{}|{}\" mtu".format(
-                    namespace, cls.key, iface
+                "sonic-db-cli {} CONFIG_DB hget \"{}|{}\" mtu".format(
+                    namespace_param, cls.key, iface
                 )
             )["stdout"]
 
@@ -211,8 +213,8 @@ def mtu_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                 cls.mtu = cls.default_mtu
 
             duthost.command(
-                "sonic-db-cli -n '{}' CONFIG_DB hset \"{}|{}\" mtu {}".format(
-                    namespace, cls.key, iface, mtu
+                "sonic-db-cli {} CONFIG_DB hset \"{}|{}\" mtu {}".format(
+                    namespace_param, cls.key, iface, mtu
                 )
             )["stdout"]
 
@@ -230,12 +232,11 @@ def mtu_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         @classmethod
         def restore_mtu(cls):
             duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-            namespace = duthost.get_namespace_from_asic_id(
-                cls.asic_index
-            ) if duthost.is_multi_asic else ''
+            namespace_param = NAMESPACE_SUFFIX.format(
+                duthost.get_namespace_from_asic_id(cls.asic_index)) if duthost.is_multi_asic else ''
             duthost.command(
-                "sonic-db-cli -n '{}' CONFIG_DB hset \"{}|{}\" mtu {}".format(
-                    namespace, cls.key, cls.iface, cls.mtu
+                "sonic-db-cli {} CONFIG_DB hset \"{}|{}\" mtu {}".format(
+                    namespace_param, cls.key, cls.iface, cls.mtu
                 )
             )["stdout"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines; https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier: -->
### Description of PR

Fixing syntax issue arising from using "-n '' " in single asic cases Explanation : It’s observed that the fanout RX port (Eth141 in T1) seems is set at an MTU of 1500, and the DUT RX port is set at 9100, while it is supposed to be the other way round. On changing the fanout MTU to the intended value - 9100, and the DUT to a value of 1500, we are seeing the intended result - packets are not being dropped at the fanout and instead at the DUT.

The issue seems to be the in sonic-db cli command used to modify the CONFIG_DB value - there is a “-n {} “ parameter included to specify the asic namespace for all cases, however the value inside the bracket is made empty (‘’) for single asic - therefore leaving a parameter -n with no value - this is a syntax error - therefore when the mtu value at the DUT is initially pulled from the db clu into cls.mtu, it has a blank value due to the wrong command. After this, there is a conditional statement that assigns a “default” 9100 value to a blank cls.mtu which therefore causes the DUT port MTU to be set to 9100 instead of 1500.

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix -->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

test_drop_counters.py::test_ip_pkt_with_exceeded_mtu was giving this error

name="test_ip_pkt_with_exceeded_mtu[port_channel_members-croc-xx36-dut]" <failure message="Failed: 'RX_ERR' drop counter was not incremented on iface Ethernet232. DUT RX_ERR == [0]; Sent == 1000" Logs: /auto/sonic-logs/crocodile-T0/6266/t0_croc_6266_nightly/drop_packets 

FAILED drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[port_channel_members-croc-t1-dut] - Failed: 'RX_ERR' drop counter was not incremented on iface Ethernet80. DUT RX_ERR == [0]; Sent == 1000
FAILED drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[rif_members-croc-t1-dut] - Failed: 'RX_ERR' drop counter was not incremented on iface Ethernet160. DUT RX_ERR == [0]; Sent == 1000

Here, packets that were supposed to be dropped at the DUT were instead being dropped at the PTF and never reaching the DUT - this is because the DUT and the PTF's relevant ports had the opposite of the desired MTU values - the DUT was given a high MTU of 9100, while the PTF was given an MTU of 1500, therefore the large sized packets, that were supposed to pass through the 9100 MTU PTF, were instead dropped there because of the 1500 MTU, never reaching the DUT. 

This is because of the universal use of the "-n " parameter in the sonic-db cli commands used to modify the MTUs of the relevant ports, get existent MTUs, and interact with the redis DBs in general. This -n parameter should only be included when working with a multi-asic setup, since we will have to specify the asic number, and therefore when included with single asic cases, is causing the failure of the MTU modification, retrieval etc. 

#### How did you do it?
Modified the commands such that the -n parameter was only included conditionally, based on the single/multi-asic nature of the setup. 

#### How did you verify/test it?
Tested on crocodile topologies - T1, T0 - where this failure was seen. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation? Link to the wiki page?
-->

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
