### PR TITLE
Include hostname and tracking ID when uploading warm-reboot results to Kusto

### DIFF
--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -183,7 +183,7 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData'] (ReportId: string, TrackingId: string, TestbedName: string, ['RebootType']:string,
+.create table ['RebootTimingData'] (ReportId: string, TrackingId: string, TestbedName: string, BaseImage:string, TargetImage:string, HwSku:string, ['RebootType']:string,
                                     ['ControlplaneArpPing']:string, ['ControlplaneDowntime']:string, ['DataplaneLostPackets']:string, ['DataplaneDowntime']:string,
                                     ['OffsetFromKexecDatabase']:string, ['OffsetFromKexecFinalizer']:string, ['OffsetFromKexecInitView']:string, ['OffsetFromKexecSyncdCreateSwitch']:string,
                                     ['OffsetFromKexecPortInit']:string, ['OffsetFromKexecPortReady']:string, ['OffsetFromKexecSaiCreateSwitch']:string, ['OffsetFromKexecNeighborEntry']:string,
@@ -198,6 +198,9 @@
                                                             '{"column":"ReportId","Properties":{"path":"$.id"}},'
                                                             '{"column":"TrackingId","Properties":{"path":"$.tracking_id"}},'
                                                             '{"column":"TestbedName","Properties":{"path":"$[\'hostname\']"}},'
+                                                            '{"column":"HwSku","Properties":{"path":"$[\'hwsku\']"}},'
+                                                            '{"column":"BaseImage","Properties":{"path":"$[\'base_ver\']"}},'
+                                                            '{"column":"TargetImage","Properties":{"path":"$[\'target_ver\']"}},'
                                                             '{"column":"OffsetFromKexecDatabase", "Properties":{"Path":"$[\'offset_from_kexec\'][\'database\']"}},'
                                                             '{"column":"OffsetFromKexecFinalizer", "Properties":{"Path":"$[\'offset_from_kexec\'][\'finalizer\']"}},'
                                                             '{"column":"OffsetFromKexecPortInit", "Properties":{"Path":"$[\'offset_from_kexec\'][\'port_init\']"}},'

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -183,7 +183,7 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData'] (ReportId: string, TrackingId: string, TestbedName: string, BaseImage:string, TargetImage:string, HwSku:string, ['RebootType']:string,
+.create table ['RebootTimingData'] (ReportId: string, TrackingId: string, Hostname: string, BaseImage:string, TargetImage:string, HwSku:string, ['RebootType']:string,
                                     ['ControlplaneArpPing']:string, ['ControlplaneDowntime']:string, ['DataplaneLostPackets']:string, ['DataplaneDowntime']:string,
                                     ['OffsetFromKexecDatabase']:string, ['OffsetFromKexecFinalizer']:string, ['OffsetFromKexecInitView']:string, ['OffsetFromKexecSyncdCreateSwitch']:string,
                                     ['OffsetFromKexecPortInit']:string, ['OffsetFromKexecPortReady']:string, ['OffsetFromKexecSaiCreateSwitch']:string, ['OffsetFromKexecNeighborEntry']:string,
@@ -197,7 +197,7 @@
 .create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDataMapping' @'['
                                                             '{"column":"ReportId","Properties":{"path":"$.id"}},'
                                                             '{"column":"TrackingId","Properties":{"path":"$.tracking_id"}},'
-                                                            '{"column":"TestbedName","Properties":{"path":"$[\'hostname\']"}},'
+                                                            '{"column":"Hostname","Properties":{"path":"$[\'hostname\']"}},'
                                                             '{"column":"HwSku","Properties":{"path":"$[\'hwsku\']"}},'
                                                             '{"column":"BaseImage","Properties":{"path":"$[\'base_ver\']"}},'
                                                             '{"column":"TargetImage","Properties":{"path":"$[\'target_ver\']"}},'

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -183,7 +183,7 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData'] (ReportId: string, ['RebootType']:string,
+.create table ['RebootTimingData'] (ReportId: string, TrackingId: string, TestbedName: string, ['RebootType']:string,
                                     ['ControlplaneArpPing']:string, ['ControlplaneDowntime']:string, ['DataplaneLostPackets']:string, ['DataplaneDowntime']:string,
                                     ['OffsetFromKexecDatabase']:string, ['OffsetFromKexecFinalizer']:string, ['OffsetFromKexecInitView']:string, ['OffsetFromKexecSyncdCreateSwitch']:string,
                                     ['OffsetFromKexecPortInit']:string, ['OffsetFromKexecPortReady']:string, ['OffsetFromKexecSaiCreateSwitch']:string, ['OffsetFromKexecNeighborEntry']:string,
@@ -196,6 +196,8 @@
 ////////////////////////////////////////////////////////////
 .create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDataMapping' @'['
                                                             '{"column":"ReportId","Properties":{"path":"$.id"}},'
+                                                            '{"column":"TrackingId","Properties":{"path":"$.tracking_id"}},'
+                                                            '{"column":"TestbedName","Properties":{"path":"$[\'hostname\']"}},'
                                                             '{"column":"OffsetFromKexecDatabase", "Properties":{"Path":"$[\'offset_from_kexec\'][\'database\']"}},'
                                                             '{"column":"OffsetFromKexecFinalizer", "Properties":{"Path":"$[\'offset_from_kexec\'][\'finalizer\']"}},'
                                                             '{"column":"OffsetFromKexecPortInit", "Properties":{"Path":"$[\'offset_from_kexec\'][\'port_init\']"}},'

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -255,9 +255,10 @@ class KustoConnector(ReportDBConnector):
         pdu_status_data = {"data": pdu_output}
         self._ingest_data(self.RAW_PDU_STATUS_TABLE, pdu_status_data)
 
-    def upload_reboot_report(self, path_name: str = "", report_guid: str = "") -> None:
+    def upload_reboot_report(self, path_name: str = "", tracking_id: str = "", report_guid: str = "") -> None:
         reboot_timing_data = {
-            "id": report_guid
+            "id": report_guid,
+            "tracking_id": tracking_id
         }
         reboot_timing_dict = validate_json_file(path_name)
         reboot_timing_data.update(reboot_timing_dict)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -82,7 +82,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 reboot_data_regex = re.compile(
                     '.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
                 if reboot_data_regex.match(path_name):
-                    kusto_db.upload_reboot_report(path_name, tracking_id if tracking_id else report_guid)
+                    kusto_db.upload_reboot_report(path_name, tracking_id, report_guid)
                 else:
                     if args.json:
                         test_result_json = validate_junit_json_file(path_name)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -82,7 +82,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 reboot_data_regex = re.compile(
                     '.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
                 if reboot_data_regex.match(path_name):
-                    kusto_db.upload_reboot_report(path_name, report_guid)
+                    kusto_db.upload_reboot_report(path_name, tracking_id if tracking_id else report_guid)
                 else:
                     if args.json:
                         test_result_json = validate_junit_json_file(path_name)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -187,6 +187,7 @@ def get_report_summary(duthost, analyze_result, reboot_type, reboot_oper, base_o
     result_summary = {
         "reboot_type": "{}-{}".format(reboot_type, reboot_oper) if reboot_oper else reboot_type,
         "hwsku": duthost.facts["hwsku"],
+        "hostname": duthost.hostname,
         "base_ver": base_os_version[0] if base_os_version and len(base_os_version) else "",
         "target_ver": get_current_sonic_version(duthost),
         "dataplane": analyze_result.get("dataplane", {"downtime": "", "lost_packets": ""}),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

After doing a warm/fast reboot, in the post-reboot analysis, include the hostname of the device. This information will then get uploaded into Kusto as a new column. The reason for this is that in case there are some device-specific oddities that cause some things to take longer on one device compared to another device, then this will help reveal them. It also makes it easier to see what device a certain run was done on, in case there needs to be some later debugging effort.

In addition, include the external tracking ID into Kusto, so that it's easier to match it to a specific pipeline run. Add a separate column for this, to make it easier to query for that.

The two new columns do mean that existing tables will need to be modified to support this.

#### How did you do it?

#### How did you verify/test it?

Verified by updating the Kusto table and running a warm upgrade test (with upload of results to Kusto), and verified the data was populated into Kusto.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
