### PR TITLE
Revert "[CoPP] Enhancing ptftests/py3/copp_tests.py testcase to handle no trap condition"

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -260,10 +260,8 @@ class PolicyTest(ControlPlaneBaseTest):
              str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
         )
 
-        if self.has_trap:
-            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(rx_pps)
-        else:
-            assert rx_pps <= self.PPS_LIMIT_MIN, "rx_pps {}".format(rx_pps)
+        assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(
+            rx_pps)
 
 
 # SONIC config contains policer CIR=600 for ARP


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#11444


This change caused failure:

```
{
  "changed": true,
  "cmd": "/root/env-python3/bin/ptf --test-dir ptftests/py3 copp_tests.BGPTest --qlen=100000 --platform nn -t 'verbose=False;target_port=30;myip='\"'\"'10.0.0.39'\"'\"';peerip='\"'\"'10.0.0.38'\"'\"';send_rate_limit=2000;has_trap=False;hw_sku='\"'\"'Arista-7260CX3-D108C8'\"'\"'' --device-socket 0-30@tcp://127.0.0.1:10900  --device-socket 1-30@tcp://10.64.247.10:10900",
  "delta": "0:00:55.442306",
  "end": "2024-02-05 07:22:28.710549",
  "failed": true,
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2024-02-05 07:21:33.268243",
  "stderr": "/root/env-python3/bin/ptf:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\ncopp_tests.BGPTest ... FAIL\n\n======================================================================\nFAIL: copp_tests.BGPTest\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"ptftests/py3/copp_tests.py\", line 474, in runTest\n    self.run_suite()\n  File \"ptftests/py3/copp_tests.py\", line 234, in run_suite\n    self.one_port_test(self.target_port)\n  File \"ptftests/py3/copp_tests.py\", line 228, in one_port_test\n    self.check_constraints(send_count, recv_count, time_delta_ms, rx_pps)\n  File \"ptftests/py3/copp_tests.py\", line 266, in check_constraints\n    assert rx_pps <= self.PPS_LIMIT_MIN, \"rx_pps {}\".format(rx_pps)\nAssertionError: rx_pps 619\n\n----------------------------------------------------------------------\nRan 1 test in 54.617s\n\nFAILED (failures=1)",
  "stderr_lines": [
    "/root/env-python3/bin/ptf:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses",
    "  import imp",
    "copp_tests.BGPTest ... FAIL",
    "",
    "======================================================================",
    "FAIL: copp_tests.BGPTest",
    "----------------------------------------------------------------------",
    "Traceback (most recent call last):",
    "  File \"ptftests/py3/copp_tests.py\", line 474, in runTest",
    "    self.run_suite()",
    "  File \"ptftests/py3/copp_tests.py\", line 234, in run_suite",
    "    self.one_port_test(self.target_port)",
    "  File \"ptftests/py3/copp_tests.py\", line 228, in one_port_test",
    "    self.check_constraints(send_count, recv_count, time_delta_ms, rx_pps)",
    "  File \"ptftests/py3/copp_tests.py\", line 266, in check_constraints",
    "    assert rx_pps <= self.PPS_LIMIT_MIN, \"rx_pps {}\".format(rx_pps)",
    "AssertionError: rx_pps 619",
    "",
    "----------------------------------------------------------------------",
    "Ran 1 test in 54.617s",
    "",
    "FAILED (failures=1)"
  ],
  "stdout": "Using packet manipulation module: ptf.packet_scapy\n2024-02-05 07:21:34 : BGPTest\n2024-02-05 07:21:40 : Send 17405 and receive 1195 packets in the first second (PolicyTest)\n2024-02-05 07:22:10 : Sent out 45460 packets in 30s\n2024-02-05 07:22:28 : Received 18576 packets after sleep 3s\n2024-02-05 07:22:28 : \n2024-02-05 07:22:28 : Sent through NN to local ptf_nn_agent:    45460\n2024-02-05 07:22:28 : Sent through If to remote ptf_nn_agent:   45460\n2024-02-05 07:22:28 : Recv from If on remote ptf_nn_agent:      18584\n2024-02-05 07:22:28 : Recv from NN on from remote ptf_nn_agent: 18584\n2024-02-05 07:22:28 : \n2024-02-05 07:22:28 : test stats\n2024-02-05 07:22:28 : Packet sent =      45460\n2024-02-05 07:22:28 : Packet rcvd =      18576\n2024-02-05 07:22:28 : Test time = 0:00:30.000006\n2024-02-05 07:22:28 : TX PPS = 1515\n2024-02-05 07:22:28 : RX PPS = 619\n2024-02-05 07:22:28 : \n2024-02-05 07:22:28 : Checking constraints (PolicyApplied):\n2024-02-05 07:22:28 : PPS_LIMIT_MIN (540) <= rx_pps (619) <= PPS_LIMIT_MAX (780): True\n\n******************************************\nATTENTION: SOME TESTS DID NOT PASS!!!\n\nThe following tests failed:\nBGPTest\n\n******************************************",
  "stdout_lines": [
    "Using packet manipulation module: ptf.packet_scapy",
    "2024-02-05 07:21:34 : BGPTest",
    "2024-02-05 07:21:40 : Send 17405 and receive 1195 packets in the first second (PolicyTest)",
    "2024-02-05 07:22:10 : Sent out 45460 packets in 30s",
    "2024-02-05 07:22:28 : Received 18576 packets after sleep 3s",
    "2024-02-05 07:22:28 : ",
    "2024-02-05 07:22:28 : Sent through NN to local ptf_nn_agent:    45460",
    "2024-02-05 07:22:28 : Sent through If to remote ptf_nn_agent:   45460",
    "2024-02-05 07:22:28 : Recv from If on remote ptf_nn_agent:      18584",
    "2024-02-05 07:22:28 : Recv from NN on from remote ptf_nn_agent: 18584",
    "2024-02-05 07:22:28 : ",
    "2024-02-05 07:22:28 : test stats",
    "2024-02-05 07:22:28 : Packet sent =      45460",
    "2024-02-05 07:22:28 : Packet rcvd =      18576",
    "2024-02-05 07:22:28 : Test time = 0:00:30.000006",
    "2024-02-05 07:22:28 : TX PPS = 1515",
    "2024-02-05 07:22:28 : RX PPS = 619",
    "2024-02-05 07:22:28 : ",
    "2024-02-05 07:22:28 : Checking constraints (PolicyApplied):",
    "2024-02-05 07:22:28 : PPS_LIMIT_MIN (540) <= rx_pps (619) <= PPS_LIMIT_MAX (780): True",
    "",
    "******************************************",
    "ATTENTION: SOME TESTS DID NOT PASS!!!",
    "",
    "The following tests failed:",
    "BGPTest",
    "",
    "******************************************"
  ]
}
```