### PR TITLE
Fix to use non RegionalHub peers to test route entry presence

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -579,7 +579,7 @@ class TestTableValidation(object):
         neighs = cfg_facts['BGP_NEIGHBOR']
 
         # Remove the neighbor if BGP neighbor is of type RegionalHub
-        for k,v in neighs.items():
+        for k, v in neighs.items():
             if v['name'] in dev_rh_neigh:
                 neighs.pop(k)
 

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -571,8 +571,18 @@ class TestTableValidation(object):
         ipv4_routes = asic_cmd(asic_to_use, "ip -4 route")["stdout_lines"]
         ipv6_routes = asic_cmd(asic_to_use, "ip -6 route")["stdout_lines"]
 
+        cfgd_dev_neigh_md = cfg_facts['DEVICE_NEIGHBOR_METADATA'] if 'DEVICE_NEIGHBOR_METADATA' in cfg_facts else {}
+        dev_rh_neigh = [neigh for neigh in cfgd_dev_neigh_md
+                        if cfgd_dev_neigh_md[neigh]["type"] == "RegionalHub"]
+
         # get attached neighbors
         neighs = cfg_facts['BGP_NEIGHBOR']
+
+        # Remove the neighbor if BGP neighbor is of type RegionalHub
+        for k,v in neighs.items():
+            if v['name'] in dev_rh_neigh:
+                neighs.pop(k)
+
         for neighbor in neighs:
             local_ip = neighs[neighbor]['local_addr']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes '_test_voq_ipfwd.py::TestTableValidation::test_host_route_table_nbr_lb_addr_' test when the test checks for '_RegionalHub_' T3 peers loopback0 route entries.
- If there is a T3 peer of type '_RegionalHub_' and if it is present in the minigraph file or config under _DEVICE_NEIGHBOR_METADATA_, its loopback0 route entry presence check fails.
- This is because the routemaps for that '_RegionalHub_' type filter the loopback  routes advertised to SONiC T2.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

- '_test_voq_ipfwd.py::TestTableValidation::test_host_route_table_nbr_lb_addr_' test fails when the test checks for '_RegionalHub_' T3 peers loopback0 route entries.
- routemaps for that '_RegionalHub_' type filter the loopback routes advertised to SONiC T2.

#### How did you do it?

- Added a fix to use non _RegionalHub_ T3 peer device neighbors like _AZNGHub_, while checking for loopback0 route entry presence.

#### How did you verify/test it?

-  Ran all the _TestTableValidation_ suite test cases which were failing before and all of them passes now with the fix against a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/e77c484a-5392-4b08-84bf-1cfcd8f626e2)
