### PR TITLE
Skip test_memory_exhaustion on 6100 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -761,8 +761,10 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
 platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Unsupported release or platforms"
+    conditions_logical_operator: or
     conditions:
       - "(is_multi_asic==True and release in ['201911']) or (hwsku in ['Celestica-E1031-T48S4'])"
+      - "'dell_s6100' in platform"
 
 #######################################
 #####    test_platform_info.py    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Skip test_memory_exhaustion on 6100 platforms.
ADO:17449251
#### How did you do it?
add skip section for 6100
#### How did you verify/test it?
run test_memory_exhaustion on 6100 testbeds

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
