### PR TITLE
[Snappi] Changed lag port config for latest snappi version

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -295,6 +295,10 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         pc_ip_addr = str(pc_intf[pc]['peer_addr'])
 
         lag = config.lags.lag(name='Lag {}'.format(pc))[-1]
+        lag.protocol.lacp.actor_system_id = '00:00:00:00:00:01'
+        lag.protocol.lacp.actor_system_priority = 1
+        lag.protocol.lacp.actor_key = 1
+
         for i in range(len(phy_intfs)):
             phy_intf = phy_intfs[i]
 
@@ -307,11 +311,8 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
             mac = __gen_mac(port_id)
 
             lp = lag.ports.port(port_name=config.ports[port_id].name)[-1]
-            lp.protocol.lacp.actor_system_id = '00:00:00:00:00:01'
-            lp.protocol.lacp.actor_system_priority = 1
-            lp.protocol.lacp.actor_port_priority = 1
-            lp.protocol.lacp.actor_port_number = 1
-            lp.protocol.lacp.actor_key = 1
+            lp.lacp.actor_port_number = 1
+            lp.lacp.actor_port_priority = 1
 
             lp.ethernet.name = 'Ethernet Port {}'.format(port_id)
             lp.ethernet.mac = mac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: To comply with the latest stable version of snappi 0.9.1, the way in which LAG ports are setup have been modified. This PR addresses this issue by making the appropriate changes.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012
- [X] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?
Comply with the latest version of snappi
#### How did you do it?

#### How did you verify/test it?
Sanity checker snappi tests pass on lab device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
