### PR TITLE
Ignore log error related to sai_bulk_object_get_stats in test_pfcwd_status for TD2 platforms

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1714,7 +1714,8 @@ Totals               6450                 6449
         elif "Device b971" in output:
             asic = "th2"
         elif ("Broadcom Limited Device b850" in output or
-                "Broadcom Limited Broadcom BCM56850" in output):
+                "Broadcom Limited Broadcom BCM56850" in output or
+                "Broadcom Inc. and subsidiaries Broadcom BCM56850" in output):
             asic = "td2"
         elif ("Broadcom Limited Device b870" in output or
                 "Broadcom Inc. and subsidiaries Device b870" in output):

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -22,6 +22,24 @@ READ_FLEXDB_TIMEOUT = 20
 READ_FLEXDB_INTERVAL = 5
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
+    if not loganalyzer:
+        return
+
+    for duthost in duthosts:
+        asic_name = duthost.get_asic_name()
+        if asic_name in ['td2']:
+            loganalyzer[duthost.hostname].ignore_regex.extend(
+                [
+                    '.*ERR syncd#syncd:.*SAI_API_QUEUE:_brcm_sai_cosq_stat_get:.* ',
+                    '.*ERR syncd#syncd:.*SAI_API_SWITCH:sai_bulk_object_get_stats.* ',
+                ]
+            )
+
+    return
+
+
 @pytest.fixture(scope="module", autouse=True)
 def set_default_pfcwd_config(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Ignore certain log errors after the test generic_config_updater/test_pfcwd_status on TD2 platforms
  
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The test failed in the log checking stage for the errors below:
Jan  4 22:44:30.824770 ck304 ERR syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_cosq_stat_get:1972 cosq stat get failed with error Invalid parameter (0xfffffffc).
Jan  4 22:44:30.824919 ck304 ERR syncd#syncd: [none] SAI_API_SWITCH:sai_bulk_object_get_stats:670 get bulk queue stats failed with error -5.

#### How did you do it?
The error is from running checkBulkCapability(https://github.com/sonic-net/sonic-sairedis/blob/master/syncd/FlexCounter.cpp#L463), the program can continue even returning false as it will use the none-bulk way to create counters thereafter. We could safely ignore the log. We are told that the sai_bulk_object_get_stats used by checkBulkCapability is not supported on TD2 now, so the change here will be applied to all TD2 platforms.

#### How did you verify/test it?
The test can pass with this change.

#### Any platform specific information?
The change will apply to all TD2 platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
