### PR TITLE
[dualtor-io] Increase stop wait to 90s

### DIFF
--- a/tests/templates/dual_tor_sniffer.conf.j2
+++ b/tests/templates/dual_tor_sniffer.conf.j2
@@ -9,4 +9,4 @@ autorestart=false
 startsecs=1
 numprocs=1
 stopsignal=INT
-stopwaitsecs=30
+stopwaitsecs=90


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the following issue:
```
 Traffic on server 192.168.0.2 was disrupted after test end, missing 2 packets from the end of the packet flow
```
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
The reason is that, on `dualtor-120` testbed, `dual_tor_sniffer` sometimes takes around 45+ seconds to be stopped after receiving the `SIGINT`. This is because `dual_tor_sniffer` script captures more packets on `dualtor-120` as it has more vlan members and `dualtor-io` tests are sending more packets. After 30 seconds, `supervisorctl` will kill the `dual_tor_sniffer`, which will result in the loss of packets.
Let's increase the `stopwaitsecs` to 90s.

#### How did you verify/test it?
Run `dualtor-io` tests on `dualtor-120` testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
