### PR TITLE
Fix for parse_routes_on_vsonic for test_traffic_shift.py

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -80,6 +80,7 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
     asn = mg_facts['minigraph_bgp_asn']
+    all_routes = {}
 
     host_name_map = {}
     for hostname, neigh_host in list(neigh_hosts.items()):

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -80,7 +80,6 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
     asn = mg_facts['minigraph_bgp_asn']
-    all_routes = {}
 
     host_name_map = {}
     for hostname, neigh_host in list(neigh_hosts.items()):
@@ -116,7 +115,7 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
         for a_route in routes_json:
             # empty community string
             routes[a_route] = ""
-        all_routes[hostname] = routes
+        results[hostname] = routes
 
     all_routes = parallel_run(parse_routes_process_vsonic, (), {}, list(neigh_hosts.values()),
                               timeout=120, concurrent_tasks=8)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

-  This PR fixes issue #11266.
- In _bgp/test_traffic_shift.py_ tests, whenever '_parse_routes_on_vsonic_' method is called on neighbor host VMs, the method returns empty value instead of the routes received on neighbor host VMs.
- Due to this issue, test always returns false positive.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
- _parse_routes_on_vsonic_ method should return all the routes parsed on all neighbor host VMs.
-  Instead, it always returns empty value.
- Tests always passes with false positive result.

#### How did you do it?
- all_routes dictionary is not used as expected. Corrected the same.

#### How did you verify/test it?
- Ran some test cases which invokes method and verified it actually returns the expected routes.
_bgp/test_traffic_shift.py::test_TSA 
bgp/test_traffic_shift.py::test_TSA_TSB_with_config_reload
bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away_ 


#### Any platform specific information?
  ```SONiC OS Version: 11
  Distribution: Debian 11.8
  Kernel: 5.10.0-23-2-amd64
  Build commit: b9e6caad98
  Build date: Tue Jan  9 00:13:06 UTC 2024
  Built by: cloudtest@95bebd0dc000000
