### PR TITLE
[Arista] skip testing sfp interfaces on Arista-7050QX-32S-S4Q31

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -76,6 +76,12 @@ def xcvr_skip_list(duthosts):
             logging.debug(
                 "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
 
+        # No hwsku.json for Arista-7050-QX-32S/Arista-7050QX-32S-S4Q31
+        if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX-32S-S4Q31']:
+            sfp_list = ['Ethernet0', 'Ethernet1', 'Ethernet2', 'Ethernet3']
+            logging.debug('Skipping sfp interfaces: {}'.format(sfp_list))
+            intf_skip_list[dut.hostname].extend(sfp_list)
+
     return intf_skip_list
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is to skip testing SFP interfaces on Arista-7050QX-32S-S4Q31. They were skipped by RJ45 setting (https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/conftest.py#L70) by the hwsku.json (https://github.com/sonic-net/sonic-buildimage/pull/15251/files#diff-d66b493f5f334902184958f8afcbc387645e4033fe147bf1c0a1ac103d643d0bL5). But for some conflicts on port index setting of different breakout modes, hwsku.json would be deleted to use port_config.ini for the correct port index (https://github.com/sonic-net/sonic-buildimage/pull/17253). The change here is to skip SFP interfaces of Arista-7050QX-32S-S4Q31 in the test code. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
