### PR TITLE
[T2]: Porting PR:9655 to 202205: Cisco-8000: Modifications to Xoff for Cisco-Q100 platform.

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1298,6 +1298,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         asic_type = self.test_params['sonic_asic_type']
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_pfc = int(self.test_params['pkts_num_trig_pfc'])
+        self.hwsku = self.test_params['hwsku']
         pkts_num_trig_ingr_drp = int(
             self.test_params['pkts_num_trig_ingr_drp'])
         hwsku = self.test_params['hwsku']
@@ -1413,9 +1414,11 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of triggering PFC'
-            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
-                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
-                test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
+                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+                                 test_stage, recv_counters, recv_counters_base,
+                                 xmit_counters, xmit_counters_base))
+
             # recv port no pfc
             assert(recv_counters[pg] == recv_counters_base[pg]), \
                 'unexpectedly PFC counter increase, {}'.format(test_stage)
@@ -1480,9 +1483,11 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
                              'xmit_counters {}\n\txmit_counters_base {}\n'.format(
-                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+                                 test_stage, recv_counters,
+                                 recv_counters_base, xmit_counters,
+                                 xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \
                 'unexpectedly PFC counter not increase, {}'.format(test_stage)
@@ -1514,20 +1519,22 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
                              'xmit_counters {}\n\txmit_counters_base {}\n'.format(
-                                 test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
+                                 test_stage, recv_counters, recv_counters_base,
+                                 xmit_counters, xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \
                 'unexpectedly PFC counter not increase, {}'.format(test_stage)
             # recv port ingress drop
-            for cntr in ingress_counters:
-                if platform_asic and platform_asic == "broadcom-dnx":
-                    if cntr == 1:
-                        assert(recv_counters[cntr] > recv_counters_base[cntr]), 'unexpectedly RX drop counter ' \
-                                                                                'not increase, {}'.format(test_stage)
-                else:
-                    assert(recv_counters[cntr] > recv_counters_base[cntr]), 'unexpectedly RX drop counter' \
+            if self.hwsku not in ['Cisco-8800-LC-48H-C48']:
+                for cntr in ingress_counters:
+                    if platform_asic and platform_asic == "broadcom-dnx":
+                        if cntr == 1:
+                            assert(recv_counters[cntr] > recv_counters_base[cntr]), \
+                                'unexpectedly RX drop counter not increase, {}'.format(test_stage)
+                    else:
+                        assert(recv_counters[cntr] > recv_counters_base[cntr]), 'unexpectedly RX drop counter' \
                                                                             ' not increase, {}'.format(test_stage)
             # xmit port no egress drop
             for cntr in egress_counters:


### PR DESCRIPTION
Porting PR: #9655 to 202205:
Addressed in this PR:

1. Cisco-8000/Q100 platform doesn't add the headroom drops to the rx-drop counters (as this are not per port), so that particular check is being skipped in the PFCXoff testcase.
2. The print messages encounter this problem: https://github.com/sonic-net/sonic-mgmt/issues/9652. This PR addresses the formatting.