### PR TITLE
[bgp] Skip bgp slb fast reboot test on dualtor

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -5,6 +5,7 @@ from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.dualtor.mux_simulator_control import \
     toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa F401
 from tests.common.utilities import wait_until, delete_running_config
+from tests.common.helpers.assertions import pytest_require
 
 
 pytestmark = [
@@ -17,7 +18,11 @@ NEIGHBOR_EXABGP_PORT = 11000
 
 
 @pytest.fixture(params=["warm", "fast"])
-def reboot_type(request):
+def reboot_type(request, tbinfo):
+    pytest_require(
+        not (request.param == "fast" and "dualtor" in tbinfo["topo"]["name"]),
+        "Skip fast reboot test on dualtor topology"
+    )
     return request.param
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Dualtor doesn't support the fast reboot, let's skip it on the dualtor testbeds.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[warm-str-xxxx-acs-12-default] PASSED [ 50%]
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[fast-str-xxxx-acs-12-default] SKIPPED [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
