### PR TITLE
Add setup_streaming_telemetry fixture to cache tests

### DIFF
--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -92,7 +92,7 @@ def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup
 
 
 @pytest.mark.disable_loganalyzer
-def test_events_cache_overflow(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, 
+def test_events_cache_overflow(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry,
                                gnxi_path):
     """ Published events till cache overflow, stats should read events missed_to_cache"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -54,7 +54,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
 
 
 @pytest.mark.disable_loganalyzer
-def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
+def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
     """Create expected o/p file of events with N events. Call event-publisher tool to publish M events (M<N). Publish
     remainder of events. Verify o/p file that N events were received"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -92,7 +92,8 @@ def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_
 
 
 @pytest.mark.disable_loganalyzer
-def test_events_cache_overflow(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
+def test_events_cache_overflow(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, 
+                               gnxi_path):
     """ Published events till cache overflow, stats should read events missed_to_cache"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info("Start events cache overflow testing")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)26281324

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

In baseline test we are seeing that in some runs, config may be missing such that gnmi server is running on default port 8080. Adding setup fixture to the testcase such that gnmi environment and config is setup for the test

#### How did you do it?

Added setup fixture to test_cache

#### How did you verify/test it?

Pipeline/manual testing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
