### PR TITLE
Improve orchagent watchdog UT to handle orchagent not pause case.

### DIFF
--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -16,25 +16,33 @@ SLEEP_TIME = 10
 
 @pytest.fixture
 def pause_orchagent(duthost):
-    # find orchagent pid
-    pid = duthost.shell(
-                    r"pgrep -u root orchagent",
-                    module_ignore_errors=True)['stdout']
-    logger.info('Get orchagent pid: {}'.format(pid))
+    pid = None
+    retry = 3
+    while True:
+        retry -= 1
+        # find orchagent pid
+        pid = duthost.shell(
+                        r"pgrep -u root orchagent",
+                        module_ignore_errors=True)['stdout']
+        logger.info('Get orchagent pid: {}'.format(pid))
 
-    # pause orchagent and clear syslog
-    duthost.shell(r"sudo kill -STOP {}".format(pid), module_ignore_errors=True)
+        # pause orchagent and clear syslog
+        duthost.shell(r"sudo kill -STOP {}".format(pid), module_ignore_errors=True)
 
-    # validate orchagent paused, the stat colum should be Tl:
-    # root         124  0.3  1.6 596616 63600 pts/0    Tl   02:33   0:06 /usr/bin/orchagent
-    result = check_process_status(duthost, "'Tl.*/usr/bin/orchagent''")
-    if not result:
-        # collect log for investigation not paused reason
-        duthost.shell(r"sudo ps -auxww", module_ignore_errors=True)
-        duthost.shell(r"sudo cat /var/log/syslog | grep orchagent", module_ignore_errors=True)
+        # validate orchagent paused, the stat colum should be Tl:
+        # root         124  0.3  1.6 596616 63600 pts/0    Tl   02:33   0:06 /usr/bin/orchagent
+        result = check_process_status(duthost, "'Tl.*/usr/bin/orchagent''")
+        if result:
+            # continue UT when Orchagent paused
+            break
+        else:
+            # collect log for investigation not paused reason
+            duthost.shell(r"sudo ps -auxww", module_ignore_errors=True)
+            duthost.shell(r"sudo cat /var/log/syslog | grep orchagent", module_ignore_errors=True)
 
-        # skip UT because orchagent pause failed
-        pytest.skip("Orchagent does not paused.")
+            if retry <= 0:
+                # break UT because orchagent pause failed
+                pytest.fail("Can't pause Orchagent by pid.")
 
     duthost.shell(r"sudo truncate -s 0 /var/log/syslog", module_ignore_errors=True)
 

--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -35,7 +35,7 @@ def pause_orchagent(duthost):
 
         # skip UT because orchagent pause failed
         pytest.skip("Orchagent does not paused.")
-    
+
     duthost.shell(r"sudo truncate -s 0 /var/log/syslog", module_ignore_errors=True)
 
     yield


### PR DESCRIPTION

### Description of PR
Improve orchagent watchdog UT to handle orchagent not pause case.

Summary:
Improve orchagent watchdog UT to handle orchagent not pause case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
system_health/test_watchdog.py::test_orchagent_watchdog randomly failed on some device because orchagent does not paused by UT.
Still not found reason, add debug information also improve code.


#### How did you do it?
Improve get orchagent PID code, only get orchagent running by root user.
Add debug log when orchageent pause failed.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
