### PR TITLE
Fix invalid syntax in log analyzer

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -164,7 +164,7 @@ class LogAnalyzer:
             tmp_folder = "/tmp/loganalyzer/{}".format(self.ansible_host.hostname)
             os.makedirs(tmp_folder, exist_ok=True)
             cur_time = time.strftime("%d_%m_%Y_%H_%M_%S", time.gmtime())
-            file_path = os.path.join(tmp_folder, f"log_error_{self.marker_prefix}_{cur_time}.json")
+            file_path = os.path.join(tmp_folder, "log_error_{}_{}.json".format(self.marker_prefix, cur_time))
             logging.info("Log errors will be saved in file: {}".format(file_path))
             data = {'log_errors': log_errors}
             with open(file_path, "w+") as file:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
when running testcase with log analyzer, would get error:
E     File "/data/sonic-mgmt-int/tests/common/plugins/loganalyzer/loganalyzer.py", line 167
E       file_path = os.path.join(tmp_folder, f"log_error_{self.marker_prefix}_{cur_time}.json")
E                                                                                            ^
E   SyntaxError: invalid syntax
#### How did you do it?
use .format() instead of f""
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
