### PR TITLE
[syslog] enable/disable syslog rate limit feature in fixture

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -50,6 +50,13 @@ def restore_rate_limit(rand_selected_dut):
     Args:
         rand_selected_dut (object): DUT host object
     """
+    output = rand_selected_dut.command('config syslog --help')['stdout']
+    manually_enable_feature = False
+    if 'rate-limit-feature' in output:
+        # in 202305, the feature is disabled by default for warmboot/fastboot
+        # performance, need manually enable it via command
+        rand_selected_dut.command('config syslog rate-limit-feature enable')
+        manually_enable_feature = True
     container_data = rand_selected_dut.show_and_parse('show syslog rate-limit-container')
     host_data = rand_selected_dut.show_and_parse('show syslog rate-limit-host')
 
@@ -62,6 +69,8 @@ def restore_rate_limit(rand_selected_dut):
     rand_selected_dut.command('config syslog rate-limit-host -b {} -i {}'.format(
         host_data[0]['burst'], host_data[0]['interval']))
     rand_selected_dut.command('config save -y')
+    if manually_enable_feature:
+        rand_selected_dut.command('config syslog rate-limit-feature disable')
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -163,6 +163,14 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
         is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
     except KeyError:
         is_dhcp_server_enable = None
+
+    output = duthost.command('config syslog --help')['stdout']
+    manually_enable_feature = False
+    if 'rate-limit-feature' in output:
+        # in 202305, the feature is disabled by default for warmboot/fastboot
+        # performance, need manually enable it via command
+        duthost.command('config syslog rate-limit-feature enable')
+        manually_enable_feature = True
     for feature_name, state in list(features_dict.items()):
         if 'enabled' not in state:
             continue
@@ -175,6 +183,8 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
             if "sonic-telemetry" not in output:
                 continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
+    if manually_enable_feature:
+        duthost.command('config syslog rate-limit-feature disable')
 
 
 def collect_dut_lossless_prio(dut):


### PR DESCRIPTION
Depending on https://github.com/sonic-net/sonic-buildimage/pull/17458

**Description of PR**

Feature syslog rate limit has been disabled by default to avoid consume CPU cycles during warm / fast reboot. There are  new CLIs to enable/disable it. The PR is to automatically enable it before syslog rate limit test and disable it after.

**Summary:**
In fixture "restore_rate_limit", enable the feature at beginning, disable the feature at the end.

**Type of change**

 [ ] Bug fix
 [ ] Testbed and Framework(new/improvement)
 [x] Test case(new/improvement)

**Back port request**

 [ ] 201911
 [ ] 202012
 [ ] 202205
 [x] 202305

**Approach**

In fixture "restore_rate_limit", enable the feature at beginning, disable the feature at the end.

**What is the motivation for this PR?**

Align test code with production code change

**How did you do it?**

In fixture "restore_rate_limit", enable the feature at beginning, disable the feature at the end.

**How did you verify/test it?**

Run test case on local setup, all passed

**Any platform specific information?**

N/A

**Supported testbed topology if it's a new test case?**

N/A

Documentation