### PR TITLE
Ignore "sonic_installer list" failure during image upgrade

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -110,21 +110,35 @@ def setup_swap_if_necessary(module):
 def reduce_installed_sonic_images(module):
     log("reduce_installed_sonic_images")
 
-    _, out, _ = exec_command(module, cmd="sonic_installer list", ignore_error=True)
+    rc, out, _ = exec_command(module, cmd="sonic_installer list", ignore_error=True)
+    if rc != 0:
+        log("Failed to get sonic image list. Will try to install new image anyway.")
+        return
+
     lines = out.split('\n')
 
-    # if next boot image not same with current, set current as next boot, and delete the orinal next image
+    # if next boot image not same with current, set current as next boot, and delete the original next image
+    curr_image = ""
+    next_image = ""
     for line in lines:
         if 'Current:' in line:
             curr_image = line.split(':')[1].strip()
         elif 'Next:' in line:
             next_image = line.split(':')[1].strip()
 
+    if curr_image == "":
+        log("Failed to get current image. Will try to install new image anyway.")
+        return
+
+    if next_image == "":
+        log("Failed to get next image. Will try to install new image anyway.")
+        return
+
     if curr_image != next_image:
         log("set-next-boot")
         exec_command(module, cmd="sonic_installer set-next-boot {}".format(curr_image), ignore_error=True)
 
-    log("clearnup old image")
+    log("cleanup old image")
     exec_command(module, cmd="sonic_installer cleanup -y", ignore_error=True)
 
     log("Done reduce_installed_sonic_images")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The "sonic_installer list" command may fail and output nothing. Consequently variable "curr_image" may be referenced before assignment.

#### How did you do it?
This change enhanced the robustness of code to ignore failure of command "sonic_installer list". Then the code can try to run "sonic_installer install" anyway without reduce installed image.

This fix is still not good enough. The reason is that if "sonic_installer list" fail, most likely "sonic_installer install" would fail too. What's more, if old image is not reduced, try to install new image would also fail on devices with small flash disk.

#### How did you verify/test it?
Run on physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
