### PR TITLE
Fix DataLoader cannot be imported with py3only sonic-mgmt-docker

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -91,6 +91,7 @@ class TestbedVMFacts():
                     result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
         return result_dict
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -6,8 +6,12 @@ import yaml
 import traceback
 import ipaddress
 
-from ansible.parsing.dataloader import DataLoader
-from ansible.inventory.manager import InventoryManager
+try:
+    from ansible.parsing.dataloader import DataLoader
+    from ansible.inventory.manager import InventoryManager
+    has_dataloader = True
+except ImportError:
+    has_dataloader = False
 
 DOCUMENTATION = '''
 module: testbed_vm_info.py
@@ -51,8 +55,9 @@ class TestbedVMFacts():
         self.topofile = TOPO_PATH + 'topo_' + self.toponame + '.yml'
         self.base_vm = base_vm
         self.vm_file = vm_file
-        self.inv_mgr = InventoryManager(
-            loader=DataLoader(), sources=self.vm_file)
+        if has_dataloader:
+            self.inv_mgr = InventoryManager(
+                loader=DataLoader(), sources=self.vm_file)
 
     def get_neighbor_eos(self):
         eos = {}
@@ -75,6 +80,16 @@ class TestbedVMFacts():
             eos[eos_name] = vm_name
         return eos
 
+    def gather_veos_vms(self):
+        yaml_data = {}
+        with open(self.vm_file, 'r') as default_f:
+            yaml_data = yaml.safe_load(default_f)
+        result_dict = {}
+        for group_name, group_content in yaml_data.items():
+            if group_name.startswith('vms_'):
+                for host_name, host_info in group_content.get('hosts', {}).items():
+                    result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
+        return result_dict
 
 def main():
     module = AnsibleModule(
@@ -95,15 +110,21 @@ def main():
         vm_facts = TestbedVMFacts(
             m_args['topo'], m_args['base_vm'], m_args['vm_file'])
         neighbor_eos = vm_facts.get_neighbor_eos()
-
+        if has_dataloader:
+            hosts = vm_facts.inv_mgr.hosts
+        else:
+            hosts = vm_facts.gather_veos_vms()
         tgen_mgmt_ips = list(ipaddress.ip_network(TGEN_MGMT_NETWORK.encode().decode()))
         for index, eos in enumerate(neighbor_eos):
             vm_name = neighbor_eos[eos]
             if 'tgen' in topo_type:
                 vm_mgmt_ip[eos] = str(tgen_mgmt_ips[index])
-            elif vm_name in vm_facts.inv_mgr.hosts:
-                vm_mgmt_ip[eos] = vm_facts.inv_mgr.get_host(
-                    vm_name).get_vars()['ansible_host']
+            elif vm_name in hosts:
+                if has_dataloader:
+                    vm_mgmt_ip[eos] = vm_facts.inv_mgr.get_host(
+                        vm_name).get_vars()['ansible_host']
+                else:
+                    vm_mgmt_ip[eos] = hosts[vm_name]['ansible_host']
             else:
                 err_msg = "Cannot find the vm {} in VM inventory file {}, please make sure you have enough VMs" \
                           "for the topology you are using."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix DataLoader cannot be imported with py3only sonic-mgmt-docker

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix DataLoader cannot be imported with py3only sonic-mgmt-docker
Ansible is upgraded in py3only docker.

#### How did you do it?
If DataLoader cannot be imported, use yaml module to load the file.

#### How did you verify/test it?
With PY2 and PY3 sonic-mgmt-docker, manually run deploy-mg with physical testbed.
With PY3only sonic-mgmt-docker, manually run deploy-mg with physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
