### PR TITLE
[advanced-reboot]: Make sure tcpdump sniffer thread exits

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1777,16 +1777,15 @@ class ReloadTest(BaseTest):
 
     def start_sniffer(self, pcap_path, tcpdump_filter, timeout):
         """
-        Star tcpdump sniffer on all data interfaces
+        Start tcpdump sniffer on all data interfaces, and kill them after a specified timeout
         """
         self.tcpdump_data_ifaces = [
             iface for iface in scapyall.get_if_list() if iface.startswith('eth')]
         processes_list = []
         for iface in self.tcpdump_data_ifaces:
-            process = multiprocessing.Process(
-                target=self.start_dump_process,
-                kwargs={'iface': iface, 'pcap_path': pcap_path, 'tcpdump_filter': tcpdump_filter})
-            process.start()
+            iface_pcap_path = '{}_{}'.format(pcap_path, iface)
+            process = subprocess.Popen(['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path])
+            self.log('Tcpdump sniffer starting on iface: {}'.format(iface))
             processes_list.append(process)
 
         time_start = time.time()
@@ -1797,22 +1796,27 @@ class ReloadTest(BaseTest):
                 break
             time_start = curr_time
 
-        self.log("Going to kill all tcpdump processes by SIGINT")
-        subprocess.call(['killall', '-s', 'SIGINT', 'tcpdump'])
+        self.log("Going to kill all tcpdump processes by SIGTERM")
+        for process in processes_list:
+            process.terminate()
 
         for process in processes_list:
-            process.join()
+            process.wait(timeout=5)
+            # Return code here could be 0, so we need to explicitly check for None
+            if process.returncode is not None:
+                self.log("Tcpdump process {} terminated".format(process.args))
 
-        self.log("Killed all tcpdump processes by SIGINT")
+        for process in processes_list:
+            if process.returncode is not None:
+                continue
+            self.log("Killing tcpdump process {}".format(process.args))
+            process.kill()
+            process.wait(timeout=5)
+            # Return code here could be 0, so we need to explicitly check for None
+            if process.returncode is not None:
+                self.log("Tcpdump process {} killed".format(process.args))
 
-    def start_dump_process(self, iface, pcap_path, tcpdump_filter):
-        """
-        Start tcpdump on specific interface and save data to pcap file
-        """
-        iface_pcap_path = '{}_{}'.format(pcap_path, iface)
-        cmd = ['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path]
-        self.log('Tcpdump sniffer starting on iface: {}'.format(iface))
-        subprocess.call(cmd)
+        self.log("Killed all tcpdump processes")
 
     def create_single_pcap(self, pcap_path):
         """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In some cases, it looks like the tcpdump sniffer thread doesn't exit for whatever reason. This leads to the advanced reboot test case failing because this thread is stuck, even though the warm reboot on the device itself succeeded.

#### How did you do it?

Rework this section of code so that if tcpdump doesn't exit within 5 seconds after SIGINT is sent (or SIGTERM, now), kill it forcefully.

#### How did you verify/test it?

Ran 10 warm reboots, verify that this issue wasn't hit in those 10 warm reboots.

There can still be other failures in infra code, though.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
