### PR TITLE
Revert "[python3]migrate ecmp scripts to python3 (#5825)"

### DIFF
--- a/ansible/roles/test/files/ptftests/fg_ecmp_test.py
+++ b/ansible/roles/test/files/ptftests/fg_ecmp_test.py
@@ -161,8 +161,8 @@ class FgEcmpTest(BaseTest):
         self.router_mac = graph['dut_mac']
         self.num_flows = graph['num_flows']
         self.inner_hashing = graph['inner_hashing']
-        self.src_ipv4_interval = lpm.LpmDict.IpInterval(ipaddress.ip_address(str(IPV4_SRC_IP_RANGE[0])), ipaddress.ip_address(str(IPV4_SRC_IP_RANGE[1])))
-        self.src_ipv6_interval = lpm.LpmDict.IpInterval(ipaddress.ip_address(str(IPV6_SRC_IP_RANGE[0])), ipaddress.ip_address(str(IPV6_SRC_IP_RANGE[1])))
+        self.src_ipv4_interval = lpm.LpmDict.IpInterval(ipaddress.ip_address(unicode(IPV4_SRC_IP_RANGE[0])), ipaddress.ip_address(unicode(IPV4_SRC_IP_RANGE[1])))
+        self.src_ipv6_interval = lpm.LpmDict.IpInterval(ipaddress.ip_address(unicode(IPV6_SRC_IP_RANGE[0])), ipaddress.ip_address(unicode(IPV6_SRC_IP_RANGE[1])))
         self.vxlan_port = graph['vxlan_port']
 
         self.log(self.net_ports)
@@ -187,7 +187,7 @@ class FgEcmpTest(BaseTest):
 
     #---------------------------------------------------------------------
     def test_balancing(self, hit_count_map):
-        for port, exp_flows in list(self.exp_flow_count.items()):
+        for port, exp_flows in self.exp_flow_count.items():
             assert port in hit_count_map
             num_flows = hit_count_map[port]
             deviation = float(num_flows)/float(exp_flows)
@@ -210,7 +210,7 @@ class FgEcmpTest(BaseTest):
         return deviation_max
 
     def fg_ecmp(self):
-        ipv4 = isinstance(ipaddress.ip_address(self.dst_ip),
+        ipv4 = isinstance(ipaddress.ip_address(self.dst_ip.decode('utf8')),
                 ipaddress.IPv4Address)
         # initialize all parameters
         if self.inner_hashing:
@@ -230,7 +230,7 @@ class FgEcmpTest(BaseTest):
                 try:
                     tuple_to_port_map = json.load(fp)
                 except ValueError:
-                    print('Decoding JSON failed for persist map')
+                    print 'Decoding JSON failed for persist map'
                     assert False
 
         if tuple_to_port_map is None or self.dst_ip not in tuple_to_port_map:
@@ -263,7 +263,7 @@ class FgEcmpTest(BaseTest):
 
         elif self.test_case == 'initial_hash_check':
             self.log("Ensure that flow to port map is maintained when the same flow is re-sent...")
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -277,7 +277,7 @@ class FgEcmpTest(BaseTest):
         elif self.test_case == 'hash_check_warm_boot':
             self.log("Ensure that flow to port map is maintained when the same flow is re-sent...")
             total_flood_pkts = 0
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -316,7 +316,7 @@ class FgEcmpTest(BaseTest):
 
         elif self.test_case == 'bank_check':
             self.log("Send the same flows once again and verify that they end up on the same bank...")
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -337,7 +337,7 @@ class FgEcmpTest(BaseTest):
                 withdraw_port_grp = self.exp_port_set_one
             else:
                 withdraw_port_grp = self.exp_port_set_two
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -359,7 +359,7 @@ class FgEcmpTest(BaseTest):
                 add_port_grp = self.exp_port_set_one
             else:
                 add_port_grp = self.exp_port_set_two
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -379,7 +379,7 @@ class FgEcmpTest(BaseTest):
                 active_port_grp = self.exp_port_set_two
             else:
                 active_port_grp = self.exp_port_set_one
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -401,7 +401,7 @@ class FgEcmpTest(BaseTest):
             else:
                 active_port_grp = self.exp_port_set_one
 
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -421,7 +421,7 @@ class FgEcmpTest(BaseTest):
         elif self.test_case == 'net_port_hashing':
             self.log("Send packets destined to network ports and ensure hash distribution is as expected")
 
-            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
                 if self.inner_hashing:
                     in_port = random.choice(self.serv_ports)
                 else:

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -64,13 +64,13 @@ class InnerHashTest(BaseTest):
         self.fib = fib.Fib(self.test_params['fib_info'])
         self.router_mac = self.test_params['router_mac']
 
-        inner_src_ip_range = [str(x) for x in self.test_params['inner_src_ip_range'].split(',')]
-        inner_dst_ip_range = [str(x) for x in self.test_params['inner_dst_ip_range'].split(',')]
+        inner_src_ip_range = [unicode(x) for x in self.test_params['inner_src_ip_range'].split(',')]
+        inner_dst_ip_range = [unicode(x) for x in self.test_params['inner_dst_ip_range'].split(',')]
         self.inner_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_src_ip_range[0]), ip_address(inner_src_ip_range[1]))
         self.inner_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_dst_ip_range[0]), ip_address(inner_dst_ip_range[1]))
 
-        outer_src_ip_range = [str(x) for x in self.test_params['outer_src_ip_range'].split(',')]
-        outer_dst_ip_range = [str(x) for x in self.test_params['outer_dst_ip_range'].split(',')]
+        outer_src_ip_range = [unicode(x) for x in self.test_params['outer_src_ip_range'].split(',')]
+        outer_dst_ip_range = [unicode(x) for x in self.test_params['outer_dst_ip_range'].split(',')]
         self.outer_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_src_ip_range[0]), ip_address(outer_src_ip_range[1]))
         self.outer_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_dst_ip_range[0]), ip_address(outer_dst_ip_range[1]))
 
@@ -177,7 +177,7 @@ class InnerHashTest(BaseTest):
         rand_int = random.randint(1, 99)
         src_mac = '00:12:ab:34:cd:' + str(rand_int)
         dst_mac = str(rand_int) + ':12:ab:34:cd:00'
-        if ip_network(str(ip_src)).version == 4:
+        if ip_network(unicode(ip_src)).version == 4:
             pkt = simple_tcp_packet(
                 eth_dst=dst_mac,
                 eth_src=src_mac,
@@ -215,7 +215,7 @@ class InnerHashTest(BaseTest):
         @param sport: Inner packet src port
         @param ip_proto: Inner packet ip protocol
         '''
-        if ip_network(str(self.outer_dst_ip)).version == 4:
+        if ip_network(unicode(self.outer_dst_ip)).version == 4:
             (matched_index, received) = self.check_ipv4_route_nvgre(hash_key, src_port, ip_dst, ip_src, dport, sport, ip_proto)
         else:
             (matched_index, received) = self.check_ipv6_route_nvgre(hash_key, src_port, ip_dst, ip_src, dport, sport, ip_proto)
@@ -370,7 +370,7 @@ class InnerHashTest(BaseTest):
         @param sport: Inner packet src port
         @param ip_proto: Inner packet ip protocol
         '''
-        if ip_network(str(self.outer_dst_ip)).version == 4:
+        if ip_network(unicode(self.outer_dst_ip)).version == 4:
             (matched_index, received) = self.check_ipv4_route_vxlan(hash_key, src_port, ip_dst, ip_src, dport, sport, ip_proto)
         else:
             (matched_index, received) = self.check_ipv6_route_vxlan(hash_key, src_port, ip_dst, ip_src, dport, sport, ip_proto)

--- a/tests/ecmp/inner_hashing/test_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing.py
@@ -78,8 +78,7 @@ class TestDynamicInnerHashing():
                        params=ptf_params,
                        log_file=log_file,
                        qlen=PTF_QLEN,
-                       socket_recv_size=16384,
-                       is_python3=True)
+                       socket_recv_size=16384)
 
             retry_call(check_pbh_counters,
                        fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times,
@@ -109,8 +108,7 @@ class TestDynamicInnerHashing():
                            params=ptf_params,
                            log_file=log_file,
                            qlen=PTF_QLEN,
-                           socket_recv_size=16384,
-                           is_python3=True)
+                           socket_recv_size=16384)
 
             retry_call(check_pbh_counters,
                        fargs=[duthost, swapped_outer_ipver, swapped_inner_ipver, balancing_test_times,
@@ -151,5 +149,4 @@ class TestStaticInnerHashing():
                            "symmetric_hashing": symmetric_hashing},
                    log_file=log_file,
                    qlen=PTF_QLEN,
-                   socket_recv_size=16384,
-                   is_python3=True)
+                   socket_recv_size=16384)

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -73,8 +73,7 @@ class TestDynamicInnerHashingLag():
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,
-                       socket_recv_size=16384,
-                       is_python3=True)
+                       socket_recv_size=16384)
 
         retry_call(check_pbh_counters,
                    fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times,

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -76,8 +76,7 @@ class TestWRDynamicInnerHashing():
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,
-                       socket_recv_size=16384,
-                       is_python3=True)
+                       socket_recv_size=16384)
             reboot_thr.join()
 
 
@@ -116,6 +115,5 @@ class TestWRStaticInnerHashing():
                            "symmetric_hashing": symmetric_hashing},
                    log_file=log_file,
                    qlen=PTF_QLEN,
-                   socket_recv_size=16384,
-                   is_python3=True)
+                   socket_recv_size=16384)
         reboot_thr.join()

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -77,6 +77,5 @@ class TestWRDynamicInnerHashingLag():
                            "symmetric_hashing": symmetric_hashing},
                    log_file=log_file,
                    qlen=PTF_QLEN,
-                   socket_recv_size=16384,
-                   is_python3=True)
+                   socket_recv_size=16384)
         reboot_thr.join()

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -224,8 +224,7 @@ def partial_ptf_runner(ptfhost, test_case, dst_ip, exp_flow_count, **kwargs):
             platform_dir="ptftests",
             params= params,
             qlen=1000,
-            log_file=log_file,
-            is_python3=True)
+            log_file=log_file)
 
 
 def validate_packet_flow_without_neighbor_resolution(ptfhost, duthost, ip_to_port, prefix_list):


### PR DESCRIPTION
This reverts commit ac802b63e1ce00fb876c78aa1d256c4a7e01c93e.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Reverts the python3 migrate PR on 202205 because run_tests.sh is not supporting python3 on 202205.
Will fixing failures on local tests.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [ ] 202305