### PR TITLE
Cherrypick 10245 and 10481 to 202205.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pytest
 import time
+import re
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -49,6 +50,15 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
+
+
+def is_longlink(dut, profile):
+    if dut.sonichost._facts['platform'] in \
+            ["x86_64-88_lc0_36fh_mo-r0", "x86_64-88_lc0_36fh_m-r0"]:
+        match = re.search("_([0-9]*)m_", profile)
+        if match:
+            return int(match.group(1)) > 2000
+    return False
 
 
 class PfcCmd(object):
@@ -116,15 +126,16 @@ class PfcCmd(object):
         )
 
     @staticmethod
-    def update_alpha(dut, port, profile, value):
+    def update_alpha(dut, port, profile, value, static_th):
         """
-        Update dynamic threshold value in buffer profile
+        Update dynamic threshold value or static_th value in buffer profile
 
         Args:
             dut(AnsibleHost) : dut instance
             port(string) : port name
             profile(string) : profile name
             value(int) : dynamic threshold value to update
+            static_th(int) : or static threshold value to update
         """
         logger.info("Updating dynamic threshold for {} to {}".format(profile, value))
         asic = dut.get_port_asic_instance(port)
@@ -135,11 +146,18 @@ class PfcCmd(object):
             db = "4"
         table_template = BF_PROFILE if db == "4" else BF_PROFILE_TABLE
 
-        asic.run_redis_cmd(
-            argv = [
-                "redis-cli", "-n", db, "HSET", table_template.format(profile), "dynamic_th", value
-            ]
-        )
+        if is_longlink(dut, profile):
+            asic.run_redis_cmd(
+                argv=[
+                    "redis-cli", "-n", db, "HSET", table_template.format(profile), "static_th", static_th
+                ]
+            )
+        else:
+            asic.run_redis_cmd(
+                argv=[
+                    "redis-cli", "-n", db, "HSET", table_template.format(profile), "dynamic_th", value
+                ]
+            )
 
     @staticmethod
     def get_mmu_params(dut, port, dual_tor_ports):
@@ -180,13 +198,21 @@ class PfcCmd(object):
             pg_profile = pg_profile.split(DB_SEPARATORS[db])[-1][:-1]
         table_template = BF_PROFILE if db == "4" else BF_PROFILE_TABLE
 
-        alpha = asic.run_redis_cmd(
-            argv = [
-                "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "dynamic_th"
-            ]
-        )[0].encode("utf-8")
+        static_th = 0
+        if is_longlink(dut, pg_profile):
+            static_th = six.text_type(asic.run_redis_cmd(
+                argv=[
+                    "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "static_th"
+                ]
+            )[0])
+        else:
+            alpha = six.text_type(asic.run_redis_cmd(
+                argv=[
+                    "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "dynamic_th"
+                ]
+            )[0])
 
-        return pg_profile, alpha
+        return pg_profile, alpha, static_th
 
 
 class PfcPktCntrs(object):
@@ -357,9 +383,9 @@ class SetupPfcwdFunc(object):
         Args:
             port(string) : DUT port
         """
-        self.pg_profile, self.alpha = PfcCmd.get_mmu_params(self.dut, port, dual_tor_ports)
+        self.pg_profile, self.alpha, self.static_th = PfcCmd.get_mmu_params(self.dut, port, dual_tor_ports)
 
-    def update_mmu_params(self, mmu_action, port):
+    def update_mmu_params(self, dut, mmu_action, port):
         """
         Update dynamic threshold value
 
@@ -368,17 +394,23 @@ class SetupPfcwdFunc(object):
                                 for value "restore", set back to original threshold
             port(string) : port name
         """
-        if int(self.alpha) <= -6:
-            new_alpha = -5
-        elif int(self.alpha) >= 3:
-            new_alpha = 2
+        new_alpha = self.alpha
+        new_static_th = self.static_th
+        if is_longlink(dut, self.pg_profile):
+            if int(self.static_th) > 0:
+                new_static_th = int(int(self.static_th) / 2)
         else:
-            new_alpha = int(self.alpha) + 1
+            if int(self.alpha) <= -6:
+                new_alpha = -5
+            elif int(self.alpha) >= 3:
+                new_alpha = 2
+            else:
+                new_alpha = int(self.alpha) + 1
 
         if mmu_action == "change":
-            PfcCmd.update_alpha(self.dut, port, self.pg_profile, new_alpha)
+            PfcCmd.update_alpha(self.dut, port, self.pg_profile, new_alpha, new_static_th)
         elif mmu_action == "restore":
-            PfcCmd.update_alpha(self.dut, port, self.pg_profile, self.alpha)
+            PfcCmd.update_alpha(self.dut, port, self.pg_profile, self.alpha, self.static_th)
         time.sleep(2)
 
     def resolve_arp(self, vlan, is_dualtor=False):
@@ -735,7 +767,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.log_handle[port] = loganalyzer
 
         if mmu_action is not None:
-            self.update_mmu_params(mmu_action, port)
+            self.update_mmu_params(dut, mmu_action, port)
 
         if restore:
             loganalyzer = self.log_handle[port]
@@ -982,7 +1014,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 logger.info("--- Stop pfc storm on port {}".format(port))
                 self.storm_hndle.stop_storm()
             # restore alpha
-            PfcCmd.update_alpha(self.dut, port, self.pg_profile, self.alpha)
+            PfcCmd.update_alpha(self.dut, port, self.pg_profile, self.alpha, self.static_th)
             logger.info("--- Stop PFC WD ---")
             self.dut.command("pfcwd stop")
 


### PR DESCRIPTION
Porting both 10245 and 10481 to 202205.

**PR: 10245:**
Update the tests in tests/pfcwd/test_pfcwd_function.py to use static_th for profiles which use static_th. The default handling was for profiles using dynamic_th.

**Approach**
**What is the motivation for this PR?**
For interfaces using long links, cisco-8000 enabled static buffer pool and the profiles using this pool has static_th.
The pfcwd tests were developed for profiles with dynamic_th where the alpha was changed in the test case.

This was not applicable to static profiles and enhanced the test to handle the updated pool and profile types.

**How did you verify/test it?**
Verified on cisco-8000 system, on interfaces with long links (120km) that use static_th for profiles and static buffer pool.

A related change to update mmuconfig utility was made in sonic-buildimage via
https://github.com/sonic-net/sonic-utilities/pull/2775

**Supported testbed topology if it's a new test case?**
This change was tested on a T2 platform, but will work for any buffer pool/profile using static thresholds

**PR:10481**
The pfcwd_function test uses platform type to check if the DUT platform is HBM or not. This might not work all the time. This PR changes it to use the cable length as the way to verify if HBM is enabled or not.