### PR TITLE
[202205] Fix syntax error in drop_packet.py

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -866,7 +866,7 @@ def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
         )
-    setattr(pkt[testutils.scapy.scapy.all.IP], pkt_field, value)
+    setattr(pkt[packet.IP], pkt_field, value)
 
     group = "L3"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
@@ -887,8 +887,8 @@ def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
         )
-    tcp = pkt[testutils.scapy.scapy.all.TCP]
-    del pkt[testutils.scapy.scapy.all.IP]
+    tcp = pkt[packet.TCP]
+    del pkt[packet.IP]
     pkt.type = 0x800
     pkt = pkt/tcp
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to fix syntax error in `drop_packet.py`.
```
>       setattr(pkt[testutils.scapy.scapy.all.IP], pkt_field, value)
E       AttributeError: 'module' object has no attribute 'scapy'
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
The PR is to fix syntax error in `drop_packet.py`.

#### How did you do it?
Backport the change from master branch.

#### How did you verify/test it?
Verified by statically syntax check.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
