### PR TITLE
[Nvidia] Use python3 when invoking ptf_runner in test_bgp_speaker

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -337,7 +337,8 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
                            "asic_type": asic_type,
                            "test_balancing": False},
                    log_file="/tmp/bgp_speaker_test.FibTest.log",
-                   socket_recv_size=16384)
+                   socket_recv_size=16384,
+                   is_python3=True)
 
     logger.info("Withdraw routes")
     withdraw_route(ptfip, lo_addr, prefix, nexthop_ips[1].ip, port_num[0])


### PR DESCRIPTION
Use python3 when invoking ptf_runner in test_bgp_speaker

### Description of PR
In the test_bgp_speaker.py, there is no is_python3=True option when invoking ptf_runner function.
Add is_python3=True option in ptf_runner function invoking.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Add is_python3=True in ptf_runner function invoking.

#### How did you do it?
Add is_python3=True in ptf_runner function invoking.

#### How did you verify/test it?
Test it in internal regression of Nvidia.

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
