### PR TITLE
[Conditional mark] Remove xfail mark for test_advanced_reboot

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -738,10 +738,6 @@ platform_tests/mellanox/test_reboot_cause.py:
 ####    test_advanced_reboot      #####
 #######################################
 platform_tests/test_advanced_reboot.py:
-  xfail:
-    reason: "Xfail advanced reboot on TD3 due to known SAI issue in SAI 8.4+"
-    conditions:
-      - "hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and release in ['202305', 'master']"
   skip:
     reason: "Unsupported platform"
     conditions_logical_operator: or


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Remove xfail mark on test_advanced_reboot case since Broadcom has fix for it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Enable test_advanced_reboot case.

#### How did you do it?
Remove xfail conditional mark on test_advanced_reboot.py.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
