### PR TITLE
Modify incorrect pytest.mark.topology format

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.asic('broadcom'),
-    pytest.mark.topology('t0'),
-    pytest.mark.topology('t1'),
+    pytest.mark.topology('t0', 't1'),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix incorrect topo mark format. Currently, this case is skipped on T1 testbed.

#### How did you do it?
Add T1 into pytest.mark.topology
   ` pytest.mark.topology('t0', 't1'),`

#### How did you verify/test it?
Run `tests/ecmp/test_ecmp_sai_value.py` on T1 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
