### PR TITLE
Move public functions from `upgrade_image.py` to `common.py`.

### DIFF
--- a/.azure-pipelines/common.py
+++ b/.azure-pipelines/common.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import logging
+import json
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+base_path = os.path.realpath(os.path.join(_self_dir, ".."))
+if base_path not in sys.path:
+    sys.path.append(base_path)
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
+if ansible_path not in sys.path:
+    sys.path.append(ansible_path)
+
+from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory     # noqa E402
+
+logger = logging.getLogger(__name__)
+
+
+def get_pdu_managers(sonichosts, conn_graph_facts):
+    """Get PDU managers for all the devices to be upgraded.
+
+    Args:
+        sonichosts (SonicHosts): Instance of class SonicHosts
+        conn_graph_facts (dict): Connection graph dict.
+
+    Returns:
+        dict: A dict of PDU managers. Key is device hostname. Value is the PDU manager object for the device.
+    """
+    pdu_managers = {}
+    device_pdu_links = conn_graph_facts['device_pdu_links']
+    device_pdu_info = conn_graph_facts['device_pdu_info']
+    for hostname in sonichosts.hostnames:
+        pdu_links = device_pdu_links[hostname]
+        pdu_info = device_pdu_info[hostname]
+        pdu_vars = {}
+        for pdu_name in pdu_info.keys():
+            pdu_vars[pdu_name] = sonichosts.get_host_visible_vars(pdu_name)
+
+        pdu_managers[hostname] = pdu_manager_factory(hostname, pdu_links, pdu_info, pdu_vars)
+    return pdu_managers
+
+
+def check_reachability(localhost, sonichosts):
+    hosts_reachability = {}
+
+    logger.info("Check ICMP ping")
+    for hostname, ip in zip(sonichosts.hostnames, sonichosts.ips):
+        hosts_reachability[hostname] = True
+        logger.info("Ping {} @{} from localhost".format(hostname, ip))
+        ping_failed = localhost.command(
+            "timeout 2 ping {} -c 1".format(ip), module_ignore_errors=True
+        ).get("localhost", {}).get("failed")
+        if ping_failed:
+            logger.info("Ping {} @{} from localhost failed.".format(hostname, ip))
+            hosts_reachability[hostname] = False
+
+    logger.info("Check if ansible can SSH to sonichosts")
+    for hostname, ping_result in sonichosts.ping(module_ignore_errors=True).items():
+        if ping_result["failed"]:
+            logger.info("SSH to {} failed.".format(hostname))
+            hosts_reachability[hostname] = False
+
+    logger.info("Hosts reachability: {}".format(json.dumps(hosts_reachability, indent=2)))
+
+    return hosts_reachability

--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -11,13 +11,14 @@ image may has been updated by people for debugging purpose. Upgrade to a previou
 target image is clean.
 """
 import argparse
-import json
 import logging
 import os
 import requests
 import sys
 
 from setuptools import distutils
+from common import get_pdu_managers, check_reachability
+
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
@@ -31,7 +32,6 @@ if ansible_path not in sys.path:
 from devutil.devices.factory import init_localhost, init_testbed_sonichosts         # noqa E402
 from devutil.devices.sonic import upgrade_image                                     # noqa E402
 
-from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory     # noqa E402
 
 logger = logging.getLogger(__name__)
 
@@ -76,55 +76,6 @@ def validate_args(args):
             )
         )
         args.skip_prev_image = True
-
-
-def get_pdu_managers(sonichosts, conn_graph_facts):
-    """Get PDU managers for all the devices to be upgraded.
-
-    Args:
-        sonichosts (SonicHosts): Instance of class SonicHosts
-        conn_graph_facts (dict): Connection graph dict.
-
-    Returns:
-        dict: A dict of PDU managers. Key is device hostname. Value is the PDU manager object for the device.
-    """
-    pdu_managers = {}
-    device_pdu_links = conn_graph_facts['device_pdu_links']
-    device_pdu_info = conn_graph_facts['device_pdu_info']
-    for hostname in sonichosts.hostnames:
-        pdu_links = device_pdu_links[hostname]
-        pdu_info = device_pdu_info[hostname]
-        pdu_vars = {}
-        for pdu_name in pdu_info.keys():
-            pdu_vars[pdu_name] = sonichosts.get_host_visible_vars(pdu_name)
-
-        pdu_managers[hostname] = pdu_manager_factory(hostname, pdu_links, pdu_info, pdu_vars)
-    return pdu_managers
-
-
-def check_reachability(localhost, sonichosts):
-    hosts_reachability = {}
-
-    logger.info("Check ICMP ping")
-    for hostname, ip in zip(sonichosts.hostnames, sonichosts.ips):
-        hosts_reachability[hostname] = True
-        logger.info("Ping {} @{} from localhost".format(hostname, ip))
-        ping_failed = localhost.command(
-            "timeout 2 ping {} -c 1".format(ip), module_ignore_errors=True
-        ).get("localhost", {}).get("failed")
-        if ping_failed:
-            logger.info("Ping {} @{} from localhost failed.".format(hostname, ip))
-            hosts_reachability[hostname] = False
-
-    logger.info("Check if ansible can SSH to sonichosts")
-    for hostname, ping_result in sonichosts.ping(module_ignore_errors=True).items():
-        if ping_result["failed"]:
-            logger.info("SSH to {} failed.".format(hostname))
-            hosts_reachability[hostname] = False
-
-    logger.info("Hosts reachability: {}".format(json.dumps(hosts_reachability, indent=2)))
-
-    return hosts_reachability
 
 
 def main(args):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There are some public functions in script `.azure-pipelines/upgrade_image.py`, which will be used by other scripts. In this PR, I move these functions to common file, thus others can share these functions. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
There are some public functions in script `.azure-pipelines/upgrade_image.py`, which will be used by other scripts. In this PR, I move these functions to common file, thus others can share these functions. 

#### How did you do it?
I move some public functions to common file, thus others can share these functions. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
