### PR TITLE
skip collecting pcap file when ptf cmd executes successfully

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -8,7 +8,7 @@ from datetime import datetime
 logger = logging.getLogger(__name__)
 
 
-def ptf_collect(host, log_file):
+def ptf_collect(host, log_file, result):
     pos = log_file.rfind('.')
     filename_prefix = log_file[0:pos] if pos > -1 else log_file
 
@@ -18,6 +18,9 @@ def ptf_collect(host, log_file):
     filename_log = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.log'
     host.fetch(src=log_file, dest=filename_log, flat=True, fail_on_missing=False)
     allure.attach.file(filename_log, 'ptf_log: ' + filename_log, allure.attachment_type.TEXT)
+    if result["rc"] == 0:
+        # when ptf cmd execution result is 0 (success), we need to skip collecting pcap file
+        return
     pcap_file = filename_prefix + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
@@ -88,7 +91,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     try:
         result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors)
         if log_file:
-            ptf_collect(host, log_file)
+            ptf_collect(host, log_file, result)
         if result:
             allure.attach(json.dumps(result, indent=4), 'ptf_console_result', allure.attachment_type.TEXT)
         if module_ignore_errors:
@@ -96,7 +99,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                 return result
     except Exception:
         if log_file:
-            ptf_collect(host, log_file)
+            ptf_collect(host, log_file, result)
         traceback_msg = traceback.format_exc()
         allure.attach(traceback_msg, 'ptf_runner_exception_traceback', allure.attachment_type.TEXT)
         logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, traceback_msg))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?

in some corner case, qos sai test generated big pcap file, and spend much time to upload these pcap files.
somehow, it spend more than 10 hours to upload a single pcap file. as below:

![image](https://github.com/sonic-net/sonic-mgmt/assets/112069142/d7489f8b-c4a7-415d-bee2-8fca1e5bbf56)



#### How did you do it?

when ptf cmd execution result is 0 (success), we need to skip collecting pcap file to scale down entire test time.

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
