### PR TITLE
[Snappi] Update pause frame counting logic for DUT

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -560,10 +560,6 @@ def verify_pause_frame_count_dut(duthost,
                 pytest_assert(pfc_pause_rx_frames > 0,
                               "PFC pause frames should be received and counted in RX PFC counters for priority {}"
                               .format(prio))
-            else:
-                # PFC pause frames should not be received when test traffic is not paused
-                pytest_assert(pfc_pause_rx_frames == 0,
-                              "PFC pause frames should not be received and counted in RX PFC counters")
 
 
 def verify_tx_frame_count_dut(duthost,

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -264,6 +264,7 @@ def run_pfc_test(api,
     # Verify PFC pause frame count on the DUT
     verify_pause_frame_count_dut(duthost=duthost,
                                  test_traffic_pause=test_traffic_pause,
+                                 global_pause=global_pause,
                                  snappi_extra_params=snappi_extra_params)
 
     # Verify in flight TX lossless packets do not leave the DUT when traffic is expected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When verifying pause frames being generated/transmitted and received by the DUT during PFC tests, the way in which received pause frames are counted for lossy test cases or when the pause is not expected to be paused is incorrect. All PFC tests receive PFC frames from the traffic generator to congest the DUT's egress port, hence the check to ensure if this number is 0 is incorrect. 

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Bug fix for test failures
#### How did you do it?
Remove illogical check
#### How did you verify/test it?
Tested on lab devices
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
