### PR TITLE
[Nvidia] Change bfd_responder support python3

### DIFF
--- a/tests/vxlan/vxlan_ecmp_utils.py
+++ b/tests/vxlan/vxlan_ecmp_utils.py
@@ -822,7 +822,7 @@ class Ecmp_Utils(object):
                 dut_mac, str(dut_loop_ips).replace('\'', '"'), monitor_file)
         supervisor_conf_content = '''
 [program:bfd_responder]
-command=ptf --test-dir /root/ptftests bfd_responder.BFD_Responder''' +\
+command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 bfd_responder.BFD_Responder''' +\
             ' --platform-dir /root/ptftests -t' + \
             ''' '{}' --relax  --platform remote
 process_name=bfd_responder


### PR DESCRIPTION
Change bfd_responder to support python3
Update ptf command for running bfd_responder

### Description of PR
Change bfd_responder to support python3

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Change bfd_responder to support python3
#### How did you do it?
Update bfd_responder.py
Change ptf command to support python3
#### How did you verify/test it?
Run it in Nvidia internal regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
