### PR TITLE
[dualtor] use 'get_pdu_controller' to ensure same dut in test_power_off_reboot

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -70,14 +70,14 @@ def _power_off_reboot_helper(kwargs, power_on_event=None):
 
 
 def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, conn_graph_facts,
-                          xcvr_skip_list, pdu_controller, power_off_delay):
+                          xcvr_skip_list, get_pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
     @param localhost: Fixture for interacting with localhost through ansible
     @param conn_graph_facts: Fixture parse and return lab connection graph
     @param xcvr_skip_list: list of DUT's interfaces for which transeiver checks are skipped
-    @param pdu_controller: The python object of psu controller
+    @param get_pdu_controller: The python object of psu controller
     @param power_off_delay: Pytest parameter. The delay between turning off and on the PSU
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
@@ -85,7 +85,7 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     if duthost.facts["asic_type"] in UNSUPPORTED_ASIC_TYPE:
         pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform"
                     .format(duthost.facts["asic_type"]))
-    pdu_ctrl = pdu_controller
+    pdu_ctrl = get_pdu_controller(duthost)
     if pdu_ctrl is None:
         pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
     is_chassis = duthost.get_facts().get("modular_chassis")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
https://github.com/sonic-net/sonic-mgmt/pull/8646 made a change in fixture 'pdu_controller' to always choose supervisor if device is chassis, for non-chassis it'll choose a random dut. PR 8646 will work in the same way for single-dut, but for dualtor, the randomly chosen dut could be different dut than the one under testing.

This PR call 'get_pdu_controller' to ensure pdu_controller is getting on the same dut.

There is no generic fix for this scenario that use "enum_supervisor_dut_hostname" for both tests and fixture `pdu_controller`, because platform_tests/conftest.py have a autouse fixture skip_on_simx that makes all platform tests use rand_one_dut_hostname.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
