### PR TITLE
Make stable for testcase test_counterpoll_watermark.py

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -106,6 +106,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
             config_reload(duthost)
         elif 'reboot' in config_apply_method:
             reboot(duthost, localhost)
+    # Sleep for 60 seconds to wait for config DB to be ready or else the next step will cause testcase failure
+    time.sleep(60)
     # verify all counterpolls are disabled after reload or reboot
     with allure.step("Verifying output of {} on {} after {} ..."
                      .format(CounterpollConstants.COUNTERPOLL_SHOW, duthost.hostname, config_apply_method)):
@@ -205,8 +207,6 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
 
 
 def verify_all_counterpoll_status(duthost, expected):
-    # Need to sleep 60 seconds to wait for config DB to be ready
-    time.sleep(60)
     verify_counterpoll_status(duthost, RELEVANT_COUNTERPOLLS, expected)
 
 

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -205,6 +205,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
 
 
 def verify_all_counterpoll_status(duthost, expected):
+    # Need to sleep 60 seconds to wait for config DB to be ready
+    time.sleep(60)
     verify_counterpoll_status(duthost, RELEVANT_COUNTERPOLLS, expected)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Sometime the test_counterpoll_watermark.py will fail due to:
RuntimeError: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
This is because test case reloads the config DB or does reboot and does not wait for enough time. Config DB is not ready.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Sometime the test_counterpoll_watermark.py will fail due to:
RuntimeError: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
This is because test case reloads the config DB or does reboot and does not wait for enough time. Config DB is not ready.

#### How did you do it?
Add a sleep after config reload

#### How did you verify/test it?
Manually run with testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
