### PR TITLE
[test gap] Add test script to verify if HASH_SEED and OFFSET_ECMP value is correct

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -410,6 +410,16 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
       - "asic_type not in ['mellanox']"
       - "'dualtor' in topo_name"
 
+ecmp/test_ecmp_sai_value.py:
+  skip:
+    reason: "Only support Broadcom T1 topology with 20230531.10 or later image"
+    conditions:
+      - "topo_type not in ['t1']"
+      - "asic_type not in ['broadcom']"
+      - "branch in ['internal-202305']"
+      - "release in ['202305']"
+      - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 10"
+
 ecmp/test_fgnhg.py:
   skip:
     conditions_logical_operator: or

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -416,8 +416,7 @@ ecmp/test_ecmp_sai_value.py:
     conditions:
       - "topo_type not in ['t1']"
       - "asic_type not in ['broadcom']"
-      - "branch in ['internal-202305']"
-      - "release in ['202305']"
+      - "release not in ['202305']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 10"
 
 ecmp/test_fgnhg.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -417,7 +417,7 @@ ecmp/test_ecmp_sai_value.py:
       - "topo_type not in ['t1']"
       - "asic_type not in ['broadcom']"
       - "release not in ['202305']"
-      - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 10"
+      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 10"
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -412,12 +412,13 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_sai_value.py:
   skip:
-    reason: "Only support Broadcom T1 topology with 20230531.10 or later image"
+    reason: "Only support Broadcom T1/T0 topology with 20230531.11 or later image"
+    conditions_logical_operator: or
     conditions:
-      - "topo_type not in ['t1']"
+      - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
       - "release not in ['202305']"
-      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 10"
+      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 11"
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -417,8 +417,8 @@ ecmp/test_ecmp_sai_value.py:
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
-      - "release not in ['202305']"
-      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 11"
+      - "release in ['201911', '202012', '202205', '202211']"
+      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 12"
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -412,13 +412,12 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_sai_value.py:
   skip:
-    reason: "Only support Broadcom T1/T0 topology with 20230531.11 or later image"
+    reason: "Only support Broadcom T1/T0 topology with 20230531.12 or later image"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
       - "release in ['201911', '202012', '202205', '202211']"
-      - "release in ['202305'] and build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 12"
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -1,0 +1,129 @@
+import pytest
+import re
+import logging
+from tests.common import config_reload
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.asic('broadcom'),
+    pytest.mark.topology('t1'),
+    pytest.mark.disable_loganalyzer
+]
+
+seed_cmd = [
+    'bcmcmd "getreg RTAG7_HASH_SEED_A"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_A_PIPE0"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_A_PIPE1"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_A_PIPE2"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_A_PIPE3"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE0"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE1"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE2"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE3"'
+]
+
+offset_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP"'
+# offset_0xa_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP" | grep OFFSET_ECMP=0xa | wc -l'
+
+
+def parse_hash_seed(output):
+    logger.info("Checking seed config: {}".format(output))
+    # RTAG7_HASH_SEED_A.ipipe0[1][0x16001500]=0: <HASH_SEED_A=0>
+    # Regular expression pattern to find both HASH_SEED_A and HASH_SEED_B
+    pattern = r'HASH_SEED_[A|B]=(0x?[0-9a-fA-F]?)'
+
+    matches = re.findall(pattern, output)
+    if len(matches) == 1:
+        logger.info("HASH_SEED value: {}".format(matches[0]))
+        numeric_value = matches[0]
+    else:
+        pytest.fail("Matched number of HASH_SEED is not correct.")
+    return numeric_value
+
+
+def parse_ecmp_offset(outputs):
+    # Regular expression pattern to extract OFFSET_ECMP values (hexadecimal)
+    pattern = r'OFFSET_ECMP=(0x?[0-9a-fA-F]?)'
+
+    # Extracted values
+    extracted_values = []
+
+    for line in outputs.splitlines():
+        line = line.strip()
+        matches = re.findall(pattern, line)
+        if len(matches) == 1:
+            value = matches[0]
+            extracted_values.append(value)
+        elif len(matches) == 0:
+            continue
+        else:
+            pytest.fail("Matched number of OFFSET_ECMP is not correct.")
+    return extracted_values
+
+
+@pytest.mark.parametrize("parameter", ["", "restart_syncd", "reload"])
+def test_ecmp_hash_seed_value(duthosts, enum_rand_one_per_hwsku_frontend_hostname, parameter):
+    """
+    Check ecmp HASH_SEED
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asic = duthost.facts["asic_type"]
+
+    if (asic != "broadcom"):
+        pytest.skip("Unsupported asic type: {}".format(asic))
+        return
+    if parameter == "":
+        for cmd in seed_cmd:
+            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+            hash_seed = parse_hash_seed(output)
+            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+    elif parameter == "restart_syncd":
+        duthost.command("docker restart syncd", module_ignore_errors=True)
+        logging.info("Wait until all critical services are fully started")
+        wait_critical_processes(duthost)
+        for cmd in seed_cmd:
+            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+            hash_seed = parse_hash_seed(output)
+            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+    elif parameter == "reload":
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        for cmd in seed_cmd:
+            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+            hash_seed = parse_hash_seed(output)
+            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+
+
+@pytest.mark.parametrize("parameter", ["", "restart_syncd", "reload"])
+def test_ecmp_offset_value(duthosts, enum_rand_one_per_hwsku_frontend_hostname, parameter):
+    """
+    Check ecmp HASH_OFFSET
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asic = duthost.facts["asic_type"]
+
+    if (asic != "broadcom"):
+        pytest.skip("Unsupported asic type: {}".format(asic))
+        return
+    if parameter == "":
+        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
+        offset_list = parse_ecmp_offset(output)
+        count_0xa = offset_list.count('0xa')
+        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+    elif parameter == "restart_syncd":
+        duthost.command("docker restart syncd", module_ignore_errors=True)
+        logging.info("Wait until all critical services are fully started")
+        wait_critical_processes(duthost)
+        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
+        offset_list = parse_ecmp_offset(output)
+        count_0xa = offset_list.count('0xa')
+        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+    elif parameter == "reload":
+        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
+        offset_list = parse_ecmp_offset(output)
+        count_0xa = offset_list.count('0xa')
+        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -96,14 +96,13 @@ def check_config_bcm_file(duthost, topo_type):
     """
     Read the config bcm file and check if sai_hash_seed_config_hash_offset_enable is set
     """
-    ls_command = "docker exec syncd ls -al /etc/sai.d/ | grep config.bcm"
+    ls_command = "docker exec syncd cat /etc/sai.d/sai.profile | grep SAI_INIT_CONFIG_FILE"
     ls_output = duthost.shell(ls_command, module_ignore_errors=True)['stdout']
     # Check if the file exists
     if ls_output:
-        file_name = ls_output.split()[-1]
+        file_name = ls_output.split("=")[-1]
         logging.info("Config bcm file found:{}".format(file_name))
-        cat_command = "docker exec syncd cat /etc/sai.d/{} | grep sai_hash_seed_config_hash_offset_enable".format(
-            file_name)
+        cat_command = "docker exec syncd cat {} | grep sai_hash_seed_config_hash_offset_enable".format(file_name)
         cat_output = duthost.shell(cat_command, module_ignore_errors=True)['stdout']
         if cat_output:
             value = cat_output.split("=")[-1]
@@ -195,7 +194,7 @@ def test_ecmp_hash_seed_value(localhost, duthosts, tbinfo, enum_rand_one_per_hws
     if parameter == "common":
         check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "restart_syncd":
-        duthost.command("docker restart syncd", module_ignore_errors=True)
+        duthost.command("sudo systemctl restart syncd", module_ignore_errors=True)
         logging.info("Wait until all critical services are fully started")
         wait_critical_processes(duthost)
         check_hash_seed_value(duthost, asic_name, topo_type)
@@ -241,7 +240,7 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     if parameter == "common":
         check_ecmp_offset_value(duthost, asic_name, topo_type)
     elif parameter == "restart_syncd":
-        duthost.command("docker restart syncd", module_ignore_errors=True)
+        duthost.command("sudo systemctl restart syncd", module_ignore_errors=True)
         logging.info("Wait until all critical services are fully started")
         wait_critical_processes(duthost)
         check_ecmp_offset_value(duthost, asic_name, topo_type)

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -120,7 +120,7 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type):
     TH/TH2: the count of 0xa is 67
     TD2: the count of 0xa is 33
     """
-    pytest_assert(wait_until(300, 20, check_syncd_is_running, duthost), "syncd is not running!")
+    pytest_assert(wait_until(300, 20, 0, check_syncd_is_running, duthost), "syncd is not running!")
     output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
     offset_list = parse_ecmp_offset(output)
     if topo_type == "t0":

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -4,12 +4,15 @@ import logging
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import get_host_visible_vars
+from tests.common.reboot import reboot, REBOOT_TYPE_COLD, REBOOT_TYPE_WARM
 
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.asic('broadcom'),
+    pytest.mark.topology('t0'),
     pytest.mark.topology('t1'),
     pytest.mark.disable_loganalyzer
 ]
@@ -27,11 +30,22 @@ seed_cmd = [
     'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE3"'
 ]
 
+seed_cmd_td2 = [
+    'bcmcmd "getreg RTAG7_HASH_SEED_A"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B"'
+]
+
+seed_cmd_td3 = [
+    'bcmcmd "getreg RTAG7_HASH_SEED_A"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_A_PIPE0"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B"',
+    'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE0"',
+]
+
 offset_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP"'
-# offset_0xa_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP" | grep OFFSET_ECMP=0xa | wc -l'
 
 
-def parse_hash_seed(output):
+def parse_hash_seed(output, asic_name):
     logger.info("Checking seed config: {}".format(output))
     # RTAG7_HASH_SEED_A.ipipe0[1][0x16001500]=0: <HASH_SEED_A=0>
     # Regular expression pattern to find both HASH_SEED_A and HASH_SEED_B
@@ -66,64 +80,135 @@ def parse_ecmp_offset(outputs):
     return extracted_values
 
 
-@pytest.mark.parametrize("parameter", ["", "restart_syncd", "reload"])
-def test_ecmp_hash_seed_value(duthosts, enum_rand_one_per_hwsku_frontend_hostname, parameter):
+def check_hash_seed_value(duthost, asic_name, topo_type):
+    """
+    Check the value of HASH_SEED
+    t0: HASH_SEED is set to 0
+    t1: HASH_SEED is set to 0xa
+    """
+    if asic_name == "td2":
+        seed_cmd_input = seed_cmd_td2
+    elif asic_name == "td3":
+        seed_cmd_input = seed_cmd_td3
+    else:
+        seed_cmd_input = seed_cmd
+    for cmd in seed_cmd_input:
+        output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+        hash_seed = parse_hash_seed(output, asic_name)
+        if topo_type == "t1":
+            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+        elif topo_type == "t0":
+            pytest_assert(hash_seed == '0', "HASH_SEED is not set to 0")
+
+
+def check_ecmp_offset_value(duthost, asic_name, topo_type):
+    """
+    Check the value of OFFSET_ECMP
+    TH/TH2: the count of 0xa is 67
+    TD2: the count of 0xa is 33
+    """
+    output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
+    offset_list = parse_ecmp_offset(output)
+    count_0xa = offset_list.count('0xa')
+    if topo_type == "t0":
+        count_0xa = offset_list.count('0')
+        pytest_assert(count_0xa == 392, "the count of 0 OFFSET_ECMP is not correct.")
+    elif topo_type == "t1":
+        if asic_name == "td2":
+            pytest_assert(count_0xa >= 33, "the count of 0xa OFFSET_ECMP is not correct.")
+        else:
+            pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+    else:
+        pytest.fail("Unsupported topology type: {}".format(topo_type))
+
+
+@pytest.mark.parametrize("parameter", ["common", "restart_syncd", "reload", "reboot", "warm-reboot"])
+def test_ecmp_hash_seed_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname, parameter):
     """
     Check ecmp HASH_SEED
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
+    topo_type = tbinfo['topo']['type']
+    hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
+    hwsku = duthost.facts['hwsku']
+    supported_platforms = ['broadcom_td2_hwskus', 'broadcom_td3_hwskus', 'broadcom_th_hwskus',
+                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus']
+    asic_name = None
+    for platform in supported_platforms:
+        supported_skus = hostvars.get(platform, [])
+        if hwsku in supported_skus:
+            asic_name = platform.split('_')[1]
+        else:
+            continue
+    if asic_name is None:
+        pytest.skip("Unsupported platform: {}".format(hwsku))
 
-    if (asic != "broadcom"):
+    if asic != "broadcom":
         pytest.skip("Unsupported asic type: {}".format(asic))
-        return
-    if parameter == "":
-        for cmd in seed_cmd:
-            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
-            hash_seed = parse_hash_seed(output)
-            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+
+    if parameter == "common":
+        check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "restart_syncd":
         duthost.command("docker restart syncd", module_ignore_errors=True)
         logging.info("Wait until all critical services are fully started")
         wait_critical_processes(duthost)
-        for cmd in seed_cmd:
-            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
-            hash_seed = parse_hash_seed(output)
-            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+        check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "reload":
+        logging.info("Run config reload on DUT")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
-        for cmd in seed_cmd:
-            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
-            hash_seed = parse_hash_seed(output)
-            pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
+        check_hash_seed_value(duthost, asic_name, topo_type)
+    elif parameter == "reboot":
+        logging.info("Run cold reboot on DUT")
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None)
+        check_hash_seed_value(duthost, asic_name, topo_type)
+    elif parameter == "warm-reboot" and topo_type == "t0":
+        logging.info("Run warm reboot on DUT")
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None, reboot_kwargs=None)
+        check_hash_seed_value(duthost, asic_name, topo_type)
 
 
-@pytest.mark.parametrize("parameter", ["", "restart_syncd", "reload"])
-def test_ecmp_offset_value(duthosts, enum_rand_one_per_hwsku_frontend_hostname, parameter):
+@pytest.mark.parametrize("parameter", ["common", "restart_syncd", "reload", "reboot", "warm-reboot"])
+def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname, parameter):
     """
     Check ecmp HASH_OFFSET
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
+    topo_type = tbinfo['topo']['type']
+    hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
+    hwsku = duthost.facts['hwsku']
+    supported_platforms = ['broadcom_td2_hwskus', 'broadcom_td3_hwskus', 'broadcom_th_hwskus',
+                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus']
+    asic_name = None
+    for platform in supported_platforms:
+        supported_skus = hostvars.get(platform, [])
+        if hwsku in supported_skus:
+            asic_name = platform.split('_')[1]
+        else:
+            continue
+    if asic_name is None:
+        pytest.skip("Unsupported platform: {}".format(hwsku))
 
     if (asic != "broadcom"):
         pytest.skip("Unsupported asic type: {}".format(asic))
-        return
-    if parameter == "":
-        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
-        offset_list = parse_ecmp_offset(output)
-        count_0xa = offset_list.count('0xa')
-        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+
+    if parameter == "common":
+        check_ecmp_offset_value(duthost, asic_name, topo_type)
     elif parameter == "restart_syncd":
         duthost.command("docker restart syncd", module_ignore_errors=True)
         logging.info("Wait until all critical services are fully started")
         wait_critical_processes(duthost)
-        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
-        offset_list = parse_ecmp_offset(output)
-        count_0xa = offset_list.count('0xa')
-        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+        check_ecmp_offset_value(duthost, asic_name, topo_type)
     elif parameter == "reload":
-        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
-        offset_list = parse_ecmp_offset(output)
-        count_0xa = offset_list.count('0xa')
-        pytest_assert(count_0xa >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+        logging.info("Run config reload on DUT")
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        check_hash_seed_value(duthost, asic_name, topo_type)
+    elif parameter == "reboot":
+        logging.info("Run cold reboot on DUT")
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None)
+        check_ecmp_offset_value(duthost, asic_name, topo_type)
+    elif parameter == "warm-reboot" and topo_type == "t0":
+        logging.info("Run warm reboot on DUT")
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None, reboot_kwargs=None)
+        check_ecmp_offset_value(duthost, asic_name, topo_type)


### PR DESCRIPTION
…ue is correct

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
It's a new test script test_ecmp_sai_value.py to verify if HASH_SEED and OFFSET_ECMP value is correct after 20230531.10 image on Broadcom T1 testbed.
Cover the changes in https://github.com/sonic-net/sonic-buildimage/pull/17505.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
It's a new test script test_ecmp_sai_value.py to verify if HASH_SEED and OFFSET_ECMP value is correct after 20230531.10 image on Broadcom T1 testbed.

#### How did you do it?
Check Broadcom register values via bcmcmd.
Also cover syncd restart and config reload scenarios.

#### How did you verify/test it?
run ecmp/test_ecmp_sai_value.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
