### PR TITLE
Ignoring error Failed to get port by bridge port ID

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -188,3 +188,6 @@ r, ".* ERR syncd\d*#syncd.*SAI_API_UNSPECIFIED:sai_bulk_object_get_stats.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/25018599
 r, ".* ERROR: Failed to parse lldp age.*"
+
+# Race condition while removing a vlan member, no functionality impact
+r, ". *ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID.*"


### PR DESCRIPTION
### What is the motivation for this PR?
orchagent has two threads, one of the threads is receiving messages to remove members from VLAN and the other thread is receiving FDB events (LEARN, AGE etc.) from syncd/SAI. There can be a race condition where FDB events were already in flight for a member which was getting removed from the VLAN. If orchagent processes the request to remove the member from VLAN first and then processes the FDB event, it will not find the port since bridge port ID is not valid any more. Because of this, we see an error message like ' ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID' in syslogs This error is completely harmless and does not affect the functionality.

This PR ignores above error message so that it does not cause the testcase to fail.

### How did you do it?
The error message in syslog is ignored by adding a line 'r, ". ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID."' to loganalyzer_common_ignore.txt file.

### How did you verify/test it?
Ran the test and made sure that these error messages are getting ignored

### Type of change
 Bug fix

### Back port request
 202305