### PR TITLE
[devutils]Fix output error for pdu_status in devutils

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -315,7 +315,10 @@ def pdu_action_on_dut(host, attrs, action):
                 'output_watts': 0,
         })
         status['power_on'] = status['power_on'] or outlet['outlet_on']
-        status['output_watts'] = status['output_watts'] + int(outlet['output_watts'])
+        if 'output_watts' not in outlet:
+            status['output_watts'] = 'N/A'
+        else:
+            status['output_watts'] = status['output_watts'] + int(outlet.get('output_watts', 0))
         psu_status[psu_name] = status
     ret['PSU status'] = psu_status
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After the changes in https://github.com/sonic-net/sonic-mgmt/pull/10087, some PDUs(such as APC controller rPDU) don't have MIB OID for power. There will be TypeError if get output_watts directly.

before fix:
```
zhaohuisun@sonic-mgmt-zhaohuisun2:/data/sonic-mgmt-int/ansible$ ./devutils -l str3-msn4600c-acs-05 -i str3 -a pdu_status -j
Traceback (most recent call last):
  File "./devutils", line 509, in <module>
    main()
  File "./devutils", line 505, in main
    action_dispatcher(parameters)
  File "./devutils", line 388, in action_dispatcher
    parameters['action'](parameters)
  File "./devutils", line 345, in action_pdu_status
    show_data_output(header, data, parameters['json'], parameters['out'])
  File "./devutils", line 192, in show_data_output
    output_content = json.dumps(sorted(data, key=lambda x: x['Host']), indent=4)
  File "./devutils", line 192, in <lambda>
    output_content = json.dumps(sorted(data, key=lambda x: x['Host']), indent=4)
TypeError: string indices must be integers
```

after fix:
```
zhaohuisun@sonic-mgmt-zhaohuisun2:/data/sonic-mgmt-int/ansible$ ./devutils -l str3-msn4600c-acs-05 -i str3 -a pdu_status -j
[
    {
        "Host": "str3-msn4600c-acs-05",
        "PSU status": {
            "PSU1": {
                "power_on": true,
                "output_watts": "N/A"
            },
            "PSU2": {
                "power_on": true,
                "output_watts": "N/A"
            }
        },
        "PDU status": [
            {
                "outlet_id": ".6",
                "outlet_on": true,
                "pdu_name": "pdu-92",
                "psu_name": "PSU1",
                "feed_name": "N/A"
            },
            {
                "outlet_id": ".9",
                "outlet_on": true,
                "pdu_name": "pdu-93",
                "psu_name": "PSU2",
                "feed_name": "N/A"
            }
        ],
        "Summary": [],
        "Action": "status"
    }
]
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Handle the situation if there is no output_watts got from PDU.

#### How did you do it?
Set output_watts to N/A if there is no output_watts got from PDU.

#### How did you verify/test it?
Run  `./devutils -l str3-msn4600c-acs-05 -i str3 -a pdu_status -j`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
