### PR TITLE
Fix the issue of port down on arista_7050_qx32s after running test_replace_fec

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -3,6 +3,7 @@ import pytest
 import re
 import random
 
+from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
@@ -256,6 +257,10 @@ def test_replace_fec(duthosts, rand_one_dut_hostname, ensure_dut_readiness, fec)
             current_status_fec = check_interface_status(duthost, "FEC")
             pytest_assert(current_status_fec == fec,
                           "Failed to properly configure interface FEC to requested value {}".format(fec))
+
+            # The rollback after the test cannot revert the fec, when fec is not configured in config_db.json
+            if duthost.facts['platform'] in ['x86_64-arista_7050_qx32s']:
+                config_reload(duthost)
         else:
             expect_op_failure(output)
     finally:

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -260,7 +260,7 @@ def test_replace_fec(duthosts, rand_one_dut_hostname, ensure_dut_readiness, fec)
 
             # The rollback after the test cannot revert the fec, when fec is not configured in config_db.json
             if duthost.facts['platform'] in ['x86_64-arista_7050_qx32s']:
-                config_reload(duthost)
+                config_reload(duthost, safe_reload=True)
         else:
             expect_op_failure(output)
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add config reload at the end of test_replace_fec for platform arista_7050_qx32s
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The generic_config_updater/test_eth_interface.py::test_replace_fec[fc] will change FEC to FC on 40G ports. It results in port down as expected. Then it expects to use rollback_or_reload() to revert the change of FEC, but FEC is not changed back even the rollback in rollback_or_reload() returns successfully. This result of down port will affect all the following tests, because in the setup of the following test files, it will wait for port up and only use 'shutdown/restart' to recover the down port. That doesn't work to recover FEC here; 'config reload' is needed.

#### How did you do it?
Apply 'config reload' to the end of test_replace_fec for platform arista_7050_qx32s

#### How did you verify/test it?
Checked that after the test, all ports are up.

#### Any platform specific information?
This change will only affect arista_7050_qx32s

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
