### PR TITLE
[Route flap] add module_ignore_errors to shell command to let it return empty output

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -255,7 +255,7 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                     if per_hop['interfaceName'] in internal_intfs:
                         continue
                     port = per_hop['interfaceName']
-                    neigh = duthost.shell("show ip int | grep -w {}".format(port))['stdout']
+                    neigh = duthost.shell("show ip int | grep -w {}".format(port), module_ignore_errors=True)['stdout']
                     if neigh == '':
                         logger.info("{} is still internal interface, skipping".format(port))
                     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)https://github.com/sonic-net/sonic-mgmt/issues/10811

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
