### PR TITLE
[Fix]:PFC multidut helper fix for latest traffic_generator.py

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -4,7 +4,6 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401
-from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
     get_lossless_buffer_size, get_pg_dropped_packets,\
     stop_pfcwd, disable_packet_aging, sec_to_nanosec,\

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -1,32 +1,42 @@
 import logging
+import time
+
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401
+from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_egress_lossless_buffer_size, stop_pfcwd, disable_packet_aging,\
-    sec_to_nanosec, get_pfc_frame_count, packet_capture, config_capture_pkt # noqa F401
+    get_lossless_buffer_size, get_pg_dropped_packets,\
+    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
+    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+    traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port # noqa F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp # noqa F401
-from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows,\
-    generate_background_flows, generate_pause_flows, run_traffic, verify_pause_flow, verify_basic_test_flow,\
-    verify_background_flow, verify_pause_frame_count_dut, verify_egress_queue_frame_count, verify_in_flight_buffer_pkts,\
-    verify_unset_cev_pause_frame_count # noqa F401
-from tests.common.snappi_tests.snappi_test_params import SnappiTestParams # noqa F401
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
+    generate_background_flows, generate_pause_flows, run_traffic, verify_pause_flow, verify_basic_test_flow, \
+    verify_background_flow, verify_pause_frame_count_dut, verify_egress_queue_frame_count, \
+    verify_in_flight_buffer_pkts, verify_unset_cev_pause_frame_count, verify_tx_frame_count_dut, \
+    verify_rx_frame_count_dut
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame
+
 
 logger = logging.getLogger(__name__)
 
+dut_port_config = []
 PAUSE_FLOW_NAME = 'Pause Storm'
 TEST_FLOW_NAME = 'Test Flow'
 TEST_FLOW_AGGR_RATE_PERCENT = 45
 BG_FLOW_NAME = 'Background Flow'
 BG_FLOW_AGGR_RATE_PERCENT = 45
-DATA_PKT_SIZE = 1024
 data_flow_pkt_size = 1024
-DATA_FLOW_DURATION_SEC = 2
-DATA_FLOW_DELAY_SEC = 1
+DATA_FLOW_DURATION_SEC = 15
 data_flow_delay_sec = 1
 SNAPPI_POLL_DELAY_SEC = 2
+PAUSE_FLOW_DUR_BASE_SEC = data_flow_delay_sec + DATA_FLOW_DURATION_SEC
 TOLERANCE_THRESHOLD = 0.05
+CONTINUOUS_MODE = -5
+ANSIBLE_POLL_DELAY_SEC = 4
 
 
 def run_pfc_test(api,
@@ -42,7 +52,7 @@ def run_pfc_test(api,
                  test_traffic_pause,
                  snappi_extra_params=None):
     """
-    Run a multidut PFC test
+    Run a PFC test
     Args:
         api (obj): snappi session
         testbed_config (obj): testbed L1/L2/L3 configuration
@@ -50,6 +60,7 @@ def run_pfc_test(api,
         conn_data (dict): the dictionary returned by conn_graph_fact.
         fanout_data (dict): the dictionary returned by fanout_graph_fact.
         duthost (Ansible host instance): device under test
+        dut_port (str): DUT port to test
         global_pause (bool): if pause frame is IEEE 802.3X pause
         pause_prio_list (list): priorities to pause for pause frames
         test_prio_list (list): priorities of test flows
@@ -57,6 +68,7 @@ def run_pfc_test(api,
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
         test_traffic_pause (bool): if test flows are expected to be paused
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+
     Returns:
         N/A
     """
@@ -66,7 +78,6 @@ def run_pfc_test(api,
 
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
-    rx_port_id = rx_port["port_id"]
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
 
@@ -77,58 +88,128 @@ def run_pfc_test(api,
     stop_pfcwd(duthost2, tx_port['asic_value'])
     disable_packet_aging(duthost2)
 
-    """ Rate percent must be an integer """
-    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+    global DATA_FLOW_DURATION_SEC
+    global data_flow_delay_sec
+
+    dut_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]['peer_port']
+
+    port_id = 0
+    pytest_assert(port_id is not None,
+                  'Fail to get ID for port {}'.format(dut_port))
+
+    # Rate percent must be an integer
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT / len(bg_prio_list))
+    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+
+    # Generate base traffic config
+    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
+                                                                     port_config_list=port_config_list,
+                                                                     port_id=port_id)
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
 
     if snappi_extra_params.headroom_test_params is not None:
-        global DATA_FLOW_DURATION_SEC
-        DATA_FLOW_DURATION_SEC = 10
-        global data_flow_delay_sec
-        data_flow_delay_sec = 2
+        DATA_FLOW_DURATION_SEC += 10
+        data_flow_delay_sec += 2
 
         # Set up pfc delay parameter
         l1_config = testbed_config.layer1[0]
         pfc = l1_config.flow_control.ieee_802_1qbb
         pfc.pfc_delay = snappi_extra_params.headroom_test_params[0]
 
+    if snappi_extra_params.poll_device_runtime:
+        # If the switch needs to be polled as traffic is running for stats,
+        # then the test runtime needs to be increased for the polling delay
+        DATA_FLOW_DURATION_SEC += ANSIBLE_POLL_DELAY_SEC
+        data_flow_delay_sec = ANSIBLE_POLL_DELAY_SEC
+
     if snappi_extra_params.packet_capture_type != packet_capture.NO_CAPTURE:
         # Setup capture config
-        config_capture_pkt(testbed_config=testbed_config,
-                           port_id=rx_port_id,
-                           capture_type=snappi_extra_params.packet_capture_type,
-                           capture_name=snappi_extra_params.packet_capture_type.value + "_" + str(rx_port_id))
+        if snappi_extra_params.is_snappi_ingress_port_cap:
+            # packet capture is required on the ingress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["rx_port_name"]]
+        else:
+            # packet capture will be on the egress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["tx_port_name"]]
 
-    # Generate base traffic config
-    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
-                                                                     port_config_list=port_config_list,
-                                                                     port_id=rx_port_id)
-    ########
+        snappi_extra_params.packet_capture_file = snappi_extra_params.packet_capture_type.value
+
+        config_capture_pkt(testbed_config=testbed_config,
+                           port_names=snappi_extra_params.packet_capture_ports,
+                           capture_type=snappi_extra_params.packet_capture_type,
+                           capture_name=snappi_extra_params.packet_capture_file)
+        logger.info("Packet capture file: {}.pcapng".format(snappi_extra_params.packet_capture_file))
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": test_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": None,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if snappi_extra_params.traffic_flow_config.background_flow_config is None and \
+       snappi_extra_params.gen_background_traffic:
+        snappi_extra_params.traffic_flow_config.background_flow_config = {
+            "flow_name": BG_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": bg_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": None,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if snappi_extra_params.traffic_flow_config.pause_flow_config is None:
+        snappi_extra_params.traffic_flow_config.pause_flow_config = {
+            "flow_name": PAUSE_FLOW_NAME,
+            "flow_dur_sec": None,
+            "flow_rate_percent": None,
+            "flow_rate_pps": calc_pfc_pause_flow_rate(speed_gbps),
+            "flow_rate_bps": None,
+            "flow_pkt_size": 64,
+            "flow_pkt_count": None,
+            "flow_delay_sec": 0,
+            "flow_traffic_type": traffic_flow_mode.CONTINUOUS
+        }
+
+    if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
+        # PFC pause frame capture is requested
+        valid_pfc_frame_test = True
+    else:
+        # PFC pause frame capture is not requested
+        valid_pfc_frame_test = False
+
+    if valid_pfc_frame_test:
+        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_dur_sec"] = DATA_FLOW_DURATION_SEC + \
+            data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC
+        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
+            traffic_flow_mode.FIXED_DURATION
+
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,
-                        test_flow_name=TEST_FLOW_NAME,
                         test_flow_prio_list=test_prio_list,
-                        test_flow_rate_percent=test_flow_rate_percent,
-                        test_flow_dur_sec=DATA_FLOW_DURATION_SEC,
-                        test_flow_delay_sec=data_flow_delay_sec,
-                        test_flow_pkt_size=data_flow_pkt_size,
                         prio_dscp_map=prio_dscp_map,
                         snappi_extra_params=snappi_extra_params)
 
-    # Generate background flow config
-    generate_background_flows(testbed_config=testbed_config,
-                              bg_flow_name=BG_FLOW_NAME,
-                              bg_flow_prio_list=bg_prio_list,
-                              bg_flow_rate_percent=bg_flow_rate_percent,
-                              bg_flow_dur_sec=DATA_FLOW_DURATION_SEC,
-                              bg_flow_delay_sec=data_flow_delay_sec,
-                              bg_flow_pkt_size=data_flow_pkt_size,
-                              prio_dscp_map=prio_dscp_map,
-                              snappi_extra_params=snappi_extra_params)
+    if snappi_extra_params.gen_background_traffic:
+        # Generate background flow config
+        generate_background_flows(testbed_config=testbed_config,
+                                  bg_flow_prio_list=bg_prio_list,
+                                  prio_dscp_map=prio_dscp_map,
+                                  snappi_extra_params=snappi_extra_params)
 
     # Generate pause storm config
     generate_pause_flows(testbed_config=testbed_config,
-                         pause_flow_name=PAUSE_FLOW_NAME,
                          pause_prio_list=pause_prio_list,
                          global_pause=global_pause,
                          snappi_extra_params=snappi_extra_params)
@@ -138,49 +219,81 @@ def run_pfc_test(api,
     all_flow_names = [flow.name for flow in flows]
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
-    """ Run traffic """
-    flow_stats = run_traffic(api=api,
-                             config=testbed_config,
-                             data_flow_names=data_flow_names,
-                             all_flow_names=all_flow_names,
-                             exp_dur_sec=DATA_FLOW_DURATION_SEC + data_flow_delay_sec,
-                             snappi_extra_params=snappi_extra_params)
+    # Clear PFC, queue and interface counters before traffic run
+    duthost = duthost1
+    duthost.command("pfcstat -c")
+    time.sleep(1)
+    duthost1.command("sonic-clear queuecounters")
+    time.sleep(1)
+    duthost.command("sonic-clear counters")
+    time.sleep(1)
 
-    speed_str = testbed_config.layer1[0].speed
-    speed_gbps = int(speed_str.split('_')[1])
+    """ Run traffic """
+    tgen_flow_stats, switch_flow_stats = run_traffic(duthost=duthost,
+                                                     api=api,
+                                                     config=testbed_config,
+                                                     data_flow_names=data_flow_names,
+                                                     all_flow_names=all_flow_names,
+                                                     exp_dur_sec=DATA_FLOW_DURATION_SEC + data_flow_delay_sec,
+                                                     snappi_extra_params=snappi_extra_params)
+
+    # Reset pfc delay parameter
+    pfc = testbed_config.layer1[0].flow_control.ieee_802_1qbb
+    pfc.pfc_delay = 0
+
+    # Verify PFC pause frames
+    if valid_pfc_frame_test:
+        is_valid_pfc_frame = validate_pfc_frame(snappi_extra_params.packet_capture_file + ".pcapng")
+        pytest_assert(is_valid_pfc_frame, "PFC frames invalid")
+        return
 
     # Verify pause flows
-    verify_pause_flow(flow_metrics=flow_stats,
+    verify_pause_flow(flow_metrics=tgen_flow_stats,
                       pause_flow_name=PAUSE_FLOW_NAME)
 
-    # Verify background flows
-    verify_background_flow(flow_metrics=flow_stats,
-                           bg_flow_name=BG_FLOW_NAME,
-                           bg_flow_rate_percent=bg_flow_rate_percent,
-                           bg_flow_dur_sec=DATA_FLOW_DURATION_SEC,
-                           bg_flow_pkt_size=data_flow_pkt_size,
-                           speed_gbps=speed_gbps,
-                           tolerance=TOLERANCE_THRESHOLD,
-                           snappi_extra_params=snappi_extra_params)
+    if snappi_extra_params.gen_background_traffic:
+        # Verify background flows
+        verify_background_flow(flow_metrics=tgen_flow_stats,
+                               speed_gbps=speed_gbps,
+                               tolerance=TOLERANCE_THRESHOLD,
+                               snappi_extra_params=snappi_extra_params)
 
     # Verify basic test flows metrics from ixia
-    verify_basic_test_flow(flow_metrics=flow_stats,
-                           test_flow_name=TEST_FLOW_NAME,
-                           test_flow_rate_percent=test_flow_rate_percent,
-                           test_flow_dur_sec=DATA_FLOW_DURATION_SEC,
-                           test_flow_pkt_size=data_flow_pkt_size,
+    verify_basic_test_flow(flow_metrics=tgen_flow_stats,
                            speed_gbps=speed_gbps,
                            tolerance=TOLERANCE_THRESHOLD,
                            test_flow_pause=test_traffic_pause,
                            snappi_extra_params=snappi_extra_params)
 
+    # Verify PFC pause frame count on the DUT
+    verify_pause_frame_count_dut(duthost=duthost,
+                                 test_traffic_pause=test_traffic_pause,
+                                 snappi_extra_params=snappi_extra_params)
+
+    # Verify in flight TX lossless packets do not leave the DUT when traffic is expected
+    # to be paused, or leave the DUT when the traffic is not expected to be paused
+    verify_egress_queue_frame_count(duthost=duthost,
+                                    switch_flow_stats=switch_flow_stats,
+                                    test_traffic_pause=test_traffic_pause,
+                                    snappi_extra_params=snappi_extra_params)
+
     if test_traffic_pause:
         # Verify in flight TX packets count relative to switch buffer size
-        verify_in_flight_buffer_pkts(duthost=duthost2,
-                                     flow_metrics=flow_stats,
-                                     test_flow_name=TEST_FLOW_NAME,
-                                     test_flow_pkt_size=data_flow_pkt_size,
+        verify_in_flight_buffer_pkts(duthost=duthost,
+                                     flow_metrics=tgen_flow_stats,
                                      snappi_extra_params=snappi_extra_params)
-        # Verify PFC pause frame count
-        verify_pause_frame_count_dut(duthost=duthost2,
-                                     snappi_extra_params=snappi_extra_params)
+    else:
+        # Verify zero pause frames are counted when the PFC class enable vector is not set
+        verify_unset_cev_pause_frame_count(duthost=duthost,
+                                           snappi_extra_params=snappi_extra_params)
+
+    if test_traffic_pause and not snappi_extra_params.gen_background_traffic:
+        # Verify TX frame count on the DUT when traffic is expected to be paused
+        # and only test traffic flows are generated
+        verify_tx_frame_count_dut(duthost=duthost,
+                                  snappi_extra_params=snappi_extra_params)
+
+        # Verify TX frame count on the DUT when traffic is expected to be paused
+        # and only test traffic flows are generated
+        verify_rx_frame_count_dut(duthost=duthost,
+                                  snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -90,8 +90,6 @@ def run_pfc_test(api,
     global DATA_FLOW_DURATION_SEC
     global data_flow_delay_sec
 
-    #dut_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]['peer_port']
-
     port_id = 0
 
     # Rate percent must be an integer

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -90,6 +90,7 @@ def run_pfc_test(api,
     global DATA_FLOW_DURATION_SEC
     global data_flow_delay_sec
 
+    # Port id of Rx port for traffic config
     port_id = 0
 
     # Rate percent must be an integer

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -3,14 +3,14 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
-    fanout_graph_facts # noqa F401
+    fanout_graph_facts  # noqa F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
     get_lossless_buffer_size, get_pg_dropped_packets,\
     stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
     get_pfc_frame_count, packet_capture, config_capture_pkt,\
     traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa F401
-from tests.common.snappi_tests.port import select_ports, select_tx_port # noqa F401
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp # noqa F401
+from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa F401
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_background_flows, generate_pause_flows, run_traffic, verify_pause_flow, verify_basic_test_flow, \
     verify_background_flow, verify_pause_frame_count_dut, verify_egress_queue_frame_count, \
@@ -90,7 +90,7 @@ def run_pfc_test(api,
     global DATA_FLOW_DURATION_SEC
     global data_flow_delay_sec
 
-    dut_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]['peer_port']
+    #dut_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]['peer_port']
 
     port_id = 0
 

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -51,7 +51,7 @@ def run_pfc_test(api,
                  test_traffic_pause,
                  snappi_extra_params=None):
     """
-    Run a PFC test
+    Run a multidut PFC test
     Args:
         api (obj): snappi session
         testbed_config (obj): testbed L1/L2/L3 configuration
@@ -93,8 +93,6 @@ def run_pfc_test(api,
     dut_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]['peer_port']
 
     port_id = 0
-    pytest_assert(port_id is not None,
-                  'Fail to get ID for port {}'.format(dut_port))
 
     # Rate percent must be an integer
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT / len(bg_prio_list))

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -4,12 +4,12 @@ import logging
 from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts                                                                              # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
-     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports,\
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
      get_multidut_tgen_peer_port_set, cleanup_config                                                 # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
+from files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -44,6 +44,7 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     Returns:
         N/A
     """
+
     pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -9,7 +9,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      get_multidut_tgen_peer_port_set, cleanup_config                                                 # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from files.multidut_helper import run_pfc_test                      # noqa: F401
+from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR is to fix the issue faced while running the latest master branch due to changes in traffic_generator.py 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
This PR is to accommodate the latest changes that went into the traffic_generation.py file

#### How did you do it?
Instead of passing the parameters as arguments for the fixtures that were used for creating traffic flows, the parameters were defined on snappi_extra_params object and there by reducing the arguments on the flow creation fixtures, this made the code significantly compact and scalable


#### How did you verify/test it?
After the changes the scripts were rerun on Arista DUT and ensured the cases run fine

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?
T1 and T2

### Output

AzDevOps@5158df942848:~/sonic-mgmt/tests$ py.test --inventory ../ansible/snappi-sonic --host-pattern sonic-s6100-dut --testbed vms-snappi-sonic --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --skip_sanity --disable_loganalyzer snappi_tests/multidut2/test_multidut_global_pause_with_snappi.py 
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts =====================================================================================================================
platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
ansible: 2.8.20
rootdir: /var/AzDevOps/sonic-mgmt/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, celery-4.4.7, ansible-2.2.4, forked-1.3.0, html-1.22.1, metadata-1.11.0, repeat-0.9.1, xdist-1.28.0
collecting 1 item                                                                                                                                                                                                                                             
--------------------------------------------------------------------------------------------------------------------- live log collection ---------------------------------------------------------------------------------------------------------------------
19:10:09 __init__.pytest_collection_modifyitems   L0582 INFO   | Available basic facts that can be used in conditional skip:
{
  "topo_type": "ptf", 
  "testbed": "vms-snappi-sonic", 
  "topo_name": "ptf64"
}

----------------------------------------------------------------------------------------------------------------------- live log setup ------------------------------------------------------------------------------------------------------------------------
19:10:09 __init__.set_default                     L0054 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
19:10:09 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
19:10:15 ptfhost_utils.run_icmp_responder_session L0239 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
19:10:15 conftest.creds_on_dut                    L0702 INFO   | dut sonic-s6100-dut belongs to groups [u'snappi-sonic', u'sonic', u'sonic_dell64_40', 'fanout']
19:10:15 conftest.creds_on_dut                    L0726 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
19:10:15 conftest.creds_on_dut                    L0726 INFO   | skip empty var file ../ansible/group_vars/all/env.yml
19:10:16 conftest.nbrhosts                        L0519 INFO   | No VMs exist for this topology: ptf64
19:10:16 conftest.core_dump_and_config_check      L2030 INFO   | Collecting core dumps before test on sonic-s6100-dut
19:10:16 conftest.core_dump_and_config_check      L2039 INFO   | Collecting running config before test on sonic-s6100-dut
19:10:21 __init__.sanity_check                    L0125 INFO   | Skip sanity check according to command line argument
19:10:21 conftest.generate_params_dut_hostname    L1106 INFO   | Using DUTs ['sonic-s6100-dut'] in testbed 'vms-snappi-sonic'
19:10:21 conftest.rand_one_dut_hostname           L0376 INFO   | Randomly select dut sonic-s6100-dut for testing
19:10:21 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
19:10:21 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
19:10:21 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
19:10:21 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
19:10:21 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
19:10:21 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
19:10:21 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
19:10:21 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
19:10:21 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
19:10:21 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
19:10:21 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
19:10:21 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
19:10:21 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
19:10:21 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
19:10:21 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
19:10:22 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
19:10:22 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossless_prio_list setup starts --------------------
19:10:24 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossless_prio_list setup ends --------------------
19:10:24 __init__.loganalyzer                     L0045 INFO   | Log analyzer is disabled
19:10:24 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_multidut_snappi_ports setup starts --------------------
19:10:24 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_multidut_snappi_ports setup ends --------------------
------------------------------------------------------------------------------------------------------------------------ live log call ------------------------------------------------------------------------------------------------------------------------
19:10:24 snappi_fixtures.__intf_config_multidut   L0728 INFO   | Configuring Dut: sonic-s6100-dut with port Ethernet76 with IP 20.0.1.1/24
19:10:25 snappi_fixtures.__intf_config_multidut   L0728 INFO   | Configuring Dut: sonic-s6100-dut with port Ethernet64 with IP 20.0.2.1/24
19:10:46 connection._warn                         L0246 WARNING| Verification of certificates is disabled
19:10:46 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.78.135 address...
19:10:46 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.78.135:443.
19:10:46 connection._info                         L0243 INFO   | Connection established to `https://10.36.78.135:443 on linux`
19:11:00 connection._info                         L0243 INFO   | Using IxNetwork api server version 9.30.2212.7
19:11:00 connection._info                         L0243 INFO   | User info IxNetwork/ixnetworkweb/admin-48-23591
19:11:01 snappi_api.info                          L1132 INFO   | snappi-0.9.1
19:11:01 snappi_api.info                          L1132 INFO   | snappi_ixnetwork-0.8.2
19:11:01 snappi_api.info                          L1132 INFO   | ixnetwork_restpy-1.0.64
19:11:01 snappi_api.info                          L1132 INFO   | Config validation 0.016s
19:11:03 snappi_api.info                          L1132 INFO   | Ports configuration 1.747s
19:11:04 snappi_api.info                          L1132 INFO   | Captures configuration 0.158s
19:11:06 snappi_api.info                          L1132 INFO   | Add location hosts [10.36.78.53] 2.397s
19:11:10 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 4.167s
19:11:11 snappi_api.info                          L1132 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', u'novusHundredGigNonFanOut'), ('Port 1', u'novusHundredGigNonFanOut')]
19:11:11 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.509s
19:11:16 snappi_api.info                          L1132 INFO   | Location preemption [10.36.78.53;4;1, 10.36.78.53;4;4] 0.110s
19:11:36 snappi_api.info                          L1132 INFO   | Location connect [Port 0, Port 1] 20.799s
19:11:37 snappi_api.warning                       L1138 WARNING| Port 0 connectedLinkDown
19:11:37 snappi_api.warning                       L1138 WARNING| Port 1 connectedLinkDown
19:11:37 snappi_api.info                          L1132 INFO   | Location state check [Port 0, Port 1] 0.267s
19:11:37 snappi_api.info                          L1132 INFO   | Location configuration 33.053s
19:11:48 snappi_api.info                          L1132 INFO   | Layer1 configuration 11.595s
19:11:48 snappi_api.info                          L1132 INFO   | Lag Configuration 0.088s
19:11:49 snappi_api.info                          L1132 INFO   | Convert device config : 0.227s
19:11:49 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
19:11:49 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.658s
19:11:49 snappi_api.info                          L1132 INFO   | Devices configuration 0.963s
19:11:57 snappi_api.info                          L1132 INFO   | Flows configuration 7.300s
19:12:05 snappi_api.info                          L1132 INFO   | Start interfaces 8.443s
19:12:06 snappi_api.info                          L1132 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
19:12:06 traffic_generation.run_traffic           L0280 INFO   | Wait for Arp to Resolve ...
19:12:07 traffic_generation.run_traffic           L0297 INFO   | Starting transmit on all flows ...
19:12:11 snappi_api.info                          L1132 INFO   | Flows generate/apply 3.132s
19:12:23 snappi_api.info                          L1132 INFO   | Flows clear statistics 12.123s
19:12:23 snappi_api.info                          L1132 INFO   | Captures start 0.000s
19:12:27 snappi_api.info                          L1132 INFO   | Flows start 3.583s
19:12:27 traffic_generation.run_traffic           L0304 INFO   | Polling DUT for traffic statistics for 23 seconds ...
19:14:13 traffic_generation.run_traffic           L0322 INFO   | DUT polling complete
19:14:15 traffic_generation.run_traffic           L0338 INFO   | All test and background traffic flows stopped
19:14:17 traffic_generation.run_traffic           L0361 INFO   | Dumping per-flow statistics
19:14:18 traffic_generation.run_traffic           L0365 INFO   | Stopping transmit on all remaining flows
19:14:24 snappi_api.info                          L1132 INFO   | Flows stop 5.381s
19:14:33 snappi_fixtures.cleanup_config           L0881 INFO   | Removing Configuration on Dut: sonic-s6100-dut with port Ethernet76 with ip :20.0.1.1/24
19:14:35 snappi_fixtures.cleanup_config           L0881 INFO   | Removing Configuration on Dut: sonic-s6100-dut with port Ethernet64 with ip :20.0.2.1/24
PASSED                                                                                                                                                                                                                                                  [100%]
---------------------------------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------------------------------
19:14:36 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
19:14:50 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
19:14:50 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
19:14:52 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
19:14:52 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
19:14:52 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
19:14:52 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
19:14:52 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
19:14:52 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
19:14:57 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
19:14:58 conftest.core_dump_and_config_check      L2067 INFO   | Collecting core dumps after test on sonic-s6100-dut
19:14:59 conftest.core_dump_and_config_check      L2084 INFO   | Collecting running config after test on sonic-s6100-dut
19:15:00 conftest.core_dump_and_config_check      L2209 WARNING| Core dump or config check failed for test_multidut_global_pause_with_snappi.py, results: {"core_dump_check": {"new_core_dumps": {"sonic-s6100-dut": []}, "pass": true}, "config_db_check": {"cur_only_config": {"sonic-s6100-dut": {"null": {}}}, "inconsistent_config": {"sonic-s6100-dut": {"null": {}}}, "pre_only_config": {"sonic-s6100-dut": {"null": {"VLAN_MEMBER": {"Vlan2|Ethernet64": {"tagging_mode": "untagged"}, "Vlan2|Ethernet72": {"tagging_mode": "untagged"}, "Vlan2|Ethernet68": {"tagging_mode": "untagged"}, "Vlan2|Ethernet76": {"tagging_mode": "untagged"}}}}}, "pass": false}}
19:15:00 conftest.__dut_reload                    L1962 INFO   | dut reload called on sonic-s6100-dut
19:15:01 config_reload.config_reload              L0093 INFO   | reloading config_db
19:17:38 parallel.on_terminate                    L0086 INFO   | process __dut_reload--<MultiAsicSonicHost sonic-s6100-dut> terminated with exit code None
19:17:38 parallel.parallel_run                    L0223 INFO   | Completed running processes for target "__dut_reload" in 0:02:38.593772 seconds


====================================================================================================================== warnings summary =======================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

snappi_tests/multidut2/test_multidut_global_pause_with_snappi.py::test_global_pause[linecard_configuration_set0-non_chassis_single_line_card]
  /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py:81: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------------
19:17:38 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
==================== 1 passed, 4 warnings in 450.18 seconds ====================
INFO:root:Can not get Allure report URL. Please check logs
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
