### PR TITLE
[202205] fix qos test prints on multiple lines

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -577,7 +577,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
                                                        1, dst_port_ip['peer_addr'], '192.168.0.1',
                                                        '00:00:00:00:00:00', None)
                         send_packet(self, dst_port_id, arpreq_pkt)
-                        
+
             # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
             if self.test_port_ips:
                 ips = [ip for ip in get_peer_addresses(self.test_port_ips)]
@@ -1516,8 +1516,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
+                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
                                  test_stage, recv_counters,
                                  recv_counters_base, xmit_counters,
                                  xmit_counters_base))
@@ -1552,8 +1552,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t'
+                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
                                  test_stage, recv_counters, recv_counters_base,
                                  xmit_counters, xmit_counters_base))
             # recv port pfc

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1512,8 +1512,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send packets short of ingress drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \
@@ -1546,8 +1546,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             test_stage = 'after send a few packets to trigger drop'
-            sys.stderr.write('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
-                             'xmit_counters {}\n\txmit_counters_base {}\n'.format(
+            sys.stderr.write(('{}:\n\trecv_counters {}\n\trecv_counters_base {}\n\t' + \
+                             'xmit_counters {}\n\txmit_counters_base {}\n').format(
                                  test_stage, recv_counters, recv_counters_base, xmit_counters, xmit_counters_base))
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg]), \


### PR DESCRIPTION
This is the same issue as solved in https://github.com/sonic-net/sonic-mgmt/pull/8990 but fixing a couple other lines in the same file.

Without this change we only format the 2nd line:
```
{}:
recv_counters {}
recv_counters_base {}
xmit_counters after send a few packets to trigger drop
xmit_counters_base [0, 1, 0, 0, 0, 118382, 0, 0, 0, 0, 8457920, 279, 0, 0, 56257, 8, 9, 0]
```

With this change both lines are formatted correctly:
```
after send a few packets to trigger drop:
        recv_counters [0, 35, 0, 0, 0, 492567, 0, 0, 0, 0, 32405952, 283, 0, 0, 227941, 3253, 9, 0]
        recv_counters_base [0, 35, 0, 0, 0, 457145, 0, 0, 0, 0, 30138944, 283, 0, 0, 227740, 3253, 9, 0]
        xmit_counters [0, 63, 0, 0, 0, 0, 0, 0, 0, 0, 12546615, 168250, 0, 0, 0, 4366, 2188, 0]
        xmit_counters_base [0, 62, 0, 0, 0, 0, 0, 0, 0, 0, 12540919, 168170, 0, 0, 0, 4362, 2186, 0]
```