### PR TITLE
crm/test_crm.py: Skip namespace check on single asic systems

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -946,7 +946,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
         portToLag = {}
         for lag, lagData in mg_facts["minigraph_portchannels"].items():
             # Check if Portchannel belongs to this namespace
-            if lagData['namespace'] != asichost.namespace:
+            if duthost.sonichost.is_multi_asic and lagData['namespace'] != asichost.namespace:
                 continue
             for member in lagData['members']:
                 portToLag[member] = lag


### PR DESCRIPTION
Fixes #10990 

The conditional added in https://github.com/sonic-net/sonic-mgmt/pull/10342 doesn't work on single-asic systems:
```
(Pdb) asichost.namespace
(Pdb) asichost
<SonicAsic 0>
(Pdb) lagData['namespace']
u''
```

Skip the check on single-asic systems

### Back port request
- [x] 202205
- [x] 202305
