### PR TITLE
Fix add topo code issue when running with py3only sonic-mgmt-docker

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -33,7 +33,10 @@ class Connection(ConnectionBase):
 
     def _build_command(self):
         self._ssh_command = ['ssh', '-tt', '-q']
-        ansible_ssh_args = C.ANSIBLE_SSH_ARGS
+        if hasattr(C, 'ANSIBLE_SSH_ARGS'):
+            ansible_ssh_args = C.ANSIBLE_SSH_ARGS
+        else:
+            ansible_ssh_args = None
         if ansible_ssh_args:
             self._ssh_command += shlex.split(ansible_ssh_args)
         else:

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -47,7 +47,7 @@
   - name: Gather exabgp v4 programs
     set_fact:
       program_group_name: "exabgpv4"
-      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '(.*)', 'exabgp-\\1') | join(',')}}"
+      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1') | join(',')}}"
 
   - name: Configure exabgpv4 group
     template:
@@ -73,7 +73,7 @@
   - name: Gather exabgp v6 programs
     set_fact:
       program_group_name: "exabgpv6"
-      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '(.*)', 'exabgp-\\1-v6') | join(',')}}"
+      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1-v6') | join(',')}}"
 
   - name: Configure exabgpv6 group
     template:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix add topo code issue when running with py3only sonic-mgmt-docer

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Two issues are found when add topo with py3only docker
1. regex didn't work
2. Ansible constants didn't have ANSIBLE_SSH_ARGS attribute.

#### How did you do it?
Code change.

#### How did you verify/test it?
With PY3 only sonic-mgmt-docker, manually run remove topo/add topo on physical testbed.
With PY2 and PY3 sonic-mgmt-docker, manually run remove topo/add topo on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
