### PR TITLE
Disable iface_loopback_action tests on Broadcom switches

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -672,9 +672,11 @@ http/test_http_copy.py:
 #######################################
 iface_loopback_action/test_iface_loopback_action.py:
   skip:
-    reason: "Test does not support dualtor topology."
+    reason: "Test not supported on Broadcom SKUs or dualtor topology."
+    conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
+      - "asic_type in ['broadcom']"
 
 #######################################
 #####      iface_namingmode       #####


### PR DESCRIPTION
### Description of PR
Disable iface_loopback_action tests on Broadcom switches.


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

