### PR TITLE
[202305] xfail test_pfc_watermark_extra_lossless for brcm platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -992,14 +992,14 @@ qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_active:
   xfail:
     reason: "test_pfc_watermark_extra_lossless_active is not support on broadcom platform yet"
     conditions:
-      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+      - "asic_type in ['broadcom']"
       - https://github.com/sonic-net/sonic-mgmt/issues/11271
 
 qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_standby:
   xfail:
     reason: "test_pfc_watermark_extra_lossless_standby is not support on broadcom platform yet"
     conditions:
-      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+      - "asic_type in ['broadcom']"
       - https://github.com/sonic-net/sonic-mgmt/issues/11271
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -988,6 +988,18 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions:
       - "asic_type not in ['cisco-8000']"
 
+qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_active:
+  xfail:
+    reason: "test_pfc_watermark_extra_lossless_active is not support on broadcom platform yet"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+
+qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_standby:
+  xfail:
+    reason: "test_pfc_watermark_extra_lossless_standby is not support on broadcom platform yet"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+
 #######################################
 #####         restapi             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -993,12 +993,14 @@ qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_active:
     reason: "test_pfc_watermark_extra_lossless_active is not support on broadcom platform yet"
     conditions:
       - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/11271
 
 qos/test_tunnel_qos_remap.py::test_pfc_watermark_extra_lossless_standby:
   xfail:
     reason: "test_pfc_watermark_extra_lossless_standby is not support on broadcom platform yet"
     conditions:
       - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7260CX3-C64', 'Arista-7260CX3-D108C8', 'Force10-S6100']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/11271
 
 #######################################
 #####         restapi             #####


### PR DESCRIPTION
… case yet

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

Most test_pfc_watermark_extra_lossless cases had failed on broadcom platform, since Cisco introduced it in https://github.com/sonic-net/sonic-mgmt/pull/9318 at Sep/15 in an attempt to replace test_pfc_pause_extra_lossless_standby and test_pfc_pause_extra_lossless_active.
need to tuning and enhance case for broadcom platform.


#### How did you do it?

xfail first till most cases can pass

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
