### PR TITLE
Increased timeout to relax the timing margins to update redisdb

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -288,7 +288,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn off outlet {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)
-        time.sleep(5)
+        time.sleep(15)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
@@ -302,7 +302,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn on outlet {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
-        time.sleep(5)
+        time.sleep(15)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Increased the sleep time on the test so that the redisdb had enough time to update the PSU status when it was turned off or on.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fixes Microsoft ADO 26206141

#### How did you do it?
I increased the sleep time between turning off/on the PSU and getting the PSU status from the device. This gives the device a better chance to update the true status of the PSU on the redisdb database, and subsequently provides a more accurate output to the `show platform psustatus` command.

#### How did you verify/test it?
I believe this is an issue of timing. I added timestamps to the test to check when the outlet was turned on and off and ran the test 5 times:

![image](https://github.com/sonic-net/sonic-mgmt/assets/93744978/742aa44e-c4ee-4144-b3ad-e6a98cd86d2a)

Sometimes,​ the device does not switch back from NOT OK to OK in time between when Ln 305 is called and Ln 309 is called.

![image](https://github.com/sonic-net/sonic-mgmt/assets/93744978/a6801e91-e031-4c3e-a257-5156c47852e7)


That leads to the flakiness because it takes time for the redis database to get updated, which is where we are querying psustatus information from (CMD_PLATFORM_PSUSTATUS = "show platform psustatus")

[Pass video (Opens in new window or tab)](https://microsoft-my.sharepoint.com/:v:/p/assrinivasan/ETqzbGUtTThHtCGrH_5AUpcBwX0jSgqiRcPp1UrwnojRZA?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=Dy9Nxe)
[Failed video (Opens in new window or tab)](https://microsoft-my.sharepoint.com/:v:/p/assrinivasan/EZw1nEaVondAi5lY6318fAoBRubQEnTxF5XvjKz4J4SOSQ?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=vLLbQD)

With the increased timeout to 15s, the test [passed (Opens in new window or tab)](https://microsoft-my.sharepoint.com/:v:/p/assrinivasan/EY3_CdmItTtGv8PYIYVfLdUBhLwIaOimW2Kpa1QiP3BjXw?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=SioLYS) 3/3 times.

