### PR TITLE
custom acl table test failure in dualtor-aa fix

### DIFF
--- a/tests/acl/custom_acl_table/acl_rules.json
+++ b/tests/acl/custom_acl_table/acl_rules.json
@@ -32,6 +32,21 @@
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9992"
         },
+        "CUSTOM_TABLE|RULE_PINHOLE_1": {
+            "DST_IP": "10.1.0.36/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "5"
+        },
+        "CUSTOM_TABLE|RULE_PINHOLE_2": {
+            "DST_IP": "10.1.0.38/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "4"
+        },
+        "CUSTOM_TABLE|RULE_PINHOLE_3": {
+            "DST_IP": "10.1.0.39/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "3"
+        },
         "CUSTOM_TABLE|DEFAULT_DROP_RULE_V4": {
             "ETHER_TYPE": "2048",
             "PACKET_ACTION": "DROP",

--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -297,5 +297,4 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
             acl_counter_unselected_dut = read_acl_counter(rand_unselected_dut, rule)
             acl_counter += acl_counter_unselected_dut
         # Verify acl counter
-        import pdb; pdb.set_trace()
         pytest_assert(acl_counter == 1, "ACL counter for {} didn't increase as expected".format(rule))

--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -30,16 +30,20 @@ LOG_EXPECT_ACL_RULE_FAILED_RE = ".*Failed to create ACL rule.*"
 
 
 @pytest.fixture(scope='module')
-def setup_counterpoll_interval(rand_selected_dut):
+def setup_counterpoll_interval(rand_selected_dut, rand_unselected_dut, tbinfo):
     """
     Set the counterpoll interval for acl to 1 second (10 seconds by default)
     """
     # Set polling interval to 1 second
     rand_selected_dut.shell('counterpoll acl interval 1000')
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell('counterpoll acl interval 1000')
     time.sleep(10)
     yield
     # Restore default value 10 seconds
     rand_selected_dut.shell('counterpoll acl interval 10000')
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell('counterpoll acl interval 10000')
 
 
 def clear_acl_counter(dut):
@@ -68,13 +72,15 @@ def read_acl_counter(dut, rule_name):
 
 # TODO: Move this fixture to a shared place of acl test
 @pytest.fixture(scope="module", autouse=True)
-def remove_dataacl_table(rand_selected_dut):
+def remove_dataacl_table(rand_selected_dut, rand_unselected_dut, tbinfo):
     """
     Remove DATAACL to free TCAM resources
     """
     TABLE_NAME = "DATAACL"
     data_acl_table = None
     output = rand_selected_dut.shell("sonic-cfggen -d --var-json \"ACL_TABLE\"")['stdout']
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        output = rand_unselected_dut.shell("sonic-cfggen -d --var-json \"ACL_TABLE\"")['stdout']
     try:
         acl_tables = json.loads(output)
         if TABLE_NAME in acl_tables:
@@ -87,6 +93,8 @@ def remove_dataacl_table(rand_selected_dut):
     # Remove DATAACL
     logger.info("Removing ACL table {}".format(TABLE_NAME))
     rand_selected_dut.shell(cmd="config acl remove table {}".format(TABLE_NAME))
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell(cmd="config acl remove table {}".format(TABLE_NAME))
     yield
     # Recover DATAACL
     data_acl = {}
@@ -94,17 +102,24 @@ def remove_dataacl_table(rand_selected_dut):
     cmd = 'sonic-cfggen -a \'{}\' -w'.format(json.dumps(data_acl))
     logger.info("Restoring ACL table {}".format(TABLE_NAME))
     rand_selected_dut.shell(cmd)
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell(cmd)
 
 
 @pytest.fixture(scope='module')
-def setup_custom_acl_table(rand_selected_dut):
+def setup_custom_acl_table(rand_selected_dut, rand_unselected_dut, tbinfo):
     # Define a custom table type CUSTOM_TYPE by loading a json configuration
     rand_selected_dut.copy(src=CUSTOM_ACL_TABLE_TYPE_SRC_FILE, dest=CUSTOM_ACL_TABLE_TYPE_DST_FILE)
     rand_selected_dut.shell("sonic-cfggen -j {} -w".format(CUSTOM_ACL_TABLE_TYPE_DST_FILE))
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.copy(src=CUSTOM_ACL_TABLE_TYPE_SRC_FILE, dest=CUSTOM_ACL_TABLE_TYPE_DST_FILE)
+        rand_unselected_dut.shell("sonic-cfggen -j {} -w".format(CUSTOM_ACL_TABLE_TYPE_DST_FILE))
     # Create an ACL table and bind to Vlan1000 interface
     cmd_create_table = "config acl add table CUSTOM_TABLE CUSTOM_TYPE -s ingress -p Vlan1000"
     cmd_remove_table = "config acl remove table CUSTOM_TABLE"
     loganalyzer = LogAnalyzer(ansible_host=rand_selected_dut, marker_prefix="custom_acl")
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        loganalyzer = LogAnalyzer(ansible_host=rand_unselected_dut, marker_prefix="custom_acl")
     loganalyzer.load_common_config()
 
     try:
@@ -114,42 +129,60 @@ def setup_custom_acl_table(rand_selected_dut):
         loganalyzer.ignore_regex = [r".*"]
         with loganalyzer:
             rand_selected_dut.shell(cmd_create_table)
+            if "dualtor-aa" in tbinfo["topo"]["name"]:
+                rand_unselected_dut.shell(cmd_create_table)
     except LogAnalyzerError as err:
         # Cleanup Config DB if table creation failed
         logger.error("ACL table creation failed, attempting to clean-up...")
         rand_selected_dut.shell(cmd_remove_table)
+        if "dualtor-aa" in tbinfo["topo"]["name"]:
+            rand_unselected_dut.shell(cmd_remove_table)
         raise err
 
     yield
     logger.info("Removing ACL table and custom type")
     # Remove ACL table
     rand_selected_dut.shell(cmd_remove_table)
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell(cmd_remove_table)
     # Remove custom type
     rand_selected_dut.shell("sonic-db-cli CONFIG_DB del \'ACL_TABLE_TYPE|CUSTOM_TYPE\'")
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell("sonic-db-cli CONFIG_DB del \'ACL_TABLE_TYPE|CUSTOM_TYPE\'")
 
 
 @pytest.fixture(scope='module')
-def setup_acl_rules(rand_selected_dut, setup_custom_acl_table):
+def setup_acl_rules(rand_selected_dut, rand_unselected_dut, tbinfo, setup_custom_acl_table):
     # Copy and load acl rules
     rand_selected_dut.copy(src=ACL_RULE_SRC_FILE, dest=ACL_RULE_DST_FILE)
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.copy(src=ACL_RULE_SRC_FILE, dest=ACL_RULE_DST_FILE)
     cmd_add_rules = "sonic-cfggen -j {} -w".format(ACL_RULE_DST_FILE)
     cmd_rm_rules = "acl-loader delete CUSTOM_TABLE"
 
     loganalyzer = LogAnalyzer(ansible_host=rand_selected_dut, marker_prefix="custom_acl")
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        loganalyzer = LogAnalyzer(ansible_host=rand_unselected_dut, marker_prefix="custom_acl")
     loganalyzer.match_regex = [LOG_EXPECT_ACL_RULE_FAILED_RE]
     try:
         logger.info("Creating ACL rules in CUSTOM_TABLE")
         with loganalyzer:
             rand_selected_dut.shell(cmd_add_rules)
+            if "dualtor-aa" in tbinfo["topo"]["name"]:
+                rand_unselected_dut.shell(cmd_add_rules)
     except LogAnalyzerError as err:
         # Cleanup Config DB if failed
         logger.error("ACL rule creation failed, attempting to clean-up...")
         rand_selected_dut.shell(cmd_rm_rules)
+        if "dualtor-aa" in tbinfo["topo"]["name"]:
+            rand_unselected_dut.shell(cmd_rm_rules)
         raise err
     yield
     # Remove testing rules
     logger.info("Removing testing ACL rules")
     rand_selected_dut.shell(cmd_rm_rules)
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        rand_unselected_dut.shell(cmd_rm_rules)
 
 
 def build_testing_pkts(router_mac):
@@ -215,7 +248,7 @@ def build_exp_pkt(input_pkt):
     return exp_pkt
 
 
-def test_custom_acl(rand_selected_dut, tbinfo, ptfadapter,
+def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
                     setup_acl_rules, toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
                     setup_counterpoll_interval, remove_dataacl_table):
     """
@@ -230,6 +263,7 @@ def test_custom_acl(rand_selected_dut, tbinfo, ptfadapter,
     """
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     if "dualtor" in tbinfo["topo"]["name"]:
+        mg_facts_unselected_dut = rand_unselected_dut.get_extended_minigraph_facts(tbinfo)
         vlan_name = list(mg_facts['minigraph_vlans'].keys())[0]
         # Use VLAN MAC as router MAC on dual-tor testbed
         router_mac = rand_selected_dut.get_dut_iface_mac(vlan_name)
@@ -244,6 +278,8 @@ def test_custom_acl(rand_selected_dut, tbinfo, ptfadapter,
     for _, v in mg_facts['minigraph_portchannels'].items():
         for member in v['members']:
             dst_port_indices.append(mg_facts['minigraph_ptf_indices'][member])
+            if "dualtor-aa" in tbinfo["topo"]["name"]:
+                dst_port_indices.append(mg_facts_unselected_dut['minigraph_ptf_indices'][member])
 
     test_pkts = build_testing_pkts(router_mac)
     for rule, pkt in list(test_pkts.items()):
@@ -251,9 +287,15 @@ def test_custom_acl(rand_selected_dut, tbinfo, ptfadapter,
         exp_pkt = build_exp_pkt(pkt)
         # Send and verify packet
         clear_acl_counter(rand_selected_dut)
+        if "dualtor-aa" in tbinfo["topo"]["name"]:
+            clear_acl_counter(rand_unselected_dut)
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, pkt=pkt, port_id=src_port_indice)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=dst_port_indices, timeout=5)
         acl_counter = read_acl_counter(rand_selected_dut, rule)
+        if "dualtor-aa" in tbinfo["topo"]["name"]:
+            acl_counter_unselected_dut = read_acl_counter(rand_unselected_dut, rule)
+            acl_counter += acl_counter_unselected_dut
         # Verify acl counter
+        import pdb; pdb.set_trace()
         pytest_assert(acl_counter == 1, "ACL counter for {} didn't increase as expected".format(rule))


### PR DESCRIPTION

### Description of PR
In Active-Active DUAL TOR setup, we have the following two important constraints to maintain link state of TORs:
1. gRPC communication between TORs and gRPC server (nic_simualtor).
2. Heartbeat between TORs and server (icmp_responder).

Issue-1 with the failing testcases in test_custom_acl_table.py is, it is fundamentally verifying the INGRESS ACL functionality and the ACLs being used in the test case are not aware of the above 2 points. The moment we apply the INGRESS ACL, it starts blocking the above-mentioned control packets. This results in links in randomly selected TORs going in STANDBY mode, causing test case failure.

Issue-2 with the failing test case in test_custom_acl_table.py is, it does not consider the possibility of test pkts going to unselected ToR  in A/A setup

As a fix, the proposal is to create a “pin hole” in the INGRESS ACL rule and, to configure the ACL rules on both the Active ToRs and check the counter on both the ToRs,, so that we can verify the ACL functionality. Please note that we are planning to add ACL RULES to accept the packets corresponding to ‘loopback2’ and ‘Loopback3’ in the DUAL TOR A-A Setup.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/11632

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
ACL test case failure in A/A scenario

#### How did you do it?
Added checks for dualtor-aa at relevant places in the test to configure custom ACL tables on both the ToRs and added rules to allow control pkts

#### How did you verify/test it?
Verified that the custom ACL table test case PASS in A/A Setup

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA
