### PR TITLE
Loganalyzer regex correction for test_po_update

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -36,11 +36,11 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
     # when loganalyzer is disabled, the object could be None
     if loganalyzer:
         ignoreRegex = [
-            (".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, "
+            (".*ERR syncd[0-9]*#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, "
              "NOT translating and NOT storing in ASIC DB.*"),
-            (".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent "
+            (".*ERR syncd[0-9]*#syncd: :- process_on_fdb_event: FDB notification was not sent "
              "since it contain invalid OIDs, bug.*"),
-            (".*ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID.*"),
+            (".*ERR syncd[0-9]*#syncd: :- translate_vid_to_rid: unable to get RID for VID.*"),
         ]
         loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- For PC tests '_test_po_update.py_', seen the following LogAnalyzer mismatch related messages being reported as errors.
- Issues seen in PC tests running on chassis with topo t2 multi-asic.
`
E               Match Messages:
E               Nov 11 20:41:16.136440 ixre-egl-board3 ERR syncd0#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB
E               
E               Nov 11 20:41:16.136471 ixre-egl-board3 ERR syncd0#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug?
`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

-  Loganalyzer mismatch errors seen during PC test suites for test_po_update.py tests w.r.t syncd container messages per asic as shown above.

#### How did you do it?

-  Fix the existing regex to support syncd container syslog messages per asic.

#### How did you verify/test it?

- Ran the PC test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/4e734dce-4ea8-407b-b719-ccaa8f00e44a)
