### PR TITLE
Fix TypeError in sai_qos_test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1158,8 +1158,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             margin = 2
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -1879,8 +1880,9 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         )
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         step_id = 1
         step_desc = 'disable TX for dst_port_id, dst_port_2_id, dst_port_3_id'
@@ -2336,8 +2338,9 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         # Pause egress of dut xmit port
         self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
@@ -3214,8 +3217,9 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             margin = 2
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -3671,8 +3675,10 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
+
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
         pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
         dst_pg_cntrs_base = sai_thrift_read_pg_counters(self.dst_client, port_list['dst'][dst_port_id])
@@ -3919,8 +3925,9 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             margin = 0
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -4268,8 +4275,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             'pkts_num_margin') else 8
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
-        if 'pkts_num_egr_mem' in list(self.test_params.keys()):
-            pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        pkts_num_egr_mem = self.test_params.get('pkts_num_egr_mem', None)
+        if pkts_num_egr_mem is not None:
+            pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
         xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to fix `TypeError` in `sai_qos_tests.py`.
```
"Traceback (most recent call last):", "  File \"saitests/py3/sai_qos_tests.py\", line 1883, in runTest", "    pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])", "TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'", 
```
The error is because `pkts_num_egr_mem` is `None` in the arguments.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
The PR is to fix `TypeError` in `sai_qos_tests.py`.

#### How did you do it?
Check if the value is `None` before converting into `int`.

#### How did you verify/test it?
Verified on a SN2700 testbed.
```
collected 12 items                                                                                                                                                                                                            

qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]  ^HPASSED                                                                                                                                        [  8%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]  ^HPASSED                                                                                                                                        [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_3] SKIPPED (Additional DSCPs are not supported on non-dual ToR ports)                                                                            [ 25%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_4] SKIPPED (Additional DSCPs are not supported on non-dual ToR ports)                                                                            [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_1] SKIPPED (single_dut_multi_asic is not supported on T0 topologies)                                                                   [ 41%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_2] SKIPPED (single_dut_multi_asic is not supported on T0 topologies)                                                                   [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_3] SKIPPED (single_dut_multi_asic is not supported on T0 topologies)                                                                   [ 58%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_4] SKIPPED (single_dut_multi_asic is not supported on T0 topologies)                                                                   [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_1] SKIPPED (multi-dut is not supported on T0 topologies)                                                                                           [ 75%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_2] SKIPPED (multi-dut is not supported on T0 topologies)                                                                                           [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_3] SKIPPED (multi-dut is not supported on T0 topologies)                                                                                           [ 91%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_4] SKIPPED (multi-dut is not supported on T0 topologies)                                                                                           [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
