### PR TITLE
Cisco: Qos-sai: Change the tests to use only downlink ports. 

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1118,7 +1118,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLossyProfile, duthost, localhost, get_src_dst_asic_and_duts,
-            skip_src_dst_different_asic
+            skip_src_dst_different_asic,  separated_dscp_to_tc_map_on_uplink
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -1157,6 +1157,19 @@ class TestQosSai(QosSaiBase):
 
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LossyVoq])
 
+        dst_port_id = dutConfig["testPorts"]["dst_port_id"]
+        dst_port_ip = dutConfig["testPorts"]["dst_port_ip"]
+        if separated_dscp_to_tc_map_on_uplink:
+            # We need to choose only the downlink port ids, which are associated
+            # with AZURE dscp_to_tc mapping. The uplink ports have a
+            # different mapping.
+            for index in range(len(dutConfig['testPorts']['downlink_port_ids'])):
+                if dutConfig["testPorts"]["src_port_id"] != \
+                        dutConfig['testPorts']['downlink_port_ids'][index]:
+                    dst_port_id = id
+                    dst_port_ip = dutConfig['testPorts']['downlink_port_ips'][index]
+                    break
+
         try:
             testParams = dict()
             testParams.update(dutTestParams["basicParams"])
@@ -1166,8 +1179,8 @@ class TestQosSai(QosSaiBase):
                 "pg": qosConfig[LossyVoq]["pg"],
                 "src_port_id": dutConfig["testPorts"]["src_port_id"],
                 "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-                "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
-                "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+                "dst_port_id": dst_port_id,
+                "dst_port_ip": dst_port_ip,
                 "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
                 "flow_config": flow_config,
                 "pkts_num_trig_egr_drp": qosConfig[LossyVoq]["pkts_num_trig_egr_drp"]
@@ -2010,11 +2023,20 @@ class TestQosSai(QosSaiBase):
 
         allTestPorts = []
         allTestPortIps = []
-        all_dst_info = dutConfig['testPortIps'][get_src_dst_asic_and_duts['dst_dut_index']]
-        allTestPorts.extend(list(all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].keys()))
-        allTestPortIps.extend([
-            x['peer_addr'] for x in
-            all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].values()])
+        testPortIps = dutConfig["testPortIps"]
+        if separated_dscp_to_tc_map_on_uplink:
+            # Remove the upstream ports from the test port list.
+            allTestPorts = list(set(allTestPorts) - set(dutConfig['testPorts']['uplink_port_ids']))
+            allTestPortIps = [
+                testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
+                [get_src_dst_asic_and_duts['dst_asic_index']][port]['peer_addr']
+                for port in allTestPorts]
+        else:
+            all_dst_info = dutConfig['testPortIps'][get_src_dst_asic_and_duts['dst_dut_index']]
+            allTestPorts.extend(list(all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].keys()))
+            allTestPortIps.extend([
+                x['peer_addr'] for x in
+                all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].values()])
         try:
             tc_to_q_map = dut_qos_maps['tc_to_queue_map']['AZURE']
             tc_to_dscp_map = {v: k for k, v in dut_qos_maps['dscp_to_tc_map']['AZURE'].items()}

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1166,7 +1166,7 @@ class TestQosSai(QosSaiBase):
             for index in range(len(dutConfig['testPorts']['downlink_port_ids'])):
                 if dutConfig["testPorts"]["src_port_id"] != \
                         dutConfig['testPorts']['downlink_port_ids'][index]:
-                    dst_port_id = id
+                    dst_port_id = index
                     dst_port_ip = dutConfig['testPorts']['downlink_port_ips'][index]
                     break
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -33,6 +33,7 @@ from tests.common.fixtures.duthost_utils import dut_qos_maps, \
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                        # noqa F401
+from tests.common.fixtures.duthost_utils import dut_qos_maps_module                         # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                            # noqa F401
 from tests.common.dualtor.dual_tor_utils import dualtor_ports, is_tunnel_qos_remap_enabled  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
@@ -1118,7 +1119,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLossyProfile, duthost, localhost, get_src_dst_asic_and_duts,
-            skip_src_dst_different_asic
+            skip_src_dst_different_asic, dut_qos_maps    # noqa:  F811
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq
@@ -1159,7 +1160,7 @@ class TestQosSai(QosSaiBase):
 
         dst_port_id = dutConfig["testPorts"]["dst_port_id"]
         dst_port_ip = dutConfig["testPorts"]["dst_port_ip"]
-        if separated_dscp_to_tc_map_on_uplink:
+        if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             # We need to choose only the downlink port ids, which are associated
             # with AZURE dscp_to_tc mapping. The uplink ports have a
             # different mapping.
@@ -2024,7 +2025,7 @@ class TestQosSai(QosSaiBase):
         allTestPorts = []
         allTestPortIps = []
         testPortIps = dutConfig["testPortIps"]
-        if separated_dscp_to_tc_map_on_uplink:
+        if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             # Remove the upstream ports from the test port list.
             allTestPorts = list(set(allTestPorts) - set(dutConfig['testPorts']['uplink_port_ids']))
             allTestPortIps = [

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -33,7 +33,6 @@ from tests.common.fixtures.duthost_utils import dut_qos_maps, \
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                        # noqa F401
-from tests.common.fixtures.duthost_utils import dut_qos_maps_module                         # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                            # noqa F401
 from tests.common.dualtor.dual_tor_utils import dualtor_ports, is_tunnel_qos_remap_enabled  # noqa F401
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2024,6 +2024,14 @@ class TestQosSai(QosSaiBase):
         allTestPorts = []
         allTestPortIps = []
         testPortIps = dutConfig["testPortIps"]
+        all_dst_info = dutConfig['testPortIps'][get_src_dst_asic_and_duts['dst_dut_index']]
+        allTestPorts.extend(list(all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].keys()))
+        allTestPortIps.extend([
+            x['peer_addr'] for x in
+            all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].values()])
+
+        src_port_id = dutConfig["testPorts"]["src_port_id"]
+        src_port_ip = dutConfig["testPorts"]["src_port_ip"]
         if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
             # Remove the upstream ports from the test port list.
             allTestPorts = list(set(allTestPorts) - set(dutConfig['testPorts']['uplink_port_ids']))
@@ -2031,12 +2039,8 @@ class TestQosSai(QosSaiBase):
                 testPortIps[get_src_dst_asic_and_duts['dst_dut_index']]
                 [get_src_dst_asic_and_duts['dst_asic_index']][port]['peer_addr']
                 for port in allTestPorts]
-        else:
-            all_dst_info = dutConfig['testPortIps'][get_src_dst_asic_and_duts['dst_dut_index']]
-            allTestPorts.extend(list(all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].keys()))
-            allTestPortIps.extend([
-                x['peer_addr'] for x in
-                all_dst_info[get_src_dst_asic_and_duts['dst_asic_index']].values()])
+            src_port_id = allTestPorts[0]
+            src_port_ip = allTestPortIps[0]
         try:
             tc_to_q_map = dut_qos_maps['tc_to_queue_map']['AZURE']
             tc_to_dscp_map = {v: k for k, v in dut_qos_maps['dscp_to_tc_map']['AZURE'].items()}
@@ -2046,8 +2050,10 @@ class TestQosSai(QosSaiBase):
                 "and key AZURE to run this test.")
         dscp_to_q_map = {tc_to_dscp_map[tc]: tc_to_q_map[tc] for tc in tc_to_dscp_map}
         if get_src_dst_asic_and_duts['single_asic_test']:
-            allTestPorts.remove(dutConfig["testPorts"]["src_port_id"])
-            allTestPortIps.remove(dutConfig["testPorts"]["src_port_ip"])
+            if dutConfig["testPorts"]["src_port_id"] in allTestPorts:
+                allTestPorts.remove(dutConfig["testPorts"]["src_port_id"])
+            if dutConfig["testPorts"]["src_port_ip"] in allTestPortIps:
+                allTestPortIps.remove(dutConfig["testPorts"]["src_port_ip"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -2055,8 +2061,8 @@ class TestQosSai(QosSaiBase):
             "ecn": qosConfig[queueProfile]["ecn"],
             "dst_port_ids": allTestPorts,
             "dst_port_ips": allTestPortIps,
-            "src_port_id": dutConfig["testPorts"]["src_port_id"],
-            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_id": src_port_id,
+            "src_port_ip": src_port_ip,
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "pkt_count": qosConfig[queueProfile]["pkt_count"],

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1118,7 +1118,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLossyProfile, duthost, localhost, get_src_dst_asic_and_duts,
-            skip_src_dst_different_asic,  separated_dscp_to_tc_map_on_uplink
+            skip_src_dst_different_asic
     ):
         """
             Test QoS SAI Lossy queue with non_default voq and default voq


### PR DESCRIPTION
Porting 10381 to master, along with some more mods to fix precommit errors:
Addressing the test fails when they use uplink ports. Forcing the script to use downlink ports only.