### PR TITLE
Xfail test_ro_user_banned_command on master image

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1334,6 +1334,13 @@ tacacs/test_authorization.py::test_authorization_tacacs_and_local:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11349
 
+tacacs/test_ro_user.py::test_ro_user_banned_command:
+  xfail:
+    reason: "Case failed due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/11372"
+    conditions:
+      - "release in ['master']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/11372
+
 #######################################
 #####           telemetry         #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
raise issue https://github.com/sonic-net/sonic-mgmt/issues/11372.
xfail tacacs/test_ro_user.py::test_ro_user_banned_command because code/test changes haven't been merged into master branch.

#### How did you do it?
xfail this case in condition mark file

#### How did you verify/test it?
run `tacacs/test_ro_user.py::test_ro_user_banned_command` on master branch to see if it's skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
