### PR TITLE
Fix for TC test_container_checker.py issue https://github.com/sonic-net/sonic-mgmt/issues/10475 to check if the container is in running state before stopping it 

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -180,8 +180,13 @@ def get_expected_alerting_message(container_name):
     return expected_alerting_messages
 
 
+<<<<<<< HEAD
 def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname,
                            enum_rand_one_asic_index, enum_dut_feature, tbinfo):
+=======
+def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index, enum_dut_feature,
+                           tbinfo, disable_container_autorestart):
+>>>>>>> 87730a26a (Reg: Fix for exitied Container from previous test case)
     """Tests the feature of container checker.
 
     This function will check whether the container names will appear in the Monit
@@ -203,7 +208,7 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname,
     container_name = asic.get_docker_name(service_name)
 
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker_{}".format(container_name))
-
+    sleep_time = 70
     disabled_containers = get_disabled_container_list(duthost)
 
     skip_containers = disabled_containers[:]
@@ -211,10 +216,22 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname,
     # Skip 'radv' container on devices whose role is not T0/M0.
     if tbinfo["topo"]["type"] not in ["t0", "m0"]:
         skip_containers.append("radv")
-
     pytest_require(service_name not in skip_containers,
                    "Container '{}' is skipped for testing.".format(container_name))
+<<<<<<< HEAD
 
+=======
+    feature_autorestart_states = duthost.get_container_autorestart_states()
+    if feature_autorestart_states.get(service_name) == 'enabled':
+        disable_container_autorestart(duthost)
+        time.sleep(30)
+    if not is_container_running(duthost, container_name):
+        logger.info("Container '{}' is not running ...".format(container_name))
+        logger.info("Reload config on DuT as Container is not up '{}' ...".format(duthost.hostname))
+        config_reload(duthost, safe_reload=True)
+        time.sleep(300)
+        sleep_time = 80
+>>>>>>> 87730a26a (Reg: Fix for exitied Container from previous test case)
     asic.stop_service(service_name)
     logger.info("Waiting until container '{}' is stopped...".format(container_name))
     stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
@@ -226,6 +243,6 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname,
 
     loganalyzer.expect_regex = get_expected_alerting_message(container_name)
     with loganalyzer:
-        # Wait for 1 minutes such that Monit has a chance to write alerting message into syslog.
-        logger.info("Sleep 1 minutes to wait for the alerting message...")
-        time.sleep(70)
+        # Wait for 70s to 80s  such that Monit has a chance to write alerting message into syslog.
+        logger.info("Sleep '{}'s to wait for the alerting message...".format(sleep_time))
+        time.sleep(sleep_time)

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -11,6 +11,7 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_utils import check_container_state
+from tests.common.helpers.dut_utils import is_container_running
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import get_disabled_container_list
@@ -180,13 +181,8 @@ def get_expected_alerting_message(container_name):
     return expected_alerting_messages
 
 
-<<<<<<< HEAD
-def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname,
-                           enum_rand_one_asic_index, enum_dut_feature, tbinfo):
-=======
 def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index, enum_dut_feature,
                            tbinfo, disable_container_autorestart):
->>>>>>> 87730a26a (Reg: Fix for exitied Container from previous test case)
     """Tests the feature of container checker.
 
     This function will check whether the container names will appear in the Monit
@@ -218,9 +214,6 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand
         skip_containers.append("radv")
     pytest_require(service_name not in skip_containers,
                    "Container '{}' is skipped for testing.".format(container_name))
-<<<<<<< HEAD
-
-=======
     feature_autorestart_states = duthost.get_container_autorestart_states()
     if feature_autorestart_states.get(service_name) == 'enabled':
         disable_container_autorestart(duthost)
@@ -231,7 +224,6 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand
         config_reload(duthost, safe_reload=True)
         time.sleep(300)
         sleep_time = 80
->>>>>>> 87730a26a (Reg: Fix for exitied Container from previous test case)
     asic.stop_service(service_name)
     logger.info("Waiting until container '{}' is stopped...".format(container_name))
     stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Refer: Issue https://github.com/sonic-net/sonic-mgmt/issues/10475
In the resolution process, we verify the status of the container under test to ensure it is running. If the container is found to be in exited stated, we initiate a config_reload to guarantee its running state before proceeding with the test case. To maintain accurate logging post config_reload, an additional 10-second delay is introduced for the log analyzer, compensating for the reset of the monit rc timer.

In certain scenarios, the auto-restart feature may inadvertently get enabled due to other test cases, which contradicts the prerequisite of having it disabled for the current test case. Consequently, a corrective measure has been implemented to ensure that auto-restart is appropriately disabled as part of the fix.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Issue: https://github.com/sonic-net/sonic-mgmt/issues/10475
#### How did you do it?
If the container in test is not running -> Perform config_reload to ensure its running state
Sleep time is increased for 10s in case of config_reload for Log_Analyzer
If the auto_restart feature is enabled -> Perform disable_container_autorestart to ensure the auto restart is disabled

#### How did you verify/test it?
Ran the test cases against a multi-asic line card in a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
![image](https://github.com/sonic-net/sonic-mgmt/assets/135994174/7044b850-f5f0-4083-9b60-8f31fa4a2313)

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
