### PR TITLE
Fix TypeError in pytest_assert in test_techsupport and passw_hardening

### DIFF
--- a/tests/passw_hardening/passw_hardening_utils.py
+++ b/tests/passw_hardening/passw_hardening_utils.py
@@ -91,7 +91,8 @@ def compare_passw_policies_in_linux(duthost, pam_file_expected=PAM_PASSWORD_CONF
 
     common_password_diff = [li for li in difflib.ndiff(command_password_stdout, common_password_expected) if
                             li[0] != ' ']
-    pytest_assert(len(common_password_diff) == 0, common_password_diff)
+    error_message = 'password diff: ' + '; '.join(common_password_diff)
+    pytest_assert(len(common_password_diff) == 0, error_message)
 
 
 def config_and_review_policies(duthost, passw_hardening_ob, pam_file_expected):

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -529,4 +529,8 @@ def test_techsupport_commands(
             check_cmds(cmd_group_name, cmd_group_to_check, cmd_list, strbash_in_cmdlist)
         )
 
-    pytest_assert(len(cmd_not_found) == 0, cmd_not_found)
+    error_message = ''
+    for key, commands in cmd_not_found.items():
+        error_message += "Commands not found for '{}': ".format(key) + '; '.join(commands) + '\n'
+
+    pytest_assert(len(cmd_not_found) == 0, error_message)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_techsupport_commands failed due to the following TypeError.
```
  File "/var/src/sonic-mgmt_vms64-t1-7260-14_65040f002185a20e72689ccf/tests/show_techsupport/test_techsupport.py", line 532, in test_techsupport_commands
    pytest_assert(len(cmd_not_found) == 0, cmd_not_found)
  File "/var/src/sonic-mgmt_vms64-t1-7260-14_65040f002185a20e72689ccf/tests/common/helpers/assertions.py", line 7, in pytest_assert
    pytest.fail(message)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/outcomes.py", line 198, in fail
    raise Failed(msg=reason, pytrace=pytrace)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/outcomes.py", line 38, in __init__
    raise TypeError(error_msg.format(type(self).__name__, type(msg).__name__))
TypeError: Failed expected string as 'msg' parameter, got 'defaultdict' instead.
Perhaps you meant to use a mark?
```

`cmd_not_found = defaultdict(<class 'list'>, {'frr_cmds': ["vtysh -c 'show ip route vrf all'", "vtysh -c 'show ipv6 route vrf all'"]})`

It's because cmd_not_found is defaultdict, not a string.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
When cmd_not_found is not empty, pytest_assert failed due to TypeError, defaultdict could not be used as parameter for msg type.

#### How did you do it?
Convert cmd_not_found to string format and set it as parameter for pytest_assert.

#### How did you verify/test it?
run test_techsupport.py on master image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
