### PR TITLE
Add skip for test_custom_acl_table.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3,9 +3,11 @@
 #######################################
 acl/custom_acl_table/test_custom_acl_table.py:
   skip:
-    reason: "Custom ACL not supported on older releases"
+    reason: "Custom ACL not supported on older releases or dualtor setup"
+    conditions_logical_operator: or
     conditions:
       - "release in ['201811', '201911', '202012']"
+      - "'dualtor' in topo_name"
 
 #######################################
 #####            acl              #####


### PR DESCRIPTION
Skip test_custom_acl_table.py on dualtor setup

### Description of PR
test_custom_acl_table.py is not supported to run at dualtor setup

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
test_custom_acl_table.py is not supported to run at dualtor setup
#### How did you do it?
Skip it
#### How did you verify/test it?
Verified it in interal regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
