### PR TITLE
Send gratuitous ARP packet when bringing up SONiC VM

### DIFF
--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -107,7 +107,7 @@ def session(new_params):
         ('ip route add 0.0.0.0/0 via %s table default' %
          str(new_params['mgmt_gw']), [r'#']),
         ('ip route', [r'#']),
-        ('arping -c 2 -A -I eth0 %s' % str(new_params['mgmt_ip']).split("/")[0], [r'#']),
+        ('arping -c 2 -U -P -I eth0 %s' % str(new_params['mgmt_ip']).split("/")[0], [r'#']),
         ('echo %s:%s | chpasswd' %
          (str(new_params['login']), str(new_params['new_password'])), [r'#']),
     ])

--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -107,6 +107,7 @@ def session(new_params):
         ('ip route add 0.0.0.0/0 via %s table default' %
          str(new_params['mgmt_gw']), [r'#']),
         ('ip route', [r'#']),
+        ('arping -c 2 -A -I eth0 %s' % str(new_params['mgmt_ip']).split("/")[0], [r'#']),
         ('echo %s:%s | chpasswd' %
          (str(new_params['login']), str(new_params['new_password'])), [r'#']),
     ])


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

When a new SONiC VM comes up, but the IP address assigned to it was used by something else before, there may be traffic issues until the ARP entry for that IP address expires on the router/switch connected to the management port. In some cases, there may be routers/switches that do not properly send ARP requests for whatever reason, when that IP address expires.

#### How did you do it?

To fix this issue, send a gratuitous ARP reply packet after the management IP address is configred in sonic_kickstart.py. This makes sure traffic is working, at least.

#### How did you verify/test it?

Tested by running add-topo for a KVM setup and making sure there were gratuitous ARP packets sent.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
