### PR TITLE
[SNMP]: Modify test to verify all queue indexes are present

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -11,10 +11,12 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
                      collect_techsupport_all_duts):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     q_keys = []
+    direction_type = '2'  # direction_type in OID is set to 2 to denote "egress".
 
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
     port_name_to_alias_map = {}
+    port_name_to_ns = {}
 
     for asic_id in duthost.get_asic_ids():
         namespace = duthost.get_namespace_from_asic_id(asic_id)
@@ -26,6 +28,8 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
             q_keys.extend(q_keys_ns)
         if config_facts_ns and 'port_name_to_alias_map' in config_facts_ns:
             port_name_to_alias_map.update(config_facts_ns['port_name_to_alias_map'])
+            for port_name in config_facts_ns['port_name_to_alias_map']:
+                port_name_to_ns[port_name] = namespace
 
     if not q_keys:
         pytest.skip("No queues configured on interfaces")
@@ -33,18 +37,28 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
     # Get alias : port_name map
     alias_port_name_map = {k: v for v, k in port_name_to_alias_map.items()}
 
-    q_interfaces = set()
+    q_interfaces = dict()  # {intf_name : set(queue_indexes)}
     # get interfaces which has configured queues
     for key in q_keys:
+        intf_idx = 0
+        queue_idx = 0
         intf = key.split('|')
         # 'QUEUE|Ethernet*|2'
         if len(intf) == 3:
-            q_interfaces.add(intf[1])
+            intf_idx = 1
+            queue_idx = 2
         # Voq chassis 'QUEUE|<hostname>|<asic_ns>|Ethernet*|2'
         elif len(intf) == 5:
             # Choose only interfaces on current linecard.
             if intf[1] == duthost.hostname:
-                q_interfaces.add(intf[3])
+                intf_idx = 3
+                queue_idx = 4
+        if intf_idx != 0:
+            if intf[intf_idx] in q_interfaces:
+                q_interfaces[intf[intf_idx]].add(intf[queue_idx])
+            else:
+                q_interfaces[intf[intf_idx]] = set()
+                q_interfaces[intf[intf_idx]].add(intf[queue_idx])
 
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c",
                                 community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
@@ -62,3 +76,21 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
             intf = alias_port_name_map[v['name']]
             if intf in q_interfaces and 'queues' not in v:
                 pytest.fail("port %s does not have queue counters" % v['name'])
+            # Check if queue index in QUEUE table in config_db
+            # is present in SNMP result
+            if intf in q_interfaces:
+                for queue_idx in q_interfaces[intf]:
+                    snmp_q_idx = int(queue_idx) + 1
+                    if str(snmp_q_idx) not in v['queues'][direction_type].keys():
+                        pytest.fail("Expected queue index %d not present in \
+                                     SNMP result for interface %s" % (snmp_q_idx, v['name']))
+            # compare number of unicast queues in CLI to the number of queue indexes in
+            # SNMP result
+            if port_name_to_ns[intf]:
+                show_cli = 'show queue counters -n {} {} | grep "UC" | wc -l'.format(port_name_to_ns[intf], intf)
+            else:
+                show_cli = 'show queue counters {} | grep "UC" | wc -l'.format(intf)
+            result = duthost.shell(show_cli)
+            assert len(v['queues'][direction_type].keys()) == int(result[u'stdout']),\
+                   "Port {} does not have expected number of queue \
+                   indexes in SNMP result".format(intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Modify test to detect issue https://github.com/sonic-net/sonic-buildimage/issues/17448.
#### How did you do it?
Currently test_snmp_queue only verifies that each interface does have queue counters associated with it.
It does not verify if all the expected queue counters are present.
Modify test_snmp_queue to add 2 additional checks:
1. Ensure that queue index with queue configuration in config_db, is present for each interface.
2. Ensure that the number of Unicast queue counters for each interface in 'show queue counters <interface name> is the same as the number of queue indexes in the SNMP result.
#### How did you verify/test it?
Test case passes for single-asic/multi-asic/Chassis platforms.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
