### PR TITLE
Skip test_ecmp_sai_value on internal and 202311 image

### DIFF
--- a/ansible/library/dut_basic_facts.py
+++ b/ansible/library/dut_basic_facts.py
@@ -56,8 +56,6 @@ def main():
                     results['release'] = '201911'
                 elif 'master' in results['build_version']:
                     results['release'] = 'master'
-                elif 'internal' in results['build_version']:
-                    results['release'] = 'internal'
                 else:
                     results['release'] = 'unknown'
 

--- a/ansible/library/dut_basic_facts.py
+++ b/ansible/library/dut_basic_facts.py
@@ -56,6 +56,8 @@ def main():
                     results['release'] = '201911'
                 elif 'master' in results['build_version']:
                     results['release'] = 'master'
+                elif 'internal' in results['build_version']:
+                    results['release'] = 'internal'
                 else:
                     results['release'] = 'unknown'
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -501,9 +501,14 @@ ecmp/test_ecmp_sai_value.py:
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
-      - "release in ['201911', '202012', '202205', '202211', '202311', 'master']"
+      - "release in ['201911', '202012', '202205', '202211', 'master']"
       - "'internal' in build_version"
       - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
+  xfail:
+    reason: "This feature is not supported in 202311 as the code was not merged into 202311"
+    conditions:
+      - "release in ['202311']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/11310
 
 ecmp/test_fgnhg.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -496,12 +496,13 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_sai_value.py:
   skip:
-    reason: "Only support Broadcom T1/T0 topology with 20230531.12 or later image, 7050cx3 T1 doesn't enable this feature"
+    reason: "Only support Broadcom T1/T0 topology with 20230531 image, 7050cx3 T1 doesn't enable this feature"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
-      - "release in ['201911', '202012', '202205', '202211', 'master', 'internal']"
+      - "release in ['201911', '202012', '202205', '202211', '202311', 'master']"
+      - "'internal' in build_version"
       - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
 
 ecmp/test_fgnhg.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently, release is unknown for internal image, if we use release in condition mark file to check internal, it doesn't work.
Change to use build_version instead.
Also skip it on 202311 image which doesn't have this fix.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Currently, release is unknown for internal image, if we use release in condition mark file to check internal, it doesn't work.
Change to use build_version instead.
Also skip it on 202311 image which doesn't have this fix.

#### How did you do it?
Change to use build_version instead.
Add 202311 in skipped list

#### How did you verify/test it?
run ecmp/test_ecmp_sai_value.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
