### PR TITLE
ACL testcase fix for Cisco 8122 Platform

### DIFF
--- a/tests/acl/templates/acltb_test_rules.j2
+++ b/tests/acl/templates/acltb_test_rules.j2
@@ -510,6 +510,36 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
+                            },
+                            "34": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 34
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback2}}/32"
+                                    }
+                                }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback3}}/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_test_rules_part_1.j2
+++ b/tests/acl/templates/acltb_test_rules_part_1.j2
@@ -125,6 +125,36 @@
                                         "destination-port": "179"
                                     }
                                 }
+                            },
+                            "29": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 29
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback2}}/32"
+                                    }
+                                }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback3}}/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -510,6 +510,36 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
+                            },
+                            "34": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 34
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback2}}/32"
+                                    }
+                                }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{Loopback3}}/32"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -25,6 +25,8 @@ from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
+from tests.common.utilities import is_ipv4_address
+from tests.common.dualtor.dual_tor_common import active_active_ports
 
 logger = logging.getLogger(__name__)
 
@@ -1172,11 +1174,22 @@ class TestBasicAcl(BaseAclTest):
             acl_table: Configuration info for the ACL table.
 
         """
+        if active_active_ports:
+            sonichost = dut.get_asic_or_sonic_host(None)
+            config_facts = sonichost.get_running_config_facts()
+            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback2"]
+                    if is_ipv4_address(_.split("/")[0])][0]
+            tor_ipv4_address = tor_ipv4_address.split("/")[0]
+            dut.host.options["variable_manager"].extra_vars.update({"Loopback2": tor_ipv4_address})
+
+            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback3"]
+                    if is_ipv4_address(_.split("/")[0])][0]
+            tor_ipv4_address = tor_ipv4_address.split("/")[0]
+            dut.host.options["variable_manager"].extra_vars.update({"Loopback3": tor_ipv4_address})
+
         table_name = acl_table["table_name"]
         dut.host.options["variable_manager"].extra_vars.update({"acl_table_name": table_name})
-
         logger.info("Generating basic ACL rules config for ACL table \"{}\" on {}".format(table_name, dut))
-
         dut_conf_file_path = os.path.join(DUT_TMP_DIR, "acl_rules_{}.json".format(table_name))
         dut.template(src=os.path.join(TEMPLATE_DIR, ACL_RULES_FULL_TEMPLATE[ip_version]),
                      dest=dut_conf_file_path)
@@ -1200,9 +1213,20 @@ class TestIncrementalAcl(BaseAclTest):
             acl_table: Configuration info for the ACL table.
 
         """
+        if active_active_ports:
+            sonichost = dut.get_asic_or_sonic_host(None)
+            config_facts = sonichost.get_running_config_facts()
+            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback2"]
+                    if is_ipv4_address(_.split("/")[0])][0]
+            tor_ipv4_address = tor_ipv4_address.split("/")[0]
+            dut.host.options["variable_manager"].extra_vars.update({"Loopback2": tor_ipv4_address})
+            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback3"]
+                    if is_ipv4_address(_.split("/")[0])][0]
+            tor_ipv4_address = tor_ipv4_address.split("/")[0]
+            dut.host.options["variable_manager"].extra_vars.update({"Loopback3": tor_ipv4_address})
+
         table_name = acl_table["table_name"]
         dut.host.options["variable_manager"].extra_vars.update({"acl_table_name": table_name})
-
         logger.info("Generating incremental ACL rules config for ACL table \"{}\""
                     .format(table_name))
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -763,6 +763,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                 counters_after[PACKETS_COUNT] += acl_facts[duthost]['after'][rule][PACKETS_COUNT]
                 counters_after[BYTES_COUNT] += acl_facts[duthost]['after'][rule][BYTES_COUNT]
                 if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
+                        duthost.facts["hwsku"] == "Cisco-8122-O64" or
                         duthost.facts["hwsku"] == "Cisco-8111-O32" or
                         duthost.facts["hwsku"] == "Cisco-8111-C32" or
                         duthost.facts["hwsku"] == "Cisco-8111-O62C2"):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

ACL test fix for 8122, Added more HWSKU to skip the Byte Accounting.

Summary:
Fixes # (issue)
ACL byte counters not supported in Cisco 8122 and test_acl.py tests (32 Testcases) fails due to assertion for byte counters.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Add Fix for failing testcase in test_acl.py.

#### How did you do it?
Added check to skip byte accounting for Cisco 8122 Platform

#### How did you verify/test it?
Verified that all the ACL testcases are passing for Cisco 8122 Platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
