### PR TITLE
Modify DUT vtysh commands with right dut asic-index

### DIFF
--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -107,8 +107,9 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
 
 
 def test_bgp_peer_group_password(setup):
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
-        -c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['peer_group_v4'], bgp_pass,
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
+        -c "end"'.format(setup['dut_asn'], setup['peer_group_v4'], bgp_pass,
                          setup['peer_group_v6'], bgp_pass)
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
 
@@ -128,8 +129,9 @@ def test_bgp_peer_group_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] != 'established'
 
     # set password on neighbor
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}"' \
-        .format(setup['neigh_asic_index'], setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
+    ns = '-n ' + str(setup['neigh_asic_index']) if setup['neigh_asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config"  -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}"' \
+        .format(setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
                 bgp_pass)
     logger.debug(setup['neighhost'].shell(cmd, module_ignore_errors=True))
     logger.debug(setup['neighhost'].shell("show run bgp"))
@@ -144,8 +146,9 @@ def test_bgp_peer_group_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] == 'established'
 
     # mismatch peer group passwords
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
-          -c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
+          -c "end"'.format(setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
                            setup['peer_group_v6'], mismatch_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
@@ -166,9 +169,10 @@ def test_bgp_peer_group_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] != 'established'
 
     # turn off peer group passwords on DUT
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c "no neighbor {} password {}"'\
-        '-c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
-                          setup['peer_group_v6'], mismatch_pass)
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "no neighbor {} password {}" \
+          -c "no neighbor {} password {}" -c "end"'.format(setup['dut_asn'], setup['peer_group_v4'],
+                                                           mismatch_pass, setup['peer_group_v6'], mismatch_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
 
@@ -179,9 +183,10 @@ def test_bgp_peer_group_password(setup):
     logger.debug(setup['duthost'].shell('show run bgp'))
 
     # remove passwords from neighbor
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c "no neighbor {} password {}"'\
-          .format(setup['neigh_asic_index'], setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
-                  bgp_pass)
+    ns = '-n ' + str(setup['neigh_asic_index']) if setup['neigh_asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "no neighbor {} password {}" \
+                            -c "no neighbor {} password {}"'.format(setup['neigh_asn'], setup['dut_ip_v4'],
+                                                                    bgp_pass, setup['dut_ip_v6'], bgp_pass)
     logger.debug(setup['neighhost'].shell(cmd, module_ignore_errors=True))
     logger.debug(setup['neighhost'].shell("show run bgp"))
 
@@ -194,9 +199,9 @@ def test_bgp_peer_group_password(setup):
 
 
 def test_bgp_neighbor_password(setup):
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
-        -c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['neigh_ip_v4'], bgp_pass,
-                         setup['neigh_ip_v6'], bgp_pass)
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
+        -c "end"'.format(setup['dut_asn'], setup['neigh_ip_v4'], bgp_pass, setup['neigh_ip_v6'], bgp_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
 
@@ -218,8 +223,9 @@ def test_bgp_neighbor_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] != 'established'
 
     # configure password on neighbor
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}"' \
-          .format(setup['neigh_asic_index'], setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
+    ns = '-n ' + str(setup['neigh_asic_index']) if setup['neigh_asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}"' \
+          .format(setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
                   bgp_pass)
     logger.debug(setup['neighhost'].shell(cmd, module_ignore_errors=True))
     logger.debug(setup['neighhost'].shell("show run bgp"))
@@ -232,9 +238,9 @@ def test_bgp_neighbor_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] == 'established'
 
     # mismatch passwords
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
-        -c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['neigh_ip_v4'], mismatch_pass,
-                         setup['neigh_ip_v6'], mismatch_pass)
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
+        -c "end"'.format(setup['dut_asn'], setup['neigh_ip_v4'], mismatch_pass, setup['neigh_ip_v6'], mismatch_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
 
@@ -254,8 +260,9 @@ def test_bgp_neighbor_password(setup):
     assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v6']]['state'] != 'established'
 
     # remove password configs
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c \
-        "no neighbor {} password {}" -c "end"'.format(setup['asic_index'], setup['dut_asn'],
+    ns = '-n ' + str(setup['asic_index']) if setup['asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c \
+        "no neighbor {} password {}" -c "end"'.format(setup['dut_asn'],
                                                       setup['neigh_ip_v4'], mismatch_pass, setup['neigh_ip_v6'],
                                                       mismatch_pass)
 
@@ -265,9 +272,10 @@ def test_bgp_neighbor_password(setup):
         logger.error("Error configuring BGP password")
         return False
 
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c "no neighbor {} password {}"'\
-          .format(setup['neigh_asic_index'], setup['neigh_asn'], setup['dut_ip_v4'], bgp_pass, setup['dut_ip_v6'],
-                  bgp_pass)
+    ns = '-n ' + str(setup['neigh_asic_index']) if setup['neigh_asic_index'] is not None else ''
+    cmd = 'vtysh ' + ns + ' -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c "no neighbor {} ' \
+                          'password {}"'.format(setup['neigh_asn'], setup['dut_ip_v4'],
+                                                bgp_pass, setup['dut_ip_v6'], bgp_pass)
     logger.debug(setup['neighhost'].shell(cmd, module_ignore_errors=True))
 
     time.sleep(bgp_config_sleeptime)

--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -145,7 +145,7 @@ def test_bgp_peer_group_password(setup):
 
     # mismatch peer group passwords
     cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}" -c "neighbor {} password {}" \
-          -c "end"'.format(setup['neigh_asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
+          -c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
                            setup['peer_group_v6'], mismatch_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
@@ -167,7 +167,7 @@ def test_bgp_peer_group_password(setup):
 
     # turn off peer group passwords on DUT
     cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c "no neighbor {} password {}"'\
-        '-c "end"'.format(setup['neigh_asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
+        '-c "end"'.format(setup['asic_index'], setup['dut_asn'], setup['peer_group_v4'], mismatch_pass,
                           setup['peer_group_v6'], mismatch_pass)
 
     command_output = setup['duthost'].shell(cmd, module_ignore_errors=True)
@@ -255,7 +255,7 @@ def test_bgp_neighbor_password(setup):
 
     # remove password configs
     cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "no neighbor {} password {}" -c \
-        "no neighbor {} password {}" -c "end"'.format(setup['neigh_asic_index'], setup['dut_asn'],
+        "no neighbor {} password {}" -c "end"'.format(setup['asic_index'], setup['dut_asn'],
                                                       setup['neigh_ip_v4'], mismatch_pass, setup['neigh_ip_v6'],
                                                       mismatch_pass)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- The 'test_bgp_authentication' tests fail with the following errors, when the test runs 'vtysh' command on t2 DUT.

      >       assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v4']]['state'] != 'established'
      E       AssertionError

        cmd        = 'vtysh -n None -c "config" -c "router bgp 65100" -c "neighbor PEER_V4 password badpassword" -c "neighbor PEER_V6 password badpassword"           -c "end"'
        command_output = {'stderr_lines': [u'/usr/bin/vtysh: line 23: [: None: integer expression expec...: [], u'start': u'2023-12-09 09:40:16.664728', u'msg': u'non-zero return code'}
- This PR fixes issue the above issue for 'test_bgp_authentication' test case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

- Fix the following errors on '_test_bgp_authentication_' test cases on t2-chassis.

      >       assert bgp_facts['bgp_neighbors'][setup['neigh_ip_v4']]['state'] != 'established'
      E       AssertionError

        cmd        = 'vtysh -n None -c "config" -c "router bgp 65100" -c "neighbor PEER_V4 password badpassword" -c "neighbor PEER_V6 password badpassword"           -c "end"'
        command_output = {'stderr_lines': [u'/usr/bin/vtysh: line 23: [: None: integer expression expec...: [], u'start': u'2023-12-09 09:40:16.664728', u'msg': u'non-zero return code'}

#### How did you do it?

-  Use the correct _asic-index_ for the _vtysh_ commands on the duthost.

#### How did you verify/test it?

- Ran the 'bgp_authentication' tests against a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/12974916-49b3-4eb5-b0b8-1d7c40152c43)
