### PR TITLE
[PR Test] use 202311 kvm image to test 202311 sonic-mgmt repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,8 @@ stages:
         TOPOLOGY: t0
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
-        KVM_IMAGE_BRANCH: "master"
-        MGMT_BRANCH: "master"
+        KVM_IMAGE_BRANCH: "202311"
+        MGMT_BRANCH: "202311"
 
   - job: t0_2vlans_elastictest
     displayName: "kvmtest-t0-2vlans by Elastictest"
@@ -78,8 +78,8 @@ stages:
         MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-        KVM_IMAGE_BRANCH: "master"
-        MGMT_BRANCH: "master"
+        KVM_IMAGE_BRANCH: "202311"
+        MGMT_BRANCH: "202311"
 
   - job: t1_lag_elastictest
     displayName: "kvmtest-t1-lag by Elastictest"
@@ -92,8 +92,8 @@ stages:
         TOPOLOGY: t1-lag
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
-        KVM_IMAGE_BRANCH: "master"
-        MGMT_BRANCH: "master"
+        KVM_IMAGE_BRANCH: "202311"
+        MGMT_BRANCH: "202311"
 
   - job: dualtor_elastictest
     displayName: "kvmtest-dualtor-t0 by Elastictest"
@@ -107,8 +107,8 @@ stages:
           MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
-          KVM_IMAGE_BRANCH: "master"
-          MGMT_BRANCH: "master"
+          KVM_IMAGE_BRANCH: "202311"
+          MGMT_BRANCH: "202311"
 
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
@@ -123,8 +123,8 @@ stages:
           MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           NUM_ASIC: 4
-          KVM_IMAGE_BRANCH: "master"
-          MGMT_BRANCH: "master"
+          KVM_IMAGE_BRANCH: "202311"
+          MGMT_BRANCH: "202311"
 
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
@@ -140,8 +140,8 @@ stages:
           TEST_SET: t0-sonic
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
-          KVM_IMAGE_BRANCH: "master"
-          MGMT_BRANCH: "master"
+          KVM_IMAGE_BRANCH: "202311"
+          MGMT_BRANCH: "202311"
 
   - job: dpu_elastictest
     displayName: "kvmtest-dpu by Elastictest"
@@ -154,8 +154,8 @@ stages:
           TOPOLOGY: dpu
           MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: "master"
-          MGMT_BRANCH: "master"
+          KVM_IMAGE_BRANCH: "202311"
+          MGMT_BRANCH: "202311"
 
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[PR Test] use 202311 kvm image to test 202311 sonic-mgmt repo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
[PR Test] use 202311 kvm image to test 202311 sonic-mgmt repo
#### How did you do it?
[PR Test] use 202311 kvm image to test 202311 sonic-mgmt repo
#### How did you verify/test it?
PR test will verify it
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
