### PR TITLE
update skip condition for cisco T2

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2245,10 +2245,11 @@ class QosSaiBase(QosBase):
             )
 
     @pytest.fixture(scope="function", autouse=False)
-    def skip_vanguard(self, get_src_dst_asic_and_duts):
-        src_asic = get_src_dst_asic_and_duts['src_asic']
-        if src_asic.sonichost.facts['platform'] in ["x86_64-88_lc0_36fh_mo-r0", "x86_64-88_lc0_36fh_m-r0"]:
+    def skip_longlink(self, dutQosConfig):
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        match = re.search("_([0-9]*)m", portSpeedCableLength)
+        if match and int(match.group(1)) > 2000:
             pytest.skip(
-                "This test is skipped since this asic is cisco-8000 Q200 longlink.")
+                "This test is skipped for longlink.")
         yield
         return

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2243,3 +2243,12 @@ class QosSaiBase(QosBase):
             self.runPtfTest(
                 ptfhost, testCase=saiQosTest, testParams=testParams
             )
+
+    @pytest.fixture(scope="function", autouse=False)
+    def skip_vanguard(self, get_src_dst_asic_and_duts):
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        if src_asic.sonichost.facts['platform'] in ["x86_64-88_lc0_36fh_mo-r0", "x86_64-88_lc0_36fh_m-r0"]:
+            pytest.skip(
+                "This test is skipped since this asic is cisco-8000 Q200 longlink.")
+        yield
+        return

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -684,7 +684,7 @@ class TestQosSai(QosSaiBase):
          "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
             self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig,
-            dutQosConfig, get_src_dst_asic_and_duts
+            dutQosConfig, get_src_dst_asic_and_duts, skip_vanguard
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -895,6 +895,14 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
+        if ('modular_chassis' in get_src_dst_asic_and_duts['src_dut'].facts and
+                get_src_dst_asic_and_duts['src_dut'].facts["modular_chassis"] == "True"):
+            if dutConfig['dstDutAsic'] != "pac":
+                pytest.skip("This test is skipped since not enough ports on cisco-8000 "
+                            "T2 Q200.")
+            if "shared_res_size_2" in sharedResSizeKey:
+                pytest.skip("This test is skipped since on cisco-8000 Q100, "
+                            "SQG thresholds have no impact on XOFF thresholds.")
 
         qosConfig = dutQosConfig["param"]
         src_dut_index = get_src_dst_asic_and_duts['src_dut_index']

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -684,7 +684,7 @@ class TestQosSai(QosSaiBase):
          "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
             self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig,
-            dutQosConfig, get_src_dst_asic_and_duts, skip_vanguard
+            dutQosConfig, get_src_dst_asic_and_duts, skip_longlink
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, testQosSaiLosslessVoq requires split-voq or fair-voq, skip vanguard(cisco Q200 longlink) since it uses default-voq.
2. testQosSaiSharedReservationSize, skip gibraltar(cisco Q200 linecard) since not enough ports.
    Skip shared_res_size_2 for pacific(cisco Q100 linecard) since on pacific, SQG thresholds have no impact on XOFF thresholds.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Vanguard:
---------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq_2024-02-03-00-37-06.xml -----------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------
00:40:50 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
==================================================================== short test summary info =====================================================================
SKIPPED [1] qos/qos_sai_base.py:2179: This test is skipped for longlink.
=========================================================== 1 skipped, 1 warning in 222.65s (0:03:42) ============================================================

----------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize_2024-02-03-00-44-40.xml ------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------
00:48:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
==================================================================== short test summary info =====================================================================
SKIPPED [1] qos/test_qos_sai.py:100: This test cannot be run since there are not enough ports. Pls see qos.yaml for the port idx's that are needed.
=========================================================== 1 skipped, 1 warning in 222.69s (0:03:42) ============================================================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
