### PR TITLE
Add cisco testbeds into auto recovery scripts. 

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -40,9 +40,7 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
 
         if type in ["arista"]:
             posix_shell_aboot(dut_console, mgmt_ip, image_url)
-        # elif type in ["Cisco"]:
-        #     return
-        elif type in ["mellanox", "nexus", "acs"]:
+        elif type in ["mellanox", "nexus", "acs", "cisco"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url)
         else:
             return

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -40,8 +40,10 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
 
         if type in ["arista"]:
             posix_shell_aboot(dut_console, mgmt_ip, image_url)
-        elif type in ["mellanox", "nexus", "acs", "cisco"]:
+        elif type in ["mellanox", "acs", "cisco"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url)
+        elif type in ["nexus"]:
+            posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=True)
         else:
             return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support Cisco testbeds. 
We notice that Cisco devices use "ONIE" to reload, so in this PR, we add Cisco testbeds into the branch which will use ONIE to recover.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support Cisco testbeds. 
We notice that Cisco devices use "ONIE" to reload, so in this PR, we add Cisco testbeds into the branch which will use ONIE to recover.

#### How did you do it?
Add cisco testbeds into the branch which will recover using ONIE. 

#### How did you verify/test it?
Run auto recover scripts on cisco devices. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
