### PR TITLE
Exclude supervisor from the dut list - BGP/test_bgp_authentication

### DIFF
--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -20,11 +20,11 @@ mismatch_pass = "badpassword"
 
 
 @pytest.fixture(scope='module')
-def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname, enum_rand_one_frontend_asic_index, request):
+def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, request):
     # verify neighbors are type sonic
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Neighbor type must be sonic")
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_frontend_dut_hostname]
     dut_asn = tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']
 
     lldp_table = duthost.shell("show lldp table")['stdout'].split("\n")[3].split()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

-  The '_test_bgp_authentication_' test fails, when the test selects t2-chassis supervisor as DUT in random.
-  This PR fixes issue the above issue for '_test_bgp_authentication_' test case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

- When a supervisor is selected in random as DUT for _test_bgp_authentication_ test case, test fails with the following error.
`E       Failed: ASIC instance not found for port eth0`

#### How did you do it?

-  Exclude supervisor from the dut list.

#### How did you verify/test it?

- Ran the 'bgp_authentication' tests against a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/a22991ff-6f7e-4f0c-b107-2269bb026fd4)

