### PR TITLE
Fix T2 advertise_withdraw test failure

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -147,7 +147,8 @@ def change_routes(action, ptf_ip, port, routes):
             messages.append(
                 "{} route {} next-hop {}".format(action, prefix, nexthop))
     wait_for_http(ptf_ip, port, timeout=60)
-    url = "https://%s:%d" % (ptf_ip, port)
+    # nosemgrep-next-line
+    url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
     r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -149,7 +149,7 @@ def change_routes(action, ptf_ip, port, routes):
     wait_for_http(ptf_ip, port, timeout=60)
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
-    r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
+    r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:
         raise Exception(
             "Change routes failed: url={}, data={}, r.status_code={}, r.reason={}, r.headers={}, r.text={}".format(

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -147,7 +147,7 @@ def change_routes(action, ptf_ip, port, routes):
             messages.append(
                 "{} route {} next-hop {}".format(action, prefix, nexthop))
     wait_for_http(ptf_ip, port, timeout=60)
-    url = "http://%s:%d" % (ptf_ip, port)
+    url = "https://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
     r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -147,9 +147,9 @@ def change_routes(action, ptf_ip, port, routes):
             messages.append(
                 "{} route {} next-hop {}".format(action, prefix, nexthop))
     wait_for_http(ptf_ip, port, timeout=60)
-    # nosemgrep-next-line
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
+    # nosemgrep-next-line
     r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:
         raise Exception(

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -43,10 +43,10 @@ class TestRouteConsistency():
         # take the snapshot of route table from all the DUTs
         self.__class__.pre_test_route_snapshot, max_prefix_cnt = self.get_route_prefix_snapshot_from_asicdb(duthosts)
         """sleep interval is calculated based on the max number of prefixes in the route table.
-           Addtional 30 seconds is added to the sleep interval to account for the time taken to
+           Addtional 60 seconds is added to the sleep interval to account for the time taken to
            withdraw and advertise the routes by peers
         """
-        self.__class__.sleep_interval = math.ceil(max_prefix_cnt/3000) + 30
+        self.__class__.sleep_interval = math.ceil(max_prefix_cnt/3000) + 60
         logger.debug("max_no_of_prefix: {} sleep_interval: {}".format(max_prefix_cnt, self.sleep_interval))
 
     def test_route_withdraw_advertise(self, duthosts, tbinfo, localhost):
@@ -86,10 +86,12 @@ class TestRouteConsistency():
             for dut_instance_name in self.pre_test_route_snapshot.keys():
                 assert self.pre_test_route_snapshot[dut_instance_name] == post_test_route_snapshot[dut_instance_name]
             logger.info("Route table is consistent across all the DUTs")
-        except Exception:
+        except Exception as e:
+            logger.error("Exception occurred: {}".format(e))
             # announce the routes back in case of any exception
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
             time.sleep(self.sleep_interval)
+            raise e
 
     def test_bgp_shut_noshut(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # Intermittent test_route_withdraw_advertise() failure on T2 topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Fixes # Intermittent test_route_withdraw_advertise() failure on T2 topology
#### How did you do it?
Based on debugging, it was found that for some of the exabgp processes, routes adv/withdrawal post message takes longer than 90 seconds(due to high route scale in t2 topology)

Fix:
1. Increase the timeout value to allow more time for requests.post.
2. Provide additional sleep after withdraw/advertise for all peers to effectively advertise/withdraw and DUT has enough time to process them and install them in ASIC Db
3. Due to try, except block of the testcase, if the exception is hit (due to assertion or otherwise), the testcase was not marked as failed. Fix is to re raise the exception

#### How did you verify/test it?
1. rerun the testcase locally.
2. Rerun the test_file with force assertion, to verify this case failed and rest of the cases passed.
3. Verified by Judy on azp run
#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
