### PR TITLE
[Fanout] Update EOS config template for Arista-7260cx3 leaf fanout

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -109,6 +109,24 @@ interface {{ intf }}
 !
 {% endfor %}
 !
+{% for i in range(65,67) %}
+{% set intf =  'Ethernet' + i|string  %}
+{%   if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
+interface {{ intf }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+   switchport mode trunk
+   switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+   spanning-tree portfast
+{%     if device_conn[inventory_hostname][intf]['speed'] == "10000" %}
+   speed forced 10000full
+{%     endif %}
+   no shutdown
+{%   else %}
+interface {{  intf }}
+   shutdown
+{%   endif %}
+{% endfor %}
+!
 interface Management 1
  description TO LAB MGMT SWITCH
  ip address {{ device_info[inventory_hostname]["ManagementIp"] }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update EOS config template for Arista-7260cx3 leaf fanout. **Support using Et65/Et66 as trunk port.**

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Update EOS config template for Arista-7260cx3 leaf fanout. Support using Et65/Et66 as trunk port.

#### How did you do it?
Update J2 template.

#### How did you verify/test it?
Verified on physical `Arista-7260CX3` fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
