### PR TITLE
platform_tests: Use VariableManager for skip modules

### DIFF
--- a/tests/platform_tests/cli/util.py
+++ b/tests/platform_tests/cli/util.py
@@ -91,7 +91,7 @@ def get_skip_mod_list(duthost, mod_key=None):
     """
 
     skip_mod_list = []
-    dut_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    dut_vars = duthost.host.options['variable_manager'].get_vars()['hostvars'][duthost.hostname]
     if 'skip_modules' in dut_vars:
         if mod_key is None:
             for mod_type in list(dut_vars['skip_modules'].keys()):
@@ -123,7 +123,7 @@ def get_skip_logical_module_list(duthost, mod_key=None):
     """
 
     skip_logical_mod_list = []
-    dut_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    dut_vars = duthost.host.options['variable_manager'].get_vars()['hostvars'][duthost.hostname]
     if 'skip_logical_modules' in dut_vars:
         if mod_key is None:
             for mod_type in list(dut_vars['skip_logical_modules'].keys()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
When using the TestbedProcessing script to generate the inventory files, the `skip_modules` variable under the `devices` section is ignored. We can instead use the `host_vars` section which adds the variable to the `host_vars/${host}.yml` file, but this file is ignored by InventoryManager, which the tests use to query the `skip_modules` variable.

#### How did you do it?

This can be fixed by using VariableManager instead, which considers all sources of inventory, including the `host_vars` and `group_vars` directories.

With this change, the following config works:

```
host_vars:
  cmp210:
    skip_modules:
      'line-cards': ['LINE-CARD3']
```

#### How did you verify/test it?

Tested by applying this patch during our internal sonic-mgmt runs and verifying that the requested skipped modules are actually skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
