### PR TITLE
Fix syntax issue in TunnelDscpToPgMapping

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1330,7 +1330,7 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     packet_size=packet_size
                 )
                 pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
-                    self.client, asic_type, port_list['src'][src_port_id])
+                    self.src_client, asic_type, port_list['src'][src_port_id])
                 logging.info(pg_shared_wm_res_base)
                 send_packet(self, src_port_id, pkt, PKT_NUM)
                 # validate pg counters increment by the correct pkt num


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix a syntax error in `TunnelDscpToPgMapping`.
The error message is as below.
```
"ERROR: sai_qos_tests.TunnelDscpToPgMapping", "----------------------------------------------------------------------", "Traceback (most recent call last):", "  File "saitests/py3/sai_qos_tests.py", line 1192, in runTest", "    self.client, asic_type, port_list['src'][src_port_id])", "AttributeError: 'TunnelDscpToPgMapping' object has no attribute 'client'", "", "----------------------------------------------------------------------", "Ran 1 test in 20.752s", "", "FAILED (errors=1)"], "stdout": "Using packet manipulation module: ptf.packet_scapy\n\n******************************************
ATTENTION: SOME TESTS DID NOT PASS!!!
The following tests errored:
TunnelDscpToPgMapping
******************************************", "stdout_lines": ["Using packet manipulation module: ptf.packet_scapy", "", "******************************************", "ATTENTION: SOME TESTS DID NOT PASS!!!", "", "The following tests errored:", "TunnelDscp
```
It's a regression caused by PR https://github.com/sonic-net/sonic-mgmt/pull/9780
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to fix a syntax error in `TunnelDscpToPgMapping`.

#### How did you do it?
Fix the variable name.

#### How did you verify/test it?
The change is verified on a physical dualtor testbed. Test can pass after this change.
```
collected 1 item                                                                                                                                                                                      

qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_pg_mapping  ^H ^HPASSED                                                                                                                       [100%] ^H ^H

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
