### PR TITLE
Relax the check on the number of PORT_READY messages

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -416,10 +416,11 @@ def verify_required_events(duthost, event_counters, timing_data, verification_er
             observed_end_count = timing_data.get(
                 key, {}).get(pattern, {}).get("End count", 0)
             expected_count = event_counters.get(pattern)
-            # If we're checking PORT_READY, and there are 0 port state change messages captured instead of however many
-            # was expected, treat it as a success. Some platforms (Mellanox, Dell S6100) have 0, some platforms (Arista
-            #  050cx3) have however many ports are up.
-            if observed_start_count != expected_count and (pattern != 'PORT_READY' or observed_start_count != 0):
+            # If we're checking PORT_READY, allow any number of PORT_READY messages between 0 and the number of ports.
+            # Some platforms appear to have a random number of these messages, other platforms have however many ports
+            # are up.
+            if observed_start_count != expected_count and (
+                    pattern != 'PORT_READY' or observed_start_count > expected_count):
                 verification_errors.append("FAIL: Event {} was found {} times, when expected exactly {} times".
                                            format(pattern, observed_start_count, expected_count))
             if key == "time_span" and observed_start_count != observed_end_count:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Sometimes, after fast reboot, there is a random number of PORT_READY messages that occur; it could be 0, it could be the number of ports that are up, it could be some number in between. The reasoning for this is a bit unclear to me. However, considering the logic here prior to my changes had a relaxed check here, restore that behavior.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
