### PR TITLE
[202205][dualtor] fixing test_downstream_ecmp_nexthops

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -968,6 +968,9 @@ def count_matched_packets_all_ports(ptfadapter, exp_packet, exp_tunnel_pkt, port
     return port_packet_count
 
 
+# behavior has changed with such that ecmp groups that span across multiple
+# mux interfaces are not balanced. Instead we expect packets to be sent to
+# a single mux interface.
 def check_nexthops_balance(rand_selected_dut,
     ptfadapter,
     dst_server_addr,
@@ -1038,6 +1041,57 @@ def check_nexthops_balance(rand_selected_dut,
                 balance = False
                 pt_assert(balance, "Hierarchical ECMP failed: packets not evenly distributed on portchannel {}".format(
                     pc))
+
+
+def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num):
+    for pc, intfs in portchannel_ports.items():
+        count = 0
+        # Collect the packets count within a single portchannel
+        for member in intfs:
+            uplink_int = int(member.strip("eth"))
+            count = count + port_packet_count.get(uplink_int, 0)
+        logging.info("Packets received on portchannel {}: {}".format(pc, count))
+
+        if count > 0 and count != expect_packet_num:
+            pytest.fail("Packets not sent up single standby port {}".format(pc))
+
+
+# verify nexthops are only sent to single active or standby mux
+def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
+                                   tbinfo, downlink_ints):
+    HASH_KEYS = ["src-port", "dst-port", "src-ip"]
+    expect_packet_num = 10000
+
+    # expect this packet to be sent to downlinks (active mux) and uplink (stanby mux)
+    expected_downlink_ports = [get_ptf_server_intf_index(rand_selected_dut, tbinfo, iface) for iface in downlink_ints]
+    portchannel_ports = get_t1_ptf_pc_ports(rand_selected_dut, tbinfo)
+    logging.info("Expecting packets in downlink ports {}".format(expected_downlink_ports))
+
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(rand_selected_dut, tbinfo))
+    port_packet_count = dict()
+    packets_to_send = generate_hashed_packet_to_server(ptfadapter, rand_selected_dut, HASH_KEYS, dst_server_addr, 10000)
+    for send_packet, exp_pkt, exp_tunnel_pkt in packets_to_send:
+        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), send_packet, count=1)
+        # expect multi-mux nexthops to focus packets to one downlink
+        all_allowed_ports = expected_downlink_ports
+        ptf_port_count = count_matched_packets_all_ports(ptfadapter, exp_packet=exp_pkt, exp_tunnel_pkt=exp_tunnel_pkt,
+                                                         ports=all_allowed_ports, timeout=0.1, count=1)
+
+        for ptf_idx, pkt_count in ptf_port_count.items():
+            port_packet_count[ptf_idx] = port_packet_count.get(ptf_idx, 0) + pkt_count
+
+    logging.info("Received packets in ports: {}".format(str(port_packet_count)))
+    for downlink_int in expected_downlink_ports:
+        # packets should be either 0 or expect_packet_num:
+        count = port_packet_count.get(downlink_int, 0)
+        logging.info("Packets received on downlink port {}: {}".format(downlink_int, count))
+        if count > 0 and count != expect_packet_num:
+            pytest.fail("Packets not sent down single active port {}".format(downlink_int))
+
+    if len(downlink_ints) == 0:
+        # All nexthops are now connected to standby mux, and the packets will be sent towards a single portchanel int
+        # Check if uplink distribution is towards a single portchannel
+        check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num)
 
 
 def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num = 100, drop = False):

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -166,7 +166,7 @@ def test_downstream_ecmp_nexthops(
                                        tbinfo, nexthop_interfaces)
 
         ### Sequentially set four mux states to standby
-        nexthop_interfaces_copy = nexthop_interfaces.copy()
+        nexthop_interfaces_copy = list(interface_to_server.keys())
         for index, interface in enumerate(nexthop_interfaces):
             logging.info("Simulate {} mux state change to Standby".format(nexthop_servers[index]))
             set_mux_state(rand_selected_dut, tbinfo, 'standby', [interface], toggle_all_simulator_ports)

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -12,9 +12,10 @@ from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import get_interface_server_map
-from tests.common.dualtor.dual_tor_utils import check_nexthops_balance
+from tests.common.dualtor.dual_tor_utils import check_nexthops_single_downlink
 from tests.common.dualtor.dual_tor_utils import add_nexthop_routes, remove_static_routes
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports
+from tests.common.dualtor.dual_tor_mock import set_mux_state
 from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
@@ -160,29 +161,28 @@ def test_downstream_ecmp_nexthops(
     add_nexthop_routes(rand_selected_dut, dst_server_addr, nexthops=nexthop_servers)
 
     try:
-        logging.info("Verify traffic to this route destination is distributed to four server ports")
-        check_nexthops_balance(rand_selected_dut, ptfadapter, dst_server_addr, tbinfo,
-            nexthop_interfaces, nexthops_count)
+        logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
+        check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
+                                       tbinfo, nexthop_interfaces)
 
         ### Sequentially set four mux states to standby
+        nexthop_interfaces_copy = nexthop_interfaces.copy()
         for index, interface in enumerate(nexthop_interfaces):
-            uplink_ports_active = index + 1
             logging.info("Simulate {} mux state change to Standby".format(nexthop_servers[index]))
             set_mux_state(rand_selected_dut, tbinfo, 'standby', [interface], toggle_all_simulator_ports)
-            logging.info("Verify traffic to this route destination is distributed to"\
-                " {} server ports and {} tunnel nexthop".format(
-                    nexthops_count-uplink_ports_active, uplink_ports_active))
-            check_nexthops_balance(rand_selected_dut, ptfadapter, dst_server_addr, tbinfo,
-                nexthop_interfaces[uplink_ports_active:nexthops_count], nexthops_count)
+            nexthop_interfaces_copy.remove(interface)
+            logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
+            check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
+                                           tbinfo, nexthop_interfaces_copy)
 
         ### Revert two mux states to active
         for index, interface in reversed(list(enumerate(nexthop_interfaces))):
             logging.info("Simulate {} mux state change back to Active".format(nexthop_servers[index]))
             set_mux_state(rand_selected_dut, tbinfo, 'active', [interface], toggle_all_simulator_ports)
-            logging.info("Verify traffic to this route destination is distributed to"\
-                " {} server ports and {} tunnel nexthop".format(nexthops_count-index, index))
-            check_nexthops_balance(rand_selected_dut, ptfadapter, dst_server_addr, tbinfo,
-                nexthop_interfaces[index:nexthops_count], nexthops_count)
+            nexthop_interfaces_copy.append(interface)
+            logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
+            check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
+                                           tbinfo, nexthop_interfaces_copy)
     finally:
         ### Remove the nexthop route
         remove_static_routes(rand_selected_dut, dst_server_addr)


### PR DESCRIPTION
What I did:
changed test_downstream_ecmp_nexthops to check if packets being sent are funneled towards a single mux neighbor or portchannel

Why I did it:
test_downstream_ecmp_nexthops fails due to swss change which programs a single active mux nexthop or a single tunnel route for a given route

How to test:
run sonic-mgmt dualtor/test_orchagent_active_tor_downstream.py test on t0 topo.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
