### PR TITLE
Fix issue with test_syslog_rate_limit

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import pytest
@@ -175,7 +176,9 @@ def verify_host_rate_limit(rand_selected_dut):
         rand_selected_dut (object): DUT host object
     """
     logger.info('Start syslog rate limit test for host')
-    rand_selected_dut.command('config syslog rate-limit-host -b {} -i {}'.format(RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL))
+    with expect_host_rsyslog_restart(rand_selected_dut):
+        cmd = 'config syslog rate-limit-host -b {} -i {}'.format(RATE_LIMIT_BURST, RATE_LIMIT_INTERVAL)
+        rand_selected_dut.command(cmd)
     rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-host')
     pytest_assert(rate_limit_data[0]['interval'] == str(RATE_LIMIT_INTERVAL),
                   'Expect rate limit interval {}, actual {}'.format(RATE_LIMIT_INTERVAL,
@@ -191,7 +194,8 @@ def verify_host_rate_limit(rand_selected_dut):
                                          RATE_LIMIT_BURST + 1,
                                          is_host=True)
 
-    rand_selected_dut.command('config syslog rate-limit-host -b {} -i {}'.format(0, 0))
+    with expect_host_rsyslog_restart(rand_selected_dut):
+        rand_selected_dut.command('config syslog rate-limit-host -b {} -i {}'.format(0, 0))
     rate_limit_data = rand_selected_dut.show_and_parse('show syslog rate-limit-host')
     pytest_assert(rate_limit_data[0]['interval'] == '0',
                   'Expect rate limit interval {}, actual {}'.format(0, rate_limit_data[0]['interval']))
@@ -242,6 +246,32 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
 
     with loganalyzer:
         duthost.command(run_generator_cmd)
+
+
+def get_host_rsyslogd_pid(duthost):
+    cmd = 'systemctl show --property MainPID --value rsyslog'
+    return int(duthost.command(cmd)['stdout'].strip())
+
+
+@contextlib.contextmanager
+def expect_host_rsyslog_restart(duthost, timeout=30):
+    current_pid = get_host_rsyslogd_pid(duthost)
+
+    yield
+
+    logger.info('Waiting for host rsyslogd to restart')
+    begin = time.time()
+    cmd = 'systemctl is-active rsyslog'
+    while time.time() < begin + timeout:
+        if get_host_rsyslogd_pid(duthost) != current_pid:
+            output = duthost.command(cmd, module_ignore_errors=True)['stdout'].strip()
+            if output == 'active':
+                logger.info('Host rsyslogd restarted')
+                return
+
+        time.sleep(1)
+
+    raise TimeoutError('Timeout waiting for host rsyslogd to restart')
 
 
 def wait_rsyslogd_restart(duthost, service_name, old_pid):


### PR DESCRIPTION

### Description of PR

There is a race condition in the rate-limit-host test code.
Changing the rate limit via the cli triggers hostcfgd to restart rsyslogd. However there is no wait to make sure this actually happens. This leads to some flakyness where loganalyzer.py would try to put a marker while the rsyslog systemd service is being restarted and crash.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix flaky test to enhance pass rate reliability.

#### How did you do it?
Reproduced on my testbed, investigated the issue, fixed the issue

#### How did you verify/test it?
Stressed the test overnight without further failure
