### PR TITLE
test_voq_chassis_app_db_consistency.py: Increase timeout of config reload and reboot

### DIFF
--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -166,12 +166,12 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
         if test_case == "config_reload_no_config_save":
             logging.info("Reloading config")
             config_reload(duthost, safe_reload=True)
-            pytest_assert(wait_until(180, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed")
         elif test_case == "config_reload_with_config_save":
             duthost.shell('sudo config save -y')
             config_reload(duthost, safe_reload=True)
-            pytest_assert(wait_until(180, 30, 0, check_db_consistency, duthosts, duthost, post_change_db_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, post_change_db_dump),
                           "DB_Consistency Failed")
         else:
             logging.info("Rebooting dut {}".format(duthost))
@@ -182,7 +182,7 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
             pytest_assert(wait_until(330, 20, 0, duthost.critical_services_fully_started),
                           "All critical services should fully started!")
-            pytest_assert(wait_until(380, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed After Reboot")
 
     finally:


### PR DESCRIPTION
All 3 testcases in `test_voq_chassis_app_db_consistency.py` were failing due to not waiting long enough after config reload or reboot on T2 topologies.

This PR increases the timeout amount to 600s, which seemed sufficient for all 3 test cases on multiple T2 setups.
E.G.
`config_reload_with_config_save & config_reload_no_config_save`
```
11/01/2024 01:45:37 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again
11/01/2024 01:46:07 utilities.wait_until                     L0125 DEBUG  | Time elapsed: 262.709992 seconds
11/01/2024 01:46:10 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again
11/01/2024 01:46:40 utilities.wait_until                     L0125 DEBUG  | Time elapsed: 295.342030 seconds
11/01/2024 01:46:43 utilities.wait_until                     L0140 DEBUG  | check_db_consistency is True, exit early with True
```

`Reboot`
```
12/01/2024 03:09:39 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again
12/01/2024 03:10:09 utilities.wait_until                     L0125 DEBUG  | Time elapsed: 362.852029 seconds
12/01/2024 03:10:12 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again
12/01/2024 03:10:42 utilities.wait_until                     L0125 DEBUG  | Time elapsed: 395.471969 seconds
12/01/2024 03:10:45 utilities.wait_until                     L0140 DEBUG  | check_db_consistency is True, exit early with True
```

Summary:
Fixes #11257 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
