### PR TITLE
[Recover via console] Change into the /mnt/flash directory while installing image in aboot.

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -152,6 +152,11 @@ def posix_shell_aboot(dut_console, mgmt_ip, image_url):
 
                     if "Aboot" in x and "#" in x:
                         # TODO: Define a function to send command here
+                        dut_console.remote_conn.send("cd /mnt/flash")
+                        dut_console.remote_conn.send("\n")
+
+                        time.sleep(1)
+
                         dut_console.remote_conn.send("ifconfig ma1 {} netmask {}".format(mgmt_ip.split('/')[0],
                                                      ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1]))
                         dut_console.remote_conn.send("\n")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When recovering testbeds whose hwsku are `arista`, we use A-boot to re-install image. In our previously code, we download image in `~` directory and the set-up file `boot-config` is in the directory `/mnt/flash`, which will cause error `flash:{{image_name}} not found or not a file`. So in this PR, we change into the /mnt/flash directory first and download image. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
When recovering testbeds whose hwsku are `arista`, we use A-boot to re-install image. In our previously code, we download image in `~` directory and the set-up file `boot-config` is in the directory `/mnt/flash`, which will cause error `flash:{{image_name}} not found or not a file`. So in this PR, we change into the /mnt/flash directory first and download image. 

#### How did you do it?
Change directory in A-boot first. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
