### PR TITLE
[route flap] Update logic to get dev_port

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -248,6 +248,8 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                     break
                 dev = json.loads(asic.run_vtysh(cmd)['stdout'])
                 for per_hop in dev[route_to_ping][0]['nexthops']:
+                    if dev_port:
+                        break
                     if 'interfaceName' not in per_hop.keys():
                         continue
                     if 'ip' not in per_hop.keys():
@@ -260,10 +262,11 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                         logger.info("{} is still internal interface, skipping".format(port))
                     else:
                         dev_port = port
-                    break
         else:
             dev = json.loads(asichost.run_vtysh(cmd)['stdout'])
             for per_hop in dev[route_to_ping][0]['nexthops']:
+                if dev_port:
+                    break
                 if 'interfaceName' not in per_hop.keys():
                     continue
                 # For chassis, even single-asic linecard could have internal interface
@@ -272,7 +275,6 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
                 if 'IB' in per_hop['interfaceName'] or 'BP' in per_hop['interfaceName']:
                     continue
                 dev_port = per_hop['interfaceName']
-                break
     pytest_assert(dev_port, "dev_port not exist")
     return dev_port, route_to_ping
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update the logic to get dev_port.
old logic will always break for 1st iteration, which will result in dev_port to be empty, at the end of function, if the first route we find is an internal route. 
new logic in this PR will break only if dev_port is non-empty or the for loop ended.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
before:
```
>       pytest_assert(dev_port, "dev_port not exist")
E       Failed: dev_port not exist

asic       = <SonicAsic 1>
asichost   = <SonicAsic 0>
cmd        = ' -c "show ip route 192.170.49.0/25 json"'
dev        = {'192.170.49.0/25': [{'destSelected': True, 'distance': 20, 'installed': True, 'installedNexthopGroupId': 69657, ...}]}
dev_port   = None
dst_prefix = routes(route=u'192.170.49.0/25', aspath=u'65503')
dst_prefix_set = set([routes(route=u'192.168.0.0/25', aspath=u'65500'), routes(route=u'192.168.0.128/25', aspath=u'65500'), routes(rout...5500'), routes(route=u'192.168.112.0/25', aspath=u'65507'), routes(route=u'192.168.112.128/25', aspath=u'65507'), ...])
duthost    = <MultiAsicSonicHost svcstr-lc3-1>
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
