### PR TITLE
[Override config table] exclude supervisor from override config tests

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -33,19 +33,19 @@ def check_image_version(duthost):
 
 
 @pytest.fixture(scope="module")
-def golden_config_exists_on_dut(duthosts, enum_rand_one_per_hwsku_hostname):
-    return file_exists_on_dut(duthosts[enum_rand_one_per_hwsku_hostname], GOLDEN_CONFIG)
+def golden_config_exists_on_dut(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    return file_exists_on_dut(duthosts[enum_rand_one_per_hwsku_frontend_hostname], GOLDEN_CONFIG)
 
 
 @pytest.fixture(scope="module")
-def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_hwsku_hostname):
+def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Setup/teardown
     Args:
         duthost: DUT.
         golden_config_exists_on_dut: Check if golden config exists on DUT.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     topo_type = tbinfo["topo"]["type"]
     if topo_type in ["m0", "mx"]:
         original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "disable")

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -169,10 +169,10 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
 
 
 def test_load_minigraph_with_golden_config(duthosts, setup_env,
-                                           enum_rand_one_per_hwsku_hostname):
+                                           enum_rand_one_per_hwsku_frontend_hostname):
     """Test Golden Config override during load minigraph
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     if duthost.is_multi_asic:
         pytest.skip("Skip override-config-table testing on multi-asic platforms,\
                     test provided golden config format is not compatible with multi-asics")

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -223,13 +223,13 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
 
 
 def test_load_minigraph_with_golden_config(duthosts, setup_env,
-                                           enum_rand_one_per_hwsku_hostname):
+                                           enum_rand_one_per_hwsku_frontend_hostname):
     """
     Test Golden Config override during load minigraph
     Note: Skip full config override for multi-asic duts for now, because we
     don't have CLI to get new golden config that contains 'localhost' and 'asicxx'
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     if not duthost.is_multi_asic:
         pytest.skip("Skip override-config-table multi-asic testing on single-asic platforms,\
                     test provided golden config format is not compatible with single-asics")

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -37,13 +37,13 @@ def check_image_version(duthost):
 
 
 @pytest.fixture(scope="module")
-def setup_env(duthosts, tbinfo, enum_rand_one_per_hwsku_hostname):
+def setup_env(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Setup/teardown
     Args:
         duthost: DUT.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     topo_type = tbinfo["topo"]["type"]
     if topo_type in ["m0", "mx"]:
         original_pfcwd_value = update_pfcwd_default_state(duthost, "/etc/sonic/init_cfg.json", "disable")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

SUP fail at that time after config reload when check for pfcwd here:            
[` pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, sonic_host),`](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/config_reload.py#L147)

This check_for_pfc_wd always return false because 
https://github.com/sonic-net/sonic-mgmt/blob/ef2836ff720a51b5d97611bfb5eed47b40d3c465/tests/configlet/util/common.py#L186 
here SUP has no frontend asics(all fabric)

This PR use fixture `enum_rand_one_per_hwsku_frontend_hostname` which ensure the random dut from chassis is not supervisor.
https://github.com/sonic-net/sonic-mgmt/blob/ef2836ff720a51b5d97611bfb5eed47b40d3c465/tests/common/helpers/dut_utils.py#L30

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/11010

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
