### PR TITLE
Save management ip into config_db.json after recovery via console. 

### DIFF
--- a/.azure-pipelines/recover_testbed/testbed_status.py
+++ b/.azure-pipelines/recover_testbed/testbed_status.py
@@ -12,8 +12,12 @@ def dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip):
     gw_ip = list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
     brd_ip = ipaddress.ip_interface(mgmt_ip).network.broadcast_address
     try:
-        ret = dut_console.send_command("sudo ip addr add {} brd {} dev eth0".format(mgmt_ip, brd_ip))  # noqa F841
+        dut_console.send_command("sudo mv /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
+
+        dut_console.send_command("sudo ip addr add {} brd {} dev eth0".format(mgmt_ip, brd_ip))
         dut_console.send_command("sudo ip route add default via {}".format(gw_ip))
+
+        dut_console.send_command("sudo config save -y")
     except Exception as e:
         logging.info(e)
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After recovery from console and get ssh session back, we need to upgrade image. But we notice that, during upgradation, while reboot, we will lose management ip again and casue the failure. In this PR, we write management ip into config_db.json to avoid the loss of management ip. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
After recovery from console and get ssh session back, we need to upgrade image. But we notice that, during upgradation, while reboot, we will lose management ip again and casue the failure. In this PR, we write management ip into config_db.json to avoid the loss of management ip. 

#### How did you do it?
After adding ip on device, re-generate config_db.json to save management ip. 

#### How did you verify/test it?
After re-generating config_db.json, do upgradation, and it won't lose management ip. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
