### PR TITLE
[202205] Improve debuggability of sonic image upgrading (#10856)

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -11,6 +11,7 @@ image may has been updated by people for debugging purpose. Upgrade to a previou
 target image is clean.
 """
 import argparse
+import json
 import logging
 import os
 import requests
@@ -41,6 +42,7 @@ RC_UPGRADE_FAILED = 3
 RC_ENABLE_FIPS_FAILED = 4
 RC_SET_DOCKER_FOLDER_SIZE_FAILED = 5
 RC_SHUTDOWN_FAILED = 6
+RC_HOSTS_UNREACHABLE = 7
 
 
 def validate_args(args):
@@ -98,6 +100,31 @@ def get_pdu_managers(sonichosts, conn_graph_facts):
     return pdu_managers
 
 
+def check_reachability(localhost, sonichosts):
+    hosts_reachability = {}
+
+    logger.info("Check ICMP ping")
+    for hostname, ip in zip(sonichosts.hostnames, sonichosts.ips):
+        hosts_reachability[hostname] = True
+        logger.info("Ping {} @{} from localhost".format(hostname, ip))
+        ping_failed = localhost.command(
+            "timeout 2 ping {} -c 1".format(ip), module_ignore_errors=True
+        ).get("localhost", {}).get("failed")
+        if ping_failed:
+            logger.info("Ping {} @{} from localhost failed.".format(hostname, ip))
+            hosts_reachability[hostname] = False
+
+    logger.info("Check if ansible can SSH to sonichosts")
+    for hostname, ping_result in sonichosts.ping(module_ignore_errors=True).items():
+        if ping_result["failed"]:
+            logger.info("SSH to {} failed.".format(hostname))
+            hosts_reachability[hostname] = False
+
+    logger.info("Hosts reachability: {}".format(json.dumps(hosts_reachability, indent=2)))
+
+    return hosts_reachability
+
+
 def main(args):
     logger.info("Validating arguments")
     validate_args(args)
@@ -121,7 +148,7 @@ def main(args):
 
     # Power cycle before upgrade
     if args.always_power_cycle:
-        logger.info("Power cycle before upgrade")
+        logger.info("Always do power cycle before upgrade")
         for hostname, pdu_manager in pdu_managers.items():
             logger.info("Turn off power outlets to {}".format(hostname))
             pdu_manager.turn_off_outlet()
@@ -133,30 +160,32 @@ def main(args):
 
     # Power cycle when unreachable
     elif args.power_cycle_unreachable:
-        logger.info("Power cycle unreachable")
-        ping_results = {}
-        needs_sleep = False
-        for hostname, ip in zip(sonichosts.hostnames, sonichosts.ips):
-            logger.info("Ping {} @{} from localhost".format(hostname, ip))
-            ping_failed = localhost.command(
-                "timeout 2 ping {} -c 1".format(ip), module_ignore_errors=True
-            ).get("localhost", {}).get("failed")
-            if ping_failed:
-                logger.info("Ping {} @{} from localhost failed. Going to power off it".format(hostname, ip))
-                ping_results[hostname] = ping_failed
-                pdu_managers[hostname].turn_off_outlet()
-                needs_sleep = True
+        logger.info("Check if sonichosts are unreachable. If unreachable, need to try power cycle")
+        hosts_reachability = check_reachability(localhost, sonichosts)
 
-        if needs_sleep:
+        power_cycle_performed = False
+        for hostname, host_reachable in hosts_reachability.items():
+            if not host_reachable:
+                logger.info("Trying to power off {}".format(hostname))
+                pdu_managers[hostname].turn_off_outlet()
+                power_cycle_performed = True
+
+        if power_cycle_performed:
             localhost.pause(seconds=30, prompt="Pause between power off/on")
 
-        for hostname, ping_failed in ping_results.items():
-            if ping_failed:
-                logger.info("Power on {}".format(hostname))
+        for hostname, host_reachable in hosts_reachability.items():
+            if not host_reachable:
+                logger.info("Trying to power on {}".format(hostname))
                 pdu_managers[hostname].turn_on_outlet()
 
-        if needs_sleep:
+        if power_cycle_performed:
             localhost.pause(seconds=180, prompt="Add some sleep to allow power cycled DUTs to come back")
+
+    logger.info("Check reachability again after possible power cycle")
+    hosts_reachability = check_reachability(localhost, sonichosts)
+    if not all(hosts_reachability.values()):
+        logger.error("Some hosts are still unreachable, abort image upgrading: {}".format(hosts_reachability))
+        sys.exit(RC_HOSTS_UNREACHABLE)
 
     # Upgrade to prev image
     if not args.skip_prev_image:
@@ -177,6 +206,8 @@ def main(args):
 
         for hostname, version in sonichosts.sonic_version.items():
             logger.info("SONiC host {} current version {}".format(hostname, version.get("build_version")))
+    else:
+        logger.info("Skipping upgrade to prev image")
 
     # Upgrade to target image
     logger.info("upgrade to target image at {}".format(args.image_url))
@@ -188,10 +219,10 @@ def main(args):
         onie_pause_time=args.onie_pause_time
     )
     if not upgrade_success:
-        logger.error("Upgrade image {} failed".format(args.image_url))
+        logger.error("Upgrade to target image {} failed".format(args.image_url))
         sys.exit(RC_UPGRADE_FAILED)
     else:
-        logger.info("Upgraded to image {}".format(args.prev_image_url))
+        logger.info("Upgrad to target image {} done".format(args.image_url))
 
     current_build_version = None
     for hostname, version in sonichosts.sonic_version.items():
@@ -209,6 +240,8 @@ def main(args):
         except Exception as e:
             logger.error("Failed to enable FIPS mode: {}".repr(e))
             sys.exit(RC_ENABLE_FIPS_FAILED)
+    else:
+        logger.info("Skip enabling FIPS")
 
     # Set docker folder size, required for platforms with small disk
     if args.docker_folder_size:
@@ -230,14 +263,14 @@ def main(args):
 
     # Force reboot the device to apply changes
     if need_shutdown:
-        logger.info("Need to shutdown")
+        logger.info("Need to force reboot")
         try:
             sonichosts.command("shutdown -r now", module_attrs={"become": True, "async": 300, "poll": 0})
+            localhost.pause(seconds=180, prompt="Pause after force reboot")
         except Exception as e:
             logger.error("Failed to shutdown: {}".repr(e))
             sys.exit(RC_SHUTDOWN_FAILED)
 
-    localhost.pause(seconds=180, prompt="Pause after reboot")
     logger.info("===== UPGRADE IMAGE DONE =====")
 
 

--- a/ansible/devutil/devices/sonic.py
+++ b/ansible/devutil/devices/sonic.py
@@ -182,6 +182,7 @@ def post_upgrade_actions(sonichosts, localhost, disk_used_percent):
 
         sonichosts.command("config bgp startup all", module_attrs={"become": True})
         sonichosts.command("config save -y", module_attrs={"become": True})
+        logger.info("Run reduce_and_add_sonic_images to cleanup disk")
         sonichosts.reduce_and_add_sonic_images(
             disk_used_pcent=disk_used_percent,
             module_attrs={"become": True}

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
 
+import logging
+import sys
+from datetime import datetime
+from os import path
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.debug_utils import config_module_logging
+
 DOCUMENTATION = '''
 module:  reduce_and_add_sonic_images
 version_added:  "1.0"
@@ -26,27 +33,36 @@ import sys
 from os import path
 from ansible.module_utils.basic import *
 
-results = {"downloaded_image_version": "Unknown", "current_stage": "Unknown"}
+results = {"downloaded_image_version": "Unknown", "current_stage": "Unknown", "messages": []}
+
+
+def log(msg):
+    global results
+
+    timestamp = datetime.utcnow()
+    results["messages"].append("{} {}".format(str(timestamp), msg))
+    logging.debug(msg)
 
 def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
     if not ignore_error and rc != 0:
-        module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" %
-                         (msg, rc, out, err))
+        module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" % (msg, rc, out, err))
     return rc, out, err
 
 
-# Return available disk size in MB
 def get_disk_free_size(module, partition):
-    _, out, _   = exec_command(module, cmd="df -BM --output=avail %s" % partition,
-                         msg="checking disk available size")
+    """Return available disk size in MB
+    """
+    _, out, _ = exec_command(module, cmd="df -BM --output=avail %s" % partition, msg="checking disk available size")
     avail = int(out.split('\n')[1][:-1])
 
     return avail
 
-# Return total/available memory size in MB, -1, -1 means failed to get the sizes
+
 def get_memory_sizes(module):
-    _, out, _   = exec_command(module, cmd="free -m", msg="checking memory total/free sizes")
+    """Return total/available memory size in MB, -1, -1 means failed to get the sizes
+    """
+    _, out, _ = exec_command(module, cmd="free -m", msg="checking memory total/free sizes")
     lines = out.split('\n')
     if len(lines) < 2:
         return -1, -1
@@ -60,21 +76,30 @@ def get_memory_sizes(module):
 
 
 def setup_swap_if_necessary(module):
+    log("Setup swap if necessary")
     df = get_disk_free_size(module, '/host')
     total, avail = get_memory_sizes(module)
     if df < 4000 or total < 0 or avail < 0:
-        # Disk free space low or failed to obtain memory information
+        log("Disk free space low or failed to obtain memory information")
         return
 
     if total < 2048 or avail < 1200:
-        # Memory size or available amount is low, there is risk of OOM during new
-        # image installation. Create a temporary swap file.
-        exec_command(module, cmd="if [ -f {0} ]; then sudo swapoff {0}; sudo rm -f {0}; fi; sudo fallocate -l 1G {0}; sudo chmod 600 {0}; sudo mkswap {0}; sudo swapon {0}".format('/host/swapfile'),
-                     msg="Create a temporary swap file")
+        log("Low free memory. Creating temp swap to avoid possible OOM during image installation")
+        exec_command(
+            module,
+            cmd="if [ -f {0} ]; then sudo swapoff {0}; sudo rm -f {0}; fi; "
+                "sudo fallocate -l 1G {0}; sudo chmod 600 {0}; sudo mkswap {0}; sudo swapon {0}"
+                .format('/host/swapfile'),
+            msg="Create a temporary swap file")
+        log("Done creating tmp swap")
+    else:
+        log("No need to setup swap")
 
 
 def reduce_installed_sonic_images(module):
-    _, out, _  = exec_command(module, cmd="sonic_installer list", ignore_error=True)
+    log("reduce_installed_sonic_images")
+
+    _, out, _ = exec_command(module, cmd="sonic_installer list", ignore_error=True)
     lines = out.split('\n')
 
     # if next boot image not same with current, set current as next boot, and delete the orinal next image
@@ -85,94 +110,164 @@ def reduce_installed_sonic_images(module):
             next_image = line.split(':')[1].strip()
 
     if curr_image != next_image:
+        log("set-next-boot")
         exec_command(module, cmd="sonic_installer set-next-boot {}".format(curr_image), ignore_error=True)
 
+    log("clearnup old image")
     exec_command(module, cmd="sonic_installer cleanup -y", ignore_error=True)
+
+    log("Done reduce_installed_sonic_images")
 
 
 def download_new_sonic_image(module, new_image_url, save_as):
+    log("download_new_sonic_image")
+
     global results
 
     if new_image_url:
-        # Before downloading new image, clean-up previous downloads first
-        exec_command(module,
-                    cmd="rm -f {}".format(save_as),
-                    msg="clean up previously downloaded image",
-                    ignore_error=True)
-        exec_command(module,
-                    cmd="curl -Lo {} {}".format(save_as, new_image_url),
-                    msg="downloading new image")
+        log("Before downloading new image, clean-up previous downloads first")
+        exec_command(
+            module,
+            cmd="rm -f {}".format(save_as),
+            msg="clean up previously downloaded image",
+            ignore_error=True
+        )
+        log("Downloading new image using curl")
+        exec_command(
+            module,
+            cmd="curl -Lo {} {}".format(save_as, new_image_url),
+            msg="downloading new image"
+        )
+        log("Completed downloading image")
+
+    free_disk_size = get_disk_free_size(module, "/")
+    log("After downloaded sonic image, latest free disk size: {}".format(free_disk_size))
 
     if path.exists(save_as):
+        log("Checking downloaded image version")
         _, out, _ = exec_command(module, cmd="sonic_installer binary_version {}".format(save_as))
         results["downloaded_image_version"] = out.rstrip('\n')
+        log("Downloaded image version: {}".format(results["downloaded_image_version"]))
 
 
 def install_new_sonic_image(module, new_image_url, save_as=None):
+    log("install new sonic image")
+
     if not save_as:
         avail = get_disk_free_size(module, "/host")
         save_as = "/host/downloaded-sonic-image" if avail >= 2000 else "/tmp/tmpfs/downloaded-sonic-image"
 
     if save_as.startswith("/tmp/tmpfs"):
-        # Create a tmpfs partition to download image to install
+        log("Create a tmpfs partition to download image to install")
         exec_command(module, cmd="mkdir -p /tmp/tmpfs", ignore_error=True)
         exec_command(module, cmd="umount /tmp/tmpfs", ignore_error=True)
 
-        exec_command(module,
-                     cmd="mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs",
-                     msg="mounting tmpfs")
+        exec_command(
+            module,
+            cmd="mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs",
+            msg="mounting tmpfs"
+        )
         download_new_sonic_image(module, new_image_url, save_as)
-        rc, out, err = exec_command(module,
-                     cmd="sonic_installer install {} -y".format(save_as),
-                     msg="installing new image", ignore_error=True)
+        log("Running sonic_installer to install image at {}".format(save_as))
+        rc, out, err = exec_command(
+            module,
+            cmd="sonic_installer install {} -y".format(save_as),
+            msg="installing new image", ignore_error=True
+        )
+        log("Done running sonic_installer to install image")
 
         exec_command(module, cmd="sync", ignore_error=True)
         exec_command(module, cmd="umount /tmp/tmpfs", ignore_error=True)
         exec_command(module, cmd="rm -rf /tmp/tmpfs", ignore_error=True)
+        log("Done umount and cleanup tmpfs")
+
         if rc != 0:
-            module.fail_json(msg="Image installation failed: rc=%d, out=%s, err=%s" %
-                         (rc, out, err))
+            module.fail_json(msg="Image installation failed: rc=%d, out=%s, err=%s" % (rc, out, err))
     else:
-        # There is enough space to install directly
+        log("There is enough space on /host to download and install directly")
         download_new_sonic_image(module, new_image_url, save_as)
-        rc, out, err = exec_command(module,
-                     cmd="sonic_installer install {} -y".format(save_as),
-                     msg="installing new image", ignore_error=True)
-        # Always remove the downloaded temp image inside /host/ before proceeding
+
+        log("Running sonic_installer to install image at {}".format(save_as))
+        rc, out, err = exec_command(
+            module,
+            cmd="sonic_installer install {} -y".format(
+                save_as),
+            msg="installing new image", ignore_error=True
+        )
+        log("Always remove the downloaded temp image inside /host/ before proceeding")
         exec_command(module, cmd="rm -f {}".format(save_as))
         if rc != 0:
-            module.fail_json(msg="Image installation failed: rc=%d, out=%s, err=%s" %
-                         (rc, out, err))
+            module.fail_json(msg="Image installation failed: rc=%d, out=%s, err=%s" % (rc, out, err))
 
     # If sonic device is configured with minigraph, remove config_db.json
     # to force next image to load minigraph.
     if path.exists("/host/old_config/minigraph.xml"):
-        exec_command(module,
-                     cmd="rm -f /host/old_config/config_db.json",
-                     msg="Remove config_db.json in preference of minigraph.xml")
+        log("Remove /host/old_config/config_db.json when /etc/old_config/minigraph.xml exists")
+        exec_command(
+            module,
+            cmd="rm -f /host/old_config/config_db.json",
+            msg="Remove config_db.json in preference of minigraph.xml"
+        )
 
 
 def work_around_for_slow_disks(module):
     # Increase hung task timeout to 600 seconds to avoid kernel panic
     # while writing lots of data to a slow disk.
+    log("work around for slow disks, increase hung task timeout to 600 seconds")
     exec_command(module, cmd="sysctl -w kernel.hung_task_timeout_secs=600", ignore_error=True)
+    log("Done work around for slow disks")
 
 
 def free_up_disk_space(module, disk_used_pcent):
     """Remove old log, core and dump files."""
+    log("free up disk space at best effort")
+
     def get_disk_used_percent(module):
         output = exec_command(module, cmd="df -BM --output=pcent /host")[1]
         return int(output.splitlines()[-1][:-1])
 
-    if get_disk_used_percent(module) > disk_used_pcent:
-        # free up spaces at best effort
+    current_used_percent = get_disk_used_percent(module)
+    log("current used percent: {}".format(current_used_percent))
+    if current_used_percent > disk_used_pcent:
+        log("Trying to free up spaces at best effort")
         exec_command(module, "rm -f /var/log/*.gz", ignore_error=True)
         exec_command(module, "rm -f /var/core/*", ignore_error=True)
         exec_command(module, "rm -rf /var/dump/*", ignore_error=True)
         exec_command(module, "rm -rf /home/admin/*", ignore_error=True)
+        latest_used_percent = get_disk_used_percent(module)
+        log("Done free up, latest used percent: {}".format(latest_used_percent))
+    else:
+        log("No need to free up disk space")
+
+    free_disk_size = get_disk_free_size(module, "/host")
+    log("After free up disk space, latest free disk size: {}".format(free_disk_size))
+
+
+def work_around_for_reboot(module):
+    # work around reboot for s6100
+    # Replace /usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/platform_reboot_pre_check
+    # Ignore any pre check and just return 0
+    log("Start workaround for S6100 reboot")
+    _, out, _ = exec_command(module, cmd="show platform summary", ignore_error=True)
+    if 'Force10-S6100' in out:
+        log("S6100 device, hack its platform_reboot_pre_check file")
+        exec_command(
+            module,
+            cmd="sudo mv /usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/platform_reboot_pre_check "
+                "/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/platform_reboot_pre_check_bak",
+            ignore_error=True
+        )
+        file_content = '''#!/bin/bash
+exit 0
+'''
+        with open("/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/platform_reboot_pre_check", 'w') as out_file:
+            out_file.write(file_content)
+    log("Done workaround for S6100 reboot")
 
 
 def main():
+    global results
+
     module = AnsibleModule(
         argument_spec=dict(
             disk_used_pcent=dict(required=False, type='int', default=8),
@@ -186,19 +281,26 @@ def main():
     save_as = module.params['save_as']
 
     try:
-        results["current_stage"] = "start"
-        work_around_for_slow_disks(module)
-        reduce_installed_sonic_images(module)
-        results["current_stage"] = "prepare"
-        if new_image_url or save_as:
+        if not new_image_url:
+            reduce_installed_sonic_images(module)
+            free_up_disk_space(module, disk_used_pcent)
+        else:
+            results["current_stage"] = "start"
+
+            work_around_for_reboot(module)
+            work_around_for_slow_disks(module)
+            reduce_installed_sonic_images(module)
+            results["current_stage"] = "prepare"
+
             free_up_disk_space(module, disk_used_pcent)
             setup_swap_if_necessary(module)
             results["current_stage"] = "install"
+
             install_new_sonic_image(module, new_image_url, save_as)
-        results["current_stage"] = "complete"
-    except:
+            results["current_stage"] = "complete"
+    except Exception:
         err = str(sys.exc_info())
-        module.fail_json(msg="Results: %s; Error: %s" % (results, err))
+        module.fail_json(msg="Exception raised during image upgrade", results=results, err=err)
 
     module.exit_json(ansible_facts=results)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Cherry-pick #10856 to 202205 branch.
The customized module reduce_and_add_sonic_images looks like a blackbox with too few messages for debugging when it failed. When upgrade image failed, we usually do not have enough information for debugging

#### How did you do it?
This change enhanced module reduce_and_add_sonic_images to return more meaningful debug messages. This change also improved the upgrade_image.py script to have better log messages. The check of reachability before image upgrading is also enhanced.

#### How did you verify/test it?
Tested run on physical devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
