### PR TITLE
[202205][link_flap] Increase redis memory threshold for m0 and mx

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -146,7 +146,9 @@ class TestContLinkFlap(object):
         if incr_redis_memory > 0.0:
             percent_incr_redis_memory = (incr_redis_memory / float(start_time_redis_memory)) * 100
             logging.info("Redis Memory percentage Increase: %d", percent_incr_redis_memory)
-            pytest_assert(percent_incr_redis_memory < 5, "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
+            incr_redis_memory_threshold = 10 if tbinfo["topo"]["type"] in ["m0", "mx"] else 5
+            pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold,
+                          "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
 
         # Orchagent CPU should consume < orch_cpu_threshold at last.
         logging.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -86,7 +86,9 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
     if incr_redis_memory > 0.0:
         percent_incr_redis_memory = (incr_redis_memory / float(start_time_redis_memory)) * 100
         logger.info("Redis Memory percentage Increase: %d", percent_incr_redis_memory)
-        pytest_assert(percent_incr_redis_memory < 5, "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
+        incr_redis_memory_threshold = 10 if tbinfo["topo"]["type"] in ["m0", "mx"] else 5
+        pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold, "Redis Memory Increase more than expected: {}"
+                      .format(percent_incr_redis_memory))
 
     # Orchagent CPU should consume < orch_cpu_threshold at last.
     logger.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -87,8 +87,8 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
         percent_incr_redis_memory = (incr_redis_memory / float(start_time_redis_memory)) * 100
         logger.info("Redis Memory percentage Increase: %d", percent_incr_redis_memory)
         incr_redis_memory_threshold = 10 if tbinfo["topo"]["type"] in ["m0", "mx"] else 5
-        pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold, "Redis Memory Increase more than expected: {}"
-                      .format(percent_incr_redis_memory))
+        pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold,
+                      "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
 
     # Orchagent CPU should consume < orch_cpu_threshold at last.
     logger.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/11045
Redis memory used would increase in M0/MX devices period (about 7% per 400+s), it would case they fail in this case sometimes.

#### How did you do it?
Increase threshold for them.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
