### PR TITLE
Support recovering Nokia devices via console

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -8,7 +8,8 @@ import socket
 import time
 import pexpect
 import ipaddress
-from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, INSTALL_OS_IN_ONIE, ONIE_START_TO_DISCOVERY, SONIC_PROMPT
+from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, INSTALL_OS_IN_ONIE, \
+    ONIE_START_TO_DISCOVERY, SONIC_PROMPT, MARVELL_ENTRY
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
@@ -72,7 +73,7 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                         continue
 
                     if is_nokia and enter_onie_flag is True:
-                        if "stop autoboot" in x:
+                        if MARVELL_ENTRY in x:
                             dut_console.remote_conn.send('\n')
                             continue
                         if "Marvell" in x and ">" in x:

--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -47,7 +47,7 @@ def get_pdu_managers(sonichosts, conn_graph_facts):
     return pdu_managers
 
 
-def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False):
+def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=False):
     oldtty = termios.tcgetattr(sys.stdin)
     enter_onie_flag = True
     gw_ip = list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
@@ -70,6 +70,14 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False):
                     if is_nexus and "loader" in x and ">" in x:
                         dut_console.remote_conn.send('reboot\n')
                         continue
+
+                    if is_nokia and enter_onie_flag is True:
+                        if "stop autoboot" in x:
+                            dut_console.remote_conn.send('\n')
+                            continue
+                        if "Marvell" in x and ">" in x:
+                            dut_console.remote_conn.send('run onie_bootcmd\n')
+                            continue
 
                     if OS_VERSION_IN_GRUB in x and enter_onie_flag is True:
                         # Send arrow key "down" here.

--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -96,6 +96,9 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                             dut_console.remote_conn.send('onie-discovery-stop\n')
                             dut_console.remote_conn.send("\n")
 
+                            if is_nokia:
+                                dut_console.remote_conn.send('umount /dev/sda2\n')
+
                             dut_console.remote_conn.send("ifconfig eth0 {} netmask {}".format(mgmt_ip.split('/')[0],
                                                          ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1]))
                             dut_console.remote_conn.send("\n")

--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -97,6 +97,7 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                             dut_console.remote_conn.send("\n")
 
                             if is_nokia:
+                                enter_onie_flag = False
                                 dut_console.remote_conn.send('umount /dev/sda2\n')
 
                             dut_console.remote_conn.send("ifconfig eth0 {} netmask {}".format(mgmt_ip.split('/')[0],

--- a/.azure-pipelines/recover_testbed/constants.py
+++ b/.azure-pipelines/recover_testbed/constants.py
@@ -46,3 +46,6 @@ ONIE_START_TO_DISCOVERY = "Discovery"
 
 # At last, if installation successes in ONIE, we will get the prompt
 SONIC_PROMPT = "sonic login:"
+
+# For Nokia testbeds, we will get the string "Hit any key to stop autoboot" to enter into Marvell
+MARVELL_ENTRY = "stop autoboot"

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -45,6 +45,8 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=True)
         elif device_type in ["mellanox", "cisco", "acs"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url)
+        elif device_type in ["nokia"]:
+            posix_shell_onie(dut_console, mgmt_ip, image_url, is_nokia=True)
         else:
             return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support nokia testbeds. 
In Nokia testbeds, they first enter into `u-boot`, and we can enter into `ONIE` through `u-boot`. So in this PR, we enhance the function which will do recover in ONIE to cover this sistuation. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support nokia testbeds. 
In Nokia testbeds, they first enter into `u-boot`, and we can enter into `ONIE` through `u-boot`. So in this PR, we enhance the function which will do recover in ONIE to cover this sistuation. 

#### How did you do it?
Enhance the function which will do recover in ONIE to cover Nokia testbeds. If the type of testbeds is Nokia, enter into ONIE through u-boot, and then, recover in ONIE. 

#### How did you verify/test it?
Recover Nokia testbeds. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
