### PR TITLE
Set port->ptf_index map empty before construction - 202205

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1542,7 +1542,7 @@ Totals               6450                 6449
     @cached(name='mg_facts')
     def get_extended_minigraph_facts(self, tbinfo, namespace = DEFAULT_NAMESPACE):
         mg_facts = self.minigraph_facts(host = self.hostname, namespace = namespace)['ansible_facts']
-        mg_facts['minigraph_ptf_indices'] = mg_facts['minigraph_port_indices'].copy()
+        mg_facts['minigraph_ptf_indices'] = {}
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indices from


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Double commit of master PR #10144

The `minigraph_ptf_indices` structure maps port names to PTF indices. From the code context, it appears that `minigraph_port_indices` was used for this mapping, but multi-dut TBs caused problems with the PTF.

It seems the more reliable way to get the ptf indices is to compose together the port_name->port_index map (`minigraph_port_indices`), and the port_index->ptf_index map (`tbinfo['topo']['ptf_map'][str(dut_index)]`). 

The pre-existing initialization of this composition to include any members of the `port_index->ptf_index` map can leave duplicate ptf_index entries for down ports, especially in dualtor scenarios. See #10139. 

Remove the extra initialization on the composition construction. 

Summary:
Fixes #10139

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on dualtor TB for PCBB watermark test cases. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
