### PR TITLE
Fix issue due to TypeError: 'dict_keys' object is not subscriptable

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -84,7 +84,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                             # ignore the prefix, if the prefix nexthop is not a frontend port
                             if po_members[ifname].keys():
                                 if 'role' in ports[list(po_members[ifname].keys())[0]] and \
-+                                        ports[list(po_members[ifname].keys())[0]]['role'] == 'Int':
+                                        ports[list(po_members[ifname].keys())[0]]['role'] == 'Int':
                                     if len(oports) == 0:
                                         skip = True
                                 else:

--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -83,8 +83,8 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                         if ifname in po_members:
                             # ignore the prefix, if the prefix nexthop is not a frontend port
                             if po_members[ifname].keys():
-                                if 'role' in ports[po_members[ifname].keys()[0]] and \
-                                        ports[po_members[ifname].keys()[0]]['role'] == 'Int':
+                                if 'role' in ports[list(po_members[ifname].keys())[0]] and \
++                                        ports[list(po_members[ifname].keys())[0]]['role'] == 'Int':
                                     if len(oports) == 0:
                                         skip = True
                                 else:


### PR DESCRIPTION
### Description of PR
Update fib_utils.py to fix issue due to TypeError: 'dict_keys' object is not subscriptable. The code was working fine on 202205 branch but was failing on 202305 branch as

decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]
-------------------------------- live log setup --------------------------------
08:39:25 __init__._fixture_func_decorator         L0073 ERROR  |
TypeError("'dict_keys' object is not subscriptable")
Traceback (most recent call last):
  File "/data/tests/common/plugins/log_section_start/__init__.py", line 71, in _fixture_func_decorator
    return fixture_func(*args, **kargs)
  File "/data/tests/common/fixtures/fib_utils.py", line 304, in fib_info_files
    fib_info = get_t2_fib_info(duthosts, duts_config_facts, duts_minigraph_facts)
  File "/data/tests/common/fixtures/fib_utils.py", line 86, in get_t2_fib_info
    if 'role' in ports[po_members[ifname].keys()[0]] and \
TypeError: 'dict_keys' object is not subscriptable
ERROR                                                                    [ 25%]

This was causing failures in both fib and decap script. Simple change fixes this issue and now both scripts are passing.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Update fib_utils.py to fix issue due to TypeError: 'dict_keys' object is not subscriptable. The code was working fine on 202205 branch but was failing on 202305 branch

#### How did you do it?

#### How did you verify/test it?
Validated on T2 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
