### PR TITLE
[T2] Generate pkts_num_egr_mem in runtime

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -375,7 +375,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[xoffProfile]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig[xoffProfile]["pkts_num_trig_ingr_drp"],
-            "hwsku": dutTestParams['hwsku']
+            "hwsku":dutTestParams['hwsku'],
+            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic'])
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -650,8 +651,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_dismiss_pfc": qosConfig[xonProfile]["pkts_num_dismiss_pfc"],
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "hwsku": dutTestParams['hwsku'],
-            "pkts_num_egr_mem": qosConfig[xonProfile].get('pkts_num_egr_mem', None)
-
+            "pkts_num_egr_mem": qosConfig[xonProfile].get('pkts_num_egr_mem', None),
+            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic'])
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -1543,7 +1544,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, _skip_watermark_multi_DUT
+        resetWatermark, _skip_watermark_multi_DUT, skip_src_dst_different_asic
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -375,7 +375,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[xoffProfile]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig[xoffProfile]["pkts_num_trig_ingr_drp"],
-            "hwsku":dutTestParams['hwsku'],
+            "hwsku": dutTestParams['hwsku'],
             "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic'])
         })
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -415,13 +415,13 @@ def fill_egress_plus_one(test_case, src_port_id, pkt, queue, asic_type, pkts_num
     # Returns whether 1 packet is successfully enqueued.
     if asic_type not in ['cisco-8000']:
         return False
-    pg_cntrs_base=sai_thrift_read_pg_occupancy(
+    pg_cntrs_base = sai_thrift_read_pg_occupancy(
         test_case.src_client, port_list['src'][src_port_id])
     send_packet(test_case, src_port_id, pkt, pkts_num_egr_mem)
     max_packets = 1000
     for packet_i in range(max_packets):
         send_packet(test_case, src_port_id, pkt, 1)
-        pg_cntrs=sai_thrift_read_pg_occupancy(
+        pg_cntrs = sai_thrift_read_pg_occupancy(
             test_case.src_client, port_list['src'][src_port_id])
         if pg_cntrs[queue] > pg_cntrs_base[queue]:
             print("fill_egress_plus_one: Success, sent %d packets, SQ occupancy bytes rose from %d to %d" % (
@@ -1530,7 +1530,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         if 'cisco-8000' in asic_type and src_dst_asic_diff:
             self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
             pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(self, src_port_id, pkt,
-                                                    int(self.test_params['pg']), asic_type)
+                                                                     int(self.test_params['pg']),
+                                                                     asic_type)
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             time.sleep(2)
 
@@ -2263,11 +2264,16 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
 
         is_multi_asic = (self.clients['src'] != self.clients['dst'])
         # generate pkts_num_egr_mem in runtime
+        pkts_num_egr_mem2 = pkts_num_egr_mem3 = pkts_num_egr_mem
         if 'cisco-8000' in asic_type and src_dst_asic_diff:
-            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
-            pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(self, src_port_id, pkt,
-                                                    int(self.test_params['pg']), asic_type)
-            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
+            pkts_num_egr_mem, _ = overflow_egress(
+                self, src_port_id, pkt, int(self.test_params['pg']), asic_type)
+            pkts_num_egr_mem2, _ = overflow_egress(
+                self, src_port_id, pkt2, int(self.test_params['pg']), asic_type)
+            pkts_num_egr_mem3, _ = overflow_egress(
+                self, src_port_id, pkt3, int(self.test_params['pg']), asic_type)
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
             time.sleep(2)
 
         step_id = 1
@@ -2365,7 +2371,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 else:
                     fill_egress_plus_one(
                         self, src_port_id,
-                        pkt2, int(self.test_params['pg']), asic_type, pkts_num_egr_mem)
+                        pkt2, int(self.test_params['pg']), asic_type, pkts_num_egr_mem2)
                     send_packet(
                         self, src_port_id, pkt2,
                         (pkts_num_leak_out + pkts_num_dismiss_pfc +
@@ -2402,7 +2408,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 else:
                     fill_egress_plus_one(
                         self, src_port_id,
-                        pkt3, int(self.test_params['pg']), asic_type, pkts_num_egr_mem)
+                        pkt3, int(self.test_params['pg']), asic_type, pkts_num_egr_mem3)
                     send_packet(self, src_port_id, pkt3, pkts_num_leak_out + 1)
             else:
                 send_packet(self, src_port_id, pkt3, pkts_num_leak_out + 1)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -409,70 +409,26 @@ def fill_leakout_plus_one(
     return False
 
 
-def fill_egress_plus_one(
-        test_case, src_port_id, pkt, queue, asic_type, pkts_num_egr_mem=0,
-        dst_port_id=None, pkt2=None):
-    # Attempts to queue 1 packet while compensating for a varying packet leakout and egress queues.
+def fill_egress_plus_one(test_case, src_port_id, pkt, queue, asic_type, pkts_num_egr_mem):
+    # Attempts to enqueue 1 packet while compensating for a varying packet leakout and egress queues.
     # pkts_num_egr_mem is the number of packets in full egress queues, to provide an initial filling boost
-    # Returns whether 1 packet was successfully enqueued.
-    #
-    # pkts_num_egr_mem=0 is not applicable for multi-src-port cases
-    # for multi-src-port case, get pkts_num_egr_mem via overflow_egress(),
-    # then call fill_egress_plus_one() with pkts_num_egr_mem
-    if asic_type in ['cisco-8000']:
-        # if pkts_num_egr_mem unknown, get estimated pkts_num_egr_mem
-        if pkts_num_egr_mem == 0:
-            if dst_port_id is None:
-                raise RuntimeError(
-                    "fill_egress_plus_one: please input pkts_num_egr_mem or "
-                    "dst_port_id", file=sys.stderr)
-            pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(
-                test_case, src_port_id, pkt, queue, asic_type)
-            # tx enable
-            test_case.sai_thrift_port_tx_enable(
-                test_case.dst_client, asic_type, [dst_port_id])
-            # tx disable
-            test_case.sai_thrift_port_tx_disable(test_case.dst_client, asic_type, [dst_port_id])
-
-        pkt_list = [pkt]
-        if pkt2:
-            pkt_list.append(pkt2)
-        for packet in pkt_list:
-            # send 1 packet, if pg occupancy increases, return
-            pg_cntrs_base = sai_thrift_read_pg_occupancy(
-                test_case.src_client, port_list['src'][src_port_id])
-            send_packet(test_case, src_port_id, packet, 1)
-            pg_cntrs = sai_thrift_read_pg_occupancy(
-                test_case.src_client, port_list['src'][src_port_id])
-            if pg_cntrs[queue] > pg_cntrs_base[queue]:
-                print("fill_egress_plus_one: Success, sent 1 packets, SQ occupancy bytes rose from %d to %d" % (
-                    pg_cntrs_base[queue], pg_cntrs[queue]), file=sys.stderr)
-                continue
-
-            # fill egress plus one
-            pg_cntrs_base = sai_thrift_read_pg_occupancy(
-                test_case.src_client, port_list['src'][src_port_id])
-            send_packet(test_case, src_port_id, packet, pkts_num_egr_mem)
-            max_packets = 1000
-            for packet_i in range(max_packets):
-                send_packet(test_case, src_port_id, packet, 1)
-                pg_cntrs = sai_thrift_read_pg_occupancy(
-                    test_case.src_client, port_list['src'][src_port_id])
-                if pg_cntrs[queue] > pg_cntrs_base[queue]:
-                    print("fill_egress_plus_one: Success, sent %d packets, SQ occupancy bytes rose from %d to %d" % (
-                        pkts_num_egr_mem + packet_i + 1, pg_cntrs_base[queue], pg_cntrs[queue]), file=sys.stderr)
-                    break
-            if pg_cntrs[queue] <= pg_cntrs_base[queue]:
-                raise RuntimeError(
-                    "fill_egress_plus_one: Failure, sent %d packets, SQ "
-                    "occupancy bytes rose from %d to %d" % (
-                        pkts_num_egr_mem + max_packets,
-                        pg_cntrs_base[queue],
-                        pg_cntrs[queue]),
-                    file=sys.stderr)
-                return False
-
-    return True
+    # Returns whether 1 packet is successfully enqueued.
+    if asic_type not in ['cisco-8000']:
+        return False
+    pg_cntrs_base=sai_thrift_read_pg_occupancy(
+        test_case.src_client, port_list['src'][src_port_id])
+    send_packet(test_case, src_port_id, pkt, pkts_num_egr_mem)
+    max_packets = 1000
+    for packet_i in range(max_packets):
+        send_packet(test_case, src_port_id, pkt, 1)
+        pg_cntrs=sai_thrift_read_pg_occupancy(
+            test_case.src_client, port_list['src'][src_port_id])
+        if pg_cntrs[queue] > pg_cntrs_base[queue]:
+            print("fill_egress_plus_one: Success, sent %d packets, SQ occupancy bytes rose from %d to %d" % (
+                pkts_num_egr_mem + packet_i + 1, pg_cntrs_base[queue], pg_cntrs[queue]), file=sys.stderr)
+            return True
+    raise RuntimeError("fill_egress_plus_one: Failure, sent %d packets, SQ occupancy bytes rose from %d to %d" % (
+            pkts_num_egr_mem + max_packets, pg_cntrs_base[queue], pg_cntrs[queue]))
 
 
 def overflow_egress(test_case, src_port_id, pkt, queue, asic_type):
@@ -1500,6 +1456,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             self.test_params['pkts_num_trig_ingr_drp'])
         hwsku = self.test_params['hwsku']
         platform_asic = self.test_params['platform_asic']
+        src_dst_asic_diff = self.test_params['src_dst_asic_diff']
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
@@ -1568,6 +1525,14 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_egr_mem = None
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+
+        # generate pkts_num_egr_mem in runtime
+        if 'cisco-8000' in asic_type and src_dst_asic_diff:
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+            pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(self, src_port_id, pkt,
+                                                    int(self.test_params['pg']), asic_type)
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+            time.sleep(2)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -2156,6 +2121,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             hysteresis = 0
         hwsku = self.test_params['hwsku']
+        src_dst_asic_diff = self.test_params['src_dst_asic_diff']
         self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
         # get a snapshot of counter values at recv and transmit ports
@@ -2296,6 +2262,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             pkts_num_egr_mem = int(pkts_num_egr_mem)
 
         is_multi_asic = (self.clients['src'] != self.clients['dst'])
+        # generate pkts_num_egr_mem in runtime
+        if 'cisco-8000' in asic_type and src_dst_asic_diff:
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+            pkts_num_egr_mem, extra_bytes_occupied = overflow_egress(self, src_port_id, pkt,
+                                                    int(self.test_params['pg']), asic_type)
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+            time.sleep(2)
 
         step_id = 1
         step_desc = 'disable TX for dst_port_id, dst_port_2_id, dst_port_3_id'


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Use overflow_egress() to generate pkts_num_egr_mem in runtime if src and dst's asic types are different.
The pkts_num_egr_mem varies too much in different combinations. The qos params are based on ingress (Q100), so the pkts_num_egr_mem is 5915, but in Q100->Q200, pkts_num_egr_mem is 7536, 7536-5915 = 1621. It will cost too much time to send packets one by one for 1621 iterations.

With this, pg watermark case had to be skipped if src and dst asic-type are different. Because with using overflow_egress, it sends some extra packets, and that makes pg watermark increasing which fails the case. The case expects pg watermark to be 0 at the beginning. We can unskip it after thrift rpc api supports watermark clear.

In PFCXon case, overflow_egress() is called for all of 3 flows to get pkts_num_egr_mem1/2/3, this is because pacific counter-A threshold0 is 7MB, xoff threshold will be decreased for the 2nd flow.

Summary:

202205 PR: https://github.com/sonic-net/sonic-mgmt/pull/10277

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
