### PR TITLE
Update kexec regex for Bookworm

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -197,7 +197,7 @@ def get_report_summary(duthost, analyze_result, reboot_type, reboot_oper, base_o
 
 def get_kexec_time(duthost, messages, result):
     reboot_pattern = re.compile(
-        r'.* NOTICE admin: Rebooting with /sbin/kexec -e to.*...')
+        r'.* NOTICE (?:admin|root): Rebooting with /sbin/kexec -e to.*...')
     reboot_time = "N/A"
     logging.info("FINDING REBOOT PATTERN")
     for message in messages:

--- a/tests/platform_tests/templates/expect_boot_messages
+++ b/tests/platform_tests/templates/expect_boot_messages
@@ -1,4 +1,4 @@
-r, ".* NOTICE admin: Rebooting with /sbin/kexec -e to.*..."
+r, ".* NOTICE (?:admin|root): Rebooting with /sbin/kexec -e to.*..."
 
 r, ".* systemd.* (Stopping|Stopped|Starting|Started).* Database container.*"
 r, ".* NOTICE admin: (Stopping|Stopped|Starting|Started).* (?!syncd|swss|gbsyncd).* service.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

The "Rebooting with /sbin/kexec" log regex has changed with Bookworm. Instead of using the `admin` user, the `root` user is used instead. Update the regex message to match that.

#### How did you do it?

#### How did you verify/test it?

Verified on KVM running master branch image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
