### PR TITLE
[Chassis-packet]: Only check for external facing bgp sessions

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -57,6 +57,9 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         ndp_dict[ip] = iface
 
     for k, v in list(bgp_facts['bgp_neighbors'].items()):
+        if 'chassis-packet' in duthosts[0].facts.get('switch_type'):
+            if 'ARISTA' not in v['description']:
+                break
         # Only consider established bgp sessions
         if v['state'] == 'established':
             assert (k in arp_dict.keys() or k in ndp_dict.keys())


### PR DESCRIPTION
### Description of PR
In case of chassis-packet, Only check for external facing bgp sessions.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
In case of chassis-packet, Only check for external facing bgp sessions.

#### How did you do it?

#### How did you verify/test it?
Verified it on T2 profile 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
