### PR TITLE
update pcbb xoff test threshold for 7050 dualtor

### DIFF
--- a/tests/qos/files/qos_params.td3.yaml
+++ b/tests/qos/files/qos_params.td3.yaml
@@ -457,31 +457,31 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 58620
-                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_trig_pfc: 59124
+                    pkts_num_trig_ingr_drp: 59749
                     pkts_num_margin: 4
                 pcbb_xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 58620
-                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_trig_pfc: 59124
+                    pkts_num_trig_ingr_drp: 59749
                     pkts_num_margin: 4
                 pcbb_xoff_3:
                     outer_dscp: 2
                     dscp: 3
                     ecn: 1
                     pg: 2
-                    pkts_num_trig_pfc: 58620
-                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_trig_pfc: 59124
+                    pkts_num_trig_ingr_drp: 59749
                     pkts_num_margin: 4
                 pcbb_xoff_4:
                     outer_dscp: 6
                     dscp: 4
                     ecn: 1
                     pg: 6
-                    pkts_num_trig_pfc: 58620
-                    pkts_num_trig_ingr_drp: 59245
+                    pkts_num_trig_pfc: 59124
+                    pkts_num_trig_ingr_drp: 59749
                     pkts_num_margin: 4
                 hdrm_pool_size:
                     dscps: [3, 4]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

7050 dualtor 's pcbb xoff testcase fail, because of threshold is incorrect

#### How did you do it?

qos_param_generator.py don't support test_tunnel_qos_remap.py yet.
so directly update threshold , like previous PR https://github.com/sonic-net/sonic-mgmt/pull/8624

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
