### PR TITLE
Add a skip to test_pmon_syseepromd_kill_and_start_status because of community issue #11087

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -846,6 +846,12 @@ platform_tests/daemon/test_chassisd.py:
     conditions:
       - "release in ['201811', '201911', '202012']"
 
+platform_tests/daemon/test_syseepromd.py::test_pmon_syseepromd_kill_and_start_status:
+  skip:
+    reason: "Skip based at community issue https://github.com/sonic-net/sonic-mgmt/issues/11087"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/11087"
+
 platform_tests/mellanox/test_check_sfp_using_ethtool.py:
   skip:
     reason: "Deprecated as Mellanox do not use ethtool in release 202305 or higher"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Add a skip to platform_tests/daemon/test_syseepromd.py::test_pmon_syseepromd_kill_and_start_status because of community issue [#11087](https://github.com/sonic-net/sonic-mgmt/issues/11087)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
there is a community test issue that is causing this test to fail.

#### How did you do it?
open a community issue for failure and add the test to skip

#### Any platform-specific information?
any platform is affected by the issue

