### PR TITLE
Add delay when CRM output returns NULL

### DIFF
--- a/tests/fdb/utils.py
+++ b/tests/fdb/utils.py
@@ -4,6 +4,7 @@ import pprint
 from ptf.mask import Mask
 import ptf.testutils as testutils
 import ptf.packet as scapy
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -28,6 +29,12 @@ def IntToMac(intMac):
 
 
 def get_crm_resources(duthost, resource, status):
+    retry_count = 5
+    count = 0
+    while len(duthost.get_crm_resources()) == 0 and count < retry_count:
+        logger.debug("CRM resources not fully populated, retry after 2 seconds: count: {}".format(count))
+        time.sleep(2)
+        count = count + 1
     return duthost.get_crm_resources().get("main_resources").get(resource).get(status)
 
 


### PR DESCRIPTION
### Description of PR
In some sonic-mgmt test FDB runs, CRM CLI output returns NULL output causing script to fail.

Summary:
Fixes # (issue)
Add delay of 2 seconds and retry few times to get the valid CRM output.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### How did you do it?
- By adding a delay and retry when CRM output is empty.

#### How did you verify/test it?
- Verified in single and dual-tor setups.
