### PR TITLE
Allow fewer PORT_READY messages than expected

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -410,7 +410,8 @@ def verify_required_events(duthost, event_counters, timing_data, verification_er
             observed_end_count = timing_data.get(
                 key, {}).get(pattern, {}).get("End count", 0)
             expected_count = event_counters.get(pattern)
-            if observed_start_count != expected_count:
+            if (observed_start_count != expected_count and pattern != 'PORT_READY') or\
+                    (observed_start_count > expected_count and pattern == 'PORT_READY'):
                 verification_errors.append("FAIL: Event {} was found {} times, when expected exactly {} times".
                                            format(pattern, observed_start_count, expected_count))
             if key == "time_span" and observed_start_count != observed_end_count:

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -410,8 +410,10 @@ def verify_required_events(duthost, event_counters, timing_data, verification_er
             observed_end_count = timing_data.get(
                 key, {}).get(pattern, {}).get("End count", 0)
             expected_count = event_counters.get(pattern)
-            if (observed_start_count != expected_count and pattern != 'PORT_READY') or\
-                    (observed_start_count > expected_count and pattern == 'PORT_READY'):
+            # If we're checking PORT_READY, and there are 0 port state change messages captured instead of however many
+            # was expected, treat it as a success. Some platforms (Mellanox, Dell S6100) have 0, some platforms (Arista
+            #  050cx3) have however many ports are up.
+            if observed_start_count != expected_count and (pattern != 'PORT_READY' or observed_start_count != 0):
                 verification_errors.append("FAIL: Event {} was found {} times, when expected exactly {} times".
                                            format(pattern, observed_start_count, expected_count))
             if key == "time_span" and observed_start_count != observed_end_count:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

For fast-reboot, it's currently assumed that the number of PORT_READY messages will equal the number of ports that are up; for warm-reboot, there should be 0 PORT_READY messages. However, on some platforms, it seems that there are no PORT_READY messages generated with state changes (i.e. where the port changes from down to up) during fast-reboot.

#### How did you do it?

For now, loosen the check for the number of PORT_READY messages to accept fewer messages.

#### How did you verify/test it?

#### Any platform specific information?

Change made primarily for Mellanox platforms.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
