### PR TITLE
Improve TACACS UT by add retry and print syslog when login failed for debug.

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -8,6 +8,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.utilities import find_duthost_on_role
 from tests.common.utilities import get_upstream_neigh_type
+from tests.syslog.syslog_utils import is_mgmt_vrf_enabled
 
 
 pytestmark = [
@@ -215,3 +216,21 @@ def test_default_route_with_bgp_flap(duthosts, tbinfo):
         duthost.command("sudo config bgp startup all")
         if not wait_until(300, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())):
             pytest.fail("not all bgp sessions are up after config reload")
+
+
+def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
+    """
+    check if ipv6 default route nexthop address uses global address
+
+    """
+    duthost = find_duthost_on_role(
+        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+    
+    # When management-vrf enabled, IPV6 route of management interface will not add to 'default' route table
+    if is_mgmt_vrf_enabled(duthost):
+        logging.info("Ignore IPV6 default route table test because management-vrf enabled")
+        return
+
+    ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
+    pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
+                    "IPV6 rules does not include default route table: {}".format(ipv6_rules))

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -225,7 +225,7 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
     """
     duthost = find_duthost_on_role(
         duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
-    
+
     # When management-vrf enabled, IPV6 route of management interface will not add to 'default' route table
     if is_mgmt_vrf_enabled(duthost):
         logging.info("Ignore IPV6 default route table test because management-vrf enabled")
@@ -233,4 +233,4 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
 
     ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
     pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
-        "IPV6 rules does not include default route table: {}".format(ipv6_rules))
+                  "IPV6 rules does not include default route table: {}".format(ipv6_rules))

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -233,4 +233,4 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
 
     ipv6_rules = duthost.command("ip -6 rule list")["stdout"]
     pytest_assert("32767:\tfrom all lookup default" in ipv6_rules,
-                    "IPV6 rules does not include default route table: {}".format(ipv6_rules))
+        "IPV6 rules does not include default route table: {}".format(ipv6_rules))

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -130,7 +130,8 @@ def rw_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     dutip = duthost.mgmt_ip
     ssh_client = ssh_connect_remote(dutip,
                                     tacacs_creds['tacacs_rw_user'],
-                                    tacacs_creds['tacacs_rw_user_passwd'])
+                                    tacacs_creds['tacacs_rw_user_passwd'],
+                                    duthost)
     yield ssh_client
     ssh_client.close()
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -32,6 +32,21 @@ def ssh_connect_remote(remote_ip, remote_username, remote_password):
     return ssh
 
 
+def ssh_connect_remote_retry(remote_ip, remote_username, remote_password, duthost):
+    retry_count = 3
+    while retry_count > 0:
+        try:
+            return ssh_connect_remote(remote_ip, remote_username, remote_password)
+        except paramiko.ssh_exception.AuthenticationException as e:
+            logger.info("Paramiko SSH connect failed with authentication: " + repr(e))
+
+            # get syslog for debug
+            recent_syslog = duthost.shell('sudo tail -100 /var/log/syslog')['stdout']
+            logger.debug("Target device syslog: {}".format(recent_syslog))
+        
+        time.sleep(1)
+        retry -= 1
+
 def check_ssh_connect_remote_failed(remote_ip, remote_username, remote_password):
     login_failed = False
     try:
@@ -66,10 +81,11 @@ def check_ssh_output_any_of(res_stream, exp_vals, timeout=10):
 def remote_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
-    with ssh_connect_remote(
+    with ssh_connect_remote_retry(
         dutip,
         tacacs_creds['tacacs_authorization_user'],
-        tacacs_creds['tacacs_authorization_user_passwd']
+        tacacs_creds['tacacs_authorization_user_passwd'],
+        duthost
     ) as ssh_client:
         yield ssh_client
 
@@ -78,10 +94,11 @@ def remote_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds)
 def remote_rw_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
-    with ssh_connect_remote(
+    with ssh_connect_remote_retry(
         dutip,
         tacacs_creds['tacacs_rw_user'],
-        tacacs_creds['tacacs_rw_user_passwd']
+        tacacs_creds['tacacs_rw_user_passwd'],
+        duthost
     ) as ssh_client:
         yield ssh_client
 


### PR DESCRIPTION
Improve TACACS UT by add retry and print syslog when login failed for debug.

### Description of PR
Improve TACACS UT by add retry and print syslog when login failed for debug.

##### Work item tracking
- Microsoft ADO: 25947581

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Authorization and accounting UT randomly failed because login failed, can't find enough information in current log.

#### How did you do it?
Improve TACACS UT by add retry and print syslog when login failed for debug.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
