### PR TITLE
enable compute-ai for 8111-t1

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -201,7 +201,16 @@
   - name: enable tunnel_qos_remap for T1 in dualtor deployment
     set_fact:
       enable_tunnel_qos_remap: true
-    when: "('leafrouter' == (vm_topo_config['dut_type'] | lower)) and (hwsku in hwsku_list_dualtor_t1) and not (is_ixia_testbed)"
+    when: "((vm_topo_config['dut_type'] | lower) in ['leafrouter', 'backendleafrouter']) and (hwsku in hwsku_list_dualtor_t1) and not (is_ixia_testbed)"
+
+  - name: gather hwsku that supports Compute-AI deployment
+    set_fact:
+      hwsku_list_compute_ai: "['Cisco-8111-O64']"
+
+  - name: enable Compute-AI deployment
+    set_fact:
+      enable_compute_ai_deployment: true
+    when: "('t1' in topo) and (hwsku in hwsku_list_compute_ai) and not (is_ixia_testbed)"
 
   - name: set default vm file path
     set_fact:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -201,7 +201,7 @@
   - name: enable tunnel_qos_remap for T1 in dualtor deployment
     set_fact:
       enable_tunnel_qos_remap: true
-    when: "((vm_topo_config['dut_type'] | lower) in ['leafrouter', 'backendleafrouter']) and (hwsku in hwsku_list_dualtor_t1) and not (is_ixia_testbed)"
+    when: "(('leafrouter' == (vm_topo_config['dut_type'] | lower)) or ('backendleafrouter' == (vm_topo_config['dut_type'] | lower))) and (hwsku in hwsku_list_dualtor_t1) and not (is_ixia_testbed)"
 
   - name: gather hwsku that supports Compute-AI deployment
     set_fact:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -210,7 +210,7 @@
   - name: enable Compute-AI deployment
     set_fact:
       enable_compute_ai_deployment: true
-    when: "('t1' in topo) and (hwsku in hwsku_list_compute_ai) and not (is_ixia_testbed)"
+    when: "(hwsku in hwsku_list_compute_ai) and not (is_ixia_testbed)"
 
   - name: set default vm file path
     set_fact:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -286,7 +286,10 @@ class ParseTestbedTopoinfo():
             vm_topo_config['dut_asn'] = dut_asn
 
         if hwsku == 'Cisco-8111-O64':
-            vm_topo_config['dut_type'] = "BackEndLeafRouter"
+            if 't1' in topo_name:
+                vm_topo_config['dut_type'] = "BackEndLeafRouter"
+            elif 't0' in topo_name:
+                vm_topo_config['dut_type'] = "BackEndToRRouter"
 
         for slot, asic_definition in slot_definition.items():
             asic_topo_config[slot] = dict()

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -285,7 +285,7 @@ class ParseTestbedTopoinfo():
             vm_topo_config['dut_type'] = topo_definition['configuration_properties']['common']['dut_type']
             vm_topo_config['dut_asn'] = dut_asn
 
-        if ('t1' in topo_name) and (hwsku == 'Cisco-8111-O64'):
+        if hwsku == 'Cisco-8111-O64':
             vm_topo_config['dut_type'] = "BackEndLeafRouter"
 
         for slot, asic_definition in slot_definition.items():

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -285,6 +285,9 @@ class ParseTestbedTopoinfo():
             vm_topo_config['dut_type'] = topo_definition['configuration_properties']['common']['dut_type']
             vm_topo_config['dut_asn'] = dut_asn
 
+        if ('t1' in topo_name) and (hwsku == 'Cisco-8111-O64'):
+            vm_topo_config['dut_type'] = "BackEndLeafRouter"
+
         for slot, asic_definition in slot_definition.items():
             asic_topo_config[slot] = dict()
             for asic in asic_definition:

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -59,6 +59,13 @@
             <a:Value>Gemini</a:Value>
           </a:DeviceProperty>
 {% endif %}
+{% if enable_compute_ai_deployment|default('false')|bool %}
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Compute-AI</a:Value>
+          </a:DeviceProperty>
+{% endif %}
 {% if dhcp_servers %}
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

enable Compute-AI deployment for 8111 T1 device

#### How did you do it?

#### How did you verify/test it?

run "deploy-mg" command on below device, check if ai deployment is enabled:
|Topo      |     HWSKU        |  result                 |
|----------|------------------|-------------------------|
|t1-64-lag | Cisco-8111-O64   |  pass, w/ ai deployment |
|t1-56-lag | Cisco-8101-O8C48 |  pass, w/o ai deploy    |
|t0-64     | Cisco-8111-O64   |  pass, w/o ai deploy    |

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
