### PR TITLE
Fix iface_namingmode alias check

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 PORT_TOGGLE_TIMEOUT = 30
 
+QUEUE_COUNTERS_RE_FMT = r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'
 
 def skip_test_for_multi_asic(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -397,14 +398,19 @@ def test_show_pfc_counters(setup, setup_config_mode):
     logger.info('pfc_rx:\n{}'.format(pfc_rx))
     logger.info('pfc_tx:\n{}'.format(pfc_tx))
 
+    pfc_rx_names = [x.strip().split(' ')[0] for x in pfc_rx.splitlines()]
+    pfc_tx_names = [x.strip().split(' ')[0] for x in pfc_tx.splitlines()]
+    logger.info('pfc_rx_names:\n{}'.format(pfc_rx_names))
+    logger.info('pfc_tx_names:\n{}'.format(pfc_tx_names))
+
     if mode == 'alias':
         for alias in setup['port_alias']:
-            assert (alias in pfc_rx) and (alias in pfc_tx)
-            assert (setup['port_alias_map'][alias] not in pfc_rx) and (setup['port_alias_map'][alias] not in pfc_tx)
+            assert (alias in pfc_rx_names) and (alias in pfc_tx_names)
+            assert (setup['port_alias_map'][alias] not in pfc_rx_names) and (setup['port_alias_map'][alias] not in pfc_tx_names)
     elif mode == 'default':
         for intf in setup['default_interfaces']:
-            assert (intf in pfc_rx) and (intf in pfc_tx)
-            assert (setup['port_name_map'][intf] not in pfc_rx) and (setup['port_name_map'][intf] not in pfc_tx)
+            assert (intf in pfc_rx_names) and (intf in pfc_tx_names)
+            assert (setup['port_name_map'][intf] not in pfc_rx_names) and (setup['port_name_map'][intf] not in pfc_tx_names)
 
 
 class TestShowPriorityGroup():
@@ -526,17 +532,19 @@ class TestShowQueue():
         if mode == 'alias':
             for intf in interfaces:
                 alias = setup['port_name_map'][intf]
-                assert (re.search(r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'
-                                  .format(alias), queue_counter) is not None) \
-                    and (setup['port_alias_map'][alias] not in queue_counter)
+                assert (re.search(QUEUE_COUNTERS_RE_FMT.format(alias),
+                                  queue_counter) is not None) \
+                    and (re.search(QUEUE_COUNTERS_RE_FMT.format(setup['port_alias_map'][alias]),
+                                   queue_counter) is None)
                 intfsChecked += 1
         elif mode == 'default':
             for intf in interfaces:
                 if intf not in setup['port_name_map']:
                     continue
-                assert (re.search(r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'
-                                  .format(intf), queue_counter) is not None) \
-                    and (setup['port_name_map'][intf] not in queue_counter)
+                assert (re.search(QUEUE_COUNTERS_RE_FMT.format(intf),
+                    queue_counter) is not None) \
+                    and (re.search(QUEUE_COUNTERS_RE_FMT.format(setup['port_name_map'][intf]),
+                        queue_counter) is None)
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -19,6 +19,7 @@ PORT_TOGGLE_TIMEOUT = 30
 
 QUEUE_COUNTERS_RE_FMT = r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'
 
+
 def skip_test_for_multi_asic(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     if duthost.is_multi_asic:
@@ -406,11 +407,13 @@ def test_show_pfc_counters(setup, setup_config_mode):
     if mode == 'alias':
         for alias in setup['port_alias']:
             assert (alias in pfc_rx_names) and (alias in pfc_tx_names)
-            assert (setup['port_alias_map'][alias] not in pfc_rx_names) and (setup['port_alias_map'][alias] not in pfc_tx_names)
+            assert (setup['port_alias_map'][alias] not in pfc_rx_names) and \
+                (setup['port_alias_map'][alias] not in pfc_tx_names)
     elif mode == 'default':
         for intf in setup['default_interfaces']:
             assert (intf in pfc_rx_names) and (intf in pfc_tx_names)
-            assert (setup['port_name_map'][intf] not in pfc_rx_names) and (setup['port_name_map'][intf] not in pfc_tx_names)
+            assert (setup['port_name_map'][intf] not in pfc_rx_names) and \
+                (setup['port_name_map'][intf] not in pfc_tx_names)
 
 
 class TestShowPriorityGroup():
@@ -542,9 +545,9 @@ class TestShowQueue():
                 if intf not in setup['port_name_map']:
                     continue
                 assert (re.search(QUEUE_COUNTERS_RE_FMT.format(intf),
-                    queue_counter) is not None) \
+                                  queue_counter) is not None) \
                     and (re.search(QUEUE_COUNTERS_RE_FMT.format(setup['port_name_map'][intf]),
-                        queue_counter) is None)
+                                   queue_counter) is None)
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The `iface_namingmode` test attempts to verify that the original interface name is not present in counters output when alias mode is requested, but it winds up matching if the original interface name is a substring of an alias name (e.g., Ethernet1 would match Ethernet12 in the output and cause the test to fail).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
This PR fixes a bug where the test mistakenly matches a substring of an interface name when looking for the original name of another interface (e.g., Ethernet12 matches Ethernet1)

#### How did you do it?
I isolated the interface names from the CLI output and matched against the whole interface name, instead of doing a substring match on the entire output.

#### How did you verify/test it?
I ran the test manually against a DUT which was affected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
