### PR TITLE
[chassis] Fixed expected_num_asics for Supervisor in test_show_platform

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -82,7 +82,12 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
         expected_hwsku = dut_vars['sonic_hwsku'] if 'sonic_hwsku' in dut_vars else None
     expected_platform = dut_vars['sonic_hw_platform'] if 'sonic_hw_platform' in dut_vars else None
     expected_asic = dut_vars['asic_type'] if 'asic_type' in dut_vars else None
-    expected_num_asic = str(dut_vars['num_asics']) if 'num_asics' in dut_vars else None
+
+    # for expected_num_asic, get number of asics listed in asics_present list in dut_vars
+    expected_num_asic = str(len(dut_vars['asics_present'])) if 'asics_present' in dut_vars else None
+    # if expected_num_asic is still None use 'num_asics' from dut_vars
+    if not expected_num_asic:
+        expected_num_asic = str(dut_vars['num_asics']) if 'num_asics' in dut_vars else None
 
     expected_fields_values = {expected_platform, expected_hwsku, expected_asic}
     if len(unexpected_fields) != 0:


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
On Chassis Supervisor, show platform summary displays number of asic present based on the number of Fabric Cards inserted. This number could less than max asics supported by the Chassis supervisor.

In show_platorm_summary test, this number is checked against the num_asics var from dut_vars which represents max asics supported on DUT. When Chassis is not fully populated with max FC cards, this test fails.

Fix: Get the number of asics expected from asics_present car from dut_vars and use that to validate the show platform summary output

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-buildimage/issues/17819)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
test_show_platform::test_show_platform_summary  test case failure for Chassis SUpervisor when the chassis has less then max numbers of FCs 

#### How did you do it?
Get the number of asics expected from asics_present car from dut_vars and use that to validate the show platform summary output

#### How did you verify/test it?
Run test_show_platform::test_show_platform_summary on Supervisor where populated FC num < Max FC supported

#### Any platform specific information?
Chassis

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Logs:
With Fix:

```
- generated xml file: /run_logs/watchdog_fix/platform_tests/cli/test_show_platform.py::test_show_platform_summary_2024-01-30-16-46-26.xml -
=========================== short test summary info ============================
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc1]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc2]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-sup]
=================== 4 passed, 1 warning in 104.16s (0:01:44) ===================
```

without FIx:
```
=========================== short test summary info ============================
FAILED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-sup]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc0]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc1]
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_summary[sfd-t2-lc2]
============== 1 failed, 3 passed, 1 warning in 106.39s (0:01:46) ==============
```