### PR TITLE
Remove the redundant log analyzer in next hop group test

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -15,7 +15,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device, get_chip_type
 from tests.common.innovium_data import is_innovium_device
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import toggle_one_link
 from tests.common.platform.device_utils import fanout_switch_port_lookup
@@ -314,7 +313,7 @@ def build_pkt(dest_mac, ip_addr, ttl, flow_count):
     return pkt, exp_packet
 
 
-def test_nhop_group_member_count(duthost, tbinfo):
+def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
     """
     Test next hop group resource count. Steps:
     - Add test IP address to an active IP interface
@@ -325,6 +324,9 @@ def test_nhop_group_member_count(duthost, tbinfo):
     - clean up
     - Verify no errors and crash
     """
+    if loganalyzer:
+        for analyzer in list(loganalyzer.values()):
+            analyzer.ignore_regex.extend(loganalyzer_ignore_regex_list())
     # Set of parameters for Cisco-8000 devices
     if is_cisco_device(duthost):
         default_max_nhop_paths = 2
@@ -394,13 +396,6 @@ def test_nhop_group_member_count(duthost, tbinfo):
         nhop_group_count = crm_stat["available_nhop_grp"]
     else:
         nhop_group_count = min(max_nhop, nhop_group_limit) + extra_nhops
-    # initialize log analyzer
-    marker = "NHOP TEST PATH COUNT {} {}".format(nhop_group_count, eth_if)
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker)
-    marker = loganalyzer.init()
-    loganalyzer.load_common_config()
-    loganalyzer.expect_regex = []
-    loganalyzer.ignore_regex.extend(loganalyzer_ignore_regex_list())
 
     logger.info("Adding {} next hops on {}".format(nhop_group_count, eth_if))
     # create nexthop group
@@ -426,9 +421,6 @@ def test_nhop_group_member_count(duthost, tbinfo):
         asic.command(
             "crm config polling interval {}".format(crm_before["polling"])
         )
-
-    # check for any errors or crash
-    loganalyzer.analyze(marker)
 
     # verify the test used up all the NHOP group resources
     # skip this check on Mellanox as ASIC resources are shared


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We don't need to initialize a new log analyzer instance in the test since the default one is enable on the test.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Remove the redundant log analyzer in next hop group test.
#### How did you do it?
Use the default log analyzer instance initialized by plugin.
#### How did you verify/test it?
Run the test, passed and the syslog is analyzed correctly.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
