### PR TITLE
Modify dhcp_relay test case in two vlan scenario to have secondary subnets 

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -170,6 +170,9 @@
           <VlanID>{{ vlan_param['id'] }}</VlanID>
           <Tag>{{ vlan_param['tag'] }}</Tag>
           <Subnets>{{ vlan_param['prefix'] | ipaddr('network') }}/{{ vlan_param['prefix'] | ipaddr('prefix') }}</Subnets>
+{% if 'secondary_subnet' in vlan_param %}
+          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ipaddr('secondary_subnet') }}<SecondarySubnets>
+{% endif %}
 {% if 'mac' in vlan_param %}
           <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
 {% endif %}
@@ -208,6 +211,13 @@
           <AttachTo>{{ vlan }}</AttachTo>
           <Prefix>{{ vlan_param['prefix'] }}</Prefix>
         </IPInterface>
+{%if 'secondary_subnet' in vlan_param %}
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>{{ vlan }}</AttachTo>
+          <Prefix>{{ vlan_param['secondary_subnet'] }}</Prefix>
+        </IPInterface>
+{% endif %}
 {% endfor %}
 {% for vlan, vlan_param in vlan_configs.items() %}
 {%   if 'prefix_v6' in vlan_param %}

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -65,6 +65,7 @@ topology:
           id: 100
           intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
           prefix: 192.168.0.1/22
+          secondary_subnet: 192.169.0.1/22
           prefix_v6: fc02:100::1/64
           tag: 100
         Vlan200:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Modified the test to suit the secondary subnets scenario, the dhcp related changes are in the PR: https://github.com/sonic-net/sonic-buildimage/pull/17012

Summary:
Fixes # (issue): NA

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
This is to test the changes included in the HLD: https://github.com/sonic-net/SONiC/pull/1470
#### How did you do it?
Added a new secondary subnets entry in the topology file and added parsing logic for the same
#### How did you verify/test it?
The existing test cases of dhcp_relay
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
