### PR TITLE
Fix pause_orchagent fixture stop wrong orchagent on dualtor issue

### DIFF
--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -15,7 +15,8 @@ SLEEP_TIME = 10
 
 
 @pytest.fixture
-def pause_orchagent(duthost):
+def pause_orchagent(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     pid = None
     retry = 3
     while True:
@@ -92,7 +93,7 @@ def create_log_analyzer(duthost):
     return loganalyzer, marker
 
 
-def test_orchagent_watchdog(duthosts, enum_rand_one_per_hwsku_hostname, pause_orchagent):
+def test_orchagent_watchdog(duthosts, enum_rand_one_per_hwsku_hostname, pause_orchagent):           # noqa: F401
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # if watchdog_processes does not exits, watchdog been disabled


### PR DESCRIPTION
Fix pause_orchagent fixture stop wrong orchagent on dualtor issue.

### Description of PR
Fix pause_orchagent fixture stop wrong orchagent on dualtor issue.

##### Work item tracking
- Microsoft ADO: 26458455

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Orchagent watchdog UT failed on DualTor device because pause_orchagent pause orchagent on one tor but UT run on another tor.

#### How did you do it?
Fix pause_orchagent fixture, use enum_rand_one_per_hwsku_hostname as parameter to stop orchagent on correct tor.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
