### PR TITLE
Make routing type field names consistent

### DIFF
--- a/tests/dash/crm/files/del_dash_crm_config.json
+++ b/tests/dash/crm/files/del_dash_crm_config.json
@@ -60,7 +60,7 @@
     },
     {
         "DASH_ROUTE_TABLE:F4939FEFC47E:20.2.2.0/24": {
-            "action_type": "vnet",
+            "routing_type": "vnet",
             "vnet": "Vnet2"
     },
         "OP": "DEL"

--- a/tests/dash/crm/files/set_dash_crm_config.json
+++ b/tests/dash/crm/files/set_dash_crm_config.json
@@ -51,7 +51,7 @@
         },
         {
                 "DASH_ROUTE_TABLE:F4939FEFC47E:20.2.2.0/24" : {
-                        "action_type":"vnet",
+                        "routing_type":"vnet",
                         "vnet":"Vnet2"
                 },
                 "OP": "SET"

--- a/tests/dash/proto_utils.py
+++ b/tests/dash/proto_utils.py
@@ -38,7 +38,7 @@ def vnet_from_json(json_obj):
 
 def vnet_mapping_from_json(json_obj):
     pb = VnetMapping()
-    pb.action_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
+    pb.routing_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
     pb.underlay_ip.ipv4 = socket.htonl(int(ipaddress.IPv4Address(json_obj["underlay_ip"])))
     pb.mac_address = bytes.fromhex(json_obj["mac_address"].replace(":", ""))
     pb.use_dst_vni = json_obj["use_dst_vni"] == "true"
@@ -67,23 +67,23 @@ def eni_from_json(json_obj):
 
 def route_from_json(json_obj):
     pb = Route()
-    if json_obj["action_type"] == "vnet":
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET
+    if json_obj["routing_type"] == "vnet":
+        pb.routing_type = RoutingType.ROUTING_TYPE_VNET
         pb.vnet = json_obj["vnet"]
-    elif json_obj["action_type"] == "vnet_direct":
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET_DIRECT
+    elif json_obj["routing_type"] == "vnet_direct":
+        pb.routing_type = RoutingType.ROUTING_TYPE_VNET_DIRECT
         pb.vnet_direct.vnet = json_obj["vnet"]
         pb.vnet_direct.overlay_ip.ipv4 = socket.htonl(int(ipaddress.IPv4Address(json_obj["overlay_ip"])))
-    elif json_obj["action_type"] == "direct":
-        pb.action_type = RoutingType.ROUTING_TYPE_DIRECT
+    elif json_obj["routing_type"] == "direct":
+        pb.routing_type = RoutingType.ROUTING_TYPE_DIRECT
     else:
-        pytest.fail("Unknown action type %s" % json_obj["action_type"])
+        pytest.fail("Unknown routing type %s" % json_obj["routing_type"])
     return pb
 
 
 def route_rule_from_json(json_obj):
     pb = RouteRule()
-    pb.action_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
+    pb.routing_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
     pb.priority = int(json_obj["priority"])
     pb.pa_validation = json_obj["pa_validation"] == "true"
     if json_obj["pa_validation"] == "true":

--- a/tests/dash/templates/dash_basic_config.j2
+++ b/tests/dash/templates/dash_basic_config.j2
@@ -55,7 +55,7 @@
         },
         {
                 "DASH_ROUTE_TABLE:{{ eni }}:{{ remote_ca_prefix }}" : {
-                        "action_type":"{{ routing_action }}"
+                        "routing_type":"{{ routing_action }}"
 {%- if lookup_overlay_ip is defined -%},
                         "overlay_ip": "{{ lookup_overlay_ip }}"
 {%- endif %}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
- Some DB fields are named 'action_type' when they contain routing_type information instead. Rename these fields to 'routing_type' to avoid confusion with 'action_type' fields

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
