### PR TITLE
Ignore the migration error in upgrade path test when downgrading to the from_image

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -150,6 +150,9 @@ def download_new_sonic_image(module, new_image_url, save_as):
         _, out, _ = exec_command(module, cmd="sonic_installer binary_version {}".format(save_as))
         results["downloaded_image_version"] = out.rstrip('\n')
         log("Downloaded image version: {}".format(results["downloaded_image_version"]))
+        # Save the binary version to file
+        exec_command(module, cmd="sudo echo {} > /tmp/downloaded-sonic-image-version".format(
+            results["downloaded_image_version"]))
 
 
 def install_new_sonic_image(module, new_image_url, save_as=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore the package migration error in upgrade path test when downgrading to the from image.
When downgrading from a newer version to an older one via sonic-installer, there could be package migration error because the older version doesn't contain some new packages.
We need to ignore this kind of errors in the upgrade path test.
```
tests.common.devices.base:base.py:104 /root/mars/workspace/sonic-mgmt/tests/upgrade_path/upgrade_helpers.py::install_sonic#89: [r-tigon-04] AnsibleModule::reduce_and_add_sonic_images Result => {"failed": true, "msg": "Image installation failed: rc=1, out=efi not supported - exiting without verification

Installing image SONiC-OS-202205_3_rc.13-a8586b250_Internal and setting it as default...
Command: bash /host/downloaded-sonic-image
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in SONiC
ONIE Installer: platform: x86_64-mellanox-r0
onie_platform: x86_64-mlnx_msn4600c-r0
Installing SONiC to /host/image-202205_3_rc.13-a8586b250_Internal
Archive:  fs.zip
   creating: /host/image-202205_3_rc.13-a8586b250_Internal/boot/
  inflating: /host/image-202205_3_rc.13-a8586b250_Internal/boot/config-5.10.0-18-2-amd64  
  inflating: /host/image-202205_3_rc.13-a8586b250_Internal/boot/System.map-5.10.0-18-2-amd64  
  inflating: /host/image-202205_3_rc.13-a8586b250_Internal/boot/initrd.img-5.10.0-18-2-amd64  
  inflating: /host/image-202205_3_rc.13-a8586b250_Internal/boot/vmlinuz-5.10.0-18-2-amd64  
 extracting: /host/image-202205_3_rc.13-a8586b250_Internal/fs.squashfs  
Switch CPU vendor is: GenuineIntel
Switch CPU cstates are: disabled
EXTRA_CMDLINE_LINUX=
Installed SONiC base image SONiC-OS successfully

Command: grub-set-default --boot-directory=/host 0

Command: config-setup backup
Taking backup of current configuration

Command: mkdir -p /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mount -t squashfs /host/image-202205_3_rc.13-a8586b250_Internal/fs.squashfs /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: sonic-cfggen -d -y /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/sonic/sonic_version.yml -t /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/usr/share/sonic/templates/sonic-environment.j2
Command: umount -r -f /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: rm -rf /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mkdir -p /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mount -t squashfs /host/image-202205_3_rc.13-a8586b250_Internal/fs.squashfs /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mkdir -p /host/image-202205_3_rc.13-a8586b250_Internal/rw
Command: mkdir -p /host/image-202205_3_rc.13-a8586b250_Internal/work
Command: mkdir -p /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mount overlay -t overlay -o rw,relatime,lowerdir=/tmp/image-202205_3_rc.13-a8586b250_Internal-fs,upperdir=/host/image-202205_3_rc.13-a8586b250_Internal/rw,workdir=/host/image-202205_3_rc.13-a8586b250_Internal/work /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: mkdir -p /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/var/lib/docker
Command: mount --bind /host/image-202205_3_rc.13-a8586b250_Internal/docker /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/var/lib/docker
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs mount proc /proc -t proc
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs mount sysfs /sys -t sysfs
Command: cp /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/default/docker /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/tmp/docker_config_backup
Command: sh -c echo 'DOCKER_OPTS=\"$DOCKER_OPTS -H unix:// --storage-driver=overlay2 --bip=240.127.1.1/24 --iptables=false --ipv6=true --fixed-cidr-v6=fd00::/80 \"' >> /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/default/docker
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs /usr/lib/docker/docker.sh start
Command: cp /var/lib/sonic-package-manager/packages.json /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/tmp/packages.json
Command: touch /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/tmp/docker.sock
Command: mount --bind /var/run/docker.sock /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/tmp/docker.sock
Command: cp /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/resolv.conf /tmp/resolv.conf.backup
Command: cp /etc/resolv.conf /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/resolv.conf
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs sh -c command -v sonic-package-manager
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs sonic-package-manager migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock -y
Command: chroot /tmp/image-202205_3_rc.13-a8586b250_Internal-fs /usr/lib/docker/docker.sh stop
Command: mv /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/tmp/docker_config_backup /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/default/docker
Command: cp /tmp/resolv.conf.backup /tmp/image-202205_3_rc.13-a8586b250_Internal-fs/etc/resolv.conf
Command: umount -f -R /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: umount -r -f /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
Command: rm -rf /tmp/image-202205_3_rc.13-a8586b250_Internal-fs
, err=Warning: 'sonic_installer' command is deprecated and will be removed in the future
Please use 'sonic-installer' instead
mount: /sys/fs/cgroup/cpu: cgroup already mounted on /sys/fs/cgroup.
mount: /sys/fs/cgroup/cpuacct: cgroup already mounted on /sys/fs/cgroup.
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"initrd.img.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz\" file in \"/\" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about \"vmlinuz.old\" file in \"/\" when searching for (sub)modules (No such file or directory)
migrating package ****
Traceback (most recent call last):
  File \"/usr/local/bin/sonic_installer\", line 8, in <module>
    sys.exit(sonic_installer())
  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 764, in __call__
    return self.main(*args, **kwargs)
  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 717, in main
    rv = self.invoke(ctx)
  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File \"/usr/local/lib/python3.9/dist-packages/click/core.py\", line 555, in invoke
    return callback(*args, **kwargs)
  File \"/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py\", line 604, in install
    migrate_sonic_packages(bootloader, binary_image_version)
  File \"/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py\", line 384, in migrate_sonic_packages
    run_command_or_raise([\"chroot\", new_image_mount, SONIC_PACKAGE_MANAGER, \"migrate\",
  File \"/usr/local/lib/python3.9/dist-packages/sonic_installer/common.py\", line 51, in run_command_or_raise
    raise SonicRuntimeException(\"Failed to run command '{0}'\".format(argv))
sonic_installer.exception.SonicRuntimeException: Failed to run command '['chroot', '/tmp/image-202205_3_rc.13-a8586b250_Internal-fs', 'sonic-package-manager', 'migrate', '/tmp/packages.json', '--dockerd-socket', '/tmp/docker.sock', '-y']'
", "invocation": {"module_args": {"save_as": "/host/downloaded-sonic-image", "disk_used_pcent": 8, "new_image_url": null}
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Ignore the migration error in upgrade path test when downgrading to the from_image
#### How did you do it?
1. Save the downloaded image version to a temp file in the download_new_sonic_image() method of ansible/library/reduce_and_add_sonic_images.py, so that we can still get the image version even when the call of reduce_and_add_sonic_images fails.
2. When downgrading to the from_image in the test_upgrade_path, if the reduce_and_add_sonic_images fails and the exception is package migration error, ignore the error and continue to reboot the switch. In case of other failrues, still throw the exception.
#### How did you verify/test it?
Run the test test_upgrade_path on multiple setups, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
