### PR TITLE
[sonic-mgmt] Call docker cmd on appropriate container in generate_telemetry_config() funct

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -53,7 +53,7 @@ class GNMIEnvironment(object):
                 self.gnmi_container = "telemetry"
                 # GNMI program is telemetry or gnmi-native
                 res = duthost.shell("docker exec %s supervisorctl status" % self.gnmi_container,
-                      module_ignore_errors=True)
+                                    module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"
                 else:

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -52,7 +52,8 @@ class GNMIEnvironment(object):
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
                 # GNMI program is telemetry or gnmi-native
-                res = duthost.shell("docker exec %s supervisorctl status" % self.gnmi_container, module_ignore_errors=True)
+                res = duthost.shell("docker exec %s supervisorctl status" % self.gnmi_container,
+                      module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"
                 else:

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -52,7 +52,7 @@ class GNMIEnvironment(object):
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
                 # GNMI program is telemetry or gnmi-native
-                res = duthost.shell("docker exec telemetry supervisorctl status", module_ignore_errors=True)
+                res = duthost.shell("docker exec %s supervisorctl status" % self.gnmi_container, module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"
                 else:


### PR DESCRIPTION
### Description of PR
`generate_telemetry_config()` function already establishes that the GNMI container is 'telemetry' so call docker supervisorctl status using this container name.

Summary:
Fixes # 
https://github.com/aristanetworks/sonic-qual.msft/issues/61

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran gnmi tests with this change in our test environment.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
