### PR TITLE
Add IPV6 default route test

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -8,6 +8,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.utilities import find_duthost_on_role
 from tests.common.utilities import get_upstream_neigh_type
+from tests.syslog.syslog_utils import is_mgmt_vrf_enabled
 
 
 pytestmark = [
@@ -215,3 +216,21 @@ def test_default_route_with_bgp_flap(duthosts, tbinfo):
         duthost.command("sudo config bgp startup all")
         if not wait_until(300, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())):
             pytest.fail("not all bgp sessions are up after config reload")
+
+
+def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
+    """
+    check if ipv6 default route nexthop address uses global address
+
+    """
+    duthost = find_duthost_on_role(
+        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+    
+    # When management-vrf enabled, IPV6 route of management interface will not add to 'default' route table
+    if is_mgmt_vrf_enabled(duthost):
+        logging.info("Ignore IPV6 default route table test because management-vrf enabled")
+        return
+
+    ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
+    pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
+                    "IPV6 rules does not include default route table: {}".format(ipv6_rules))

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -225,7 +225,7 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
     """
     duthost = find_duthost_on_role(
         duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
-    
+
     # When management-vrf enabled, IPV6 route of management interface will not add to 'default' route table
     if is_mgmt_vrf_enabled(duthost):
         logging.info("Ignore IPV6 default route table test because management-vrf enabled")
@@ -233,4 +233,4 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
 
     ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
     pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
-        "IPV6 rules does not include default route table: {}".format(ipv6_rules))
+                  "IPV6 rules does not include default route table: {}".format(ipv6_rules))

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -233,4 +233,4 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
 
     ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
     pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
-                    "IPV6 rules does not include default route table: {}".format(ipv6_rules))
+        "IPV6 rules does not include default route table: {}".format(ipv6_rules))


### PR DESCRIPTION
Add IPV6 default route test.

### Description of PR
Add IPV6 default route test.

##### Work item tracking
- Microsoft ADO: 25798732

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Add IPV6 default route test.

#### How did you do it?
Add IPV6 default route test.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
