### PR TITLE
[Crm/test_crm_nexthop]: Fix test_crm_nexthop testcase due to all inte…

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -624,6 +624,7 @@ def test_crm_nexthop(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             nexthop_del_cmd = "config route del prefix 3001::0/64 nexthop {}".format(nexthop)
         asichost.sonichost.del_member_from_vlan(1000, 'Ethernet1')
         asichost.shell(ip_add_cmd)
+        asichost.shell("config interface startup Ethernet1")
     else:
         nexthop_add_cmd = "{ip_cmd} neigh replace {nexthop} \
                         lladdr 11:22:33:44:55:66 dev {iface}"\


### PR DESCRIPTION
…rfaces in down state

### Description of PR
This PR fixes the testcase test_crm_nexthop failure due to https://github.com/sonic-net/sonic-mgmt/pull/8051

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
In the PR - https://github.com/sonic-net/sonic-mgmt/pull/8051: There was a new fixture added to shut down all interfaces before the testcase (test_crm_nexthop) starts. This however does not work well for test_crm_nexthop testcase. This testcase adds a static route via one of the ptf interfaces(ethernet1). The interface which is directly connected to the PTF's interface needs to be up in order for the added static route to be effective. Only if it is up, the crm resources will be utilized and the used and available counter for ipv4_nexthop will be incremented and decremented respectively. Since all interfaces are shut down, the static route added by this testcase wont be effective and hence will not use any crm resources. 

#### How did you do it?
The fix here is to bring up the interface used in the testcase so that the static route added will be in effect and the crm resource will be utilized. Since the interface in test is "Ethernet1", code is added to bring this interface up and then continue the testcase. 

#### How did you verify/test it?
Ran test_crm_nexthop to see if the testcase passes both ipv4 and ipv6 cases.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA
