### PR TITLE
[Conditional mark] Remove xfail mark of warm reboot cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -57,11 +57,7 @@ arp/test_wr_arp.py:
     conditions:
       - "'dualtor' in topo_name"
       - https://github.com/sonic-net/sonic-buildimage/issues/16502
-  xfail:
-    reason: "Warm reboot has a known issue on 202305 branch"
-    conditions:
-      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Force10-S6100', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q44', 'Arista-7260CX3-D108C8'] and release in ['202305']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/10077
+
 
 #######################################
 #####            bfd              #####
@@ -812,7 +808,7 @@ pfcwd/test_pfcwd_warm_reboot.py:
    xfail:
      reason: "Warm Reboot is not supported in dualtor and has a known issue on 202305 branch"
      conditions:
-        - "('dualtor' in topo_name) or (hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Force10-S6100', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q44', 'Arista-7260CX3-D108C8'] and release in ['202305'])"
+        - "'dualtor' in topo_name"
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
 #######################################
@@ -870,10 +866,6 @@ platform_tests/test_auto_negotiation.py:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"
     conditions: https://github.com/sonic-net/sonic-mgmt/issues/5447
 
-platform_tests/test_cont_warm_reboot.py:
-  xfail:
-    reason: "warm reboot has a known issue on 202305 branch"
-    conditions: "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Force10-S6100', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q44', 'Arista-7260CX3-D108C8'] and release in ['202305']"
 
 #######################################
 #####           qos               #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -866,6 +866,12 @@ platform_tests/test_auto_negotiation.py:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"
     conditions: https://github.com/sonic-net/sonic-mgmt/issues/5447
 
+platform_tests/test_cont_warm_reboot.py:
+  skip:
+    reason: "Warm Reboot is not supported in dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
 
 #######################################
 #####           qos               #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes
Remove xfail marks on warm-reboot cases since Broadcom has fix for it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Enable warm-reboot cases.
Workitem: 26255229
#### How did you do it?
Remove xfail conditional mark on:
- pfcwd/test_pfcwd_warm_reboot.py
- platform_tests/test_cont_warm_reboot.py
- arp/test_wr_arp.py
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
