### PR TITLE
[CoPP] Enhancing ptftests/py3/copp_tests.py testcase to handle no trap condition

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -260,8 +260,10 @@ class PolicyTest(ControlPlaneBaseTest):
              str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
         )
 
-        assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(
-            rx_pps)
+        if self.has_trap:
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(rx_pps)
+        else:
+            assert rx_pps <= self.PPS_LIMIT_MIN, "rx_pps {}".format(rx_pps)
 
 
 # SONIC config contains policer CIR=600 for ARP


### PR DESCRIPTION
…copp_tests.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR fixes [Issue#11434](https://github.com/sonic-net/sonic-mgmt/issues/11434) which caused failure in test_copp.py::test_add_new_trap and test_remove_trap. The test uninstalls trap as first step in test and sends traffic to verify uninstallation of the trap. Since trap is disabled, no packets are expected from DUT to PTF, so rx_pps will be 0. 
But, in [PR#8199](https://github.com/sonic-net/sonic-mgmt/pull/8199), BGPTest was has policer limit and was changed to PolicyTest and it does not have the condition to check for trap status, thus failing test_copp.py when trap is disabled


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes Issue#11434
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To fix copp tests failure caused by missing condition to check trap status 
#### How did you do it?
Added conditon to check trap status and compare packet rate accordingly in ptftests/copp_tests.py
#### How did you verify/test it?
Run test_copp.py::test_add_new_trap and test_remove_trap on M0/MX topology
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
