### PR TITLE
Modify ecmp offset value for 7060 T1 hwsku

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -416,12 +416,13 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_sai_value.py:
   skip:
-    reason: "Only support Broadcom T1/T0 topology with 20230531.12 or later image"
+    reason: "Only support Broadcom T1/T0 topology with 20230531.12 or later image, 7050cx3 T1 doesn't enable this feature"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
       - "release in ['201911', '202012', '202205', '202211']"
+      - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -421,7 +421,7 @@ ecmp/test_ecmp_sai_value.py:
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
-      - "release in ['201911', '202012', '202205', '202211']"
+      - "release in ['201911', '202012', '202205', '202211', 'master', 'internal']"
       - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
 
 ecmp/test_fgnhg.py:

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -139,7 +139,7 @@ def check_hash_seed_value(duthost, asic_name, topo_type):
             pytest_assert(hash_seed == '0', "HASH_SEED is not set to 0")
 
 
-def check_ecmp_offset_value(duthost, asic_name, topo_type):
+def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
     """
     Check the value of OFFSET_ECMP
     TH/TH2: the count of 0xa is 67
@@ -157,7 +157,7 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type):
             pytest_assert(offset_count == 392, "the count of 0 OFFSET_ECMP is not correct.")
     elif topo_type == "t1":
         offset_count = offset_list.count('0xa')
-        if asic_name == "td2":
+        if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32"]:
             pytest_assert(offset_count >= 33, "the count of 0xa OFFSET_ECMP is not correct.")
         else:
             pytest_assert(offset_count >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
@@ -237,12 +237,12 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
         pytest.skip("Unsupported asic type: {}".format(asic))
 
     if parameter == "common":
-        check_ecmp_offset_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)
     elif parameter == "restart_syncd":
         duthost.command("sudo systemctl restart syncd", module_ignore_errors=True)
         logging.info("Wait until all critical services are fully started")
         wait_critical_processes(duthost)
-        check_ecmp_offset_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)
     elif parameter == "reload":
         logging.info("Run config reload on DUT")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
@@ -250,8 +250,8 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     elif parameter == "reboot":
         logging.info("Run cold reboot on DUT")
         reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None)
-        check_ecmp_offset_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)
     elif parameter == "warm-reboot" and topo_type == "t0":
         logging.info("Run warm reboot on DUT")
         reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None, reboot_kwargs=None)
-        check_ecmp_offset_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Skip test_ecmp_sai_value script for 7050 T1 platform.
The count of 0xa for ecmp offset on 7060 T1 platform is 33, not 67. 
#### How did you do it?
Modify conditional mark accordingly.
Use hwsku to check which ecmp offset value is correct instead of asic type.

#### How did you verify/test it?
Run ecmp/test_ecmp_sai_value.py on 70609 T1 testbed and 7050cx1 T1 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
