### PR TITLE
[Github] Delete branch after "automerge" PRs are merged by workflow

### DIFF
--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -68,6 +68,6 @@ jobs:
           done
           # merge the PR
           echo ========Merging  PR========
-          gh pr merge --rebase --admin -R sonic-net/sonic-mgmt $url || true
+          gh pr merge --rebase --delete-branch --admin -R sonic-net/sonic-mgmt $url || true
           echo ========Finished PR========
         done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We are using Github workflows to automatically create PRs for cherry-picking. These auto created PRs are labeled with "automerge". Another workflow periodically scans the PRs with "automerge" label and merges them if all checks passed.

The problem is that the branch of these auto created PRs are not deleted after the PRs are merged. Consequently, the mssonicbld/sonic-mgmt repo has too many branches left over now. We'll manually do some cleanup.

Meanwhile, we also need to delete corresponding branch after PR is auto merged.

#### How did you do it?
This changed added option "--delete-branch" to the Github cli for merging PRs. With this change, branches will be automatically deleted when automerge PR is merged.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
