### PR TITLE
skipping dhcp_relay testcases for 8111 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -282,6 +282,21 @@ decap/test_decap.py::test_decap[ttl=uniform, dscp=uniform, vxlan=set_unset]:
     reason: "Not supported uniform ttl mode"
 
 #######################################
+#####         dhcp_relay        #####
+#######################################
+dhcp_relay/test_dhcp_relay.py:
+  skip:
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
+dhcp_relay/test_dhcpv6_relay.py:
+  skip:
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
+#######################################
 #####         drop_packets        #####
 #######################################
 drop_packets:
@@ -574,6 +589,12 @@ generic_config_updater:
     reason: 'generic_config_updater is not a supported feature for T2'
     conditions:
       - "'t2' in topo_name"
+
+generic_config_updater/test_dhcp_relay.py:
+  skip:
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:


### PR DESCRIPTION
### What is the motivation for this PR?:

MSFT requested to skip below testcases for 8111 platform
dhcp_relay/test_dhcp_relay.py
dhcp_relay/test_dhcpv6_relay.py
generic_config_updater/test_dhcp_relay.py

This PR makes the changes required for skipping above testcases for 8111 platform

### How did you do it?

The testcases are skipped by adding skip condition in below mentioned file tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

### How did you verify/test it?

Ran the required testcases are making changes to tests_mark_conditions.yaml file. Made sure that the testcases got skipped.

### Type of change
Test case(new/improvement)

### Back port request
202305


