### PR TITLE
Config bgp bbr by GCU cmd in test_bgp_bbr test

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -233,7 +233,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
         'bbr_route_v6_dual_dut_asn': bbr_route_v6_dual_dut_asn
     }
 
-    if tor1_namespace == DEFAULT_NAMESPACE:
+    if not setup_info['tor1_namespace']:
         logger.info('non multi-asic environment, add bbr config to running config using gcu cmd')
         add_bbr_config_to_running_config(duthost, bbr_default_state)
 

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -83,7 +83,7 @@ def add_bbr_config_to_running_config(duthost, status):
         expect_op_success(duthost, output)
     finally:
         delete_tmpfile(duthost, tmpfile)
-    
+
     time.sleep(3)
 
 
@@ -105,7 +105,7 @@ def config_bbr_by_gcu(duthost, status):
         expect_op_success(duthost, output)
     finally:
         delete_tmpfile(duthost, tmpfile)
-    
+
     time.sleep(3)
 
 

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -135,13 +135,10 @@ def disable_bbr(duthost, namespace):
 def restore_bbr_default_state(duthosts, setup, rand_one_dut_hostname, bbr_default_state):
     yield
     duthost = duthosts[rand_one_dut_hostname]
-    if setup['tor1_namespace'] != DEFAULT_NAMESPACE:
-        if bbr_default_state == 'enabled':
-            enable_bbr(duthost, setup['tor1_namespace'])
-        else:
-            disable_bbr(duthost, setup['tor1_namespace'])
+    if bbr_default_state == 'enabled':
+        enable_bbr(duthost, setup['tor1_namespace'])
     else:
-        config_bbr_by_gcu(duthost, bbr_default_state)
+        disable_bbr(duthost, setup['tor1_namespace'])
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Config bbr status by using GCU cmd since we enable YANG model for bbr in https://github.com/sonic-net/sonic-buildimage/pull/17622.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Config bbr status by GCU cmd.
#### How did you do it?
Config bbr status use cmd ```config apply-patch <json-patch>``` instead of ```sonic-cfggen```

#### How did you verify/test it?
Run bgp/test_bgp_bbr.py case on dut manually and passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
