### PR TITLE
Fix no "utcnow" attribute issue of reduce_and_add_sonic_images

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from datetime import datetime
+import time
 from os import path
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.debug_utils import config_module_logging
@@ -37,7 +37,8 @@ results = {"downloaded_image_version": "Unknown", "current_stage": "Unknown", "m
 def log(msg):
     global results
 
-    timestamp = datetime.utcnow()
+    current_time = time.time()
+    timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(current_time))
     results["messages"].append("{} {}".format(str(timestamp), msg))
     logging.debug(msg)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix no "utcnow" attribute issue of reduce_and_add_sonic_images

Recent PR #10856 improved debugability of the customzied ansible module reduce_and_add_sonic_images.
However, this module ran into issue below issue on 202205 branch:

    AttributeError(\"module 'datetime' has no attribute 'utcnow'\")

The reason is related with the notorious datetime.datetime issue. Packate datetime has module with same name datetime. If some module imported the datetime package using:
    import datetime

Then below statement for importing the datetime module may be skipped because in imported cache, there is already "datetime".
    from datetime import datetime

Consequently, `datetime.utcnow()` may fail with AttributeError.

#### How did you do it?
To avoid the mess of such issue, this PR updated the module to use the `time` module to generate timestamp.

#### How did you verify/test it?
Tested on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
