### PR TITLE
platform_tests: Fix skip_modules check in test_power_budget_info.py

### DIFF
--- a/tests/platform_tests/test_power_budget_info.py
+++ b/tests/platform_tests/test_power_budget_info.py
@@ -43,7 +43,7 @@ def test_power_redis_db(duthosts, enum_supervisor_dut_hostname, tbinfo):
                     logger.debug("psu {} in skip list skipping check".format(n_psu))
 
             elif re.match('Consumed Power', out_val):
-                mod_name = (re.split('Consumed Power', out_val))[1]
+                mod_name = (re.split('Consumed Power', out_val))[1].strip()
                 cons_power = float(out_dict[pb_name]['value'][out_val])
                 exp_total_cons_power += cons_power
                 if mod_name not in skip_mod_list:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is an extra space in the linecard name in `mod_name` which prevents the linecard name from matching that in the module skip list. This PR removes the extra whitespace from `mod_name` so the linecard name correctly matches.

Summary:
Fixes #10885

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR fixes a bug which causes a spurious test failure in `test_power_budget_info.py`.

#### How did you do it?
Remove the spurious whitespace that caused the linecard name to not match the value in the skip list.

#### How did you verify/test it?
Manually running `test_power_budget_info.py` on a device in our testbed with an extra linecard that should be skipped during the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
