### PR TITLE
[vsonic]: Don't push and load the PTF container on neighbors by default

### DIFF
--- a/ansible/roles/sonic/tasks/vsonic.yml
+++ b/ansible/roles/sonic/tasks/vsonic.yml
@@ -56,3 +56,4 @@
     - copy: src="docker-ptf.tar" dest="docker-ptf.tar"
     - shell: docker load -i docker-ptf.tar || true
     - shell: rm -f docker-ptf.tar
+  when: ptf_on_neighbor is defined and ptf_on_neighbor|bool == true

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -267,4 +267,4 @@
   - fetch: src=docker-ptf.tar dest=docker-ptf.tar flat=yes
   - shell: rm -f docker-ptf.tar
   run_once: yes
-  when: vm_type is defined and vm_type == "vsonic"
+  when: vm_type is defined and vm_type == "vsonic" and ptf_on_neighbor is defined and ptf_on_neighbor|bool == true


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

By default, don't push the docker-ptf.tar container image to the neighbor devices and load it. On setups where the neighbor VMs are running on a different server and/or there are many neighbors, this can save a good amount of time.

#### How did you do it?

Check for an option `ptf_on_neighbor`. Copy and load the PTF container on the neighbor SONiC VMs only if this option is set to true.

#### How did you verify/test it?

Loaded a kvm-t0-64-32 topo with SONiC neighbors with and without this option.

Command to deploy the PTF container on the neighbor device: `./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k vsonic add-topo vms-kvm-t0-64-32 password.txt -e ptf_on_neighbor=true`

The `-e ptf_on_neighbor=true` sets the `ptf_on_neighbor` option to true. With this set to false, or without this option specified, it will not be deployed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
