### PR TITLE
[dualtor-120] Reduce `test_fdb` runtime

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -57,7 +57,7 @@ def get_dummay_mac_count(tbinfo, duthosts, rand_one_dut_hostname):
 
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
     # Use DUMMY_MAC_COUNT_SLIM on dualtor-64 to reduce running time
-    REQUIRED_TOPO = ["t0-116", "dualtor-64"]
+    REQUIRED_TOPO = ["t0-116", "dualtor-64", "dualtor-120"]
     if tbinfo["topo"]["name"] in REQUIRED_TOPO:
         # To reduce the case running time
         logger.info("Use dummy mac count {} on topo {}\n".format(DUMMY_MAC_COUNT_SLIM, tbinfo["topo"]["name"]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Reduce the `test_fdb` runtime on `dualtor-120` testbeds for two reasons:
1. it runs over 1h on `dualtor-120` nightly.
2. as it runs over `1h`, fdb is aged sometimes, so the fdb entry number check will fail.

#### How did you do it?
Use dummy mac per port as `2` instead of `10`:

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
