### PR TITLE
Improve gnmi test for connection issue

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -32,6 +32,12 @@ class GNMIEnvironment(object):
                 self.gnmi_config_table = "GNMI"
                 self.gnmi_container = "gnmi"
                 self.gnmi_program = "gnmi-native"
+                # GNMI process is gnmi or telemetry
+                res = duthost.shell("docker exec gnmi ps -ef", module_ignore_errors=True)
+                if '/usr/sbin/gnmi' in res['stdout']:
+                    self.gnmi_process = "gnmi"
+                else:
+                    self.gnmi_process = "telemetry"
                 self.gnmi_port = 50052
                 return True
             else:
@@ -45,7 +51,13 @@ class GNMIEnvironment(object):
             if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
-                self.gnmi_program = "telemetry"
+                # GNMI program is telemetry or gnmi-native
+                res = duthost.shell("docker exec gnmi supervisorctl status", module_ignore_errors=True)
+                if 'telemetry' in res['stdout']:
+                    self.gnmi_program = "telemetry"
+                else:
+                    self.gnmi_program = "gnmi-native"
+                self.gnmi_process = "telemetry"
                 self.gnmi_port = 50051
                 return True
             else:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -46,7 +46,7 @@ def apply_cert_config(duthost):
     dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
     duthost.shell(dut_command)
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
-    dut_command = "sudo netstat -nap | grep %s" % env.gnmi_port
+    dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
     output = duthost.shell(dut_command, module_ignore_errors=True)
     if "telemetry" not in output['stdout']:
         logger.error("TCP port status: " + output['stdout'])

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -58,10 +58,10 @@ def apply_cert_config(duthost):
     output = duthost.shell(dut_command, module_ignore_errors=True)
     if "telemetry" not in output['stdout']:
         # Dump tcp port status and gnmi log
-        logger.error("TCP port status: " + output['stdout'])
+        logger.info("TCP port status: " + output['stdout'])
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         output = duthost.shell(dut_command, module_ignore_errors=True)
-        logger.error("GNMI log: " + output['stdout'])
+        logger.info("GNMI log: " + output['stdout'])
         pytest.fail("Failed to start gnmi server")
 
 
@@ -93,7 +93,7 @@ def gnmi_capabilities(duthost, localhost):
         # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
-        logger.error("GNMI log: " + res['stdout'])
+        logger.info("GNMI log: " + res['stdout'])
         return -1, output['stderr']
     else:
         return 0, output['stdout']
@@ -116,7 +116,7 @@ def gnmi_set(duthost, localhost, delete_list, update_list, replace_list):
         # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
-        logger.error("GNMI log: " + res['stdout'])
+        logger.info("GNMI log: " + res['stdout'])
         return -1, output['stderr']
     else:
         return 0, output['stdout']
@@ -135,7 +135,7 @@ def gnmi_get(duthost, localhost, path_list):
         # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
-        logger.error("GNMI log: " + res['stdout'])
+        logger.info("GNMI log: " + res['stdout'])
         return -1, [output['stderr']]
     else:
         msg = output['stdout'].replace('\\', '')

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -49,6 +49,7 @@ def apply_cert_config(duthost):
     dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
     output = duthost.shell(dut_command, module_ignore_errors=True)
     if "telemetry" not in output['stdout']:
+        # Dump tcp port status and gnmi log
         logger.error("TCP port status: " + output['stdout'])
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         output = duthost.shell(dut_command, module_ignore_errors=True)
@@ -79,6 +80,7 @@ def gnmi_capabilities(duthost, localhost):
     cmd += "-logtostderr -client_crt ./gnmiclient.crt -client_key ./gnmiclient.key -ca_crt ./gnmiCA.pem -capabilities"
     output = localhost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
+        # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
         logger.error("GNMI log: " + res['stdout'])
@@ -101,6 +103,7 @@ def gnmi_set(duthost, localhost, delete_list, update_list, replace_list):
         cmd += " -replace " + replace
     output = localhost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
+        # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
         logger.error("GNMI log: " + res['stdout'])
@@ -119,6 +122,7 @@ def gnmi_get(duthost, localhost, path_list):
         cmd += " -xpath " + path
     output = localhost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
+        # Dump gnmi log
         dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
         res = duthost.shell(dut_command, module_ignore_errors=True)
         logger.error("GNMI log: " + res['stdout'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 26460000

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
GNMI test failed on two testbeds.
I found TCP port is used by supervisor-proc-exit-listener on one testbed.
And there's no information for other testbed.

#### How did you do it?
Stop all program in gnmi container, and add more debug for gnmi connection issue.

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
