### PR TITLE
add swap memory into return available memory in reduce_and_add_sonic_images

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -66,14 +66,23 @@ def get_memory_sizes(module):
     """
     _, out, _ = exec_command(module, cmd="free -m", msg="checking memory total/free sizes")
     lines = out.split('\n')
-    if len(lines) < 2:
-        return -1, -1
 
-    fields = lines[1].split()
-    if len(fields) < 3:
-        return -1, -1
+    for line in lines:
+        if line.startswith("Mem:"):
+            fields = line.split()
+            if len(fields) < 3:
+                return -1, -1
+            else:
+                total_mem, avail_mem = int(fields[1]), int(fields[-1])
+        elif line.startswith("Swap:"):
+            fields = line.split()
+            if len(fields) < 3:
+                return -1, -1
+            else:
+                total_swap, avail_swap = int(fields[1]), int(fields[-1])
 
-    total, avail = int(fields[1]), int(fields[-1])
+    total = total_mem + total_swap
+    avail = avail_mem + avail_swap
     return total, avail
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
26322283

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Below PR enhanced the upgrade sonic image, and would check memory and disk usage before installing the image.
But not calculate SWAP memory into the total available memory space.
https://github.com/sonic-net/sonic-mgmt/pull/11151

#### How did you do it?
Add swap free memory into total available memory.

#### How did you verify/test it?
2024-01-04 07:13:09,640 DEBUG #47: *** cmd: free -m ***
2024-01-04 07:13:09,736 DEBUG #49: *** rc: 0, out:                total        used        free      shared  buff/cache   available
Mem:            1948        1359          86          27         502         419
Swap:           2047         586        1461
, err:  ***
2024-01-04 07:13:09,736 DEBUG #43: Available memory 1880, no need to free up memory space

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
