### PR TITLE
Update test_pg_headroom_update to check buffer mode before running

### DIFF
--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -77,7 +77,7 @@ def ensure_application_of_updated_config(duthost, xoff, values):
 
 
 @pytest.mark.parametrize("operation", ["replace"])
-def test_pg_headroom_update(duthost, ensure_dut_readiness, operation):
+def test_pg_headroom_update(duthost, ensure_dut_readiness, operation, skip_when_buffer_is_dynamic_model):
     asic_type = duthost.get_asic_name()
     pytest_require("td2" not in asic_type, "PG headroom should be skipped on TD2")
     tmpfile = generate_tmpfile(duthost)


### PR DESCRIPTION

### Description of PR
When buffer mode is dynamic type, the dut would not support updating qos configuration.
Base on the fact, I add a check to validate if the buffer mode is dynamic and skip test if it is.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Make the script more stable.
#### How did you do it?
Add a check
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
