### PR TITLE
Compress pcap files before copying it from pft to sonic-mgmt

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -21,8 +21,12 @@ def ptf_collect(host, log_file):
     pcap_file = filename_prefix + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
-        filename_pcap = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.pcap'
-        host.fetch(src=pcap_file, dest=filename_pcap, flat=True, fail_on_missing=False)
+        # Compress the file
+        compressed_pcap_file = pcap_file + '.tar.gz'
+        host.archive(path=pcap_file, dest=compressed_pcap_file, format='gz')
+        # Copy compressed file from ptf to sonic-mgmt
+        filename_pcap = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.pcap.tar.gz'
+        host.fetch(src=compressed_pcap_file, dest=filename_pcap, flat=True, fail_on_missing=False)
         allure.attach.file(filename_pcap, 'ptf_pcap: ' + filename_pcap, allure.attachment_type.PCAP)
 
 


### PR DESCRIPTION
Before change, it took about 15 minutes to copy a 400M pcap file from ptf to sonic-mgmt. After change, the 400M pcap file can be compressed to 4M, and the copy takes 2 seconds.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Copy large file from ptf to sonic-mgmt takes long time.
- Before change, it took about 15 minutes to copy a 400M pcap file from ptf to sonic-mgmt.
- After change, the 400M pcap file can be compressed to 4M, and the copy takes 2 seconds.

#### How did you do it?
Compress pcap file before copying it from pft to sonic-mgmt

#### How did you verify/test it?
Run same test case, pass

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
