### PR TITLE
Fix for test_crm_acl_entry test and py3 fix for API: port_on_asic() 

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import socket
+import re
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE, NAMESPACE_PREFIX
@@ -549,8 +550,13 @@ class SonicAsic(object):
 
     def port_on_asic(self, portname):
         cmd = 'sudo sonic-cfggen {} -v "PORT.keys()" -d'.format(self.cli_ns_option)
-        ports = self.shell(cmd)["stdout_lines"][0].decode("utf-8")
-        if ports is not None and portname in ports:
+        ports = self.shell(cmd)["stdout_lines"][0]
+        # The variable 'ports' is a string in format below
+        # u"dict_keys(['Ethernet144', 'Ethernet152', 'Ethernet160', 'Ethernet280'])"
+        # doing a regex match for '<interface_name>'' to get the **exact** port.
+        # Without which a check like --> ('Ethernet16' in ports) returns true, because
+        # Ethernet16 matches as a substring to Ethernet160 which is present in 'ports'
+        if ports is not None and re.search(r"'{}'".format(portname), ports):
             return True
         return False
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -991,6 +991,9 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
         # PCs are a single bind point
         portToLag = {}
         for lag, lagData in mg_facts["minigraph_portchannels"].items():
+            # Check if Portchannel belongs to this namespace
+            if lagData['namespace'] != asichost.namespace:
+                continue
             for member in lagData['members']:
                 portToLag[member] = lag
         aclBindings = mg_facts["minigraph_acls"]["DataAcl"]


### PR DESCRIPTION

### Approach
#### What is the motivation for this PR?

Cherry-pick of PR #10342 in 202205

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
