### PR TITLE
Update sysfs node name/path according to production code change

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -5,7 +5,8 @@ This script contains re-usable functions for checking status of hw-management re
 """
 import logging
 import re
-from tests.common.mellanox_data import get_platform_data
+from pkg_resources import parse_version
+from tests.common.mellanox_data import get_hw_management_version, get_platform_data
 from tests.common.utilities import wait_until
 
 MAX_FAN_SPEED_THRESHOLD = 0.15
@@ -41,7 +42,7 @@ def check_sysfs(dut):
     @summary: Check various hw-management related sysfs under /var/run/hw-management
     """
     platform_data = get_platform_data(dut)
-    sysfs_config = generate_sysfs_config(platform_data)
+    sysfs_config = generate_sysfs_config(dut, platform_data)
     logging.info("Collect mellanox sysfs facts")
     sysfs_facts = dut.sysfs_facts(config=sysfs_config)['ansible_facts']
 
@@ -247,7 +248,7 @@ def _is_fan_speed_in_range(sysfs_facts):
     return True
 
 
-def generate_sysfs_config(platform_data):
+def generate_sysfs_config(dut, platform_data):
     config = list()
     config.append(generate_sysfs_symbolink_config())
     config.append(generate_sysfs_asic_config())
@@ -256,7 +257,7 @@ def generate_sysfs_config(platform_data):
     config.append(generate_sysfs_cpu_core_config(platform_data))
     config.append(generate_sysfs_fan_config(platform_data))
     if platform_data['psus']['hot_swappable']:
-        config.append(generate_sysfs_psu_config(platform_data))
+        config.append(generate_sysfs_psu_config(dut, platform_data))
     config.append(generate_sysfs_sfp_config(platform_data))
     return config
 
@@ -369,8 +370,8 @@ def generate_sysfs_cpu_core_config(platform_data):
     }
 
 
-def generate_sysfs_psu_config(platform_data):
-    return {
+def generate_sysfs_psu_config(dut, platform_data):
+    data = {
         'name': 'psu_info',
         'start': 1,
         'count': platform_data['psus']['number'],
@@ -386,15 +387,15 @@ def generate_sysfs_psu_config(platform_data):
             },
             {
                 'name': 'temp',
-                'cmd_pattern': 'cat /var/run/hw-management/thermal/psu{}_temp',
+                'cmd_pattern': 'cat /var/run/hw-management/thermal/psu{}_temp1',
             },
             {
                 'name': 'max_temp',
-                'cmd_pattern': 'cat /var/run/hw-management/thermal/psu{}_temp_max',
+                'cmd_pattern': 'cat /var/run/hw-management/thermal/psu{}_temp1_max',
             },
             {
                 'name': 'max_temp_alarm',
-                'cmd_pattern': 'cat /var/run/hw-management/thermal/psu{}_temp_max_alarm',
+                'cmd_pattern': 'cat /var/run/hw-management/alarm/psu{}_temp1_max_alarm',
             },
             {
                 'name': 'fan_speed',
@@ -402,6 +403,12 @@ def generate_sysfs_psu_config(platform_data):
             }
         ]
     }
+    hw_mgmt_version = get_hw_management_version(dut)
+    if parse_version(hw_mgmt_version) < parse_version('7.0030.2003'):
+        data['properties'][2]['cmd_pattern'] = 'cat /var/run/hw-management/thermal/psu{}_temp'
+        data['properties'][3]['cmd_pattern'] = 'cat /var/run/hw-management/thermal/psu{}_temp_max'
+        data['properties'][4]['cmd_pattern'] = 'cat /var/run/hw-management/thermal/psu{}_temp_max_alarm'
+    return data
 
 
 def generate_sysfs_sfp_config(platform_data):

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -7,7 +7,6 @@ from pkg_resources import parse_version
 from tests.platform_tests.thermal_control_test_helper import mocker, FanStatusMocker, ThermalStatusMocker, \
     SingleFanMocker
 from tests.common.mellanox_data import get_hw_management_version, get_platform_data
-from .minimum_table import get_min_table
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 

--- a/tests/system_health/mellanox/mellanox_device_mocker.py
+++ b/tests/system_health/mellanox/mellanox_device_mocker.py
@@ -1,12 +1,12 @@
 from ..device_mocker import DeviceMocker
-from tests.common.mellanox_data import get_platform_data
+from pkg_resources import parse_version
+from tests.common.mellanox_data import get_platform_data, get_hw_management_version
 from tests.platform_tests.mellanox.mellanox_thermal_control_test_helper import MockerHelper, FanDrawerData, FanData, \
     FAN_NAMING_RULE
 
 
 class AsicData(object):
     TEMPERATURE_FILE = '/run/hw-management/thermal/asic'
-    THRESHOLD_FILE = '/run/hw-management/thermal/mlxsw/temp_trip_hot'
 
     def __init__(self, mock_helper):
         self.helper = mock_helper
@@ -15,7 +15,11 @@ class AsicData(object):
         self.helper.mock_value(AsicData.TEMPERATURE_FILE, str(value))
 
     def get_asic_temperature_threshold(self):
-        value = self.helper.read_value(AsicData.THRESHOLD_FILE)
+        threshold_file = '/run/hw-management/thermal/asic_temp_emergency'
+        hw_mgmt_version = get_hw_management_version(self.helper.dut)
+        if parse_version(hw_mgmt_version) < parse_version('7.0030.2003'):
+            threshold_file = '/run/hw-management/thermal/mlxsw/temp_trip_hot'
+        value = self.helper.read_value(threshold_file)
         return int(value)
 
 


### PR DESCRIPTION
**Why I did this**

Some sysfs node names have been changed in production code, this PR is to align the changes based on different hw-management version

**How I did this**

For different hw-management version, sonic-mgmt code should use different sysfs node name.

**How I test it**

Run sonic-mgmt regression test