### PR TITLE
Ignoring loganalyzer error 'Failed to get port by bridge port ID'

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -195,6 +195,9 @@ r, ".* ERR ntpd.*: statistics directory .* does not exist or is unwriteable, err
 # NTPsec logs a message with ERR in it at NOTICE level when exiting gracefully, ignore it
 r, ".* NOTICE ntpd.*: ERR: ntpd exiting on signal 15.*"
 
+# Race condition while removing a vlan member, no functionality impact
+r, ". *ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID.*"
+
 # https://github.com/sonic-net/sonic-buildimage/issues/7895
 # https://github.com/Azure/sonic-sairedis/issues/582
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_ISOLATION_GROUP"


### PR DESCRIPTION
### Description of PR
orchagent has two threads, one of the threads is receiving messages to remove members from VLAN and the other thread is receiving FDB events (LEARN, AGE etc.) from syncd/SAI.
There can be a race condition where FDB events were already in flight for a member which was getting removed from the VLAN. If orchagent processes the request to remove the member from VLAN first and then processes the FDB event, it will not find the port since bridge port ID is not valid any more. Because of this, we see an error message like ' ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID' in syslogs
This error is completely harmless and does not affect the functionality.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305

### Approach
Adding a line 'r, ". *ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID.*"' to loganalyzer_common_ignore.txt file.

### Verification
Ran the test and made sure that these error messages are getting ignored

