### PR TITLE
[ecmp offset] Fix the incorrect count of ports for 7050qx

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -152,15 +152,23 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
         offset_count = offset_list.count('0')
         if asic_name == "td3":
             # For TD3, RTAG7_PORT_BASED_HASH.ipipe0[1]: <OFFSET_ECMP=2,>
-            pytest_assert(offset_count == 391, "the count of 0 OFFSET_ECMP is not correct.")
+            pytest_assert(offset_count == 391, "the count of 0 OFFSET_ECMP is not correct. \
+                          Expected {}, but got {}.".format(391, offset_count))
+        elif hwsku in ["Arista-7050-QX-32S", "Arista-7050QX32S-Q32"]:
+            # For TD2, 7050qx, the total number of ports are 362
+            pytest_assert(offset_count == 362, "the count of 0 OFFSET_ECMP is not correct. \
+                          Expected {}, but got {}.".format(362, offset_count))
         else:
-            pytest_assert(offset_count == 392, "the count of 0 OFFSET_ECMP is not correct.")
+            pytest_assert(offset_count == 392, "the count of 0 OFFSET_ECMP is not correct. \
+                          Expected {}, but got {}.".format(392, offset_count))
     elif topo_type == "t1":
         offset_count = offset_list.count('0xa')
         if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32"]:
-            pytest_assert(offset_count >= 33, "the count of 0xa OFFSET_ECMP is not correct.")
+            pytest_assert(offset_count >= 33, "the count of 0xa OFFSET_ECMP is not correct. \
+                          Expected >= 33, but got {}.".format(offset_count))
         else:
-            pytest_assert(offset_count >= 67, "the count of 0xa OFFSET_ECMP is not correct.")
+            pytest_assert(offset_count >= 67, "the count of 0xa OFFSET_ECMP is not correct. \
+                          Expected >= 67, but got {}.".format(offset_count))
     else:
         pytest.fail("Unsupported topology type: {}".format(topo_type))
 

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -154,7 +154,7 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
             # For TD3, RTAG7_PORT_BASED_HASH.ipipe0[1]: <OFFSET_ECMP=2,>
             pytest_assert(offset_count == 391, "the count of 0 OFFSET_ECMP is not correct. \
                           Expected {}, but got {}.".format(391, offset_count))
-        elif hwsku in ["Arista-7050-QX-32S", "Arista-7050QX32S-Q32"]:
+        elif asic_name == "td2":
             # For TD2, 7050qx, the total number of ports are 362
             pytest_assert(offset_count == 362, "the count of 0 OFFSET_ECMP is not correct. \
                           Expected {}, but got {}.".format(362, offset_count))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fix the incorrect count of ports for 7050qx, it's 362, not 392.

#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
