### PR TITLE
fix the everflow testbed failure on dualtor A-A

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -8,6 +8,11 @@ from . import everflow_test_utilities as everflow_utils
 
 from tests.ptf_runner import ptf_runner
 from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, DEFAULT_SERVER_IP
+
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby     # noqa F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup            # noqa F401
+from tests.common.dualtor.dual_tor_common import active_active_ports                            # noqa F401
+
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
@@ -19,6 +24,7 @@ pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
 ]
 
+logger = logging.getLogger(__name__)
 
 MEGABYTE = 1024 * 1024
 DEFAULT_PTF_SOCKET_RCV_SIZE = 1 * MEGABYTE
@@ -79,6 +85,20 @@ class EverflowIPv4Tests(BaseEverflowTest):
     DEFAULT_DST_IP = "30.0.0.1"
     MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3", "j2c+", "jr2"]
 
+    @pytest.fixture
+    def setup_active_active_ports(self, active_active_ports, rand_selected_dut, rand_unselected_dut,                  # noqa F811
+                                  config_active_active_dualtor_active_standby,                        # noqa F811
+                                  validate_active_active_dualtor_setup):                                        # noqa F811
+        if active_active_ports:
+            # for active-active dualtor, the upstream traffic is ECMPed to both ToRs, so let's
+            # config the unselected ToR as standby to ensure all ethernet type packets are
+            # forwarded to the selected ToR.
+            logger.info("Configuring {} as active".format(rand_selected_dut.hostname))
+            logger.info("Configuring {} as standby".format(rand_unselected_dut.hostname))
+            config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+
+        return
+                                      
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request):        # noqa F811
         """
@@ -128,7 +148,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
-                                       toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor,
+                                       setup_active_active_ports):    # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -228,7 +249,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo,
-                                          toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor,
+                                          setup_active_active_ports):     # noqa F811
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -296,7 +318,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo,
-                                                  toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor,
+                                                  setup_active_active_ports):     # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -387,7 +410,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo,
-                                                toggle_all_simulator_ports_to_rand_selected_tor):       # noqa F811
+                                                toggle_all_simulator_ports_to_rand_selected_tor,
+                                                setup_active_active_ports):       # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -498,7 +522,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             partial_ptf_runner,
             config_method,
             tbinfo,
-            toggle_all_simulator_ports_to_rand_selected_tor     # noqa F811
+            toggle_all_simulator_ports_to_rand_selected_tor,
+            setup_active_active_ports                           # noqa F811
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
         This tests single rate three color policer mode and specifically checks CIR value

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -148,8 +148,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
-                                       toggle_all_simulator_ports_to_rand_selected_tor,
-                                       setup_active_active_ports):    # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                       setup_active_active_ports):    
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -249,8 +249,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo,
-                                          toggle_all_simulator_ports_to_rand_selected_tor,
-                                          setup_active_active_ports):     # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                          setup_active_active_ports):     
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -318,8 +318,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo,
-                                                  toggle_all_simulator_ports_to_rand_selected_tor,
-                                                  setup_active_active_ports):     # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                                  setup_active_active_ports):     
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -410,8 +410,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo,
-                                                toggle_all_simulator_ports_to_rand_selected_tor,
-                                                setup_active_active_ports):       # noqa F811
+                                                toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
+                                                setup_active_active_ports):       
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -522,8 +522,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             partial_ptf_runner,
             config_method,
             tbinfo,
-            toggle_all_simulator_ports_to_rand_selected_tor,
-            setup_active_active_ports                           # noqa F811
+            toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+            setup_active_active_ports                           
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
         This tests single rate three color policer mode and specifically checks CIR value


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After debug and investigation, this failure of "test_everflow_testbed" on dualtor A-A including two issues:

the mux status is standby on the selected DUT.
the test pkts are not sent to selected DUT, which has everflow rule config.
The rootcause of 1 is due to BGP shutdown. In the script, it tries to shutdown all BGP during setup, which makes T1 not reachable from the TOR. Then the DUT moves itself into standby mode. That's from the design of mux state machine.

The rootcause of 2 is similiar to the following issue:
https://github.com/sonic-net/sonic-mgmt/pull/8158

We need fall back to active-standby mode to test this scenario for
active-active ports.


Summary:
Fixes # (issue)
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/9983)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x ] 202205
- [x ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on A-A


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
