### PR TITLE
[tests/route]: Add a test to verify orchagent behavior with duplicate…

### DIFF
--- a/docs/testplan/duplicate-route-test-plan.md
+++ b/docs/testplan/duplicate-route-test-plan.md
@@ -1,0 +1,83 @@
+# Duplicate-routes test plan
+
+* [Overview](#Overview)
+   * [Scope](#Scope)
+   * [Testbed](#Testbed)
+* [Setup configuration](#Setup%20configuration)
+* [Test cases](#Test%20cases)
+
+## Overview
+The purpose is to make sure that duplicate routes matching an existing loopback IP or vlan IP prefix does not cause orchagent to crash or restart.
+The test expects that the device is configured with a baseline configuration that has both loopback and vlan interfaces with valid IPv4 and IPv6 addresses.
+
+### Scope
+The test is targeting a running SONiC system with fully functioning configuration. The purpose of the test is to verify that SAI error SAI_STATUS_ITEM_ALREADY_EXISTS for route objects are gracefully handled by orchagent.
+The expectation is that orchagent should not crash or restart in such cases.
+
+### Testbed
+The test could run on T0/M0 testbeds that have both loopback and vlan interface configurations.
+
+## Setup configuration
+This test requires that loopback and vlan interfaces are configured with valid IPv4 and IPv6 addresses. All other required configurations are added dynamically at the beginning of the test and restored at the end of the test.
+
+## Test
+The test will verify that routes matching a loopback IP prefix or vlan IP prefix does not cause orchagent to crash or restart.
+
+
+## Test cases
+
+### Test case # 1 – Duplicate Loopback IPv4 route
+
+#### Test objective
+Verify that adding a duplicate IPv4 route that matches a Loopback interface IPv4 address does not cause orchagent crash/restart
+
+#### Test steps
+* Setup valid interface IPv4 addresses and neighbors on any of the UP interfaces on the device
+* Generate route with prefix that matches a Loopback IPv4 address on the device and nexthop via one of the neighbors configured before.
+* Save PID of orchagent before configuring the routes generated in the step before
+* Configure the generated route in APP_DB using swssconfig utlity
+* Make sure that expected log messages are seen using loganalyzer to confirm that the functionality is being tested as intended
+* Confirm that orchagent is still running and verify that newly obtained PID of orchagent matches the previously saved PID
+* Restore the DUT configuration by removing the previouly configured route, IP addresses and neighbors
+
+### Test case # 2 – Duplicate Loopback IPv6 route
+
+#### Test objective
+Verify that adding a duplicate IPv6 route that matches a Loopback interface IPv6 address does not cause orchagent crash/restart
+
+#### Test steps
+* Setup valid interface IPv6 addresses and neighbors on any of the UP interfaces on the device
+* Generate route with prefix that matches a Loopback IPv6 address on the device and nexthop via one of the neighbors configured before.
+* Save PID of orchagent before configuring the routes generated in the step before
+* Configure the generated route in APP_DB using swssconfig utlity
+* Make sure that expected log messages are seen using loganalyzer to confirm that the functionality is being tested as intended
+* Confirm that orchagent is still running and verify that newly obtained PID of orchagent matches the previously saved PID
+* Restore the DUT configuration by removing the previouly configured route, IP addresses and neighbors
+
+### Test case # 3 – Duplicate Vlan IPv4 route
+
+#### Test objective
+Verify that adding a duplicate IPv4 route that matches a Vlan interface IPv4 address does not cause orchagent crash/restart
+
+#### Test steps
+* Setup valid interface IPv4 addresses and neighbors on any of the UP interfaces on the device
+* Generate route with prefix that matches a Vlan IPv4 address on the device and nexthop via one of the neighbors configured before.
+* Save PID of orchagent before configuring the routes generated in the step before
+* Configure the generated route in APP_DB using swssconfig utlity
+* Make sure that expected log messages are seen using loganalyzer to confirm that the functionality is being tested as intended
+* Confirm that orchagent is still running and verify that newly obtained PID of orchagent matches the previously saved PID
+* Restore the DUT configuration by removing the previouly configured route, IP addresses and neighbors
+
+### Test case # 4 – Duplicate Vlan IPv6 route
+
+#### Test objective
+Verify that adding a duplicate IPv6 route that matches a Vlan interface IPv6 address does not cause orchagent crash/restart
+
+#### Test steps
+* Setup valid interface IPv6 addresses and neighbors on any of the UP interfaces on the device
+* Generate route with prefix that matches a Vlan IPv6 address on the device and nexthop via one of the neighbors configured before.
+* Save PID of orchagent before configuring the routes generated in the step before
+* Configure the generated route in APP_DB using swssconfig utlity
+* Make sure that expected log messages are seen using loganalyzer to confirm that the functionality is being tested as intended
+* Confirm that orchagent is still running and verify that newly obtained PID of orchagent matches the previously saved PID
+* Restore the DUT configuration by removing the previouly configured route, IP addresses and neighbors

--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -17,3 +17,11 @@ def pytest_addoption(parser):
 @pytest.fixture(scope='module')
 def get_function_conpleteness_level(pytestconfig):
     return pytestconfig.getoption("--completeness_level")
+
+
+@pytest.fixture(scope='module', params=[4, 6])
+def ip_versions(request):
+    """
+    Parameterized fixture for IP versions.
+    """
+    yield request.param

--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -12,7 +12,7 @@ from tests.route.utils import generate_intf_neigh, generate_route_file, prepare_
 
 
 pytestmark = [
-    pytest.mark.topology("any"),
+    pytest.mark.topology("t0", "m0"),
     pytest.mark.device_type('vs')
 ]
 
@@ -75,10 +75,10 @@ def interface_types(request):
 
 @pytest.fixture(autouse=True)
 def verify_expected_loganalyzer_logs(
-    enum_frontend_dut_hostname, loganalyzer
+    enum_rand_one_per_hwsku_frontend_hostname, loganalyzer
 ):
     """
-    Verify that expected failure messages are seen in logs during test execution.
+    Verify that expected failure messages are seen in logs during test execution
     Args:
         duthost: DUT fixture
         loganalyzer: Loganalyzer utility fixture
@@ -90,21 +90,22 @@ def verify_expected_loganalyzer_logs(
         ]
     if loganalyzer:
         # Skip if loganalyzer is disabled
-        loganalyzer[enum_frontend_dut_hostname].expect_regex.extend(
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].expect_regex.extend(
             expectRegex
         )
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reload_dut(duthosts, enum_frontend_dut_hostname):
-    duthost = duthosts[enum_frontend_dut_hostname]
+def reload_dut(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     yield
     config_reload(duthost)
 
 
 @pytest.fixture
-def setup_routes(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, ip_versions, interface_types):
-    duthost = duthosts[enum_frontend_dut_hostname]
+def setup_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                 enum_rand_one_frontend_asic_index, ip_versions, interface_types):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     cfg_facts = get_cfg_facts(duthost)
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
     prefixes = []
@@ -140,8 +141,9 @@ def setup_routes(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_as
     duthost.shell("rm {}".format(route_file_set))
 
 
-def test_duplicate_routes(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, setup_routes):
-    duthost = duthosts[enum_frontend_dut_hostname]
+def test_duplicate_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                          enum_rand_one_frontend_asic_index, setup_routes):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     swss_cfg_file_set = setup_routes
 
     # Get orchagent pid before applying config

--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -1,0 +1,168 @@
+import pytest
+import json
+import random
+import logging
+
+from time import sleep
+from netaddr import IPNetwork
+from tests.common import config_reload
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
+from tests.route.utils import generate_intf_neigh, generate_route_file, prepare_dut, cleanup_dut
+
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.device_type('vs')
+]
+
+logger = logging.getLogger(__name__)
+
+LOG_EXPECT_ADD_ROUTE_FAILED = ".*Failed to create route.*"
+
+
+def get_cfg_facts(duthost):
+    # return config db contents(running-config)
+    tmp_facts = json.loads(duthost.shell(
+        "sonic-cfggen -d --print-data")['stdout'])
+
+    return tmp_facts
+
+
+def get_intf_ips(interface_name, cfg_facts):
+    prefix_to_intf_table_map = {
+        'Vlan': 'VLAN_INTERFACE',
+        'PortChannel': 'PORTCHANNEL_INTERFACE',
+        'Ethernet': 'INTERFACE',
+        'Loopback': 'LOOPBACK_INTERFACE'
+    }
+
+    intf_table_name = None
+
+    ip_facts = {
+        'ipv4': [],
+        'ipv6': []
+    }
+
+    for pfx, t_name in list(prefix_to_intf_table_map.items()):
+        if pfx in interface_name:
+            intf_table_name = t_name
+            break
+
+    if intf_table_name is None:
+        return ip_facts
+
+    for intf in cfg_facts[intf_table_name]:
+        if '|' in intf:
+            if_name, ip = intf.split('|')
+            if interface_name in if_name:
+                ip = IPNetwork(ip)
+                if ip.version == 4:
+                    ip_facts['ipv4'].append(ip)
+                else:
+                    ip_facts['ipv6'].append(ip)
+
+    return ip_facts
+
+
+@pytest.fixture(params=['Loopback', 'Vlan'])
+def interface_types(request):
+    """
+    Parameterized fixture for interface types.
+    """
+    yield request.param
+
+
+@pytest.fixture(autouse=True)
+def verify_expected_loganalyzer_logs(
+    enum_frontend_dut_hostname, loganalyzer
+):
+    """
+    Verify that expected failure messages are seen in logs during test execution.
+    Args:
+        duthost: DUT fixture
+        loganalyzer: Loganalyzer utility fixture
+    """
+    expectRegex = [
+        ".*ERR.* meta_sai_validate_route_entry:.* already exists.*",
+        ".*ERR.* status: SAI_STATUS_ITEM_ALREADY_EXISTS.*",
+        ".*ERR.* addRoutePost: Failed to create route.*",
+        ]
+    if loganalyzer:
+        # Skip if loganalyzer is disabled
+        loganalyzer[enum_frontend_dut_hostname].expect_regex.extend(
+            expectRegex
+        )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def reload_dut(duthosts, enum_frontend_dut_hostname):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    yield
+    config_reload(duthost)
+
+
+@pytest.fixture
+def setup_routes(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, ip_versions, interface_types):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    cfg_facts = get_cfg_facts(duthost)
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    prefixes = []
+
+    if interface_types == 'Loopback':
+        # Get loopback ips
+        intf_ips = get_intf_ips('Loopback', cfg_facts)
+        pytest_assert(len(intf_ips) > 0, "No IP configured on Loopback0")
+    else:
+        # Get vlan ips
+        intf_ips = get_intf_ips('Vlan', cfg_facts)
+        pytest_assert(len(intf_ips) > 0, "No IP configured on any Vlan")
+
+    # Generate interfaces and neighbors
+    intf_neighs, str_intf_nexthop = generate_intf_neigh(
+        asichost, 1, ip_versions)
+    if ip_versions == 4:
+        prefixes.append(str(random.choice(intf_ips['ipv4'])).split("/")[0])
+    else:
+        prefixes.append(str(random.choice(intf_ips['ipv6'])).split("/")[0])
+
+    # Setup interface IPs and neighbors
+    prepare_dut(asichost, intf_neighs)
+
+    # Generate a temp json file for route configuration
+    route_file_set = duthost.shell("mktemp")["stdout"]
+    generate_route_file(duthost, prefixes, str_intf_nexthop, route_file_set, "SET")
+
+    yield route_file_set
+
+    # Remove interface IPs and neighbors
+    cleanup_dut(asichost, intf_neighs)
+    duthost.shell("rm {}".format(route_file_set))
+
+
+def test_duplicate_routes(duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, setup_routes):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    swss_cfg_file_set = setup_routes
+
+    # Get orchagent pid before applying config
+    pid_before = duthost.shell("pidof orchagent")['stdout']
+
+    # Apply route configuration
+    logger.info("Applying routes via swssconfig...")
+    json_set = "/dev/stdin < {}".format(swss_cfg_file_set)
+
+    result = duthost.docker_exec_swssconfig(
+        json_set, "swss", enum_rand_one_frontend_asic_index
+    )
+
+    if result["rc"] != 0:
+        pytest.fail(
+            "Failed to apply route configuration file: {}".format(result["stderr"])
+        )
+
+    sleep(5)
+
+    # Verify that orchagent has not crashed
+    verify_orchagent_running_or_assert(duthost)
+    pid_after = duthost.shell("pidof orchagent")['stdout']
+    pytest_assert(pid_before == pid_after, "Error: Orchagent restarted")

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import logging
 import time
 import re
@@ -12,6 +11,8 @@ from datetime import datetime
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.generators import generate_ips
+from tests.route.utils import generate_intf_neigh, generate_route_file, prepare_dut, cleanup_dut
+
 
 CRM_POLL_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
@@ -92,14 +93,6 @@ def ignore_expected_loganalyzer_exceptions(
         )
 
 
-@pytest.fixture(params=[4, 6])
-def ip_versions(request):
-    """
-    Parameterized fixture for IP versions.
-    """
-    yield request.param
-
-
 @pytest.fixture(scope="function", autouse=True)
 def reload_dut(duthosts, enum_rand_one_per_hwsku_frontend_hostname, request):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -122,103 +115,6 @@ def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
     time.sleep(wait_time)
-
-
-def prepare_dut(asichost, intf_neighs):
-    for intf_neigh in intf_neighs:
-        # Set up interface
-        asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "add")
-        # Set up neighbor
-        asichost.run_ip_neigh_cmd(
-            "replace "
-            + intf_neigh["neighbor"]
-            + " lladdr "
-            + intf_neigh["mac"]
-            + " dev "
-            + intf_neigh["interface"]
-        )
-
-
-def cleanup_dut(asichost, intf_neighs):
-    for intf_neigh in intf_neighs:
-        # Delete neighbor
-        asichost.run_ip_neigh_cmd(
-            "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
-        )
-        # remove interface
-        asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "remove")
-
-
-def generate_intf_neigh(asichost, num_neigh, ip_version):
-    interfaces = asichost.show_interface(command="status")["ansible_facts"][
-        "int_status"
-    ]
-    up_interfaces = []
-    for intf, values in list(interfaces.items()):
-        if values["admin_state"] == "up" and values["oper_state"] == "up":
-            up_interfaces.append(intf)
-    if not up_interfaces:
-        raise Exception("DUT does not have up interfaces")
-
-    # Generate interfaces and neighbors
-    intf_neighs = []
-    str_intf_nexthop = {"ifname": "", "nexthop": ""}
-
-    idx_neigh = 0
-    for itfs_name in up_interfaces:
-        if not itfs_name.startswith("PortChannel") and interfaces[itfs_name][
-            "vlan"
-        ].startswith("PortChannel"):
-            continue
-        if interfaces[itfs_name]["vlan"] == "trunk":
-            continue
-        if ip_version == 4:
-            intf_neigh = {
-                "interface": itfs_name,
-                # change prefix ip starting with 3 to avoid overlap with any bgp ip
-                "ip": "30.%d.0.1/24" % (idx_neigh + 1),
-                "neighbor": "30.%d.0.2" % (idx_neigh + 1),
-                "mac": "54:54:00:ad:48:%0.2x" % idx_neigh,
-            }
-        else:
-            intf_neigh = {
-                "interface": itfs_name,
-                "ip": "%x::1/64" % (0x2000 + idx_neigh),
-                "neighbor": "%x::2" % (0x2000 + idx_neigh),
-                "mac": "54:54:00:ad:48:%0.2x" % idx_neigh,
-            }
-
-        intf_neighs.append(intf_neigh)
-        if idx_neigh == 0:
-            str_intf_nexthop["ifname"] += intf_neigh["interface"]
-            str_intf_nexthop["nexthop"] += intf_neigh["neighbor"]
-        else:
-            str_intf_nexthop["ifname"] += "," + intf_neigh["interface"]
-            str_intf_nexthop["nexthop"] += "," + intf_neigh["neighbor"]
-        idx_neigh += 1
-        if idx_neigh == num_neigh:
-            break
-
-    if not intf_neighs:
-        raise Exception("DUT does not have interfaces available for test")
-
-    return intf_neighs, str_intf_nexthop
-
-
-def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
-    route_data = []
-    for prefix in prefixes:
-        key = "ROUTE_TABLE:" + prefix
-        route = {}
-        route["ifname"] = str_intf_nexthop["ifname"]
-        route["nexthop"] = str_intf_nexthop["nexthop"]
-        route_command = {}
-        route_command[key] = route
-        route_command["OP"] = op
-        route_data.append(route_command)
-
-    # Copy json file to DUT
-    duthost.copy(content=json.dumps(route_data, indent=4), dest=dir, verbose=False)
 
 
 def exec_routes(

--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -1,0 +1,97 @@
+import json
+
+
+def generate_intf_neigh(asichost, num_neigh, ip_version):
+    interfaces = asichost.show_interface(command="status")["ansible_facts"][
+        "int_status"
+    ]
+    up_interfaces = []
+    for intf, values in list(interfaces.items()):
+        if values["admin_state"] == "up" and values["oper_state"] == "up":
+            up_interfaces.append(intf)
+    if not up_interfaces:
+        raise Exception("DUT does not have up interfaces")
+
+    # Generate interfaces and neighbors
+    intf_neighs = []
+    str_intf_nexthop = {"ifname": "", "nexthop": ""}
+
+    idx_neigh = 0
+    for itfs_name in up_interfaces:
+        if not itfs_name.startswith("PortChannel") and interfaces[itfs_name][
+            "vlan"
+        ].startswith("PortChannel"):
+            continue
+        if interfaces[itfs_name]["vlan"] == "trunk":
+            continue
+        if ip_version == 4:
+            intf_neigh = {
+                "interface": itfs_name,
+                # change prefix ip starting with 3 to avoid overlap with any bgp ip
+                "ip": "30.%d.0.1/24" % (idx_neigh + 1),
+                "neighbor": "30.%d.0.2" % (idx_neigh + 1),
+                "mac": "54:54:00:ad:48:%0.2x" % idx_neigh,
+            }
+        else:
+            intf_neigh = {
+                "interface": itfs_name,
+                "ip": "%x::1/64" % (0x2000 + idx_neigh),
+                "neighbor": "%x::2" % (0x2000 + idx_neigh),
+                "mac": "54:54:00:ad:48:%0.2x" % idx_neigh,
+            }
+
+        intf_neighs.append(intf_neigh)
+        if idx_neigh == 0:
+            str_intf_nexthop["ifname"] += intf_neigh["interface"]
+            str_intf_nexthop["nexthop"] += intf_neigh["neighbor"]
+        else:
+            str_intf_nexthop["ifname"] += "," + intf_neigh["interface"]
+            str_intf_nexthop["nexthop"] += "," + intf_neigh["neighbor"]
+        idx_neigh += 1
+        if idx_neigh == num_neigh:
+            break
+
+    if not intf_neighs:
+        raise Exception("DUT does not have interfaces available for test")
+
+    return intf_neighs, str_intf_nexthop
+
+
+def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
+    route_data = []
+    for prefix in prefixes:
+        key = "ROUTE_TABLE:" + prefix
+        route = {}
+        route["ifname"] = str_intf_nexthop["ifname"]
+        route["nexthop"] = str_intf_nexthop["nexthop"]
+        route_command = {}
+        route_command[key] = route
+        route_command["OP"] = op
+        route_data.append(route_command)
+
+    # Copy json file to DUT
+    duthost.copy(content=json.dumps(route_data, indent=4), dest=dir, verbose=False)
+
+
+def prepare_dut(asichost, intf_neighs):
+    for intf_neigh in intf_neighs:
+        # Set up interface
+        asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "add")
+        # Set up neighbor
+        asichost.run_ip_neigh_cmd(
+            "replace "
+            + intf_neigh["neighbor"]
+            + " lladdr "
+            + intf_neigh["mac"]
+            + " dev "
+            + intf_neigh["interface"]
+        )
+
+
+def cleanup_dut(asichost, intf_neighs):
+    for intf_neigh in intf_neighs:
+        # Delete neighbor
+        cmd = "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
+        asichost.run_ip_neigh_cmd(cmd)
+        # remove interface
+        asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "remove")

--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -91,7 +91,8 @@ def prepare_dut(asichost, intf_neighs):
 def cleanup_dut(asichost, intf_neighs):
     for intf_neigh in intf_neighs:
         # Delete neighbor
-        cmd = "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
-        asichost.run_ip_neigh_cmd(cmd)
+        asichost.run_ip_neigh_cmd(
+            "del " + intf_neigh["neighbor"] + " dev " + intf_neigh["interface"]
+        )
         # remove interface
         asichost.config_ip_intf(intf_neigh["interface"], intf_neigh["ip"], "remove")


### PR DESCRIPTION
… routes

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
    * Added a script to verify that routes matching a loopback IP prefix or vlan IP prefix does not cause orchagent to crash
    * Moved common utility functions used in route test cases to route/utils.py and moved ip_versions fixture to conftest.py
Summary:
Fixes # (25135266)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
    A bug in IP assignment in production resulted in routes being advertised by Sirius TORs that matched the vlan IP of a 
    gemini TOR pair. When orchagent on the Gemini TORs programmed this route, both of them crashed at the same time 
    with error SAI_STATUS_ITEM_ALREADY_EXISTS. This sonic-mgmt test is a repair item for this production incident so that 
    such incidents will not happen in the field.
#### How did you do it?
    Programmed routes with prefix matching loopback and vlan IPs on the device using swssconfig and verified that 
    orchagent does not crash in such a scenario, even though SAI_STATUS_ITEM_ALREADY_EXISTS error code is returned from 
    SAI.
#### How did you verify/test it?
    By running the sonic-mgmt test tests/route/test_duplicate_route.py on multiple testbeds.
#### Any platform specific information?
    N/A
#### Supported testbed topology if it's a new test case?
    T0, M0
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
