### PR TITLE
Add Serial Number check test case.

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -102,8 +102,8 @@ def test_platform_serial_no(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = "sudo decode-syseeprom -s"
-    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
     get_serial_no_cmd = duthost.command(cmd)
+    logging.info("Verifying output of '{}' on '{}' ...".format(get_serial_no_cmd, duthost.hostname))
     get_serial_no_output = get_serial_no_cmd["stdout"].replace('\x00', '')
     expected_serial_no = dut_vars['serial']
     pytest_assert(get_serial_no_output == expected_serial_no,

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -96,6 +96,21 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
                                                                                            duthost.hostname))
 
 
+def test_platform_serial_no(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
+    """
+    @summary: Verify device's serial no with output of `sudo decode-syseeprom -s`
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    cmd = "sudo decode-syseeprom -s"
+    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
+    get_serial_no_cmd = duthost.command(cmd)
+    get_serial_no_output = get_serial_no_cmd["stdout"].replace('\x00', '')
+    expected_serial_no = dut_vars['serial']
+    pytest_assert(get_serial_no_output == expected_serial_no,
+                  "Expected serial_no '{}' is not matching with {} in syseeprom on '{}'".
+                  format(expected_serial_no, get_serial_no_output, duthost.hostname))
+
+
 def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
     """
     @summary: Verify output of `show platform syseeprom`


### PR DESCRIPTION
**Summary**
This PR adds the `test_platform_serial_no` test case that can help identifing the serial no. mismatching issue.

**Type of change**
 - [ ] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [x] Test case(new/improvement)
 
**Approach**
Use `decode-syseeprom -s` to compare with modeled inventory information.

**What is the motivation for this PR?**
We were hitting complains that prod devices had mismatch serial number, later, we have this [fix](https://github.com/sonic-net/sonic-buildimage/pull/17440), now we need align this gap by adding this test case.

**How did you do it?**
Compare `decode-syseeprom -s` output with inventory data.

**How did you verify/test it?**
Ran the test in multiple platform lab devices, which shows passed.

**Any platform specific information?**
This is common test issue.

Signed-off-by: Xincun Li [xincun.li@microsoft.com](mailto:xincun.li@microsoft.com)