### PR TITLE
[Recover testbed] Fix format issue in common function duthost_console

### DIFF
--- a/.azure-pipelines/recover_testbed/dut_connection.py
+++ b/.azure-pipelines/recover_testbed/dut_connection.py
@@ -104,6 +104,8 @@ def get_ssh_info(sonichost):
 def duthost_console(sonichost, conn_graph_facts, localhost):
     console_host, console_port, console_type, console_username = get_console_info(sonichost, conn_graph_facts)
     console_type = "console_" + console_type
+    if "/" in console_host:
+        console_host = console_host.split("/")[0]
 
     # console password and sonic_password are lists, which may contain more than one password
     sonicadmin_alt_password = sonichost.vm.get_vars(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
If ManagementIP in inventory file contains "/", it will fail when connecting to console session while recovering testbeds. 
Reference: #11281 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
If ManagementIP in inventory file contains "/", it will fail when connecting to console session while recovering testbeds. 

#### How did you do it?
Add support for "/" in ManagementIP.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
