### PR TITLE
[GCU E2E Testing] Fix test_eth_interface.py::test_update_speed KVM speed selection

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -526,12 +526,6 @@ generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
     conditions:
       - "asic_type in ['cisco-8000']"
 
-generic_config_updater/test_eth_interface.py::test_update_speed:
-  skip:
-    reason: 'Skip this script due to this not being a production scenario and misleading StateDB output for valid speed'
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/8143
-
 generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33-True]:
   skip:
     reason: 'Skipping test on mellanox platform due to bug of https://github.com/sonic-net/sonic-mgmt/issues/7733'

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -121,9 +121,9 @@ def get_port_speeds_for_test(duthost):
     """
     speeds_to_test = []
     invalid_speed_yang = ("20a", False)
+    invalid_speed_state_db = None
     if duthost.get_facts()['asic_type'] == 'vs':
         valid_speeds = ['20000', '40000']
-        invalid_speed_state_db = None  # StateDB in vs has no speed restrictions, so set as empty
     else:
         valid_speeds = duthost.get_supported_speeds('Ethernet0')
         if valid_speeds:

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -123,7 +123,7 @@ def get_port_speeds_for_test(duthost):
     invalid_speed_yang = ("20a", False)
     if duthost.get_facts()['asic_type'] == 'vs':
         valid_speeds = ['20000', '40000']
-        invalid_speed_state_db = ('1999', False)
+        invalid_speed_state_db = None  # StateDB in vs has no speed restrictions, so set as empty
     else:
         valid_speeds = duthost.get_supported_speeds('Ethernet0')
         if valid_speeds:
@@ -132,7 +132,8 @@ def get_port_speeds_for_test(duthost):
     valid_speeds_to_test = random.sample(valid_speeds, 2 if len(valid_speeds) >= 2 else len(valid_speeds))
     speeds_to_test = [(speed, True) for speed in valid_speeds_to_test]
     speeds_to_test.append(invalid_speed_yang)
-    speeds_to_test.append(invalid_speed_state_db)
+    if invalid_speed_state_db:
+        speeds_to_test.append(invalid_speed_state_db)
     return speeds_to_test
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
ADO 26158280
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
KVM StateDB has no restrictions on port speed. This PR updates GCU test_eth_interface.py::test_update_speed to reflect this. 
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
