### PR TITLE
Add ip information into `/etc/network/interface` after testbed is recovered via console. 

### DIFF
--- a/.azure-pipelines/recover_testbed/interfaces.j2
+++ b/.azure-pipelines/recover_testbed/interfaces.j2
@@ -1,0 +1,13 @@
+#
+{% block mgmt_interface %}
+# The management network interface
+auto eth0
+iface eth0 inet static
+    address {{ addr }}
+    netmask {{ mask }}
+    ################ management network policy routing rules
+    #### management port up rules"
+    up ip route add default via {{ gwaddr }} dev eth0 table default
+    up ip rule add from {{ addr }}/32 table default
+{% endblock mgmt_interface %}
+#

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import sys
+import ipaddress
 from common import do_power_cycle, check_sonic_installer, posix_shell_aboot, posix_shell_onie
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
@@ -55,13 +56,26 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
 
 def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
     for sonichost in sonichosts:
-        # sonic_username, sonic_password, sonic_ip = get_ssh_info(sonichost)
+        # Get dut ip with network mask
+        mgmt_ip = conn_graph_facts["device_info"][sonichost.hostname]["ManagementIp"]
+
         need_to_recover = False
         for i in range(3):
             dut_ssh = duthost_ssh(sonichost)
 
             if type(dut_ssh) == tuple:
                 logger.info("SSH success.")
+
+                # Add ip info into /etc/network/interface
+                extra_vars = {
+                    'addr': mgmt_ip.split('/')[0],
+                    'mask': ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1],
+                    'gwaddr': list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
+                }
+                sonichost.vm.extra_vars.update(extra_vars)
+                sonichost.template(src="../.azure-pipelines/recover_testbed/interfaces.j2",
+                                   dest="/etc/network/interface")
+
                 sonic_username = dut_ssh[0]
                 sonic_password = dut_ssh[1]
                 sonic_ip = dut_ssh[2]
@@ -81,8 +95,6 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
                 logger.info("Authentication failed. Passwords are incorrect.")
                 return
 
-            # Get dut ip with network mask
-            mgmt_ip = conn_graph_facts["device_info"][sonichost.hostname]["ManagementIp"]
             if need_to_recover:
                 recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_url, hwsku)
 

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -121,7 +121,8 @@ def main(args):
     logger.info("Initializing hosts")
     localhost = init_localhost(args.inventory, options={"verbosity": args.verbosity})
     sonichosts = init_testbed_sonichosts(
-        args.inventory, args.testbed_name, testbed_file=args.tbfile, options={"verbosity": args.verbosity}
+        args.inventory, args.testbed_name, testbed_file=args.tbfile,
+        options={"verbosity": args.verbosity, "become": "True"}
     )
 
     if not localhost or not sonichosts:

--- a/.azure-pipelines/recover_testbed/testbed_status.py
+++ b/.azure-pipelines/recover_testbed/testbed_status.py
@@ -12,7 +12,6 @@ def dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip):
     gw_ip = list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
     brd_ip = ipaddress.ip_interface(mgmt_ip).network.broadcast_address
     try:
-        # TODO: Add mgmt ip into file /etc/network/interfaces -- ip, mask, gw
         ret = dut_console.send_command("sudo ip addr add {} brd {} dev eth0".format(mgmt_ip, brd_ip))  # noqa F841
         dut_console.send_command("sudo ip route add default via {}".format(gw_ip))
     except Exception as e:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #10806 , we support auto recovery of testbeds via console. After power cycle, we will add ip and route information on device. And in this PR, we will add these information into file `/etc/network/interface` to avoid losing management ip again after reboot. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
In PR #10806 , we support auto recovery of testbeds via console. After power cycle, we will add ip and route information on device. And in this PR, we will add these information into file `/etc/network/interface` to avoid losing management ip again after reboot. 

#### How did you do it?
Give the template of `/etc/network/interface` and after power cycle, fill in this template and set it on device. 

#### How did you verify/test it?
When the scripts finish running, reboot the device, and it will not lose management ip. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
