### PR TITLE
enhance test_authorization_tacacs_only case since slim image has no telemetry

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -13,6 +13,7 @@ from tests.common.utilities import skip_release, wait_until
 from .utils import check_server_received
 from tests.override_config_table.utilities import backup_config, restore_config, \
         reload_minigraph_with_golden_config
+from tests.common.helpers.dut_utils import is_container_running
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -205,7 +206,6 @@ def test_authorization_tacacs_only(
         "show interfaces counters -a -p 3",
         "show ip bgp neighbor",
         "show ipv6 bgp neighbor",
-        "show feature status telemetry",
         "touch testfile",
         "chmod +w testfile",
         "echo \"test\" > testfile",
@@ -227,6 +227,14 @@ def test_authorization_tacacs_only(
         "configlet --help",
         "sonic-db-cli  CONFIG_DB HGET \"FEATURE|macsec\" state"
     ]
+
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    telemetry_is_running = is_container_running(duthost, 'telemetry')
+    gnmi_is_running = is_container_running(duthost, 'gnmi')
+    if not telemetry_is_running and gnmi_is_running:
+        commands.append("show feature status gnmi")
+    else:
+        commands.append("show feature status telemetry")
 
     for subcommand in commands:
         exit_code, stdout, stderr = ssh_run_command(remote_user_client, subcommand)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
26638180

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
For slim images, telemetry has been disabled due to memory limitation.
"show feature status telemetry" is not supported.

#### How did you do it?
Check the docker status, if telemetry is not running, but gnmi is running, then modify the cmd to "show feature status gnmi"

#### How did you verify/test it?
Run case locally

#### Any platform specific information?
DUT which running slim image

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
