### PR TITLE
Fix loopback action reload test

### DIFF
--- a/tests/iface_loopback_action/iface_loopback_action_helper.py
+++ b/tests/iface_loopback_action/iface_loopback_action_helper.py
@@ -634,3 +634,13 @@ def check_interface_state(duthost, rif_interfaces, state='up'):
         return all(interface in ports_down for interface in rif_interfaces)
 
     return all(interface not in ports_down for interface in rif_interfaces)
+
+
+def is_rif_counters_ready(duthost):
+    """
+    Check whether the rif counters are all available
+    """
+    result = duthost.shell("show interfaces counters rif")
+    if len(result['stdout_lines']) == 2 or 'N/A' in result['stdout']:
+        return False
+    return True

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import random
-import time
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
@@ -12,7 +11,7 @@ from .iface_loopback_action_helper import verify_traffic
 from .iface_loopback_action_helper import config_loopback_action
 from .iface_loopback_action_helper import clear_rif_counter
 from .iface_loopback_action_helper import verify_interface_loopback_action
-from .iface_loopback_action_helper import verify_rif_tx_err_count
+from .iface_loopback_action_helper import verify_rif_tx_err_count, is_rif_counters_ready
 from .iface_loopback_action_helper import shutdown_rif_interfaces, startup_rif_interfaces
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 
@@ -103,10 +102,10 @@ def test_loopback_action_reload(request, duthost, localhost, ptfadapter, ports_c
             reboot(duthost, localhost, reboot_type)
             pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                           "All critical services should be fully started!")
-        # Wait 180s for the rif counter to initialize
-        time.sleep(180)
         pytest_assert(wait_until(60, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
+        # Wait for the rif counter to initialize
+        wait_until(180, 10, 0, is_rif_counters_ready, duthost)
     with allure.step("Verify the loopback action is correct after config reload"):
         with allure.step("Check the looback action is configured correctly with cli command"):
             verify_interface_loopback_action(duthost, rif_interfaces, action_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The rif counters are checked in the test  test_loopback_action_reload after reload/reboot.
But the counters will not be available right after the reload/reboot, need to wait for the initialization.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. Add a wait_until for the rif counters.
2. Combine the codes of checking interface status after reload/reboot into one.
#### How did you verify/test it?
Run the test in regression, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
