### PR TITLE
Update test_pktgen.py to check cpu util of only specified process

### DIFF
--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -38,6 +38,7 @@ PKTGEN_CMDS = [
 
 CPU_CMD = "show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'"
 
+
 def get_port_list(duthost, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     return list(mg_facts["minigraph_ports"].keys())

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -77,7 +77,6 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     '''
     duthost = duthosts[enum_dut_hostname]
     router_mac = duthost.asic_instance(enum_frontend_asic_index).get_router_mac()
-    
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='pktgen')
     loganalyzer.load_common_config()
     

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -81,7 +81,7 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
 
     cpu_threshold = setup_thresholds
     # Check CPU util before sending traffic
-    cpu_before = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | awk '{print $9}'")["stdout_lines"]
+    cpu_before = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'")["stdout_lines"]
     for entry in cpu_before:
         pytest_assert(
             float(entry) < cpu_threshold,
@@ -119,7 +119,7 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     15000 packets were expected but only {} found".format(port, 15000-int(interf_counters)))
 
     # Check CPU util after sending traffic
-    cpu_after = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | awk '{print $9}'")["stdout_lines"]
+    cpu_after = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'")["stdout_lines"]
     for entry in cpu_after:
         pytest_assert(
             float(entry) < cpu_threshold,

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -134,7 +134,7 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     # Check kernel messages for errors after sending traffic
     logging.info("Check dmesg")
     dmesg = duthost.command("sudo dmesg")
-    error_keywords = ["crash", "Out of memory",
+    error_keywords = ["crash", "Out of memory", \
                       "Call Trace", "Exception", "panic"]
     for err_kw in error_keywords:
         assert not re.match(err_kw, dmesg["stdout"], re.I), \

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -22,7 +22,6 @@ CLEANUP_CMDS = [
                 "echo 'rem_device_all' > /proc/net/pktgen/kpktgend_0"
 ]
 
-
 PKTGEN_CMDS = [
                 "echo 'add_device {}' > /proc/net/pktgen/kpktgend_0",
                 "echo 'count 15000' > /proc/net/pktgen/{}",
@@ -37,6 +36,7 @@ PKTGEN_CMDS = [
                 "echo 'udp_dst_max 5001' > /proc/net/pktgen/{}",
                 ]
 
+CPU_CMD = "show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'"
 
 def get_port_list(duthost, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -81,11 +81,11 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
 
     cpu_threshold = setup_thresholds
     # Check CPU util before sending traffic
-    cpu_before = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'")["stdout_lines"]
+    cpu_before = duthost.shell(CPU_CMD)["stdout_lines"]
     for entry in cpu_before:
         pytest_assert(
             float(entry) < cpu_threshold,
-            "Cpu util was above threshold {} for atleast 1 process"
+            "Cpu util was above threshold {} for pktgen process"
             " before sending pktgen traffic".format(cpu_threshold))
 
     # Check number of existing core/crash files
@@ -119,11 +119,11 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     15000 packets were expected but only {} found".format(port, 15000-int(interf_counters)))
 
     # Check CPU util after sending traffic
-    cpu_after = duthost.shell("show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'")["stdout_lines"]
+    cpu_after = duthost.shell(CPU_CMD)["stdout_lines"]
     for entry in cpu_after:
         pytest_assert(
             float(entry) < cpu_threshold,
-            "Cpu util was above threshold {} for atleast 1 process"
+            "Cpu util was above threshold {} for pktgen process"
             " after sending pktgen traffic".format(cpu_threshold))
 
     # Check number of new core/crash files

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -77,10 +77,10 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
     '''
     duthost = duthosts[enum_dut_hostname]
     router_mac = duthost.asic_instance(enum_frontend_asic_index).get_router_mac()
-
+    
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='pktgen')
     loganalyzer.load_common_config()
-
+    
     cpu_threshold = setup_thresholds
     # Check CPU util before sending traffic
     cpu_before = duthost.shell(CPU_CMD)["stdout_lines"]
@@ -111,7 +111,7 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
             duthost.shell("sudo echo 'start' > /proc/net/pktgen/pgctrl")
     except LogAnalyzerError as err:
         raise err
-
+        
     # Verify packet count from pktgen
     pktgen_param = duthost.shell("cat /proc/net/pktgen/{}".format(port))["stdout"]
     pktgen_param = pktgen_param.split("\n")[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update test_pktgen.py to check cpu util of only specified process before and after running pktgen

Summary:
Fixes # (issue)
Checking all procs leads to higher probability of failure before starting pktgen

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205
- [x ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Checked the command
root@m64-tor-0:/home/cisco# show proc cpu --verbose | sed '1,/CPU/d' | grep pktgen | awk '{print $9}'
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
