### PR TITLE
Fix unknown unicast issue

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -546,6 +546,12 @@ class AclVlanOuterTest_Base(object):
         if stage == EGRESS:
             # Wait arp
             pytest_assert(wait_until(30, 1, 0, check_arp_status, duthost, dst_ip), "arp table is not updated")
+            # Learn MAC on leaf-fanout to avoid unknown unicast traffic
+            switch_arptable = duthost.switch_arptable()['ansible_facts']
+            mac = switch_arptable['arptable']['v4'][dst_ip]['macaddress']
+            mac_pkt = testutils.simple_tcp_packet(eth_src=mac)
+            for port in dst_port:
+                testutils.send(ptfadapter, port, mac_pkt)
 
         table_name = ACL_TABLE_NAME_TEMPLATE.format(stage, ip_version)
         try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_acl_outer_vlan failed on some testbeds, and root cause is unknown unicast traffic discarded on leaf fanout switch.
Fixes # (issue)
Microsoft ADO: 25919519

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
test_acl_outer_vlan failed on some testbeds, and root cause is unknown unicast traffic discarded on leaf fanout switch.

#### How did you do it?
Send packet to leaf fanout switch to learn MAC address, and then leaf fanout can find destination for unicast traffic.

#### How did you verify/test it?
Run test_acl_outer_vlan test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
