### PR TITLE
fix 6100 testQosSaiLossyQueue failure caused by leakout

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3680,9 +3680,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +
                             pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
             else:
+                if check_leackout_compensation_support(asic_type, hwsku):
+                    pkts_num_leak_out = 0
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_leak_out +
                             pkts_num_trig_egr_drp - 1 - margin)
+                if check_leackout_compensation_support(asic_type, hwsku):
+                    time.sleep(5)
+                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                                   xmit_counters_base, self, src_port_id, pkt, 10)
 
             if hwsku == 'Arista-7050CX3-32S-D48C8' or hwsku == 'Arista-7050CX3-32S-C32' or \
                     hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

encounter testQosSaiLossyQueue  failure for 6100

#### How did you do it?

it caused by leakout, so compensate leakout using existing funciotn

#### How did you verify/test it?

pass local test

t1:
```
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED [ 33%]
... omitted ...
=========================== short test summary info ============================
SKIPPED [1] qos/qos_sai_base.py:604: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [1] qos/qos_sai_base.py:611: multi-dut is not supported on T1 topologies
============= 1 passed, 2 skipped, 1 warning in 974.02s (0:16:14) ==============
```

t0:
```
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED [ 33%]
... omitted ... 
========================================================================================== short test summary info ==========================================================================================
SKIPPED [1] qos/qos_sai_base.py:591: single_dut_multi_asic is not supported on T0 topologies
SKIPPED [1] qos/qos_sai_base.py:609: multi-dut is not supported on T0 topologies
=========================================================================== 1 passed, 2 skipped, 1 warning in 1225.47s (0:20:25) ============================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
