### PR TITLE
[202205][portchannel] Fix arp issue in test_lag_member_traffic (#11316)

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -4,12 +4,12 @@ import time
 import logging
 import json
 import ipaddress
+import json
 import sys
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.ptf_runner import ptf_runner
-from tests.common.utilities import wait_until
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, copy_arp_responder_py   # lgtm[py/unused-import]
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,8 @@ HWSKU_INTF_NUMBERS_DICT = {
 # To save time when debugging: if True, wouldn't run config_reload() in dut_teardown() and wouldn't recover acl table
 IS_DEBUG = False
 DEAFULT_NUMBER_OF_MEMBER_IN_LAG = 8
+DISABLE_ARP_REPLY = 8
+ENABLE_ARP_REPLY = 0
 
 def transfer_vlan_member(duthost, src_vlan_id, dst_vlan_id, member_name):
     """
@@ -100,6 +102,15 @@ def dut_teardown(duthost, dut_ports, src_vlan_id, vlan):
         config_reload(duthost)
 
 
+def set_arp_reply(ptfhost, interface_list, value):
+    """
+    Disable / Enable arp reply per interface
+    """
+    for interface in interface_list:
+        ptfhost.shell("sysctl -w net.ipv4.conf.{}.arp_ignore={}".format(interface, value))
+    ptfhost.shell("sysctl -p")
+
+
 def ptf_teardown(ptfhost, ptf_ports):
     """
     Restore ptf configuration
@@ -108,6 +119,9 @@ def ptf_teardown(ptfhost, ptf_ports):
         ptfhost: PTF host object
         ptf_lag_map: imformation about lag in ptf
     """
+    # Restore linux arp response
+    set_arp_reply(ptfhost, [PTF_LAG_NAME, ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]], ENABLE_ARP_REPLY)
+
     ptfhost.set_dev_no_master(PTF_LAG_NAME)
 
     port_name_list = ptf_ports[ATTR_PORT_BEHIND_LAG].values()
@@ -119,6 +133,7 @@ def ptf_teardown(ptfhost, ptf_ports):
     ptfhost.shell("ip addr del {} dev {}".format(ptf_ports["ip"][ATTR_PORT_NOT_BEHIND_LAG],
                                                  ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]))
     ptfhost.ptf_nn_agent()
+    ptfhost.shell('supervisorctl stop arp_responder', module_ignore_errors=True)
 
 def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
     """
@@ -152,6 +167,8 @@ def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
     duthost.shell("config interface ip add Vlan{} {}".format(vlan["id"], vlan["ip"]))
     duthost.add_member_to_vlan(vlan["id"], DUT_LAG_NAME, False)
     transfer_vlan_member(duthost, src_vlan_id, vlan["id"], dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"])
+    duthost.shell("sonic-clear fdb all")
+    duthost.shell("sonic-clear arp")
 
 
 def setup_ptf_lag(ptfhost, ptf_ports):
@@ -178,8 +195,27 @@ def setup_ptf_lag(ptfhost, ptf_ports):
     ptfhost.startup_lag(PTF_LAG_NAME)
     ptfhost.add_ip_to_dev(ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], port_not_behind_lag_ip)
     ptfhost.ptf_nn_agent()
+    setup_arp_responder(ptf_ports, ptfhost)
     # Wait for lag sync
     time.sleep(10)
+
+
+def setup_arp_responder(ptf_ports, ptfhost):
+    # Disable linux arp response on port, let arp_responder to response.
+    set_arp_reply(ptfhost, [PTF_LAG_NAME, ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]], DISABLE_ARP_REPLY)
+
+    arp_responder_conf = {}
+    arp_responder_conf[PTF_LAG_NAME] = [ptf_ports["ip"]["lag"].split("/")[0]]
+    arp_responder_conf[ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"]] = \
+        [ptf_ports["ip"]["port_not_behind_lag"].split("/")[0]]
+    with open("/tmp/from_t1.json", "w") as ar_config:
+        json.dump(arp_responder_conf, ar_config)
+    ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+    ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
+    ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
+
+    ptfhost.shell("supervisorctl reread && supervisorctl update")
+    ptfhost.shell("supervisorctl restart arp_responder")
 
 
 def generate_port_config(duthost, tbinfo):
@@ -313,12 +349,12 @@ def ptf_dut_setup_and_teardown(duthost, ptfhost, tbinfo):
         setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id)
         setup_ptf_lag(ptfhost, ptf_ports)
 
-        yield dut_ports, ptf_ports, vlan
+        yield ptf_ports, vlan
     except Exception as err:
         pytest.fail("Setup failed with error: {}".format(err))
     finally:
-        dut_teardown(duthost, dut_ports, src_vlan_id, vlan)
         ptf_teardown(ptfhost, ptf_ports)
+        dut_teardown(duthost, dut_ports, src_vlan_id, vlan)
 
 def test_lag_member_status(duthost, ptf_dut_setup_and_teardown):
     """
@@ -361,17 +397,6 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
     ptf_runner(ptfhost, TEST_DIR, "lag_test.LagMemberTrafficTest", "/root/ptftests", params=params)
 
 
-def check_arp(duthost, port_name, ip_address):
-    res = duthost.shell("show arp", module_ignore_errors=True)
-    if res["rc"] != 0:
-        return False
-    output_lines = res["stdout_lines"]
-    for line in output_lines:
-        if ip_address in line and port_name in line:
-            return True
-    return False
-
-
 def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_teardown):
     """
     Test traffic about ports in a lag
@@ -383,22 +408,6 @@ def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_te
         4.) Send ICMP request packet from port not behind lag in PTF to port behind lag in PTF, and then verify recieve the packet in port behind lag
     """
     ptfhost = common_setup_teardown
-    dut_ports, ptf_ports, vlan = ptf_dut_setup_and_teardown
-    vlan_ip = vlan["ip"].split("/")[0]
-    ping_format = "timeout 1 ping -c 1 -w 1 -I {} {}"
-    not_behind_lag_ping_cmd = ping_format.format(ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], vlan_ip)
-    behind_lag_ping_cmd = " & ".join([ping_format.format(port, vlan_ip) for port in ptf_ports[ATTR_PORT_BEHIND_LAG]
-                                      .values()])
-    duthost.shell("sonic-clear fdb all")
-    duthost.shell("sonic-clear arp")
-    time.sleep(20)
-    # ping dut from port not behind lag, port not behind lag and lag interface to refresh arp table in dut.
-    ptfhost.shell((not_behind_lag_ping_cmd + " & " + behind_lag_ping_cmd + "&" +
-                  ping_format.format(PTF_LAG_NAME, vlan_ip)), module_ignore_errors=True)
-    pytest_assert(wait_until(10, 1, 0, check_arp, duthost, DUT_LAG_NAME, ptf_ports["ip"]["lag"].split("/")[0]),
-                  "Arp info for portchannel is not correct")
-    pytest_assert(wait_until(10, 1, 0, check_arp, duthost, dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"],
-                             ptf_ports["ip"][ATTR_PORT_NOT_BEHIND_LAG].split("/")[0]),
-                  "Arp info for port not behind lag is not correct")
+    ptf_ports, vlan = ptf_dut_setup_and_teardown
 
     run_lag_member_traffic_test(duthost, vlan, ptf_ports, ptfhost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/11316
test_lag_member_traffic would sometimes fail due to PTF response wrong ARP packet. This PR is to fix this issue.

#### How did you do it?
Use arp_responder in ptf to reply arp request.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
