### PR TITLE
Enhance the test route flap

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -11,6 +11,7 @@ import ptf.packet as scapy
 from ptf.mask import Mask
 from natsort import natsorted
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 pytestmark = [
     pytest.mark.topology("any"),
@@ -286,6 +287,12 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
     nexthop = common_config.get('nhipv4', NHIPV4)
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+
+    ignoreRegex = [
+        ".*ERR.*\"missed_FRR_routes\".*"
+    ]
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="stress_routes_helper")
+    loganalyzer.ignore_regex.extend(ignoreRegex)
     # On dual-tor, unicast upstream l3 packet destination mac should be vlan mac
     # After routing, output packet source mac will be replaced with port-channel mac (same as dut_mac)
     # On dual-tor, vlan mac is different with dut_mac. U0/L0 use same vlan mac for AR response


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_route_flap is flaky, sometimes errored out due to missed_frr_routes check, which is a transient log print, we should ignore it during route flap test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Enhance robust of test_route_flap

#### How did you do it?
Ignore error which is expected.

#### How did you verify/test it?
Run manual test.

03:02:53 test_route_flap.test_route_flap          L0384 INFO   | End
PASSED                                                                                                                                                                                                                                                   [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
