### PR TITLE
[202205] Revert LPM test due to design change back and fix the issue of issue of test_check_sfputil_low_power_mode

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -8,8 +8,8 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import wait_until
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
-from tests.common.fixtures.duthost_utils import shutdown_ebgp
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa F401
+from tests.common.fixtures.duthost_utils import shutdown_ebgp  # noqa F401
 
 from platform_api_test_base import PlatformApiTestBase
 
@@ -30,8 +30,9 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+
 @pytest.fixture(scope="class")
-def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts, shutdown_ebgp):
+def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts, shutdown_ebgp):  # noqa F811
     sfp_setup = {}
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -64,6 +65,7 @@ def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, c
 
     if request.cls is not None:
         request.cls.sfp_setup = sfp_setup
+
 
 @pytest.mark.usefixtures("setup")
 class TestSfpApi(PlatformApiTestBase):
@@ -690,8 +692,8 @@ class TestSfpApi(PlatformApiTestBase):
                     expected_mask = expected_mask >> 1
         self.assert_expectations()
 
-    def _check_lpmode_status(self, sfp,platform_api_conn, i, state):
-        return state ==  sfp.get_lpmode(platform_api_conn, i)
+    def _check_lpmode_status(self, sfp, platform_api_conn, i, state):
+        return state == sfp.get_lpmode(platform_api_conn, i)
 
     def test_lpmode(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests both the get_lpmode() and set_lpmode() APIs"""

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -4,7 +4,6 @@ Check SFP status and configure SFP using sfputil.
 This script covers test case 'Check SFP status and configure SFP' in the SONiC platform test plan:
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
-
 import logging
 import time
 import copy
@@ -15,9 +14,7 @@ from util import parse_eeprom
 from util import parse_output
 from util import get_dev_conn
 from tests.common.utilities import skip_release
-from tests.common.fixtures.duthost_utils import shutdown_ebgp  # noqa F401
-from tests.common.mellanox_data import is_mellanox_device
-from tests.common.utilities import wait_until
+from tests.common.fixtures.duthost_utils import shutdown_ebgp
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -30,9 +27,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-
-def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                                conn_graph_facts, xcvr_skip_list):
+def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -49,14 +44,11 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
-
-@pytest.mark.parametrize("cmd_sfp_error_status",
-                         ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                                    conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
+@pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
     """
-    @summary: Check SFP error status using 'sfputil show error-status' and
-     'sfputil show error-status --fetch-from-hardware' This feature is supported on 202106 and above
+    @summary: Check SFP error status using 'sfputil show error-status' and 'sfputil show error-status --fetch-from-hardware'
+              This feature is supported on 202106 and above
 
     @param: cmd_sfp_error_status: fixture representing the command used to test
     """
@@ -76,8 +68,7 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
             assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
 
 
-def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                              conn_graph_facts, xcvr_skip_list):
+def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -95,8 +86,7 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 
-def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                             conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):  # noqa F811
+def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -109,9 +99,9 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         if intf not in xcvr_skip_list[duthost.hostname]:
             phy_intf = portmap[intf][0]
             if phy_intf in tested_physical_ports:
-                logging.info(
-                    "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
-                continue
+               logging.info(
+                "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+               continue
             tested_physical_ports.add(phy_intf)
             logging.info("resetting {} physical interface {}".format(intf, phy_intf))
             reset_result = duthost.command("{} {}".format(cmd_sfp_reset, intf))
@@ -139,8 +129,7 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])
 
 
-def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                                      conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):  # noqa F811
+def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP low power mode
 
@@ -160,103 +149,19 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     original_lpmode = copy.deepcopy(parsed_lpmode)
-    original_interface_status = duthost.get_interfaces_status()
-
-    logging.info("Check the value of lpmode is correct for all interfaces not in xcvr_skip_list")
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
             assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
-    logging.info("Get interfaces which support lpmode")
-    tested_lpmode_ports, tested_lpmode_ports_with_admin_up = _get_support_ldpmode_physical_ports(
-        duthost, xcvr_skip_list, asichost, dev_conn, portmap, original_interface_status)
+    logging.info("Try to change SFP lpmode")
+    tested_physical_ports = set()
 
-    if len(tested_lpmode_ports) == 0:
-        pytest.skip("None of the ports supporting LPM, skip the test")
-
-    try:
-
-        if is_mellanox_device(duthost) and len(tested_lpmode_ports_with_admin_up) > 0:
-            logging.info("For ports with admin up, set lpmode to on, check ports are still up and lpmode is still off")
-            shutdown_ports = list(tested_lpmode_ports_with_admin_up)
-            _set_and_check_lpmode(duthost, portmap, tested_lpmode_ports_with_admin_up, original_lpmode,
-                                  is_set_original_lpmode=False, is_check_original_mode=True)
-            assert wait_until(60, 1, 0, duthost.links_status_up, shutdown_ports),\
-                "ports {} are not up after set".format(shutdown_ports)
-
-            # for nvidia devices, need to shutdown the port before setting the port into lp mode
-            logging.info("Shut down ports:{}".format(shutdown_ports))
-            duthost.shutdown_multiple(shutdown_ports)
-            assert wait_until(60, 1, 0, duthost.links_status_down, shutdown_ports), "ports {} are not all down".format(
-                shutdown_ports)
-
-        logging.info("Toggle the lpmode and check if the value is correct")
-        _set_and_check_lpmode(duthost, portmap, tested_lpmode_ports, original_lpmode,
-                              is_set_original_lpmode=False, is_check_original_mode=False)
-
-        logging.info("Set original lpmode, and check if the value is correct")
-        _set_and_check_lpmode(duthost, portmap, tested_lpmode_ports, original_lpmode,
-                              is_set_original_lpmode=True, is_check_original_mode=True)
-
-        logging.info("Check sfp presence again after setting lpmode")
-        sfp_presence = duthost.command(cmd_sfp_presence)
-        parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-        for intf in dev_conn:
-            if intf not in xcvr_skip_list[duthost.hostname]:
-                assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
-                assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
-
-        if is_mellanox_device(duthost) and len(tested_lpmode_ports_with_admin_up) > 0:
-            logging.info("Check ports {}: are still down after change ldpmode".format(shutdown_ports))
-            assert wait_until(60, 1, 0, duthost.links_status_down, shutdown_ports), "ports {} are not all down".format(
-                shutdown_ports)
-
-            # for nvidia devices, need to restore the tested ports to up
-            logging.info("Startup ports:{}".format(shutdown_ports))
-            startup_tested_ports(duthost, shutdown_ports)
-
-        logging.info("Check interface status")
-        cmd = "show interfaces transceiver eeprom {} | grep 400ZR".format(asichost.cli_ns_option)
-        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            logging.info("sleeping for 60 seconds for ZR optics to come up")
-            time.sleep(60)
-
-        namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
-        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        # TODO Remove this logic when minigraph facts supports namespace in multi_asic
-        up_ports = mg_facts["minigraph_ports"]
-        if enum_frontend_asic_index is not None:
-            # Check if the interfaces of this ASIC is present in conn_graph_facts
-            up_ports = {k: v for k, v in portmap.items() if k in mg_facts["minigraph_ports"]}
-        intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
-        assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
-            "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])
-
-    except Exception as err:
-        raise AssertionError(err)
-
-    finally:
-        if is_mellanox_device(duthost) and len(tested_lpmode_ports_with_admin_up) > 0:
-            # for nvidia device, need to check if the tested port is restored. If no, we need restore it
-            logging.info("Check ports {}: are still down after change ldpmode".format(shutdown_ports))
-            if not duthost.links_status_up(shutdown_ports):
-                logging.info("Recover shutdown ports:{}".format(shutdown_ports))
-                startup_tested_ports(duthost, shutdown_ports)
-
-
-def _get_support_ldpmode_physical_ports(
-        duthost, xcvr_skip_list, asichost, dev_conn, portmap, original_interface_status):
-    tested_lpmode_physical_ports = set()
-    tested_lpmode_ports = set()
-    tested_lpmode_ports_with_admin_up = set()
+    not_supporting_lpm_physical_ports = set()
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             phy_intf = portmap[intf][0]
-            if phy_intf in tested_lpmode_physical_ports:
-                tested_lpmode_ports.add(intf)
-                if intf in original_interface_status and original_interface_status[intf]["admin"].lower() == "up":
-                    tested_lpmode_ports_with_admin_up.add(intf)
+            if phy_intf in tested_physical_ports:
                 logging.info(
                     "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
                 continue
@@ -269,57 +174,76 @@ def _get_support_ldpmode_physical_ports(
             power_class_docker_cmd = asichost.get_docker_cmd(power_class_cmd, "database")
             power_class = duthost.command(power_class_docker_cmd)["stdout"]
 
-            if "QSFP" not in sfp_type or "Power Class 1" in power_class:
+            if not "QSFP" in sfp_type or "Power Class 1" in power_class:
+                logging.info("skip testing port {} which doesn't support LPM".format(intf))
+                not_supporting_lpm_physical_ports.add(phy_intf)
+                continue
+            tested_physical_ports.add(phy_intf)
+            logging.info("setting {} physical interface {}".format(intf, phy_intf))
+            new_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
+            lpmode_set_result = duthost.command("{} {} {}".format(cmd_sfp_set_lpmode, new_lpmode, intf))
+            assert lpmode_set_result["rc"] == 0, "'{} {} {}' failed".format(cmd_sfp_set_lpmode, new_lpmode, intf)
+    time.sleep(10)
+
+    if len(tested_physical_ports) == 0:
+        pytest.skip("None of the ports supporting LPM, skip the test")
+
+    logging.info("Check SFP lower power mode again after changing SFP lpmode")
+    lpmode_show = duthost.command(cmd_sfp_show_lpmode)
+    parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
+            assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
+            assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
+
+    logging.info("Try to change SFP lpmode")
+    tested_physical_ports = set()
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
+            phy_intf = portmap[intf][0]
+            if phy_intf in not_supporting_lpm_physical_ports:
                 logging.info("skip testing port {} which doesn't support LPM".format(intf))
                 continue
-            tested_lpmode_physical_ports.add(phy_intf)
-            tested_lpmode_ports.add(intf)
-            if intf in original_interface_status and original_interface_status[intf]["admin"].lower() == "up":
-                tested_lpmode_ports_with_admin_up.add(intf)
-
-    return tested_lpmode_ports, tested_lpmode_ports_with_admin_up
-
-
-def _set_and_check_lpmode(
-        duthost, portmap, tested_lpmode_ports, original_lpmode, is_set_original_lpmode, is_check_original_mode):
-    logging.info("Try to change SFP lpmode")
-    warning_msg = "Notice: please set port admin status to down before setting power mode"
-
-    for intf in tested_lpmode_ports:
-        phy_intf = portmap[intf][0]
-        logging.info("setting {} physical interface {}".format(intf, phy_intf))
-        if is_set_original_lpmode:
+            if phy_intf in tested_physical_ports:
+                logging.info(
+                    "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+                continue
+            tested_physical_ports.add(phy_intf)
+            logging.info("restoring {} physical interface {}".format(intf, phy_intf))
             new_lpmode = original_lpmode[intf].lower()
-        else:
-            new_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
+            lpmode_set_result = duthost.command("{} {} {}".format(cmd_sfp_set_lpmode, new_lpmode, intf))
+            assert lpmode_set_result["rc"] == 0, "'{} {} {}' failed".format(cmd_sfp_set_lpmode, new_lpmode, intf)
+    time.sleep(10)
 
-        lpmode_set_result = duthost.command("{} {} {}".format(cmd_sfp_set_lpmode, new_lpmode, intf))
-        if is_mellanox_device(duthost):
-            logging.info("Check return msg include some warning info")
-            assert warning_msg in lpmode_set_result['stdout'], " Expected warning_msg:{}, actual msg: {} ".format(
-                warning_msg, lpmode_set_result['stdout'])
-
-        assert lpmode_set_result["rc"] == 0, "'{} {} {}' failed".format(cmd_sfp_set_lpmode, new_lpmode, intf)
-
-    def check_lpmode():
-        lpmode_show = duthost.command(cmd_sfp_show_lpmode)
-        parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
-        for intf in tested_lpmode_ports:
+    logging.info("Check SFP lower power mode again after changing SFP lpmode")
+    lpmode_show = duthost.command(cmd_sfp_show_lpmode)
+    parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
-            actual_lpmode = parsed_lpmode[intf].lower()
-            if is_check_original_mode:
-                expected_lpmode = original_lpmode[intf].lower()
-            else:
-                expected_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
-            assert actual_lpmode == expected_lpmode, "Unexpected SFP lpmode: actual:{}, expected:{}".format(
-                actual_lpmode, expected_lpmode)
-        return True
+            assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
-    logging.info("Check SFP lower power mode. set original lpmode:{}".format(is_set_original_lpmode))
-    assert wait_until(10, 1, 0, check_lpmode), "lpmode is not the expected one"
+    logging.info("Check sfp presence again after setting lpmode")
+    sfp_presence = duthost.command(cmd_sfp_presence)
+    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
+            assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
+            assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
+    logging.info("Check interface status")
+    cmd = "show interfaces transceiver eeprom {} | grep 400ZR".format(asichost.cli_ns_option)
+    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+        logging.info("sleeping for 60 seconds for ZR optics to come up")
+        time.sleep(60)
 
-def startup_tested_ports(duthost, tested_ports):
-    duthost.no_shutdown_multiple(tested_ports)
-    assert wait_until(120, 5, 0, duthost.links_status_up, tested_ports), "ports {} are not all up".format(
-        tested_ports)
+    namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    # TODO Remove this logic when minigraph facts supports namespace in multi_asic
+    up_ports = mg_facts["minigraph_ports"]
+    if enum_frontend_asic_index is not None:
+        # Check if the interfaces of this AISC is present in conn_graph_facts
+        up_ports = {k:v for k, v in portmap.items() if k in mg_facts["minigraph_ports"]}
+    intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
+    assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
+        "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -194,7 +194,9 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
-            assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
+            expected_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
+            assert parsed_lpmode[intf].lower() == expected_lpmode, \
+                "Unexpected SFP lpmode, actual:{}, expected:{}".format(parsed_lpmode[intf].lower(), expected_lpmode)
 
     logging.info("Try to change SFP lpmode")
     tested_physical_ports = set()
@@ -221,7 +223,9 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
-            assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
+            assert parsed_lpmode[intf].lower() == original_lpmode[intf].lower(),\
+                "Unexpected SFP lpmode. actual:{}, expected:{}".format(
+                    parsed_lpmode[intf].lower(), original_lpmode[intf].lower())
 
     logging.info("Check sfp presence again after setting lpmode")
     sfp_presence = duthost.command(cmd_sfp_presence)

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -14,7 +14,7 @@ from util import parse_eeprom
 from util import parse_output
 from util import get_dev_conn
 from tests.common.utilities import skip_release
-from tests.common.fixtures.duthost_utils import shutdown_ebgp
+from tests.common.fixtures.duthost_utils import shutdown_ebgp  # noqa F401
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -27,7 +27,9 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+
+def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                                conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -44,13 +46,14 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
-@pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
-    """
-    @summary: Check SFP error status using 'sfputil show error-status' and 'sfputil show error-status --fetch-from-hardware'
-              This feature is supported on 202106 and above
 
-    @param: cmd_sfp_error_status: fixture representing the command used to test
+@pytest.mark.parametrize("cmd_sfp_error_status",
+                         ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                                    conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
+    """
+    @summary: Check SFP error status using 'sfputil show error-status' and
+     'sfputil show error-status --fetch-from-hardware' This feature is supported on 202106 and above
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     skip_release(duthost, ["201811", "201911", "202012"])
@@ -68,7 +71,8 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
             assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
 
 
-def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                              conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -86,7 +90,8 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 
-def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
+def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                             conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):  # noqa F811
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -99,9 +104,9 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         if intf not in xcvr_skip_list[duthost.hostname]:
             phy_intf = portmap[intf][0]
             if phy_intf in tested_physical_ports:
-               logging.info(
-                "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
-               continue
+                logging.info(
+                    "skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+                continue
             tested_physical_ports.add(phy_intf)
             logging.info("resetting {} physical interface {}".format(intf, phy_intf))
             reset_result = duthost.command("{} {}".format(cmd_sfp_reset, intf))
@@ -129,7 +134,8 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])
 
 
-def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
+def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                                      conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):  # noqa F811
     """
     @summary: Check SFP low power mode
 
@@ -192,7 +198,7 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     for intf in dev_conn:
-        if intf not in xcvr_skip_list[duthost.hostname]:
+        if intf not in xcvr_skip_list[duthost.hostname] and portmap[intf][0] not in not_supporting_lpm_physical_ports:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
             expected_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
             assert parsed_lpmode[intf].lower() == expected_lpmode, \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Revert LPM test, because the implementation has been reverted to the old way.https://github.com/sonic-net/sonic-buildimage/pull/17179
2. Fix issue of test_check_sfputil_low_power_mode. Previously after setting the lpmode, test checks the value is on or off, which is not correct. we should check if the value of lpmode is the set one.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Revert lpm test

#### How did you do it?
Revert lpm test

#### How did you verify/test it?
Run lmp test on after merging https://github.com/sonic-net/sonic-buildimage/pull/17179

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
