### PR TITLE
Fix timeout waiting for escalation prompt issue

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -242,6 +242,7 @@ class AnsibleHostsBase(object):
             "forks": 6,
             "connection": "smart",
             "verbosity": 2,
+            "timeout": 30,
             "become_method": "sudo"
         }
         if options:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
While running the upgrade_image.py script to upgrade image during nightly tests, there is high probability that this script failed with "Timeout (2s) waiting for privilege escalation prompt".

#### How did you do it?
This issue is related with the upgrading of ansible to 6.7.0.

When ansible tries to connect to target device by SSH, the SSH connection plugin tries to get a timeout from PlayContext as ConnectTimeout argument value. According to the original intention, the default timeout of PlayContext is DEFAULT_TIMEOUT. It's value is taken from "timeout" in ansible.cfg file.

Actually, timeout of play_context gets its default value from base class of PlayContext. In base class of PlayContext, timeout defaults to TASK_TIMEOUT. The default value of TASK_TIMEOUT is 0.

Consequently, the SSH plugin gets value "0" for its ConnectTimeout argument. While establishing SSH connection, the SSH plugin waits 2 + "timeout" for the escalation prompt. When SSH connection is a little bit slow, the waiting could easily timed out and resulted in error "Timeout (2s) waiting for privilege escalation prompt".

Luckily, the PlayContext has default behavior of getting "timeout" from CLI arguments with higher priority than the argument defined in ansible.cfg. So the workaround is to always pass in option "timeout=30" while creating AnsibleHost. The option will be interpreted as CLI argument under the hood.

This change won't affect the behavior of ConnectTimeout and TASK_TIMEOUT.

It's a minimum change that takes the existing ansible mechanism and does not hack ansible's behavior.

#### How did you verify/test it?
Verified on physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
