### PR TITLE
[syslog] xfail syslog rate limit test and raise issue to track

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1189,6 +1189,12 @@ syslog/test_syslog_source_ip.py:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/6479
 
+syslog/test_syslog_rate_limit.py:
+  xfail:
+    reason: "Testcase xfail, raised issue to track"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/11181
+
 #######################################
 #####         system_health       #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1183,17 +1183,17 @@ syslog/test_syslog.py:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 33"
 
-syslog/test_syslog_source_ip.py:
-  skip:
-    reason: "Testcase consistent failed, raised issue to track"
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/6479
-
 syslog/test_syslog_rate_limit.py:
   xfail:
     reason: "Testcase xfail, raised issue to track"
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11181
+
+syslog/test_syslog_source_ip.py:
+  skip:
+    reason: "Testcase consistent failed, raised issue to track"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/6479
 
 #######################################
 #####         system_health       #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: xfail the syslog rate limit test and raise issue to track the progress
Fixes # (issue) Tracking issue https://github.com/sonic-net/sonic-mgmt/issues/11181

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
The syslog rate limit test will fail when randonly pick acms or syncd to test. After investigation, raise the issue to check with mellanox team.
#### How did you do it?
xfail the test
#### How did you verify/test it?
E2E
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
