### PR TITLE
[Bug_Fix] Fix cleanup.sh.j2 template doesn't destroy domain properly

### DIFF
--- a/ansible/roles/vm_set/templates/cleanup.sh.j2
+++ b/ansible/roles/vm_set/templates/cleanup.sh.j2
@@ -6,7 +6,7 @@ set -ex
 test -z "$(virsh list --state-running --name)" || virsh list --state-running --name | xargs -I % virsh destroy %
 
 # stop paused VMs
-test -z "$(virsh list --state-paused --name)" || virsh list --state-running --name | xargs -I % virsh destroy %
+test -z "$(virsh list --state-paused --name)" || virsh list --state-paused --name | xargs -I % virsh destroy %
 
 # undefine all VMs
 test -z "$(virsh list --all --name)" || virsh list --all --name | xargs -I % virsh undefine %


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
When I try run the script to clean up domains. will got error:
```
error: Failed to undefine domain vlab-01
error: Requested operation is not valid: cannot undefine transient domain
```

That's because the domain was not destroyed properly.


Fixes # (issue)
Fix the typo to destroy the domain.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
