### PR TITLE
QoSHdrmPoolsize _tx_disable_enable for all destination ports in lag

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2697,7 +2697,6 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.src_dst.update({self.src_port_ids[i]: dst_port})
             self.uniq_dst_ports = list(set(dst_port_ids))
 
-
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
 
@@ -2713,7 +2712,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
                                  [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
             rx_curr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][srcPortId])
-            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
+                                 [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             for dstPortIdx, dstPortId in enumerate(self.uniq_dst_ports):
                 port_cnt_tbl.add_row(['base dst_port{}_id{}'.format(dstPortIdx, dstPortId)] +
@@ -2722,9 +2722,11 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 port_cnt_tbl.add_row(['     dst_port{}_id{}'.format(dstPortIdx, dstPortId)] +
                                      [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         else:
-            port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] +
+                                 [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
             tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
-            port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] +
+                                 [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
     def runTest(self):
@@ -2746,9 +2748,11 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             0] for sid in self.src_port_ids]
         if self.platform_asic and self.platform_asic == "broadcom-dnx":
             xmit_counters_bases = [sai_thrift_read_port_counters(self.dst_client, self.asic_type,
-                                                                 port_list['dst'][did])[0] for did in self.uniq_dst_ports]
+                                                                 port_list['dst'][did])[0]
+                                   for did in self.uniq_dst_ports]
         else:
-            xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
+            xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client,
+                                                                  self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
@@ -2822,7 +2826,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
                                            'To fill service pool, send {} pkt with DSCP {} PG {} from'
                                            ' src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
-                                           sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
+                                                                            sidx_dscp_pg_tuples[i][2],
+                                                                            sidx_dscp_pg_tuples[i][0]))
 
             print("Service pool almost filled", file=sys.stderr)
             sys.stderr.flush()
@@ -2874,7 +2879,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 if pkt_cnt == 10:
                     if self.platform_asic and self.platform_asic == "broadcom-dnx":
                         self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, self.uniq_dst_ports)
-                    sys.exit("Too many pkts needed to trigger pfc: %d" %(pkt_cnt))
+                    sys.exit("Too many pkts needed to trigger pfc: %d" % (pkt_cnt))
                 assert(recv_counters[sidx_dscp_pg_tuples[i][2]] >
                        recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (
@@ -2957,12 +2962,13 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             if self.platform_asic and self.platform_asic == "broadcom-dnx":
                 time.sleep(8)
                 for i in range(0, self.pgs_num):
-                    pkt_cnt = self.pkts_num_hdrm_full // self.pkt_size_factor if i != self.pgs_num - 1 else self.pkts_num_hdrm_partial // self.pkt_size_factor
+                    pkt_cnt = self.pkts_num_hdrm_full // self.pkt_size_factor if i != self.pgs_num - 1 \
+                        else self.pkts_num_hdrm_partial // self.pkt_size_factor
                     self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
-                                       'To fill headroom pool, send {} pkt with DSCP {} PG {} from'
-                                       ' src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
-                                                                        sidx_dscp_pg_tuples[i][2],
-                                                                        sidx_dscp_pg_tuples[i][0]))
+                                           'To fill headroom pool, send {} pkt with DSCP {} PG {} from'
+                                           ' src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
+                                                                            sidx_dscp_pg_tuples[i][2],
+                                                                            sidx_dscp_pg_tuples[i][0]))
             print("all but the last pg hdrms filled", file=sys.stderr)
             sys.stderr.flush()
 
@@ -2983,7 +2989,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                                                                              sidx_dscp_pg_tuples[i][0]))
             else:
                 self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
-                'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
+                                       'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {}'
+                                       ' from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
+                                                                             sidx_dscp_pg_tuples[i][2],
+                                                                             sidx_dscp_pg_tuples[i][0]))
 
             recv_counters, _ = sai_thrift_read_port_counters(
                 self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
@@ -2996,8 +3005,8 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             # assert no egress drop at the dut xmit port
             if self.platform_asic != "broadcom-dnx":
-                xmit_counters, _ = sai_thrift_read_port_counters(
-                self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
+                xmit_counters, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                 port_list['dst'][self.dst_port_id])
 
             if self.platform_asic and self.platform_asic == "broadcom-dnx":
                 logging.info("On J2C+ don't support port level drop counters - so ignoring this step for now")
@@ -3028,6 +3037,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, self.uniq_dst_ports)
             else:
                 self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
+
 
 class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2592,6 +2592,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.pgs = [pg + 2 for pg in self.test_params['pgs']]
         self.src_port_ids = self.test_params['src_port_ids']
         self.src_port_ips = self.test_params['src_port_ips']
+        self.platform_asic = self.test_params['platform_asic']
         print(self.src_port_ips, file=sys.stderr)
         sys.stderr.flush()
         # get counter names to query
@@ -2684,6 +2685,18 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         def_vlan_mac = self.test_params.get('def_vlan_mac', None)
         if is_dualtor and def_vlan_mac is not None:
             self.dst_port_mac = def_vlan_mac
+        self.pkt_dst_mac = self.router_mac if self.router_mac != '' else self.dst_port_mac
+        # Collect destination ports that may be in a lag
+        if self.platform_asic and self.platform_asic == "broadcom-dnx":
+            dst_port_ids = []
+            self.src_dst = {}
+            for i in range(len(self.src_port_ids)):
+                dst_port = get_rx_port(self, 0, self.src_port_ids[i], self.pkt_dst_mac,
+                                       self.dst_port_ip, self.src_port_ips[i])
+                dst_port_ids.append(dst_port)
+                self.src_dst.update({self.src_port_ids[i]: dst_port})
+            self.uniq_dst_ports = list(set(dst_port_ids))
+
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -2700,17 +2713,23 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             port_cnt_tbl.add_row(['base src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
                                  [rx_base[srcPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
             rx_curr, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][srcPortId])
-            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] +
-                                 [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
-        port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx]
-                                                                                for fieldIdx in port_counter_indexes])
-        tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
-        port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx]
-                                                                                for fieldIdx in port_counter_indexes])
+            port_cnt_tbl.add_row(['     src_port{}_id{}'.format(srcPortIdx, srcPortId)] + [rx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+        if self.platform_asic and self.platform_asic == "broadcom-dnx":
+            for dstPortIdx, dstPortId in enumerate(self.uniq_dst_ports):
+                port_cnt_tbl.add_row(['base dst_port{}_id{}'.format(dstPortIdx, dstPortId)] +
+                                     [tx_base[dstPortIdx][fieldIdx] for fieldIdx in port_counter_indexes])
+                tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dstPortId])
+                port_cnt_tbl.add_row(['     dst_port{}_id{}'.format(dstPortIdx, dstPortId)] +
+                                     [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
+        else:
+            port_cnt_tbl.add_row(['base dst_port_id{}'.format(self.dst_port_id)] + [tx_base[fieldIdx] for fieldIdx in port_counter_indexes])
+            tx_curr, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][self.dst_port_id])
+            port_cnt_tbl.add_row(['     dst_port_id{}'.format(self.dst_port_id)] + [tx_curr[fieldIdx] for fieldIdx in port_counter_indexes])
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
     def runTest(self):
-        platform_asic = self.test_params['platform_asic']
+        asic_type = self.test_params['sonic_asic_type']
+        hwsku = self.test_params['hwsku']
 
         margin = self.test_params.get('margin')
         if not margin:
@@ -2720,28 +2739,27 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         assert (len(sidx_dscp_pg_tuples) >= self.pgs_num)
         print(sidx_dscp_pg_tuples, file=sys.stderr)
         sys.stderr.flush()
-        # Collect destination ports that may be in a lag
-        pkt_dst_mac = self.router_mac if self.router_mac != '' else self.dst_port_mac
-        dst_port_ids = []
-        for i in range(len(self.src_port_ids)):
-            dst_port_ids.append(get_rx_port(self, 0, self.src_port_ids[i], pkt_dst_mac,
-                                            self.dst_port_ip, self.src_port_ips[i]))
 
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
             0] for sid in self.src_port_ids]
-        xmit_counters_base, _ = sai_thrift_read_port_counters(
-            self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
+        if self.platform_asic and self.platform_asic == "broadcom-dnx":
+            xmit_counters_bases = [sai_thrift_read_port_counters(self.dst_client, self.asic_type,
+                                                                 port_list['dst'][did])[0] for did in self.uniq_dst_ports]
+        else:
+            xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
 
         # Pause egress of dut xmit port
-        # Disable all dst ports
-        uniq_dst_ports = list(set(dst_port_ids))
-        self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, uniq_dst_ports)
+        if self.platform_asic and self.platform_asic == "broadcom-dnx":
+            # Disable all dst ports
+            self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, self.uniq_dst_ports)
+        else:
+            self.sai_thrift_port_tx_disable(self.dst_client, self.asic_type, [self.dst_port_id])
 
         try:
             # send packets to leak out
@@ -2785,14 +2803,14 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkt_cnt = pkts_num_trig_pfc // self.pkt_size_factor
                 send_packet(
                     self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, int(pkt_cnt))
-                if platform_asic != "broadcom-dnx":
+                if self.platform_asic != "broadcom-dnx":
                     time.sleep(8)  # wait pfc counter refresh and show the counters
                     self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
                                            'To fill service pool, send {} pkt with DSCP {} PG {} from src_port{}'
                                            ' to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
                                                                  sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
-            if platform_asic and platform_asic == "broadcom-dnx":
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
                 time.sleep(8)  # wait pfc counter refresh and show the counters
                 for i in range(0, self.pgs_num):
                     if self.pkts_num_trig_pfc:
@@ -2801,10 +2819,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                         pkts_num_trig_pfc = self.pkts_num_trig_pfc_shp[i]
 
                     pkt_cnt = pkts_num_trig_pfc // self.pkt_size_factor
-                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
-                                           'To fill service pool, send {} pkt with DSCP {} PG {} from src_port{}'
-                                           ' to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
-                                                                 sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
+                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
+                                           'To fill service pool, send {} pkt with DSCP {} PG {} from'
+                                           ' src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
+                                           sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
             print("Service pool almost filled", file=sys.stderr)
             sys.stderr.flush()
@@ -2841,16 +2859,22 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     recv_counters, _ = sai_thrift_read_port_counters(
                         self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
 
-                if platform_asic != "broadcom-dnx":
+                if self.platform_asic != "broadcom-dnx":
                     time.sleep(8)   # wait pfc counter refresh
-                self.show_port_counter(
-                    self.asic_type, recv_counters_bases, xmit_counters_base,
-                    'To trigger PFC, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'
-                    .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
+                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
+                                           'To trigger PFC, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'
+                                           .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2],
+                                                   sidx_dscp_pg_tuples[i][0]))
+                if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
+                                           'To trigger PFC, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'
+                                           .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2],
+                                                   sidx_dscp_pg_tuples[i][0]))
 
                 if pkt_cnt == 10:
-                    self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, uniq_dst_ports)
-                    sys.exit("Too many pkts needed to trigger pfc: %d" % (pkt_cnt))
+                    if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                        self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, self.uniq_dst_ports)
+                    sys.exit("Too many pkts needed to trigger pfc: %d" %(pkt_cnt))
                 assert(recv_counters[sidx_dscp_pg_tuples[i][2]] >
                        recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (
@@ -2893,22 +2917,12 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(
                     self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, pkt_cnt)
                 # allow enough time for the dut to sync up the counter values in counters_db
-                if platform_asic != "broadcom-dnx":
+                if self.platform_asic != "broadcom-dnx":
                     time.sleep(8)
                     self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
                                            'To fill headroom pool, send {} pkt with DSCP {} PG {} from src_port{} '
                                            'to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
                                                                 sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
-
-            if platform_asic and platform_asic == "broadcom-dnx":
-                time.sleep(8)
-                for i in range(0, self.pgs_num):
-                    pkt_cnt = self.pkts_num_hdrm_full // self.pkt_size_factor if i != self.pgs_num - 1 \
-                        else self.pkts_num_hdrm_partial // self.pkt_size_factor
-                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
-                                           'To fill headroom pool, send {} pkt with DSCP {} PG {} from src_port{}'
-                                           ' to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
-                                                                 sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
                 recv_counters, _ = sai_thrift_read_port_counters(
                     self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
@@ -2938,9 +2952,17 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                     print("pkts sent: %d, lower bound: %d, actual headroom pool watermark: %d, upper_bound: %d" % (
                         wm_pkt_num, expected_wm, hdrm_pool_wm, upper_bound_wm), file=sys.stderr)
                     if 'innovium' not in self.asic_type:
-                        assert (expected_wm <= hdrm_pool_wm)
-                    assert (hdrm_pool_wm <= upper_bound_wm)
-
+                        assert(expected_wm <= hdrm_pool_wm)
+                    assert(hdrm_pool_wm <= upper_bound_wm)
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                time.sleep(8)
+                for i in range(0, self.pgs_num):
+                    pkt_cnt = self.pkts_num_hdrm_full // self.pkt_size_factor if i != self.pgs_num - 1 else self.pkts_num_hdrm_partial // self.pkt_size_factor
+                    self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
+                                       'To fill headroom pool, send {} pkt with DSCP {} PG {} from'
+                                       ' src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
+                                                                        sidx_dscp_pg_tuples[i][2],
+                                                                        sidx_dscp_pg_tuples[i][0]))
             print("all but the last pg hdrms filled", file=sys.stderr)
             sys.stderr.flush()
 
@@ -2953,28 +2975,32 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
 
-            self.show_port_counter(
-                self.asic_type, recv_counters_bases, xmit_counters_base,
-                'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'
-                .format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
+                                       'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {}'
+                                       ' from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
+                                                                             sidx_dscp_pg_tuples[i][2],
+                                                                             sidx_dscp_pg_tuples[i][0]))
+            else:
+                self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_base,
+                'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {} from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1], sidx_dscp_pg_tuples[i][2], sidx_dscp_pg_tuples[i][0]))
 
             recv_counters, _ = sai_thrift_read_port_counters(
                 self.src_client, self.asic_type, port_list['src'][self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
-            if platform_asic and platform_asic == "broadcom-dnx":
-                logging.info(
-                    "On J2C+ don't support port level drop counters - so ignoring this step for now")
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                logging.info("On J2C+ don't support port level drop counters - so ignoring this step for now")
             else:
                 # assert ingress drop
                 for cntr in self.ingress_counters:
                     assert(recv_counters[cntr] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr])
 
             # assert no egress drop at the dut xmit port
-            xmit_counters, _ = sai_thrift_read_port_counters(
+            if self.platform_asic != "broadcom-dnx":
+                xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, self.asic_type, port_list['dst'][self.dst_port_id])
 
-            if platform_asic and platform_asic == "broadcom-dnx":
-                logging.info(
-                    "On J2C+ don't support port level drop counters - so ignoring this step for now")
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                logging.info("On J2C+ don't support port level drop counters - so ignoring this step for now")
             else:
                 for cntr in self.egress_counters:
                     assert (xmit_counters[cntr] == xmit_counters_base[cntr])
@@ -2998,8 +3024,10 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             sys.stderr.flush()
 
         finally:
-            self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, uniq_dst_ports)
-
+            if self.platform_asic and self.platform_asic == "broadcom-dnx":
+                self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, self.uniq_dst_ports)
+            else:
+                self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, [self.dst_port_id])
 
 class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2727,7 +2727,6 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             dst_port_ids.append(get_rx_port(self, 0, self.src_port_ids[i], pkt_dst_mac,
                                             self.dst_port_ip, self.src_port_ips[i]))
 
-
         # get a snapshot of counter values at recv and transmit ports
         # queue_counters value is not of our interest here
         recv_counters_bases = [sai_thrift_read_port_counters(self.src_client, self.asic_type, port_list['src'][sid])[
@@ -2851,7 +2850,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
                 if pkt_cnt == 10:
                     self.sai_thrift_port_tx_enable(self.dst_client, self.asic_type, uniq_dst_ports)
-                    sys.exit("Too many pkts needed to trigger pfc: %d" %(pkt_cnt))
+                    sys.exit("Too many pkts needed to trigger pfc: %d" % (pkt_cnt))
                 assert(recv_counters[sidx_dscp_pg_tuples[i][2]] >
                        recv_counters_bases[sidx_dscp_pg_tuples[i][0]][sidx_dscp_pg_tuples[i][2]])
                 print("%d packets for sid: %d, pg: %d to trigger pfc" % (

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2730,9 +2730,6 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         sys.stderr.write('{}\n{}\n'.format(banner, port_cnt_tbl))
 
     def runTest(self):
-        asic_type = self.test_params['sonic_asic_type']
-        hwsku = self.test_params['hwsku']
-
         margin = self.test_params.get('margin')
         if not margin:
             margin = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Since testQosHeadroomPoolsize test takes more than one source port as input, even after tx disable, the packets could still hash from the other ports. Hence tx_disable has to be applied on all ports in the destination lag to block all the traffic during tx_disable.   
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305

### Approach
Since testQosHeadroomPoolsize test takes more than one source port as input, even after tx disable, the packets could still hash from the other ports. Hence tx_disable has to be applied on all ports in the destination lag to block all the traffic during tx_disable.  
This was achieved by
-Collecting all the dst_port_ids ports associated with the  src_port_ids
-Sending all the dst_port_ids  in a list, instead of sending a single dst_port_id  in tx_disable

#### What is the motivation for this PR?
Intermitted failure of testQosHdrmPoolsize test 

#### How did you do it?
Executed Qos test suite and verify the results 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
