### PR TITLE
Increase SSH shutdown timeout for memory exhaustion test

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-SSH_SHUTDOWN_TIMEOUT = 360
+SSH_SHUTDOWN_TIMEOUT = 480
 SSH_STARTUP_TIMEOUT = 600
 
 SSH_STATE_ABSENT = "absent"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Single ASIC linecards have more available memory than other platforms so the total available memory takes longer to exhaust. Increase the timeout accordingly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The test case is currently failing because the currently specified timeout is insufficient to exhaust the available memory on a single ASIC linecard.

#### How did you do it?
I increased the timeout by 2 minutes which ensures that the memory is fully exhausted and thus the linecard reboot gets triggered.

#### How did you verify/test it?
I ran the test manually on a device with a single ASIC linecard.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
