### PR TITLE
Move fixture skip_when_buffer_is_dynamic_model to conftest file

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -109,6 +109,14 @@ def verify_configdb_with_empty_input(duthosts, rand_one_dut_hostname):
         delete_tmpfile(duthost, tmpfile)
 
 
+@pytest.fixture(scope='function')
+def skip_when_buffer_is_dynamic_model(duthost):
+    buffer_model = duthost.shell(
+        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
+    if buffer_model == 'dynamic':
+        pytest.skip("Skip the test, because dynamic buffer config cannot be updated")
+
+
 # Function Fixture
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -211,18 +211,11 @@ def ensure_application_of_updated_config(duthost, configdb_field, value):
     )
 
 
-@pytest.fixture(scope='module', autouse=True)
-def skip_when_buffer_is_dynamic_model(duthost):
-    buffer_model = duthost.shell(
-        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
-    if buffer_model == 'dynamic':
-        pytest.skip("Skip the test, because dynamic buffer config cannot be updated")
-
-
 @pytest.mark.parametrize("configdb_field", ["ingress_lossless_pool/xoff",
                                             "ingress_lossless_pool/size", "egress_lossy_pool/size"])
 @pytest.mark.parametrize("op", ["add", "replace", "remove"])
-def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, configdb_field, op):
+def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, configdb_field, op,
+                                        skip_when_buffer_is_dynamic_model):
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {} created for json patch of field: {} and operation: {}"
                 .format(tmpfile, configdb_field, op))

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -108,7 +108,7 @@ def get_pg_lossless_profiles(duthost):
 
 
 @pytest.mark.parametrize("operation", ["replace"])
-def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation):
+def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation, skip_when_buffer_is_dynamic_model):
     pg_lossless_profiles = get_pg_lossless_profiles(duthost)
     pytest_require(pg_lossless_profiles, "DUT has no pg_lossless buffer profiles")
     new_dynamic_th = "2"
@@ -116,10 +116,10 @@ def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation):
 
     for pg_lossless_profile in pg_lossless_profiles:
         individual_patch = {
-                    "op": "{}".format(operation),
-                    "path": "/BUFFER_PROFILE/{}/dynamic_th".format(pg_lossless_profile),
-                    "value": new_dynamic_th
-                }
+            "op": "{}".format(operation),
+            "path": "/BUFFER_PROFILE/{}/dynamic_th".format(pg_lossless_profile),
+            "value": new_dynamic_th
+        }
         json_patch.append(individual_patch)
 
     tmpfile = generate_tmpfile(duthost)


### PR DESCRIPTION
Move fixture skip_when_buffer_is_dynamic_model to conftest file 
Use this fixture in mmu dynamic threshold case
Use this fixture in incremental qos case

### Description of PR
When buffer_model is dynamic type, test_incremental_qos.py and test_mmu_dynamic_threshold_config_update.py are not supported.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Skip the test_mmu_dynamic_threshold_config_update.py when switch buffer_model is dynamic type.
#### How did you do it?
Use a fixture to indicate whether buffer_model is dynamic type.
#### How did you verify/test it?
Test is in internel regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
