### PR TITLE
[sonic-mgmt] Change adaptive recovery method from config_reload to reboot for process-relates sanity check fail

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -144,7 +144,7 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
                 action = _recover_services(dut, result)
             elif result['check_item'] == 'bgp' or result['check_item'] == "neighbor_macsec_empty":
                 action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)
-            elif result['check_item'] in ['processes', 'mux_simulator']:
+            elif result['check_item'] == 'mux_simulator':
                 action = 'config_reload'
             else:
                 action = 'reboot'


### PR DESCRIPTION

### Description of PR
Apply `reboot` as the adaptive recovery method for pre-test sanity check fails related to processes.  This will recover the system in cases where a process (like orchagent) has exited and is unable to restart.

Summary:
Fixes # 10889

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Address multiple pre-test sanity check fails in a sonic-mgmt run observed when a process like orchagent has exited and is unable to restart.

#### How did you do it?

#### How did you verify/test it?
Applied this change internally for our sonic-mgmt runs and observed that multiple tests are no longer failing at pre-test sanity check.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
