### PR TITLE
[dhcp_relay] Skip DHCPv4 relay test when dhcp_server is enabled

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -30,6 +30,14 @@ DUAL_TOR_MODE = 'dual'
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def check_dhcp_server_enabled(duthost):
+    feature_status_output = duthost.show_and_parse("show feature status")
+    for feature in feature_status_output:
+        if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
+            pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
+
+
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
DHCPv4 Relay is not supported when dhcp_server is enabled, hence we need to skip related tests.

#### How did you do it?
Skip dhcp_relay tests when dhcp_server is enabled.

#### How did you verify/test it?
Run tests.
```
collected 13 items                                                                                                                                                                                                                                                                      
 
dhcp_relay/test_dhcp_relay.py::test_interface_binding SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                                         [  7%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                                [ 15%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                        [ 23%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                [ 30%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                            [ 38%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                           [ 46%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[single] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                                [ 53%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                                  [ 61%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                          [ 69%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                  [ 76%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                              [ 84%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                             [ 92%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[dual] SKIPPED (DHCPv4 relay is not supported when dhcp_server is enabled)                                                                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
