### PR TITLE
[Dash] Enhance the dash vnet test to support tcp and icmp packets

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -241,3 +241,8 @@ def asic_db_checker(duthost):
             output = duthost.shell("sonic-db-cli ASIC_DB keys 'ASIC_STATE:{}:*'".format(table))
             assert output["stdout"].strip() != "", "No entries found in ASIC_DB table {}".format(table)
     yield _check_asic_db
+
+
+@pytest.fixture(scope="function", params=['udp', 'tcp', 'echo_request', 'echo_reply'])
+def inner_packet_type(request):
+    return request.param

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -7,13 +7,32 @@ import ptf.testutils as testutils
 from constants import *  # noqa: F403
 
 
-def inbound_vnet_packets(dash_config_info):
-    inner_packet = testutils.simple_udp_packet(
+def generate_inner_packet(packet_type):
+    if packet_type == 'udp':
+        return testutils.simple_udp_packet
+    elif packet_type == 'tcp':
+        return testutils.simple_tcp_packet
+    elif packet_type == 'echo_request' or packet_type == 'echo_reply':
+        return testutils.simple_icmp_packet
+
+    return None
+
+
+def set_icmp_sub_type(packet, packet_type):
+    if packet_type == 'echo_request':
+        packet[scapy.ICMP].type = 8
+    elif packet_type == 'echo_reply':
+        packet[scapy.ICMP].type = 0
+
+
+def inbound_vnet_packets(dash_config_info, inner_packet_type='udp'):
+    inner_packet = generate_inner_packet(inner_packet_type)(
         eth_src=dash_config_info[REMOTE_ENI_MAC],
         eth_dst=dash_config_info[LOCAL_ENI_MAC],
         ip_src=dash_config_info[REMOTE_CA_IP],
         ip_dst=dash_config_info[LOCAL_CA_IP],
     )
+    set_icmp_sub_type(inner_packet, inner_packet_type)
     pa_match_vxlan_packet = testutils.simple_vxlan_packet(
         eth_src=dash_config_info[REMOTE_PTF_MAC],
         eth_dst=dash_config_info[DUT_MAC],
@@ -47,19 +66,20 @@ def inbound_vnet_packets(dash_config_info):
     return inner_packet, pa_match_vxlan_packet, pa_mismatch_vxlan_packet, masked_exp_packet
 
 
-def outbound_vnet_packets(dash_config_info, inner_extra_conf={}):
+def outbound_vnet_packets(dash_config_info, inner_extra_conf={}, inner_packet_type='udp'):
     proto = None
     if "proto" in inner_extra_conf:
         proto = int(inner_extra_conf["proto"])
         del inner_extra_conf["proto"]
 
-    inner_packet = testutils.simple_udp_packet(
+    inner_packet = generate_inner_packet(inner_packet_type)(
         eth_src=dash_config_info[LOCAL_ENI_MAC],
         eth_dst=dash_config_info[REMOTE_ENI_MAC],
         ip_src=dash_config_info[LOCAL_CA_IP],
         ip_dst=dash_config_info[REMOTE_CA_IP],
         **inner_extra_conf
     )
+    set_icmp_sub_type(inner_packet, inner_packet_type)
 
     if proto:
         inner_packet[scapy.IP].proto = proto

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -19,14 +19,16 @@ def test_outbound_vnet(
         apply_vnet_configs,
         dash_config_info,
         skip_dataplane_checking,
-        asic_db_checker):
+        asic_db_checker,
+        inner_packet_type):
     """
     Send VXLAN packets from the VM VNI
     """
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
-    _, vxlan_packet, expected_packet = packets.outbound_vnet_packets(dash_config_info)
+    _, vxlan_packet, expected_packet = packets.outbound_vnet_packets(dash_config_info,
+                                                                     inner_packet_type=inner_packet_type)
     testutils.send(ptfadapter, dash_config_info[LOCAL_PTF_INTF], vxlan_packet, 1)
     testutils.verify_packets_any(ptfadapter, expected_packet, ports=dash_config_info[REMOTE_PTF_INTF])
     # testutils.verify_packet(ptfadapter, expected_packet, dash_config_info[REMOTE_PTF_INTF])
@@ -37,11 +39,13 @@ def test_outbound_vnet_direct(
         apply_vnet_direct_configs,
         dash_config_info,
         skip_dataplane_checking,
-        asic_db_checker):
+        asic_db_checker,
+        inner_packet_type):
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
-    _, vxlan_packet, expected_packet = packets.outbound_vnet_packets(dash_config_info)
+    _, vxlan_packet, expected_packet = packets.outbound_vnet_packets(dash_config_info,
+                                                                     inner_packet_type=inner_packet_type)
     testutils.send(ptfadapter, dash_config_info[LOCAL_PTF_INTF], vxlan_packet, 1)
     testutils.verify_packets_any(ptfadapter, expected_packet, ports=dash_config_info[REMOTE_PTF_INTF])
     # testutils.verify_packet(ptfadapter, expected_packet, dash_config_info[REMOTE_PTF_INTF])
@@ -52,11 +56,13 @@ def test_outbound_direct(
         apply_direct_configs,
         dash_config_info,
         skip_dataplane_checking,
-        asic_db_checker):
+        asic_db_checker,
+        inner_packet_type):
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
-    expected_inner_packet, vxlan_packet, _ = packets.outbound_vnet_packets(dash_config_info)
+    expected_inner_packet, vxlan_packet, _ = packets.outbound_vnet_packets(dash_config_info,
+                                                                           inner_packet_type=inner_packet_type)
     testutils.send(ptfadapter, dash_config_info[LOCAL_PTF_INTF], vxlan_packet, 1)
     testutils.verify_packets_any(ptfadapter, expected_inner_packet, ports=dash_config_info[REMOTE_PTF_INTF])
     # testutils.verify_packet(ptfadapter, expected_inner_packet, dash_config_info[REMOTE_PTF_INTF])
@@ -67,7 +73,8 @@ def test_inbound_vnet_pa_validate(
         apply_inbound_configs,
         dash_config_info,
         skip_dataplane_checking,
-        asic_db_checker):
+        asic_db_checker,
+        inner_packet_type):
     """
     Send VXLAN packets from the remote VNI with PA validation enabled
 
@@ -79,7 +86,8 @@ def test_inbound_vnet_pa_validate(
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
-    _,  pa_match_packet, pa_mismatch_packet, expected_packet = packets.inbound_vnet_packets(dash_config_info)
+    _,  pa_match_packet, pa_mismatch_packet, expected_packet = packets.inbound_vnet_packets(
+        dash_config_info, inner_packet_type=inner_packet_type)
     testutils.send(ptfadapter, dash_config_info[REMOTE_PTF_INTF], pa_match_packet, 1)
     testutils.verify_packets_any(ptfadapter, expected_packet, ports=dash_config_info[LOCAL_PTF_INTF])
     testutils.send(ptfadapter, dash_config_info[REMOTE_PTF_INTF], pa_mismatch_packet, 1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhance the dash vnet test to support tcp and icmp packets.
Currently the dash vnet test only uses udp for data plane validation, we want to also cover icmp and tcp in the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Enhance the dash vnet test to support tcp and icmp packets.
#### How did you do it?
Use a parameterized fixture inner_packet_type to generate a parameter from ['udp', 'tcp', 'echo_request', 'echo_reply'] for dash vnet test. 
#### How did you verify/test it?
Run the test on DPU setup and manually checked the packets sent and received, the types are as expected.
#### Any platform specific information?
Only for dpu.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
