### PR TITLE
Select the right PDU controller in Dual-TOR testbed

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -243,7 +243,7 @@ def check_all_psu_on(dut, psu_test_results):
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_PSU_ABSENCE], indirect=True)
 def test_turn_on_off_psu_and_check_psustatus(duthosts,
-                                             pdu_controller, ignore_particular_error_log, tbinfo):
+                                             get_pdu_controller, ignore_particular_error_log, tbinfo):
     """
     @summary: Turn off/on PSU and check PSU status using 'show platform psustatus'
     """
@@ -256,7 +256,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
         psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
 
     logging.info("Create PSU controller for testing")
-    pdu_ctrl = pdu_controller
+    pdu_ctrl = get_pdu_controller(duthost)
     pytest_require(
         pdu_ctrl, "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x ] 202305

### Approach
#### What is the motivation for this PR?
In Dual-TOR testbed, the test test_turn_on_off_psu_and_check_psustatus()
1. Randomly selects a DUT 
2. Randomly selects the PDU controller for one of the DUT
The PDU controller selected at Step2 may not match with the DUT randomly selected at Step1.

This can result in the test case failing intermittently on multiple runs.

#### How did you do it?
Explicitly select the PDU controller for the randomly selected DUT in dual-TOR testbed

#### How did you verify/test it?
Run sonic-mgmt test multiple time and ensure the test_turn_on_off_psu_and_check_psustatus passes on dual-TOR testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
