### PR TITLE
Reorder eventd heartbeat testcase as first testcase

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -3,15 +3,14 @@ import pytest
 import os
 import sys
 
-EVENTS_TESTS_PATH = "./telemetry/events"
-sys.path.append(EVENTS_TESTS_PATH)
-
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, wait_tcp_connection
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
 
+EVENTS_TESTS_PATH = "./telemetry/events"
+sys.path.append(EVENTS_TESTS_PATH)
 
 BASE_DIR = "logs/telemetry"
 DATA_DIR = os.path.join(BASE_DIR, "files")

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -1,5 +1,10 @@
 import logging
 import pytest
+import os
+import sys
+
+EVENTS_TESTS_PATH = "./telemetry/events"
+sys.path.append(EVENTS_TESTS_PATH)
 
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.errors import RunAnsibleModuleFail
@@ -7,6 +12,9 @@ from tests.common.utilities import wait_until, wait_tcp_connection
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
 
+
+BASE_DIR = "logs/telemetry"
+DATA_DIR = os.path.join(BASE_DIR, "files")
 
 logger = logging.getLogger(__name__)
 
@@ -120,3 +128,30 @@ def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localh
     restore_telemetry_forpyclient(duthost, default_client_auth)
     if not has_gnmi_config:
         delete_gnmi_config(duthost)
+
+
+def do_init(duthost):
+    for i in [BASE_DIR, DATA_DIR]:
+        try:
+            os.mkdir(i)
+        except OSError as e:
+            logger.info("Dir/file already exists: {}, skipping mkdir".format(e))
+
+        duthost.copy(src="telemetry/validate_yang_events.py", dest="~/")
+
+
+@pytest.fixture(scope="module")
+def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
+    """
+    @summary: Test eventd heartbeat before testing all testcases
+    """
+
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    do_init(duthost)
+
+    module = __import__("eventd_events")
+
+    module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, None)
+
+    logger.info("Completed test file: {}".format("eventd_events test completed."))

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -48,9 +48,15 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     skip_201911_and_older(duthost)
     do_init(duthost)
 
-    # Load all events test code and run
+    # Test eventd heartbeat event first
+
+    file = "eventd_events.py"
+    module = __import__(file[:len(file)-3])
+    module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, validate_yang)
+
+    # Load rest of events
     for file in os.listdir(EVENTS_TESTS_PATH):
-        if file.endswith("_events.py"):
+        if file.endswith("_events.py") and not file.endswith("eventd_events.py"):
             module = __import__(file[:len(file)-3])
             module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, validate_yang)
             logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -27,18 +27,9 @@ def validate_yang(duthost, op_file="", yang_file=""):
     assert ret["rc"] == 0, "Yang validation failed for {}".format(yang_file)
 
 
-def do_init(duthost):
-    for i in [BASE_DIR, DATA_DIR]:
-        try:
-            os.mkdir(i)
-        except OSError as e:
-            logger.info("Dir/file already exists: {}, skipping mkdir".format(e))
-
-    duthost.copy(src="telemetry/validate_yang_events.py", dest="~/")
-
-
 @pytest.mark.disable_loganalyzer
-def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, localhost, gnxi_path):
+def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, localhost, gnxi_path,
+                test_eventd_healthy):
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema
     """
@@ -46,13 +37,6 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     logger.info("Start events testing")
 
     skip_201911_and_older(duthost)
-    do_init(duthost)
-
-    # Test eventd heartbeat event first
-
-    file = "eventd_events.py"
-    module = __import__(file[:len(file)-3])
-    module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, validate_yang)
 
     # Load rest of events
     for file in os.listdir(EVENTS_TESTS_PATH):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)25860806

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

I am changing the order of the testcases in test_events because eventd heartbeat testcase should be used as a preliminary test before all testcases since it is testing that a critical part of eventd which is heartbeat is working correctly. It is also good that it is executed first because we can use it to drain the eventd cache in case there were any published events missed due to cache overflow.

#### How did you do it?

Code change

#### How did you verify/test it?

Manual testing/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
