### PR TITLE
adding watchdog timeout values for cisco hbm platform

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -155,3 +155,10 @@ x86_64-8111_32eh_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+# Cisco-Churchill-HBM watchdog
+x86_64-8201_32fh_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554


### PR DESCRIPTION


### Description of PR
adding watchdog timeout values for cisco hbm platform 

it is needed for test_arm_too_big_timeout under test_watchdog.py

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x ] 202305

### Approach
#### What is the motivation for this PR?
need timeout values for platform api test_watchdog.py::test_arm_too_big_timeout 
#### How did you do it?
Added the necessary timeout values
#### How did you verify/test it?
Test passed with these values


