### PR TITLE
test_show_intf_xcvr.py: Added command "show interface transceiver lpmode"  

### DIFF
--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -60,24 +60,15 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 
-def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                              enum_frontend_asic_index, conn_graph_facts):
     """
     @summary: verify port mode in  'show interface transceiver lpmode'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
-    assert validate_transceiver_lpmode(sfp_lpmode), "port status incorrect in 'show interface transceiver lpmode'"
-
-
-def validate_transceiver_lpmode(output):
-    lines = output.strip().split('\n')
-    # Check if the header is present
-    if lines[0].strip() != "Port        Low-power Mode":
-        print("Invalid output format: Header missing")
-        return False
-    for line in lines[2:]:
-        port, lpmode = line.strip().split()
-        if lpmode not in ["Off", "On"]:
-            print(f"Invalid low-power mode '{lpmode}' for port '{port}'")
-            return False
-    return True
+    if intf not in xcvr_skip_list[duthost.hostname]:
+        assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -59,7 +59,7 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
-            
+
 
 def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                            enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
@@ -79,6 +79,5 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in 'show interface transceiver lpmode'"
-
-
+            assert validate_transceiver_lpmode(
+                sfp_lpmode), "Interface mode incorrect in 'show interface transceiver lpmode'"

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -57,3 +57,30 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
+
+
+def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                              enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: verify port mode in  'show interface transceiver lpmode'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+    sfp_lpmode = duthost.command(cmd_sfp_lpmode)
+    assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
+
+
+def validate_transceiver_lpmode(output):
+    lines = output.strip().split('\n')
+    # Check if the header is present
+    if lines[0].strip() != "Port        Low-power Mode":
+        print("Invalid output format: Header missing")
+        return False
+    for line in lines[2:]:
+        port, lpmode = line.strip().split()
+        if lpmode not in ["Off", "On"]:
+            print(f"Invalid low-power mode '{lpmode}' for port '{port}'")
+            return False
+    return True

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -60,13 +60,11 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 
-def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_frontend_asic_index, conn_graph_facts):
+def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @summary: verify port mode in  'show interface transceiver lpmode'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     assert validate_transceiver_lpmode(sfp_lpmode), "port status incorrect in 'show interface transceiver lpmode'"
 

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -11,6 +11,7 @@ import pytest
 from .util import parse_eeprom
 from .util import parse_output
 from .util import get_dev_conn
+from .util import validate_transceiver_lpmode
 
 cmd_sfp_presence = "show interface transceiver presence"
 cmd_sfp_eeprom = "show interface transceiver eeprom"
@@ -60,16 +61,14 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           enum_frontend_asic_index, conn_graph_facts):
+                           enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     Verify port mode in 'show interface transceiver lpmode'
-
     Args:
     - duthosts: dictionary containing DUT hosts
     - enum_rand_one_per_hwsku_frontend_hostname: enumeration to select one DUT per hardware SKU
     - enum_frontend_asic_index: enumeration for frontend ASIC index
     - conn_graph_facts: facts about connectivity graph
-
     Returns:
     - None
     """
@@ -77,8 +76,9 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     portmap, dev_conn = get_dev_conn(
         duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
-    if intf not in xcvr_skip_list[duthost.hostname]:
-        assert validate_transceiver_lpmode(
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
+            assert validate_transceiver_lpmode(
             sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
 
 

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -68,7 +68,7 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
-    assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
+    assert validate_transceiver_lpmode(sfp_lpmode), "port status incorrect in 'show interface transceiver lpmode'"
 
 
 def validate_transceiver_lpmode(output):

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -59,16 +59,26 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
-
 def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_frontend_asic_index, conn_graph_facts):
+                           enum_frontend_asic_index, conn_graph_facts):
     """
-    @summary: verify port mode in  'show interface transceiver lpmode'
+    Verify port mode in 'show interface transceiver lpmode'
+
+    Args:
+    - duthosts: dictionary containing DUT hosts
+    - enum_rand_one_per_hwsku_frontend_hostname: enumeration to select one DUT per hardware SKU
+    - enum_frontend_asic_index: enumeration for frontend ASIC index
+    - conn_graph_facts: facts about connectivity graph
+
+    Returns:
+    - None
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    global ans_host
-    ans_host = duthost
-    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+    portmap, dev_conn = get_dev_conn(
+        duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     if intf not in xcvr_skip_list[duthost.hostname]:
-        assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
+        assert validate_transceiver_lpmode(
+            sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
+
+

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -14,6 +14,7 @@ from .util import get_dev_conn
 
 cmd_sfp_presence = "show interface transceiver presence"
 cmd_sfp_eeprom = "show interface transceiver eeprom"
+cmd_sfp_lpmode = "show interface transceiver lpmode"
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -65,8 +66,6 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     @summary: verify port mode in  'show interface transceiver lpmode'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    global ans_host
-    ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -59,6 +59,7 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
+            
 
 def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                            enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
@@ -78,7 +79,6 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            assert validate_transceiver_lpmode(
-            sfp_lpmode), "Interface mode incorrect in output of 'show interface transceiver lpmode'"
+            assert validate_transceiver_lpmode(sfp_lpmode), "Interface mode incorrect in 'show interface transceiver lpmode'"
 
 

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -58,4 +58,3 @@ def validate_transceiver_lpmode(output):
             print(f"Invalid low-power mode '{lpmode}' for port '{port}'")
             return False
     return True
-

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -45,7 +45,7 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
         logging.info("ASIC {} interface_list {}".format(asic_index, dev_conn))
 
     return portmap, dev_conn
-    
+
 
 def validate_transceiver_lpmode(output):
     lines = output.strip().split('\n')

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -46,6 +46,7 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
 
     return portmap, dev_conn
     
+
 def validate_transceiver_lpmode(output):
     lines = output.strip().split('\n')
     # Check if the header is present

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -45,3 +45,17 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
         logging.info("ASIC {} interface_list {}".format(asic_index, dev_conn))
 
     return portmap, dev_conn
+    
+def validate_transceiver_lpmode(output):
+    lines = output.strip().split('\n')
+    # Check if the header is present
+    if lines[0].strip() != "Port        Low-power Mode":
+        print("Invalid output format: Header missing")
+        return False
+    for line in lines[2:]:
+        port, lpmode = line.strip().split()
+        if lpmode not in ["Off", "On"]:
+            print(f"Invalid low-power mode '{lpmode}' for port '{port}'")
+            return False
+    return True
+

--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -147,7 +147,6 @@ misc_show_cmds = [
     "show version",
     "show interface status -d all",
     "show interface transceiver presence",
-    "show interface transceiver lpmode",
     "show interface transceiver eeprom --dom",
     "show ip interface",
     "show interface counters",

--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -147,6 +147,7 @@ misc_show_cmds = [
     "show version",
     "show interface status -d all",
     "show interface transceiver presence",
+    "show interface transceiver lpmode",
     "show interface transceiver eeprom --dom",
     "show ip interface",
     "show interface counters",


### PR DESCRIPTION
ading show command "show interface transceiver lpmode"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Added cli support for "show interface transceiver lpmode" in  script test_show_intf_xcvr.py
-->

Summary:
Fixes # (issue)

### Type of change
Added New cli  "show interface transceiver lpmode" in  tech_support_cmds.py
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)  imorovement
- [ ] Test case(new/improvement).  imorovement


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Added New cli  "show interface transceiver lpmode" in  tech_support_cmds.py
#### How did you do it?


#### How did you verify/test it?
Verified on new to topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
