### PR TITLE
Align dash tests to support DPU with one single port

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -140,10 +140,12 @@ def dash_config_info(duthost, config_facts, minigraph_facts, tbinfo):
                     # and only the mac of neighbor 1 exists in the arp table.
                     # The remote ptf intf will take the value of neighbor 1
                     # because the packet to remote PA will be forwarded to the ptf port corresponding to neighbor 1.
-                    dash_info[REMOTE_PA_IP] = '10.0.2.2'
+                    fake_neighbor_2_ip = '10.0.2.2'
+                    fake_neighbor_2_prefix = "10.0.2.0/24"
+                    dash_info[REMOTE_PA_IP] = fake_neighbor_2_ip
                     dash_info[REMOTE_PTF_INTF] = dash_info[LOCAL_PTF_INTF]
                     dash_info[REMOTE_PTF_MAC] = dash_info[LOCAL_PTF_MAC]
-                    dash_info[REMOTE_PA_PREFIX] = "10.0.2.0/24"
+                    dash_info[REMOTE_PA_PREFIX] = fake_neighbor_2_prefix
                     break
             elif REMOTE_PA_IP not in dash_info:
                 dash_info[REMOTE_PA_IP] = neigh_ip

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -99,7 +99,7 @@ def use_underlay_route(request):
 
 
 @pytest.fixture(scope="function")
-def dash_config_info(duthost, config_facts, minigraph_facts):
+def dash_config_info(duthost, config_facts, minigraph_facts, tbinfo):
     dash_info = {
         ENI: "F4939FEFC47E",
         VM_VNI: 4321,
@@ -120,14 +120,26 @@ def dash_config_info(duthost, config_facts, minigraph_facts):
     dash_info[DUT_MAC] = config_facts["DEVICE_METADATA"]["localhost"]["mac"]
 
     neigh_table = duthost.switch_arptable()['ansible_facts']['arptable']
+    topo = tbinfo["topo"]["name"]
     for neigh_ip, config in list(config_facts["BGP_NEIGHBOR"].items()):
-        # Pick the first two BGP neighbor IPs since these should already be learned on the DUT
+        # For dpu with 2 ports Pick the first two BGP neighbor IPs since these should already be learned on the DUT
+        # Take neigh 1 as local PA, take neigh 2 as remote PA
         if ip_interface(neigh_ip).version == 4:
             if LOCAL_PA_IP not in dash_info:
                 dash_info[LOCAL_PA_IP] = neigh_ip
                 intf, _ = get_intf_from_ip(config['local_addr'], config_facts)
                 dash_info[LOCAL_PTF_INTF] = minigraph_facts["minigraph_ptf_indices"][intf]
                 dash_info[LOCAL_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
+                if topo == 'dpu-1' and REMOTE_PA_IP not in dash_info:
+                    # For dup with single one port, there is only one bgp neighbor. Also take the neigh 1 as local pa,
+                    # take neigh 2's IP and network as remote PA,
+                    # but the mac of remote PA will take the value of nigh 1,
+                    # and the remote ptf intf will take the value of neigh 1
+                    dash_info[REMOTE_PA_IP] = '10.0.2.2'
+                    dash_info[REMOTE_PTF_INTF] = dash_info[LOCAL_PTF_INTF]
+                    dash_info[REMOTE_PTF_MAC] = dash_info[LOCAL_PTF_MAC]
+                    dash_info[REMOTE_PA_PREFIX] = "10.0.2.0/24"
+                    break
             elif REMOTE_PA_IP not in dash_info:
                 dash_info[REMOTE_PA_IP] = neigh_ip
                 intf, intf_ip = get_intf_from_ip(config['local_addr'], config_facts)
@@ -186,11 +198,14 @@ def apply_inbound_configs(dash_inbound_configs, apply_config):
 
 
 @pytest.fixture(scope="function")
-def dash_outbound_configs(dash_config_info, use_underlay_route, minigraph_facts):
+def dash_outbound_configs(dash_config_info, use_underlay_route, minigraph_facts, tbinfo):
     if use_underlay_route:
         dash_config_info[REMOTE_PA_IP] = u"30.30.30.30"
         dash_config_info[REMOTE_PA_PREFIX] = "30.30.30.30/32"
-        dash_config_info[REMOTE_PTF_INTF] = list(minigraph_facts["minigraph_ptf_indices"].values())
+        if tbinfo["topo"]["name"] == "dpu-1":
+            dash_config_info[REMOTE_PTF_INTF] = [dash_config_info[REMOTE_PTF_INTF]]
+        else:
+            dash_config_info[REMOTE_PTF_INTF] = list(minigraph_facts["minigraph_ptf_indices"].values())
     else:
         dash_config_info[REMOTE_PTF_INTF] = [dash_config_info[REMOTE_PTF_INTF]]
 

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -123,7 +123,7 @@ def dash_config_info(duthost, config_facts, minigraph_facts, tbinfo):
     topo = tbinfo["topo"]["name"]
     for neigh_ip, config in list(config_facts["BGP_NEIGHBOR"].items()):
         # For dpu with 2 ports Pick the first two BGP neighbor IPs since these should already be learned on the DUT
-        # Take neigh 1 as local PA, take neigh 2 as remote PA
+        # Take neighbor 1 as local PA, take neighbor 2 as remote PA
         if ip_interface(neigh_ip).version == 4:
             if LOCAL_PA_IP not in dash_info:
                 dash_info[LOCAL_PA_IP] = neigh_ip
@@ -131,10 +131,15 @@ def dash_config_info(duthost, config_facts, minigraph_facts, tbinfo):
                 dash_info[LOCAL_PTF_INTF] = minigraph_facts["minigraph_ptf_indices"][intf]
                 dash_info[LOCAL_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
                 if topo == 'dpu-1' and REMOTE_PA_IP not in dash_info:
-                    # For dup with single one port, there is only one bgp neighbor. Also take the neigh 1 as local pa,
-                    # take neigh 2's IP and network as remote PA,
-                    # but the mac of remote PA will take the value of nigh 1,
-                    # and the remote ptf intf will take the value of neigh 1
+                    # For DPU with only one single port, we just have one neighbor (neighbor 1).
+                    # So, we take neighbor 1 as the local PA. For the remote PA,
+                    # we take the original neighbor 2's IP as the remote PA IP,
+                    # and the original neighbor 2's network as the remote PA network.
+                    # Take the mac of neighbor 1's mac as the mac of remote PA,
+                    # because the BGP route to neighbor 1 is the default route,
+                    # and only the mac of neighbor 1 exists in the arp table.
+                    # The remote ptf intf will take the value of neighbor 1
+                    # because the packet to remote PA will be forwarded to the ptf port corresponding to neighbor 1.
                     dash_info[REMOTE_PA_IP] = '10.0.2.2'
                     dash_info[REMOTE_PTF_INTF] = dash_info[LOCAL_PTF_INTF]
                     dash_info[REMOTE_PTF_MAC] = dash_info[LOCAL_PTF_MAC]

--- a/tests/dash/dash_acl.py
+++ b/tests/dash/dash_acl.py
@@ -155,7 +155,7 @@ class DefaultAclRule(AclRuleTest):
             ACL_PRIORITY: 255,
             ACL_ACTION: self.default_action,
             ACL_TERMINATING: "false",
-            ACL_PROTOCOL: "17",
+            ACL_PROTOCOL: "17, 6, 1, 2",
         })
 
 

--- a/tests/dash/dash_acl.py
+++ b/tests/dash/dash_acl.py
@@ -155,7 +155,7 @@ class DefaultAclRule(AclRuleTest):
             ACL_PRIORITY: 255,
             ACL_ACTION: self.default_action,
             ACL_TERMINATING: "false",
-            ACL_PROTOCOL: "17, 6, 1, 2",
+            ACL_PROTOCOL: "17, 6, 1",
         })
 
 

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -17,7 +17,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="function", autouse=True)
-def acl_default_route(duthost, ptfhost, dash_config_info):
+def acl_default_rule(duthost, ptfhost, dash_config_info):
     hwsku = duthost.facts['hwsku']
     hwsku_list_with_default_acl_action_deny = ['Nvidia-9009d3b600CVAA-C1', 'Nvidia-9009d3b600SVAA-C1']
     if hwsku in hwsku_list_with_default_acl_action_deny:

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -16,7 +16,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="function")
 def acl_default_rule(duthost, ptfhost, dash_config_info):
     hwsku = duthost.facts['hwsku']
     hwsku_list_with_default_acl_action_deny = ['Nvidia-9009d3b600CVAA-C1', 'Nvidia-9009d3b600SVAA-C1']
@@ -43,7 +43,8 @@ def test_outbound_vnet(
         dash_config_info,
         skip_dataplane_checking,
         asic_db_checker,
-        inner_packet_type):
+        inner_packet_type,
+        acl_default_rule):
     """
     Send VXLAN packets from the VM VNI
     """
@@ -63,7 +64,8 @@ def test_outbound_vnet_direct(
         dash_config_info,
         skip_dataplane_checking,
         asic_db_checker,
-        inner_packet_type):
+        inner_packet_type,
+        acl_default_rule):
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
@@ -80,7 +82,8 @@ def test_outbound_direct(
         dash_config_info,
         skip_dataplane_checking,
         asic_db_checker,
-        inner_packet_type):
+        inner_packet_type,
+        acl_default_rule):
     asic_db_checker(["SAI_OBJECT_TYPE_VNET", "SAI_OBJECT_TYPE_ENI"])
     if skip_dataplane_checking:
         return
@@ -97,7 +100,8 @@ def test_inbound_vnet_pa_validate(
         dash_config_info,
         skip_dataplane_checking,
         asic_db_checker,
-        inner_packet_type):
+        inner_packet_type,
+        acl_default_rule):
     """
     Send VXLAN packets from the remote VNI with PA validation enabled
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Align the existing dash tests to support DPU with one single port.
1.  For DPU with 2 ports, we have 2 neighbors, the first one is local PA, and the second one is remote PA. But for DPU with only one single port, we just have one neighbor (neighbor 1). So, we take neighbor 1 as the local PA. For the remote PA, we take the original neighbor 2's IP  as the remote PA IP,  and the original neighbor 2's network as the remote PA network. Take the mac of neighbor 1's mac as the mac of remote PA, because the BGP route to neighbor 1 is the default route, and only the mac of neighbor 1 exists in the arp table.  The remote ptf intf will take the value of neighbor 1 because the packet to remote PA will be forwarded to the ptf port corresponding to neighbor 1.
2.  Since some hwskus have the default acl rule action deny, we need to add the default acl rule action permit for them



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Align the existing dash tests to support DPU with one single port.

#### How did you do it?
1.  For DPU with 2 ports, we have 2 neighbors, the first one is local PA, and the second one is remote PA. But for DPU with only one single port, we just have one neighbor (neighbor 1). So, we take neighbor 1 as the local PA. For the remote PA, we take the original neighbor 2's IP  as the remote PA IP,  and the original neighbor 2's network as the remote PA network. Take the mac of neighbor 1's mac as the mac of remote PA, because the BGP route to neighbor 1 is the default route, and only the mac of neighbor 1 exists in the arp table.  The remote ptf intf will take the value of neighbor 1 because the packet to remote PA will be forwarded to the ptf port corresponding to neighbor 1.
2.  Since some hwskus have the default acl route action deny, we need to add the default acl route action permit for them

#### How did you verify/test it?
run dash tests on dpu with 1 ports and 2 ports

#### Any platform specific information?
dpu

#### Supported testbed topology if it's a new test case?


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
