### PR TITLE
 test_auto_negotiation.py: Added test coverage for port speed change with reboot.

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -405,7 +405,7 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
           speed == new_speed,
           'expect fanout speed: {}, but got {}'.format(speed, new_speed))
     else:
-        logger.info("##### This Testcase valid only platform: x86_64-8101_32fh_o-r0 ######")
+        pytest.skip(f'This test is not supported on {duthost.facts["platform"]} platform')
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -370,6 +370,7 @@ def test_force_speed(enum_speed_per_dutport_fixture):
         'expect fanout speed: {}, but got {}'.format(speed, fanout_actual_speed)
     )
 
+
 def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fixture):
     """Verify port configuration across reboot
     """

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -382,11 +382,11 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
         new_speed = '40000'
         logging.info("Step1:set port speed to 40G")
-        for dut, port in zip([duthost, fanout], [dut_port, fanout_port]):
-            logger.info('step1: Configure port speed 40G')
-            dut.set_speed(dut_port, new_speed)
-            logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
-            wait_result = wait_until(
+       for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
+           logger.info('step1: Configure port speed 40G')
+           dut.set_speed(dut_port,new_speed)
+           logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
+           wait_result = wait_until(
                      SINGLE_PORT_WAIT_TIME,
                      PORT_STATUS_CHECK_INTERVAL,
                      0,
@@ -395,12 +395,17 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
                      [dut_port],
                      new_speed
                      )
-            pytest_assert(wait_result, '{} are still down'.format(dut_port))
-            logging.info("Step3: Perform config save and reload")
-            duthost.shell('sudo config save -y')
-            config_reload(duthost, config_source="config_db", wait=120)
+           pytest_assert(wait_result, '{} are still down'.format(dut_port))
+           logging.info("Step3: Perform config save and reload")
+           duthost.shell('sudo config save -y')
+           config_reload(duthost, config_source="config_db", wait=120)
+       logger.info('step4: verify port speed')
+       speed = dut.get_speed(dut_port)
+       pytest_assert(
+          speed == new_speed,
+          'expect fanout speed: {}, but got {}'.format(speed,new_speed))
     else:
-        print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
+       print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -405,7 +405,7 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
           speed == new_speed,
           'expect fanout speed: {}, but got {}'.format(speed,new_speed))
     else:
-       print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
+       logger.info("##### This Testcase valid only platform: x86_64-8101_32fh_o-r0 ######")
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -382,7 +382,7 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
         new_speed = '40000'
         logging.info("Step1:set port speed to 40G")
-        for dut,port in zip([duthost, fanout], [dut_port, fanout_port]):
+        for dut, port in zip([duthost, fanout], [dut_port, fanout_port]):
             logger.info('step1: Configure port speed 40G')
             dut.set_speed(dut_port, new_speed)
             logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -370,6 +370,7 @@ def test_force_speed(enum_speed_per_dutport_fixture):
         'expect fanout speed: {}, but got {}'.format(speed, fanout_actual_speed)
     )
 
+
 def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fixture):
     """Verify port configuration across reboot
     Step:1 Configure port speed to 40G
@@ -400,6 +401,7 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
            config_reload(duthost, config_source="config_db", wait=120)
     else:
        print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
+
 
 @pytest.fixture(scope='module', autouse=True)
 def change_cable_length(duthost):

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -376,11 +376,11 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     dutname, portname = enum_speed_per_dutport_fixture['dutname'], enum_speed_per_dutport_fixture['port']
     duthost, dut_port, fanout, fanout_port = all_ports_by_dut[dutname][portname]
     new_speed = enum_speed_per_dutport_fixture['speed']
-    logging.info("Step1:set port speed to 40G")
-    for dut,port in zip([duthost,fanout],[dut_port,fanout_port]):
-        dut.set_speed(port,new_speed)
+    logging.info("Step1: set port speed to 40G")
+    for dut, port in zip([duthost, fanout], [dut_port, fanout_port]):
+        dut.set_speed(port, new_speed)
     logging.info("Step2: Perform config save and reload")
-    for dut,port in zip([duthost,fanout],[dut_port,fanout_port]):
+    for dut, port in zip([duthost, fanout], [dut_port, fanout_port]):
         dut.shell('sudo config save -y')
     config_reload(duthost, config_source="config_db", wait=120)
     logger.info('step3: Wait until the port status is up, expected speed: {}'.format(new_speed))

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -401,7 +401,6 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     else:
        print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
 
-
 @pytest.fixture(scope='module', autouse=True)
 def change_cable_length(duthost):
     if is_mellanox_device(duthost):

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -382,9 +382,9 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
         new_speed = '40000'
         logging.info("Step1:set port speed to 40G")
-        for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
+        for dut, port in zip([duthost, fanout], [dut_port, fanout_port]):
             logger.info('step1: Configure port speed 40G')
-            dut.set_speed(dut_port,new_speed)
+            dut.set_speed(dut_port, new_speed)
             logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
             wait_result = wait_until(
                      SINGLE_PORT_WAIT_TIME,
@@ -403,7 +403,7 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
         speed = dut.get_speed(dut_port)
         pytest_assert(
           speed == new_speed,
-          'expect fanout speed: {}, but got {}'.format(speed,new_speed))
+          'expect fanout speed: {}, but got {}'.format(speed, new_speed))
     else:
         logger.info("##### This Testcase valid only platform: x86_64-8101_32fh_o-r0 ######")
 

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -382,9 +382,9 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
         new_speed = '40000'
         logging.info("Step1:set port speed to 40G")
-        for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
+        for dut,port in zip([duthost, fanout], [dut_port, fanout_port]):
             logger.info('step1: Configure port speed 40G')
-            dut.set_speed(dut_port,new_speed)
+            dut.set_speed(dut_port, new_speed)
             logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
             wait_result = wait_until(
                      SINGLE_PORT_WAIT_TIME,

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -380,13 +380,13 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     dutname, portname = enum_speed_per_dutport_fixture['dutname'], enum_speed_per_dutport_fixture['port']
     duthost, dut_port, fanout, fanout_port = all_ports_by_dut[dutname][portname]
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
-       new_speed = '40000'
-       logging.info("Step1:set port speed to 40G")
-       for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
-           logger.info('step1: Configure port speed 40G')
-           dut.set_speed(dut_port,new_speed)
-           logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
-           wait_result = wait_until(
+        new_speed = '40000'
+        logging.info("Step1:set port speed to 40G")
+        for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
+            logger.info('step1: Configure port speed 40G')
+            dut.set_speed(dut_port,new_speed)
+            logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
+            wait_result = wait_until(
                      SINGLE_PORT_WAIT_TIME,
                      PORT_STATUS_CHECK_INTERVAL,
                      0,
@@ -395,12 +395,12 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
                      [dut_port],
                      new_speed
                      )
-           pytest_assert(wait_result, '{} are still down'.format(dut_port))
-           logging.info("Step3: Perform config save and reload")
-           duthost.shell('sudo config save -y')
-           config_reload(duthost, config_source="config_db", wait=120)
+            pytest_assert(wait_result, '{} are still down'.format(dut_port))
+            logging.info("Step3: Perform config save and reload")
+            duthost.shell('sudo config save -y')
+            config_reload(duthost, config_source="config_db", wait=120)
     else:
-       print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
+        print("This Testcase valid only platform: x86_64-8101_32fh_o-r0")
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -382,11 +382,11 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
     if duthost.facts['platform'] == 'x86_64-8101_32fh_o-r0':
         new_speed = '40000'
         logging.info("Step1:set port speed to 40G")
-       for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
-           logger.info('step1: Configure port speed 40G')
-           dut.set_speed(dut_port,new_speed)
-           logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
-           wait_result = wait_until(
+        for dut,port in zip([duthost, fanout],[dut_port, fanout_port]):
+            logger.info('step1: Configure port speed 40G')
+            dut.set_speed(dut_port,new_speed)
+            logger.info('step2: Wait until the port status is up, expected speed: {}'.format(new_speed))
+            wait_result = wait_until(
                      SINGLE_PORT_WAIT_TIME,
                      PORT_STATUS_CHECK_INTERVAL,
                      0,
@@ -395,17 +395,17 @@ def test_verify_portspeed_configuration_across_reboot(enum_speed_per_dutport_fix
                      [dut_port],
                      new_speed
                      )
-           pytest_assert(wait_result, '{} are still down'.format(dut_port))
-           logging.info("Step3: Perform config save and reload")
-           duthost.shell('sudo config save -y')
-           config_reload(duthost, config_source="config_db", wait=120)
-       logger.info('step4: verify port speed')
-       speed = dut.get_speed(dut_port)
-       pytest_assert(
+            pytest_assert(wait_result, '{} are still down'.format(dut_port))
+            logging.info("Step3: Perform config save and reload")
+            duthost.shell('sudo config save -y')
+            config_reload(duthost, config_source="config_db", wait=120)
+        logger.info('step4: verify port speed')
+        speed = dut.get_speed(dut_port)
+        pytest_assert(
           speed == new_speed,
           'expect fanout speed: {}, but got {}'.format(speed,new_speed))
     else:
-       logger.info("##### This Testcase valid only platform: x86_64-8101_32fh_o-r0 ######")
+        logger.info("##### This Testcase valid only platform: x86_64-8101_32fh_o-r0 ######")
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
Added support for port speed config with reboot

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Change the interface speed to 40G and config reload
- Verify the  speed should be configured and  no crash.
-->

Summary:
- Change the interface speed to 40G and do config reload
- Verify the  speed should be configured and  no crash.

### Type of change
Added new testcase

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
The motivation for this PR is to verify device behaviour on reboot  with 40G port speed.

#### How did you do it?
Automated new testcase "test_verify_portspeed_configuration_across_reboot"  in script 
platform_tests/test_auto_negotiation.py

#### How did you verify/test it?
deployed T0 topology
 ./run_tests.sh -n vms-sn2700-t0 -d <device name> -c platform_tests/test_auto_negotiation.py::test_verify_portspeed_configuration_across_reboot
-t t0,any -i ../ansible/inventory -l info -u -e --skip_sanity

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?
any
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
