### PR TITLE
Fix flakiness of test_monitoring_critical_processes

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -451,7 +451,12 @@ def stop_critical_processes(duthost, containers_in_namespaces):
             container_name_in_namespace = container_name
             if namespace_id != DEFAULT_ASIC_ID:
                 container_name_in_namespace += namespace_id
-
+            if 'lldp' in container_name:
+                # Killing lldpd may impact lldp-syncd process, the next around check for lldp-syncd will probably fail
+                # move lldpd to the end of the list to avoid this issue
+                critical_process_list.append(critical_process_list.pop(critical_process_list.index('lldpd')))
+                logger.info("Critical process list for {} after moving lldpd to the end: {}".format(
+                    container_name_in_namespace, critical_process_list))
             for critical_process in critical_process_list:
                 # Skip 'dsserve' process since it was not managed by supervisord
                 # TODO: Should remove the following two lines once the issue was solved in the image.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_monitoring_critical_processes sometimes fails due to
`Failed: Program 'lldp-syncd' in container 'lldp' is in the 'EXITED' state, expected 'RUNNING'`

check syslog at failed time, lldp-syncd tried to do source update, run  `/usr/sbin/lldpcli -f json show chassis` to get chassis name, but at this time, lldpd was killed, it wouldn't be able to run this command, that's why llpd-syncd is EXITED.

lldpd-syncd syncs data every 10s, that's why sometimes, it shows RUNNING right after killing lldpd, but if it hits the time of running lldpctl command, lldpd-syncd will throw exception and exit.

lldp-syncd is dependable for lldpd, so, it's unfair to kill lldpd then check the status of lldp-syncd.
test_monitoring_critical_processes checks if critical  process could be killed without any exception.
Move lldpd to the end of list, test lldpd-syncd and lldpmgrd firstly then kill lldpd at last.
This fix could avoid the flakiness of this case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix flakiness of `test_monitoring_critical_processes`.

#### How did you do it?
Move lldpd to the end of list, test lldpd-syncd and lldpmgrd firstly then kill lldpd at last.

#### How did you verify/test it?
run `process_monitoring/test_critical_process_monitoring.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
