### PR TITLE
Fix http_ready false issue

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -173,7 +173,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, t
     # check exabgp http_api port is ready
     http_ready = True
     for i in range(0, 3):
-        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i])
+        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i], timeout_s=60)
         if not http_ready:
             break
 


### PR DESCRIPTION

### Description of PR
Sometimes, exabgp http_ready status would be false when test_bgp_speaker.py is running. It was due to default timeout of wait_tcp_connection is 30 seconds. When there is some poor server or some network issue, the exabgp http service would start slower, then the wait_tcp_connection check would return fails due to timeout.
Increase the timeout time would avoid this issue.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Http ready check failure when start exabgp for bgp speaker test
#### How did you do it?
Increase the timeout value
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
