### PR TITLE
Ignore unimplemented Broadcom SAI in loganalyzer

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -29,6 +29,7 @@ r, ".* ERR kernel:.* Module gpio_ich is blacklisted.*"
 r, ".* skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID.*"
 r, ".* ERR monit.*Expected containers not running: telemetry.*"
 r, ".* sonic systemd.* kdump-tools.service - Kernel crash dump capture service.*"
+r, ".* ERR syncd#syncd: .* SAI_API_PORT:brcm_sai_get_port_attribute:\d+ Error -2 processing  port attribute ID: 17.*"
 
 # White list below messages found on KVM for now. Need to address them later.
 r, ".* ERR macsec#wpa_supplicant.*l2_packet_send.*Network is down.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`port attribute ID: 17` is `SAI_PORT_ATTR_SUPPORTED_MEDIA_TYPE`, used to get supported media type. Broadcom SAI does not implement it, so should ignore related logs in loganalyzer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
`port attribute ID: 17` is `SAI_PORT_ATTR_SUPPORTED_MEDIA_TYPE`, used to get supported media type. Broadcom SAI does not implement it, so should ignore related logs in loganalyzer.

#### How did you do it?
Update `loganalyzer_common_ignore.txt`.

#### How did you verify/test it?
Verified by running testcase `vlan/test_autostate_disabled.py` on Celestica-E1031 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
