### PR TITLE
[sanity_check] Use golden config to reboot for `adaptive_recover`

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -24,13 +24,16 @@ def reboot_dut(dut, localhost, cmd, reboot_with_running_golden_config=False):
         reboot_type = REBOOT_TYPE_COLD
 
     if reboot_with_running_golden_config:
-        logging.info("Reboot DUT with the running golden config")
-        dut.copy(
-            src="/etc/sonic/running_golden_config.json",
-            dest="/etc/sonic/config_db.json",
-            remote_src=True,
-            force=True
-        )
+        gold_config_path = "/etc/sonic/running_golden_config.json"
+        gold_config_stats = dut.stat(path=gold_config_path)
+        if gold_config_stats["stat"]["exists"]:
+            logging.info("Reboot DUT with the running golden config")
+            dut.copy(
+                src=gold_config_path,
+                dest="/etc/sonic/config_db.json",
+                remote_src=True,
+                force=True
+            )
 
     reboot(dut, localhost, reboot_type=reboot_type, safe_reboot=True, check_intf_up_ports=True)
 

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -13,7 +13,7 @@ from . import constants
 logger = logging.getLogger(__name__)
 
 
-def reboot_dut(dut, localhost, cmd):
+def reboot_dut(dut, localhost, cmd, reboot_with_running_golden_config=False):
     logging.info('Reboot DUT to recover')
 
     if 'warm' in cmd:
@@ -22,6 +22,15 @@ def reboot_dut(dut, localhost, cmd):
         reboot_type = REBOOT_TYPE_FAST
     else:
         reboot_type = REBOOT_TYPE_COLD
+
+    if reboot_with_running_golden_config:
+        logging.info("Reboot DUT with the running golden config")
+        dut.copy(
+            src="/etc/sonic/running_golden_config.json",
+            dest="/etc/sonic/config_db.json",
+            remote_src=True,
+            force=True
+        )
 
     reboot(dut, localhost, reboot_type=reboot_type, safe_reboot=True, check_intf_up_ports=True)
 
@@ -164,7 +173,7 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
             config_reload(dut, config_source='running_golden_config',
                           safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
         elif method["reboot"]:
-            reboot_dut(dut, localhost, method["cmd"])
+            reboot_dut(dut, localhost, method["cmd"], reboot_with_running_golden_config=True)
         else:
             _recover_with_command(dut, method['cmd'], wait_time)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
For `adaptive_recover`, it will reboot if `monit` has failures. But the DUT keeps using the `config_db.json`, which might be corrupted by previous tests in nightly.
Let's reboot with the running golden config for the reboot in `adaptive_recover`.

#### How did you do it?
Override `config_db.json` with the running golden config before reboot.

#### How did you verify/test it?
Run on dualtor testbed with monit service `routeCheck` fails and `config_db.json` is corrupted with mux config `manual`. 
Verify after reboot, monit is recovered and mux config is back to `auto`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
