### PR TITLE
fix pktgen cpu utilization checking

### DIFF
--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -84,9 +84,9 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     cpu_before = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | awk '{print $9}'")["stdout_lines"]
     for entry in cpu_before:
         pytest_assert(
-            float(entry) > cpu_threshold,
+            float(entry) < cpu_threshold,
             "Cpu util was above threshold {} for atleast 1 process"
-            "before sending pktgen traffic".format(cpu_threshold))
+            " before sending pktgen traffic".format(cpu_threshold))
 
     # Check number of existing core/crash files
     core_files_pre = duthost.shell("ls /var/core | wc -l")["stdout_lines"][0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

encounter pktgen failure in nightly:

symptom:
```
        # Check CPU util before sending traffic
        cpu_before = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | awk '{print $9}'")["stdout_lines"]
        for entry in cpu_before:
>           pytest_assert(
                float(entry) > cpu_threshold,
                "Cpu util was above threshold {} for atleast 1 process"
                "before sending pktgen traffic".format(cpu_threshold))
E           Failed: Cpu util was above threshold 70 for atleast 1 processbefore sending pktgen traffic

cpu_before = ['37.5', '18.8', '6.2', '6.2', '0.0', '0.0', ...]
cpu_threshold = 70
```

RCA:
"float(entry) > cpu_threshold" is incorrect assert condition, should be "float(entry) < cpu_threshold,"

#### How did you do it?

modify according above RCA

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
