### PR TITLE
[TACACS] Fix TACACS authorization issue: user can run rejected command when enable local authorization as fallback.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1284,6 +1284,15 @@ system_health/test_system_health.py::test_service_checker_with_process_exit:
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
 
 #######################################
+#####           tacacs          #####
+#######################################
+tacacs/test_authorization.py::test_authorization_tacacs_and_local:
+  skip:
+    reason: "Testcase ignored due to Github issue: https://github.com/sonic-net/sonic-mgmt/issues/11349"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/11349
+
+#######################################
 #####           telemetry         #####
 #######################################
 telemetry/test_events.py:
@@ -1397,12 +1406,3 @@ wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
     conditions:
       - "len(minigraph_portchannels) < 2"
       - "not any(len(v['members']) > 1 for _, v in minigraph_portchannels.items())"
-
-#######################################
-#####           tacacs          #####
-#######################################
-tacacs/test_authorization.py::test_authorization_tacacs_and_local:
-  skip:
-    reason: "Testcase ignored due to Github issue: https://github.com/sonic-net/sonic-mgmt/issues/11349"
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/11349

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1397,3 +1397,12 @@ wan/lacp/test_wan_lag_min_link.py::test_lag_min_link:
     conditions:
       - "len(minigraph_portchannels) < 2"
       - "not any(len(v['members']) > 1 for _, v in minigraph_portchannels.items())"
+
+#######################################
+#####           tacacs          #####
+#######################################
+tacacs/test_authorization.py::test_authorization_tacacs_and_local:
+  skip:
+    reason: "Testcase ignored due to Github issue: https://github.com/sonic-net/sonic-mgmt/issues/11349"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/11349

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -324,6 +324,11 @@ def test_authorization_tacacs_and_local(
     pytest_assert(exit_code == 1)
     check_ssh_output_any_of(stderr, ['Root privileges are required for this operation'])
 
+    # Verify TACACS+ user can't run command not in server side whitelist but have local permission.
+    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "cat /etc/passwd")
+    pytest_assert(exit_code == 1)
+    check_ssh_output_any_of(stdout, ['/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing'])
+
     # Verify Local user can't login.
     dutip = duthost.mgmt_ip
     check_ssh_connect_remote_failed(

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -324,11 +324,6 @@ def test_authorization_tacacs_and_local(
     pytest_assert(exit_code == 1)
     check_ssh_output_any_of(stderr, ['Root privileges are required for this operation'])
 
-    # Verify TACACS+ user can run command not in server side whitelist, but have local permission.
-    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "cat /etc/passwd")
-    pytest_assert(exit_code == 0)
-    check_ssh_output_any_of(stdout, ['root:x:0:0:root:/root:/bin/bash'])
-
     # Verify Local user can't login.
     dutip = duthost.mgmt_ip
     check_ssh_connect_remote_failed(


### PR DESCRIPTION
Fix TACACS authorization issue: user can run rejected command when enable local authorization as fallback.

### Description of PR
Fix TACACS authorization issue: user can run rejected command when enable local authorization as fallback.

##### Work item tracking
- Microsoft ADO: 26399545

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
per-command authorization found a code bug: When set per-command authorization to "tacacs+, local", user command blocked by server side but has local permission should failed. but currently it can success.

The UT code changed by this PR is testing and protect this incorrect behavior.

#### How did you do it?
Create issue: https://github.com/sonic-net/sonic-mgmt/issues/11349
Fix UT and ignore it temporarily by this issue.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
