### PR TITLE
Update hash_test.py to fix issue #10961

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -388,8 +388,7 @@ class HashTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
@@ -709,7 +708,8 @@ class IPinIPHashTest(HashTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
 
         send_packet(self, src_port, ipinip_pkt)


### PR DESCRIPTION
### Description of PR

Update hash_test.py to fix issue #10961. Now both hash tests are passing
=========================== short test summary info ============================
SKIPPED [2] common/helpers/assertions.py:14: The test case runs on T1 topology
PASSED fib/test_fib.py::test_basic_fib[True-True-1514]
PASSED fib/test_fib.py::test_hash[ipv4]
PASSED fib/test_fib.py::test_hash[ipv6]
PASSED fib/test_fib.py::test_ipinip_hash_negative[ipv4]
PASSED fib/test_fib.py::test_ipinip_hash_negative[ipv6]
============= 5 passed, 2 skipped, 1 warning in 7461.40s (2:04:21) =============

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?
Update hash_test.py to fix issue #10961. Now both hash tests are passing

#### How did you do it?

#### How did you verify/test it?
Validated on T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
