### PR TITLE
Dump status to debug test_tagged_arp

### DIFF
--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -149,4 +149,15 @@ def test_tagged_arp_pkt(ptfadapter, duthosts, rand_one_dut_hostname,
                 assert arp_cnt == DUMMY_ARP_COUNT, "Expect {} entries, but {} found".format(DUMMY_ARP_COUNT, arp_cnt)
             except Exception as detail:
                 logger.error("Except: {}".format(detail))
+                # Dump status for debug
+                import time
+                time.sleep(10)
+                res = duthost.command('show mac')
+                logger.info('"show mac" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
+                res = duthost.command('show arp')
+                logger.info('"show arp" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
+                res = duthost.command('show int counter')
+                logger.info('"show int counter" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
+                res = duthost.command('show int portchannel')
+                logger.info('"show int portchannel" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
                 raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
test_tagged_arp started to failure since 20220531.45, but I can't reproduce it.

#### How did you do it?
If this case failed, dump current status to verify if SONiC received arp packets.

#### How did you verify/test it?
Run test_tagged_arp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
