### PR TITLE
Disable the loganalyzer for the one static dns test

### DIFF
--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -41,6 +41,7 @@ EXCEED_MAX_ERR = r"Error: The maximum number \(3\) of nameservers exceeded"
 DUPLICATED_IP_ERR = r"Error: .* nameserver is already configured"
 
 
+@pytest.mark.disable_loganalyzer
 def test_static_dns_basic(request, duthost, localhost, mgmt_interfaces):
     """
     Basic test for the Static DNS


### PR DESCRIPTION
In the basic test, there is reboot command used, need to disable the loganalyzer to reduce err msg noise

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Disable the loganalyzer for the one static dns test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In the basic test, there is reboot command used, need to disable the loganalyzer to reduce err msg noise

#### How did you do it?
disable the loganalyzer
#### How did you verify/test it?
run the test case, and loganalyzer will not running for the test_static_dns_basic
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
