### PR TITLE
Reducing the number of packets for WRR and WRR_Change from 500 to 300.

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -13,23 +13,23 @@ qos_params:
                 pkts_num_margin: 1
             wrr:
                 ecn: 1
-                q0_num_of_pkts: 70
-                q1_num_of_pkts: 70
-                q2_num_of_pkts: 70
-                q3_num_of_pkts: 75
-                q4_num_of_pkts: 75
-                q5_num_of_pkts: 70
-                q6_num_of_pkts: 70
+                q0_num_of_pkts: 42
+                q1_num_of_pkts: 42
+                q2_num_of_pkts: 42
+                q3_num_of_pkts: 45
+                q4_num_of_pkts: 45
+                q5_num_of_pkts: 42
+                q6_num_of_pkts: 42
                 limit: 80
             wrr_chg:
                 ecn: 1
-                q0_num_of_pkts: 40
-                q1_num_of_pkts: 40
-                q2_num_of_pkts: 40
-                q3_num_of_pkts: 150
-                q4_num_of_pkts: 150
-                q5_num_of_pkts: 40
-                q6_num_of_pkts: 40
+                q0_num_of_pkts: 24
+                q1_num_of_pkts: 24
+                q2_num_of_pkts: 24
+                q3_num_of_pkts: 90
+                q4_num_of_pkts: 90
+                q5_num_of_pkts: 24
+                q6_num_of_pkts: 42
                 limit: 80
                 lossy_weight: 8
                 lossless_weight: 30
@@ -137,23 +137,23 @@ qos_params:
                 pkts_num_leak_out: 0
                 wrr:
                     ecn: 1
-                    q0_num_of_pkts: 70
-                    q1_num_of_pkts: 70
-                    q2_num_of_pkts: 70
-                    q3_num_of_pkts: 75
-                    q4_num_of_pkts: 75
-                    q5_num_of_pkts: 70
-                    q6_num_of_pkts: 70
+                    q0_num_of_pkts: 42
+                    q1_num_of_pkts: 42
+                    q2_num_of_pkts: 42
+                    q3_num_of_pkts: 45
+                    q4_num_of_pkts: 45
+                    q5_num_of_pkts: 42
+                    q6_num_of_pkts: 42
                     limit: 80
                 wrr_chg:
                     ecn: 1
-                    q0_num_of_pkts: 40
-                    q1_num_of_pkts: 40
-                    q2_num_of_pkts: 40
-                    q3_num_of_pkts: 150
-                    q4_num_of_pkts: 150
-                    q5_num_of_pkts: 40
-                    q6_num_of_pkts: 40
+                    q0_num_of_pkts: 24
+                    q1_num_of_pkts: 24
+                    q2_num_of_pkts: 24
+                    q3_num_of_pkts: 90
+                    q4_num_of_pkts: 90
+                    q5_num_of_pkts: 24
+                    q6_num_of_pkts: 24
                     limit: 80
                     lossy_weight: 8
                     lossless_weight: 30
@@ -380,23 +380,23 @@ qos_params:
                 packet_size: 1350
             wrr:
                 ecn: 1
-                q0_num_of_pkts: 70
-                q1_num_of_pkts: 70
-                q2_num_of_pkts: 70
-                q3_num_of_pkts: 75
-                q4_num_of_pkts: 75
-                q5_num_of_pkts: 70
-                q6_num_of_pkts: 70
+                q0_num_of_pkts: 42
+                q1_num_of_pkts: 42
+                q2_num_of_pkts: 42
+                q3_num_of_pkts: 45
+                q4_num_of_pkts: 45
+                q5_num_of_pkts: 42
+                q6_num_of_pkts: 42
                 limit: 80
             wrr_chg:
                 ecn: 1
-                q0_num_of_pkts: 40
-                q1_num_of_pkts: 40
-                q2_num_of_pkts: 40
-                q3_num_of_pkts: 150
-                q4_num_of_pkts: 150
-                q5_num_of_pkts: 40
-                q6_num_of_pkts: 40
+                q0_num_of_pkts: 24
+                q1_num_of_pkts: 24
+                q2_num_of_pkts: 24
+                q3_num_of_pkts: 90
+                q4_num_of_pkts: 90
+                q5_num_of_pkts: 24
+                q6_num_of_pkts: 24
                 limit: 80
                 lossy_weight: 8
                 lossless_weight: 30


### PR DESCRIPTION
### Description of PR
Both  WRR and WRR_Change send packets in bulk(500 packets as of now), and expect all packets back in bulk. When the PTF is not able to handle all packets the tests fail. We have seen this before, and had reduced the packets from 1000 to 500. But in recent MS runs, we observe that the PTF is not handling even the 500 packets. This PR addresses this by reducing the total number of packets to 300.

Summary:
Fixes the test fail issue due to PTF in @XuChen-MSFT 's  runs. 

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305

### Approach
#### What is the motivation for this PR?
This PR reduces the total number of packets used by WRR and WRR_change tests. This is to allow the PTF to handle all the packets.

#### How did you do it?
Updated the qos.yaml parameters.

#### How did you verify/test it?
Ran the test:

=============================================================================================== PASSES ===============================================================================================
_________________________________________________________________________ TestQosSai.testQosSaiDwrrWeightChange[single_asic] _________________________________________________________________________
----------------------------------------------------------------- generated xml file: /run_logs/logs/qos/tr_2024-01-10-20-58-10.xml ------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------
21:03:51 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
====================================================================================== short test summary info =======================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic]
SKIPPED [1] /data/tests/qos/qos_sai_base.py:548: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [1] /data/tests/qos/qos_sai_base.py:554: multi-dut is not supported on T1 topologies
=============================================================================== 1 passed, 2 skipped in 340.10 seconds ================================================================================
AzDevOps@99027110b121:/data/tests$ 

#### Any platform specific information?
Cisco-8000 only.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A