### PR TITLE
Ignore firmware failed to load ERR messages

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -224,3 +224,8 @@ r, ".*kdump-tools\[[0-9]+\]: no crashkernel= parameter in the kernel cmdline.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/25833053
 r, ".* ERR dualtor_neighbor_check.py: .*"
+
+# https://github.com/sonic-net/sonic-buildimage/issues/17683
+r, ".*ERR kernel: \[.*\] ccp.*firmware: failed to load amd\/amd_sev_.*.sbin .*"
+r, ".*ERR kernel: \[.*\] firmware_class: See https:\/\/wiki.debian.org\/Firmware for information about missing firmware.*"
+r, ".*ERR kernel: \[.*\] snd_hda_intel.*no codecs found!.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- Following platform errors are seen during random test runs, for example platform_tests/test_link_down.py,

```python
2023-12-04T18:08:59.9763391Z E               Dec  4 11:26:05.669304 svcstr-7250-sup-1 ERR kernel: [    2.733534] ccp 0000:09:00.2: firmware: failed to load amd/amd_sev_fam17h_model01h.sbin (-2)
2023-12-04T18:08:59.9764672Z E               
2023-12-04T18:08:59.9766037Z E               Dec  4 11:26:05.669305 svcstr-7250-sup-1 ERR kernel: [    2.743058] firmware_class: See https://wiki.debian.org/Firmware for information about missing firmware
2023-12-04T18:08:59.9767355Z E               
2023-12-04T18:08:59.9768464Z E               Dec  4 11:26:05.669323 svcstr-7250-sup-1 ERR kernel: [    2.948445] snd_hda_intel 0000:0a:00.3: no codecs found!
2023-12-04T18:08:59.9769573Z E               
2023-12-04T18:08:59.9770715Z E               Dec  4 11:26:06.382462 svcstr-7250-sup-1 INFO kdump-tools[881]: no crashkernel= parameter in the kernel cmdline ...
``` 
- Issue is reported at https://github.com/sonic-net/sonic-buildimage/issues/17683
- This PR helps to ignore these amd_sev firmware error messages from loganalyzer as it is not applicable under SONiC.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

- Ignore firmware related error messages reported at https://github.com/sonic-net/sonic-buildimage/issues/17683, during random test runs as it is not applicable under SONiC.

#### How did you do it?

- Added expected ERROR messages to the regex list in loganalyzer_common_ignore.txt.

#### How did you verify/test it?

- Ran all the tests against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
/