### PR TITLE
Fix test_counterpoll_watermark flakiness

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -5,7 +5,6 @@ Tests for the `counterpoll queue/watermark/pg-drop ...` commands in SONiC
 import allure
 import logging
 import random
-import time
 import pytest
 
 from tests.common.config_reload import config_reload
@@ -13,7 +12,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import redis_get_keys
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
-from tests.common.utilities import skip_release
+from tests.common.utilities import skip_release, wait_until
 from tests.common.reboot import reboot
 from .counterpoll_constants import CounterpollConstants
 from .counterpoll_helper import ConterpollHelper
@@ -59,6 +58,10 @@ def dut_vars(duthosts, enum_rand_one_per_hwsku_hostname, request):
     inv_files = get_inventory_files(request)
     dut_vars = get_host_visible_vars(inv_files, enum_rand_one_per_hwsku_hostname)
     yield dut_vars
+
+
+def check_counters_populated(duthost, key):
+    return bool(redis_get_keys(duthost, 'COUNTERS_DB', key))
 
 
 def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_per_hwsku_hostname, dut_vars,
@@ -117,7 +120,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
         verify_counterpoll_status(duthost, [tested_counterpoll], ENABLE)
     # Delay to allow the counterpoll to generate the maps in COUNTERS_DB
     with allure.step("waiting {} seconds for counterpoll to generate maps in COUNTERS_DB"):
-        time.sleep(RELEVANT_MAPS[tested_counterpoll][DELAY])
+        delay = RELEVANT_MAPS[tested_counterpoll][DELAY]
+        wait_until(120, 5, delay, check_counters_populated, duthost, MAPS_LONG_PREFIX.format('*'))
     # verify QUEUE or PG maps are generated into COUNTERS_DB after enabling relevant counterpoll
     with allure.step("Verifying MAPS in COUNTERS_DB on {}...".format(duthost.hostname)):
         maps_dict = RELEVANT_MAPS[tested_counterpoll]
@@ -200,8 +204,9 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
     for counterpoll in RELEVANT_COUNTERPOLLS:
         pytest_assert(counted_dict[counterpoll] > 0)
     # for watermark only, also count stats with actual values in COUNTERS_DB
-    with allure.step("counting watermark STATS in FLEX_COUNTER_DB on {}...".format(duthost.hostname)):
-        count_watermark_stats_in_counters_db(duthost)
+    if CounterpollConstants.WATERMARK in tested_counterpoll:
+        with allure.step("counting watermark STATS in FLEX_COUNTER_DB on {}...".format(duthost.hostname)):
+            count_watermark_stats_in_counters_db(duthost)
 
 
 def verify_all_counterpoll_status(duthost, expected):


### PR DESCRIPTION
### Description of PR

This test randomly picks a counter to test out of 3.
One check is only meant to run on one of these counter but ends up running for all counters.
There is another call for this check that is properly gated a few lines above, this fix essentially make sure it works the same.

The check actually works for all counters per my investigation but the delay is not sufficient for some older products. These take longer to properly populate data in COUNTERS_DB.
For this purpose a `wait_until` was introduced instead of an arbitrary sleep value.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Reduce test flakiness to increase passrate reliability

#### How did you do it?
Investigated flaky test, reproduced and looked at the code to understand what went wrong

#### How did you verify/test it?
Ran the flaky test in a loop overnight.

#### Any platform specific information?
This test seems flaky on slower products
