### PR TITLE
Update test_memory_checker loganalyzer string for Bookworm

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -464,6 +464,8 @@ class MemoryCheckerContainer(object):
 
     def get_restart_expected_logre(self):
         cap_name = self.name.capitalize()
+        if self.name == "gnmi":
+            cap_name = "GNMI"
         if "bookworm" in self.duthost.shell("grep VERSION_CODENAME /etc/os-release")['stdout'].lower():
             return [
                 r".*restart_service.*Restarting service '{}'.*".format(self.name),

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -464,15 +464,22 @@ class MemoryCheckerContainer(object):
 
     def get_restart_expected_logre(self):
         cap_name = self.name.capitalize()
-        if self.name == "gnmi":
-            cap_name = "GNMI"
-        return [
-            r".*restart_service.*Restarting service '{}'.*".format(self.name),
-            r".*Stopping {} container.*".format(cap_name),
-            r".*Stopped {} container.*".format(cap_name),
-            r".*Starting {} container.*".format(cap_name),
-            r".*Started {} container.*".format(cap_name),
-        ]
+        if "bookworm" in self.duthost.shell("grep VERSION_CODENAME /etc/os-release")['stdout'].lower():
+            return [
+                r".*restart_service.*Restarting service '{}'.*".format(self.name),
+                r".*Stopping {}.service - {} container.*".format(self.name, cap_name),
+                r".*Stopped {}.service - {} container.*".format(self.name, cap_name),
+                r".*Starting {}.service - {} container.*".format(self.name, cap_name),
+                r".*Started {}.service - {} container.*".format(self.name, cap_name),
+            ]
+        else:
+            return [
+                r".*restart_service.*Restarting service '{}'.*".format(self.name),
+                r".*Stopping {} container.*".format(cap_name),
+                r".*Stopped {} container.*".format(cap_name),
+                r".*Starting {} container.*".format(cap_name),
+                r".*Started {} container.*".format(cap_name),
+            ]
 
     def get_last_start_date(self):
         rc = self.duthost.shell(r"docker inspect --format \{{\{{.State.StartedAt\}}\}} {}".format(self.name))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In Bookworm, when stopping/starting services, systemd will include the service file name in the Stopping/Starting message, along with the service name.

#### How did you do it?

Modify the loganaylzer expected matches string to check to see if it being run on Bookworm; if so, include the service file name in the expected messages.

#### How did you verify/test it?

Manually tested on a Bookworm image, but without the gnmi container (so telemetry was used instead).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
