### PR TITLE
Increase timeout for copp test_trap_config_save_after_reboot

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -189,7 +189,7 @@ class TestCOPP(object):
         copp_utils.verify_always_enable_value(duthost, self.trap_id, "true")
         logger.info("Verify {} trap status is installed by sending traffic".format(self.trap_id))
         pytest_assert(
-            wait_until(100, 20, 0, _copp_runner, duthost, ptfhost, self.trap_id.upper(), copp_testbed, dut_type),
+            wait_until(200, 20, 0, _copp_runner, duthost, ptfhost, self.trap_id.upper(), copp_testbed, dut_type),
             "Installing {} trap fail".format(self.trap_id))
 
 


### PR DESCRIPTION
### Description of PR
We've noticed that copp test_trap_config_save_after_reboot fails occasionally due to not enough time waiting for the trap to be installed after reboot.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Address occasional test fail seen in our sonic-mgmt runs.

#### How did you do it?

#### How did you verify/test it?
Applied the timeout increase in our internal sonic-mgmt testing and observed the test passed reliably.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
