### PR TITLE
Add missing import time in test_counterpoll_watermark

### DIFF
--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -5,6 +5,7 @@ Tests for the `counterpoll queue/watermark/pg-drop ...` commands in SONiC
 import allure
 import logging
 import random
+import time
 import pytest
 
 from tests.common.config_reload import config_reload


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes missing import in test_counterpoll_watermark 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
PR #10987 cannot be merged due to missing import time.

#### How did you do it?
Add import time.

#### How did you verify/test it?
Run test_counterpoll_watermark with physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
