### PR TITLE
Adjust the memory check threshold for Mellanox-SN3800

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -39,7 +39,7 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90
-    if duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0'):
+    if duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn3800-r0'):
         memory_threshold = 65
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):
         high_cpu_consume_procs['syncd'] = 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We saw `test_cpu_memory_usage` is flaky on Mellanox-SN3800 testbed because the memory usage exceeds the threshold (60%) slightly.
```
E       AssertionError:  Memory {0: {'total': 8024224.0, 'free': 2997364.0, 'used': 4554004.0, 'used_percent': 62.6}, 1: {'total': 8024224.0, 'free': 2997184.0, 'used': 4554184.0, 'used_percent': 62.6}, 2: {'total': 8024224.0, 'free': 2996908.0, 'used': 4554456.0, 'used_percent': 62.7}, 3: {'total': 8024224.0, 'free': 2997212.0, 'used': 4554156.0, 'used_percent': 62.6}, 4: {'total': 8024224.0, 'free': 2997188.0, 'used': 4554180.0, 'used_percent': 62.6}, 5: {'total': 8024224.0, 'free': 2997456.0, 'used': 4553912.0, 'used_percent': 62.6}, 6: {'total': 8024224.0, 'free': 2997448.0, 'used': 4553920.0, 'used_percent': 62.6}, 7: {'total': 8024224.0, 'free': 2997360.0, 'used': 4554008.0, 'used_percent': 62.6}, 8: {'total': 8024224.0, 'free': 2997528.0, 'used': 4553840.0, 'used_percent': 62.6}, 9: {'total': 8024224.0, 'free': 2996472.0, 'used': 4554892.0, 'used_percent': 62.7}, 10: {'total': 8024224.0, 'free': 2997528.0, 'used': 4553840.0, 'used_percent': 62.6}, 11: {'total': 8024224.0, 'free': 2997188.0, 'used': 4554180.0, 'used_percent': 62.6}, 12: {'total': 8024224.0, 'free': 2996832.0, 'used': 4554536.0, 'used_percent': 62.7}, 13: {'total': 8024224.0, 'free': 2996904.0, 'used': 4554464.0, 'used_percent': 62.7}, 14: {'total': 8024224.0, 'free': 2996264.0, 'used': 4555104.0, 'used_percent': 62.7}, 15: {'total': 8024224.0, 'free': 2996264.0, 'used': 4555104.0, 'used_percent': 62.7}, 16: {'total': 8024224.0, 'free': 2996232.0, 'used': 4555136.0, 'used_percent': 62.7}, 17: {'total': 8024224.0, 'free': 2995980.0, 'used': 4555388.0, 'used_percent': 62.7}, 18: {'total': 8024224.0, 'free': 2861336.0, 'used': 4690032.0, 'used_percent': 64.3}, 19: {'total': 8024224.0, 'free': 2849220.0, 'used': 4702148.0, 'used_percent': 64.5}, 20: {'total': 8024224.0, 'free': 2891036.0, 'used': 4660332.0, 'used_percent': 64.0}, 21: {'total': 8024224.0, 'free': 2968556.0, 'used': 4582812.0, 'used_percent': 63.0}, 22: {'total': 8024224.0, 'free': 2967488.0, 'used': 4583880.0, 'used_percent': 63.0}, 23: {'total': 8024224.0, 'free': 2966348.0, 'used': 4585020.0, 'used_percent': 63.0}, 24: {'total': 8024224.0, 'free': 2986108.0, 'used': 4565256.0, 'used_percent': 62.8}, 25: {'total': 8024224.0, 'free': 2985172.0, 'used': 4566196.0, 'used_percent': 62.8}, 26: {'total': 8024224.0, 'free': 2984416.0, 'used': 4566952.0, 'used_percent': 62.8}, 27: {'total': 8024224.0, 'free': 2984424.0, 'used': 4566944.0, 'used_percent': 62.8}, 28: {'total': 8024224.0, 'free': 2984424.0, 'used': 4566940.0, 'used_percent': 62.8}, 29: {'total': 8024224.0, 'free': 2984396.0, 'used': 4566972.0, 'used_percent': 62.8}, 30: {'total': 8024224.0, 'free': 2983892.0, 'used': 4567476.0, 'used_percent': 62.8}, 31: {'total': 8024224.0, 'free': 2983948.0, 'used': 4567420.0, 'used_percent': 62.8}, 32: {'total': 8024224.0, 'free': 2984176.0, 'used': 4567192.0, 'used_percent': 62.8}, 33: {'total': 8024224.0, 'free': 2984436.0, 'used': 4566932.0, 'used_percent': 62.8}, 34: {'total': 8024224.0, 'free': 2945604.0, 'used': 4605780.0, 'used_percent': 63.3}, 35: {'total': 8024224.0, 'free': 2952724.0, 'used': 4598656.0, 'used_percent': 63.2}, 36: {'total': 8024224.0, 'free': 2958428.0, 'used': 4592956.0, 'used_percent': 63.1}, 37: {'total': 8024224.0, 'free': 2953836.0, 'used': 4597552.0, 'used_percent': 63.2}, 38: {'total': 8024224.0, 'free': 2984308.0, 'used': 4567084.0, 'used_percent': 62.8}, 39: {'total': 8024224.0, 'free': 2984136.0, 'used': 4567256.0, 'used_percent': 62.8}, 40: {'total': 8024224.0, 'free': 2984112.0, 'used': 4567264.0, 'used_percent': 62.8}, 41: {'total': 8024224.0, 'free': 2983564.0, 'used': 4567812.0, 'used_percent': 62.8}, 42: {'total': 8024224.0, 'free': 2983352.0, 'used': 4568020.0, 'used_percent': 62.8}, 43: {'total': 8024224.0, 'free': 2983136.0, 'used': 4568240.0, 'used_percent': 62.8}, 44: {'total': 8024224.0, 'free': 2982852.0, 'used': 4568524.0, 'used_percent': 62.8}, 45: {'total': 8024224.0, 'free': 2982900.0, 'used': 4568476.0, 'used_percent': 62.8}, 46: {'total': 8024224.0, 'free': 2982884.0, 'used': 4568488.0, 'used_percent': 62.8}, 47: {'total': 8024224.0, 'free': 2982884.0, 'used': 4568488.0, 'used_percent': 62.8}, 48: {'total': 8024224.0, 'free': 2982032.0, 'used': 4569340.0, 'used_percent': 62.8}, 49: {'total': 8024224.0, 'free': 2982136.0, 'used': 4569236.0, 'used_percent': 62.8}, 50: {'total': 8024224.0, 'free': 2982120.0, 'used': 4569252.0, 'used_percent': 62.8}, 51: {'total': 8024224.0, 'free': 2982140.0, 'used': 4569236.0, 'used_percent': 62.8}, 52: {'total': 8024224.0, 'free': 2981992.0, 'used': 4569384.0, 'used_percent': 62.8}, 53: {'total': 8024224.0, 'free': 2981576.0, 'used': 4569800.0, 'used_percent': 62.8}, 54: {'total': 8024224.0, 'free': 2980796.0, 'used': 4570576.0, 'used_percent': 62.9}, 55: {'total': 8024224.0, 'free': 2980836.0, 'used': 4570536.0, 'used_percent': 62.9}, 56: {'total': 8024224.0, 'free': 2979520.0, 'used': 4571852.0, 'used_percent': 62.9}, 57: {'total': 8024224.0, 'free': 2979064.0, 'used': 4572308.0, 'used_percent': 62.9}, 58: {'total': 8024224.0, 'free': 2979064.0, 'used': 4572308.0, 'used_percent': 62.9}, 59: {'total': 8024224.0, 'free': 2979064.0, 'used': 4572308.0, 'used_percent': 62.9}} exceeds the memory threshold 60
```
This PR is to stabilize the test by incresing the memory threshold for SN3800 from 60% to 65%.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to stabilize the test by incresing the memory threshold for SN3800 from 60% to 65%.

#### How did you do it?
 Incresing the memory threshold for SN3800 from 60% to 65%.

#### How did you verify/test it?
The change is verified on a SN3800 testbed.

#### Any platform specific information?
The change is specific to `x86_64-mlnx_msn3800-r0`.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
