### PR TITLE
Improve consistency of test_pfcwd_timer_accuracy

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -3,6 +3,8 @@ import ipaddress
 import sys
 
 from tests.common import constants
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
 if sys.version_info[0] >= 3:
@@ -364,3 +366,33 @@ def fetch_vendor_specific_diagnosis_re(duthost):
         return ""
 
     return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")
+
+def is_pfcwd_port_stormed( dut, storm_port ):
+   ''' storm_queue: Ethernet<num>:<queue_num>'''
+   stats = pfcwd_stats( dut )
+   for queue, status in stats.items():
+      if queue.startswith( storm_port ) and status == 'stormed':
+         return True
+   return False
+
+def pfcwd_stats( dut ):
+   result = dut.shell( "show pfcwd stats", module_ignore_errors=True, verbose=False )
+   if result['rc'] != 0:
+      return {}
+   return parse_pfcwd_stats( result[ 'stdout_lines' ] )
+
+def parse_pfcwd_stats( lines ):
+   stats = {}
+   for line in lines:
+      tokens = line.split()
+      queue = tokens[ 0 ]
+      if queue.startswith( 'Ether' ):
+         status = tokens[ 1 ]
+         stats[ queue ] = status
+   return stats
+
+def wait_until_pfcwd_stormed( dut, storm_port ):
+   is_stormed = wait_until(
+      10*60, 5, 0,
+      is_pfcwd_port_stormed, dut, storm_port )
+   pytest_assert( is_stormed, f"Port {storm_port} did not detect storm!" )

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -396,3 +396,16 @@ def wait_until_pfcwd_stormed( dut, storm_port ):
       10*60, 5, 0,
       is_pfcwd_port_stormed, dut, storm_port )
    pytest_assert( is_stormed, f"Port {storm_port} did not detect storm!" )
+
+def is_pfcwd_port_restored(dut, storm_port):
+    stats = pfcwd_stats( dut )
+    for queue, status in stats.items():
+        if queue.startswith( storm_port ) and status == 'operational':
+            return True
+    return False
+
+def wait_until_pfcwd_restored(dut, storm_port):
+    is_restored = wait_until(
+       10*60, 5, 0,
+       is_pfcwd_port_restored, dut, storm_port)
+    pytest_assert(is_restored, f"Port {storm_port} did not restore storm!")

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -367,45 +367,45 @@ def fetch_vendor_specific_diagnosis_re(duthost):
 
     return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")
 
-def is_pfcwd_port_stormed( dut, storm_port ):
-   ''' storm_queue: Ethernet<num>:<queue_num>'''
-   stats = pfcwd_stats( dut )
-   for queue, status in stats.items():
-      if queue.startswith( storm_port ) and status == 'stormed':
-         return True
-   return False
+def is_pfcwd_port_stormed(dut, storm_port):
+    ''' storm_queue: Ethernet<num>:<queue_num>'''
+    stats = pfcwd_stats(dut)
+    for queue, status in stats.items():
+        if queue.startswith(storm_port) and status == 'stormed':
+            return True
+    return False
 
-def pfcwd_stats( dut ):
-   result = dut.shell( "show pfcwd stats", module_ignore_errors=True, verbose=False )
-   if result['rc'] != 0:
-      return {}
-   return parse_pfcwd_stats( result[ 'stdout_lines' ] )
+def pfcwd_stats(dut):
+    result = dut.shell("show pfcwd stats", module_ignore_errors=True, verbose=False)
+    if result is None or result['rc'] != 0:
+        return {}
+    return parse_pfcwd_stats(result['stdout_lines'])
 
-def parse_pfcwd_stats( lines ):
-   stats = {}
-   for line in lines:
-      tokens = line.split()
-      queue = tokens[ 0 ]
-      if queue.startswith( 'Ether' ):
-         status = tokens[ 1 ]
-         stats[ queue ] = status
-   return stats
+def parse_pfcwd_stats(lines):
+    stats = {}
+    for line in lines:
+        tokens = line.split()
+        queue = tokens[0]
+        if queue.startswith('Ether'):
+            status = tokens[1]
+            stats[queue] = status
+    return stats
 
-def wait_until_pfcwd_stormed( dut, storm_port ):
-   is_stormed = wait_until(
-      10*60, 5, 0,
-      is_pfcwd_port_stormed, dut, storm_port )
-   pytest_assert( is_stormed, f"Port {storm_port} did not detect storm!" )
+def wait_until_pfcwd_stormed(dut, storm_port):
+    is_stormed = wait_until(
+        60, 5, 0,
+        is_pfcwd_port_stormed, dut, storm_port)
+    pytest_assert(is_stormed, f"Port {storm_port} did not detect storm!")
 
 def is_pfcwd_port_restored(dut, storm_port):
-    stats = pfcwd_stats( dut )
+    stats = pfcwd_stats(dut)
     for queue, status in stats.items():
-        if queue.startswith( storm_port ) and status == 'operational':
+        if queue.startswith(storm_port) and status == 'operational':
             return True
     return False
 
 def wait_until_pfcwd_restored(dut, storm_port):
     is_restored = wait_until(
-       10*60, 5, 0,
-       is_pfcwd_port_restored, dut, storm_port)
+        60, 5, 0,
+        is_pfcwd_port_restored, dut, storm_port)
     pytest_assert(is_restored, f"Port {storm_port} did not restore storm!")

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -9,7 +9,7 @@ from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from .files.pfcwd_helper import start_wd_on_ports
+from .files.pfcwd_helper import start_wd_on_ports, wait_until_pfcwd_stormed
 from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, fetch_vendor_specific_diagnosis_re
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
@@ -712,7 +712,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         if self.pfc_wd['fake_storm']:
             PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-        time.sleep(5)
+        wait_until_pfcwd_stormed( dut, port )
 
         # storm detect
         logger.info("Verify if PFC storm is detected on port {}".format(port))

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -171,7 +171,7 @@ class TestPfcwdAllTimer(object):
             storm_start_time_ms = time.time() * 1000
             self.storm_handle.start_storm()
             logger.info("Wait for PFC storm detected marker to appear in logs")
-            time.sleep(5)
+            time.sleep(16)
             stormed = is_pfcwd_port_stormed(self.dut, self.test_port)
             if stormed:
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve consistency of test_pfcwd_timer_accuracy for non-T2 testbeds
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Address flakiness in this test, which mainly comes from two problems: detecting PFC storm, and
asserting that the time taken to detect a PFC storm occurs very shortly after the storm is
triggered (within 800ms). This is not realistic for all platforms; the time is probably closer to around 5
seconds on average for Arista platforms.

#### How did you do it?
The PFC storm detection has a chance to randomly fail (as per https://github.com/sonic-net/sonic-mgmt/issues/10848) but it's not clear yet how to reliably reproduce this event. As a workaround, added retry logic to the test to retrigger storm if detection fails.
Consolidate the t2 and non-t2 checks to be based around asserting that time between a
storm's detection and restoration is within the expected time window of when the test starts and
stops a storm.

#### How did you verify/test it?
Verified on Arista 7260 device using t1 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
