### PR TITLE
Fix conditional mark for unsupported testcases on M0/Mx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -643,6 +643,7 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic
 generic_config_updater/test_pfcwd_status.py:
   skip:
     reason: "This test is not run on this topo type or version currently"
+    conditions_logical_operator: "OR"
     conditions:
       - "topo_type in ['m0', 'mx']"
       - "release in ['202211']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix conditional mark for unsupported testcases on M0/Mx.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix conditional mark for unsupported testcases on M0/Mx

#### How did you do it?
Specify `conditions_logical_operator: "OR"` in conditional mark.

#### How did you verify/test it?
Verified by running testcase `generic_config_updater/test_pfcwd_status.py` on M0 testbed:

```
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[single] SKIPPED (This test is not run on this topo type or version currently)                              [ 25%]
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[all] SKIPPED (This test is not run on this topo type or version currently)                                 [ 50%]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[single] SKIPPED (This test is not run on this topo type or version currently)                             [ 75%]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[all] SKIPPED (This test is not run on this topo type or version currently)                                [100%]
=========================================================================== short test summary info ===========================================================================
SKIPPED [2] generic_config_updater/test_pfcwd_status.py:159: This test is not run on this topo type or version currently
SKIPPED [2] generic_config_updater/test_pfcwd_status.py:199: This test is not run on this topo type or version currently
======================================================================= 4 skipped, 3 warnings in 37.10s =======================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
