### PR TITLE
[TACACS] Add UT to simulate device config failed because load minigraph restart BGP service and cause network not reachable.

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -641,6 +641,11 @@ def test_fallback_to_local_authorization_with_config_reload(
         During load minigraph BGP service will shutdown and restart.
         Verify still can run config save command with "tacacs+,local".
     """
+    # Skip multi-asic because override_config format are different.
+    if duthost.is_multi_asic:
+        pytest.skip("Skip test_fallback_to_local_authorization_with_config_reload for multi-asic device")
+        
+
     #  Backup config before load minigraph
     CONFIG_DB = "/etc/sonic/config_db.json"
     CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -644,7 +644,6 @@ def test_fallback_to_local_authorization_with_config_reload(
     # Skip multi-asic because override_config format are different.
     if duthost.is_multi_asic:
         pytest.skip("Skip test_fallback_to_local_authorization_with_config_reload for multi-asic device")
-        
 
     #  Backup config before load minigraph
     CONFIG_DB = "/etc/sonic/config_db.json"

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -669,7 +669,6 @@ def test_fallback_to_local_authorization_with_config_reload(
             }
         }
     }
-    logger.warning("override_config: {}".format(override_config))
     reload_minigraph_with_golden_config(duthost, override_config)
 
     # Shutdown tacacs server to simulate network unreachable because BGP shutdown

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -651,15 +651,15 @@ def test_fallback_to_local_authorization_with_config_reload(
     tacacs_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
     override_config = {
         "AAA": {
-            "authentication": { "login": "tacacs+" },
-            "accounting": { "login": "tacacs+,local" },
-            "authorization": { "login": "tacacs+,local" }
+            "authentication": {"login": "tacacs+"},
+            "accounting": {"login": "tacacs+,local"},
+            "authorization": {"login": "tacacs+,local"}
         },
         "TACPLUS": {
-            "global": { "auth_type": "login", "passkey": tacacs_passkey }
+            "global": {"auth_type": "login", "passkey": tacacs_passkey}
         },
         "TACPLUS_SERVER": {
-            tacacs_server_ip: { "priority": "60", "tcp_port": "49", "timeout": "2" }
+            tacacs_server_ip: {"priority": "60", "tcp_port": "49", "timeout": "2"}
         }
     }
     reload_minigraph_with_golden_config(duthost, override_config)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -645,30 +645,18 @@ def test_fallback_to_local_authorization_with_config_reload(
     tacacs_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
     override_config = {
         "AAA": {
-            "authentication": {
-            "login": "tacacs+"
-            },
-            "accounting": {
-            "login": "tacacs+,local"
-            },
-            "authorization": {
-            "login": "tacacs+,local"
-            }
+            "authentication": { "login": "tacacs+" },
+            "accounting": { "login": "tacacs+,local" ,
+            "authorization": { "login": "tacacs+,local" }
         },
         "TACPLUS": {
-            "global": {
-            "auth_type": "login",
-            "passkey": tacacs_passkey
-            }
+            "global": { "auth_type": "login", "passkey": tacacs_passkey }
         },
         "TACPLUS_SERVER": {
-            tacacs_server_ip: {
-            "priority": "60",
-            "tcp_port": "49",
-            "timeout": "2"
-            }
+            tacacs_server_ip: { "priority": "60", "tcp_port": "49", "timeout": "2" }
         }
     }
+
     reload_minigraph_with_golden_config(duthost, override_config)
 
     # Shutdown tacacs server to simulate network unreachable because BGP shutdown

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -11,6 +11,7 @@ from tests.tacacs.utils import per_command_authorization_skip_versions, \
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
 from .utils import check_server_received
+from tests.override_config_table.utilities import reload_minigraph_with_golden_config
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -624,3 +625,59 @@ def test_stop_request_next_server_after_reject(
     # Remove second server IP
     duthost.shell("sudo config tacacs delete %s" % tacacs_server_ipv6)
     duthost.shell("sudo config tacacs timeout 5")
+
+
+def test_fallback_to_local_authorization_with_config_reload(
+                                    ptfhost,
+                                    duthosts,
+                                    enum_rand_one_per_hwsku_hostname,
+                                    tacacs_creds,
+                                    check_tacacs,
+                                    remote_user_client,
+                                    remote_rw_user_client):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    """
+        During load minigraph BGP service will shutdown and restart.
+        Verify still can run config save command with "tacacs+,local".
+    """
+    # Reload minigraph with override per-command authorization to "tacacs+,local"
+    tacacs_server_ip = ptfhost.mgmt_ip
+    tacacs_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
+    override_config = {
+        "AAA": {
+            "authentication": {
+            "login": "tacacs+"
+            },
+            "accounting": {
+            "login": "tacacs+,local"
+            },
+            "authorization": {
+            "login": "tacacs+,local"
+            }
+        },
+        "TACPLUS": {
+            "global": {
+            "auth_type": "login",
+            "passkey": tacacs_passkey
+            }
+        },
+        "TACPLUS_SERVER": {
+            tacacs_server_ip: {
+            "priority": "60",
+            "tcp_port": "49",
+            "timeout": "2"
+            }
+        }
+    }
+    logger.warning("override_config: {}".format(override_config))
+    reload_minigraph_with_golden_config(duthost, override_config)
+
+    # Shutdown tacacs server to simulate network unreachable because BGP shutdown
+    stop_tacacs_server(ptfhost)
+
+    # Test "sudo config save -y" can success after reload minigraph
+    exit_code, stdout, stderr = ssh_run_command(remote_rw_user_client, "sudo config save -y")
+    pytest_assert(exit_code == 0)
+
+    #  Cleanup UT.
+    start_tacacs_server(ptfhost)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -645,15 +645,15 @@ def test_fallback_to_local_authorization_with_config_reload(
     tacacs_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
     override_config = {
         "AAA": {
-            "authentication": { "login": "tacacs+" },
-            "accounting": { "login": "tacacs+,local" },
-            "authorization": { "login": "tacacs+,local" }
+            "authentication": {"login": "tacacs+"},
+            "accounting": {"login": "tacacs+,local"},
+            "authorization": {"login": "tacacs+,local"}
         },
         "TACPLUS": {
-            "global": { "auth_type": "login", "passkey": tacacs_passkey }
+            "global": {"auth_type": "login", "passkey": tacacs_passkey}
         },
         "TACPLUS_SERVER": {
-            tacacs_server_ip: { "priority": "60", "tcp_port": "49", "timeout": "2" }
+            tacacs_server_ip: {"priority": "60", "tcp_port": "49", "timeout": "2"}
         }
     }
     reload_minigraph_with_golden_config(duthost, override_config)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -646,7 +646,7 @@ def test_fallback_to_local_authorization_with_config_reload(
     override_config = {
         "AAA": {
             "authentication": { "login": "tacacs+" },
-            "accounting": { "login": "tacacs+,local" ,
+            "accounting": { "login": "tacacs+,local" },
             "authorization": { "login": "tacacs+,local" }
         },
         "TACPLUS": {
@@ -656,7 +656,6 @@ def test_fallback_to_local_authorization_with_config_reload(
             tacacs_server_ip: { "priority": "60", "tcp_port": "49", "timeout": "2" }
         }
     }
-
     reload_minigraph_with_golden_config(duthost, override_config)
 
     # Shutdown tacacs server to simulate network unreachable because BGP shutdown


### PR DESCRIPTION
Add UT to simulate device config failed because load minigraph restart BGP service and cause network not reachable.

### Description of PR
Add UT to simulate device config failed because load minigraph restart BGP service and cause network not reachable.

##### Work item tracking
- Microsoft ADO: 26371616

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Device will lose BGP session after load minigraph, on management device this will cause per-command authorization failed.
To fix this issue, per-command authorization need set to "tacacs+,local" on management  device.
Add new PR to simulate this scenario and protect code.

#### How did you do it?
Add UT to simulate device config failed because load minigraph restart BGP service and cause network not reachable.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
