### PR TITLE
Fix test_show_platform_ssdhealth test for 7050QX-32S

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -702,13 +702,6 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
 
-platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
-  xfail:
-    strict: True
-    reason: "Image issue on 7050qx platforms"
-    conditions:
-      - "platform in ['x86_64-arista_7050_qx32s']"
-
 platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
   xfail:
     reason: "Testcase consistently fails, raised issue to track"


### PR DESCRIPTION
### Description of PR

Summary:  Fix test_show_platform_ssdhealth test for 7050QX-32S
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

For some reason this test was marked XFAIL though it passes fine on 202305+ It is likely related to enhancements made both to ssdutil and the arista platform library to gracefully handle emmc/eUSB devices

#### How did you do it?

Remove the pytest mark forcing XFAIL on this test for the 7050QX-32S product

#### How did you verify/test it?

Ran the test and check it passed reliably

#### Any platform specific information?

Only affecting Arista 7050QX-32S
