### PR TITLE
Fix test_bgp_update_time by increasing threshold

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -226,7 +226,7 @@ def constants(is_quagga, setup_interfaces, has_suppress_feature, pytestconfig):
         if not has_suppress_feature:
             _constants.update_interval_threshold = 1
         else:
-            _constants.update_interval_threshold = 2
+            _constants.update_interval_threshold = 2.5
 
     conn0 = setup_interfaces[0]
     _constants.routes = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Increase the check threshold in test_bgp_update_time

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
The change is to increase the check threshold, because our tests randomly failed with measurements like 2.1 and the original value looks to be arbitrary set in https://github.com/sonic-net/sonic-mgmt/pull/7907

#### How did you do it?
Increase the threshold from 2 to 2.5

#### How did you verify/test it?
The test can reliably pass after the change

#### Any platform specific information?
Arista 7260

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
