### PR TITLE
increase timeout for test_encap_dscp_rewrite

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -122,7 +122,7 @@ def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host,            
         testutils.send(ptfadapter, src_port, pkt)
         # Verify encaped packet
         try:
-            testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports)
+            testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports, timeout=20)
             logger.info("Verified DSCP combination {}".format(str(dscp_combination)))
         except AssertionError:
             logger.info("Failed to verify packet on DSCP combination {}".format(str(dscp_combination)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

encounter test_encap_dscp_rewrite failure related to ptf

#### How did you do it?

increase timeout of verify_packet_any_port in test_encap_dscp_rewrite.

#### How did you verify/test it?

since cannot manually reproduce this failure,
manually trigger nightly using test branch to verify changes, pass the nightly test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
