### PR TITLE
Update J2 100_120k qos profile to match J2c

### DIFF
--- a/tests/qos/files/qos_params.jr2.yaml
+++ b/tests/qos/files/qos_params.jr2.yaml
@@ -221,14 +221,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -245,7 +245,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
@@ -291,7 +291,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -300,7 +300,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 37549
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:


### PR DESCRIPTION
The J2c+ qos params for 100_120K was updated in https://github.com/sonic-net/sonic-mgmt/pull/10146 but it wasn't updated for J2.
This has caused failures on `testQosSaiPfcXoffLimit` because we aren't sending sufficient packets to fill up the headroom so packets aren't being dropped.

I confirmed on a J2 system with these new values we end up filling up the headroom and drop packets.

### Back port request
- [x] 202205
- [x] 202305
- [x] 202311