### PR TITLE
[dualtor-aa][sanity_check] Add checker to verify `dualtor-aa` interfaces are active on both sides

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -250,12 +250,12 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                             if 'action' in failed_result and failed_result['action'] is not None \
                                     and callable(failed_result['action']):
                                 infra_recovery_actions.append(failed_result['action'])
+                    for action in infra_recovery_actions:
+                        action()
                     for dut_name, dut_results in list(dut_failed_results.items()):
                         # Attempt to restore DUT state
                         recover(duthosts[dut_name], localhost, fanouthosts, nbrhosts, tbinfo, dut_results,
                                 recover_method)
-                    for action in infra_recovery_actions:
-                        action()
 
                 except BaseException as e:
                     request.config.cache.set("pre_sanity_check_failed", True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add checker to verify `dualtor-aa` interfaces are active on both sides. If not, try recovering by configuring mux mode, restart nic_simulator etc. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Tests are failing at setup due to dualtor-aa interfaces left in non-active status. 

#### How did you do it?
1. Added checker to confirm both sides' mux status == 1 (active).
2. Moved mux config change before `config reload` and saved `auto` config explicitly. 
3. Skip `mux_simulator` restart when there is no active-standby interfaces to avoid unnecessary errors. 

#### How did you verify/test it?
Ran `bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down`:
1. with mux config == `auto`, sanity check passed, test passed.
2. with mux config == `standby` on both sides, sanity check triggered `recover`, test passed. 
```
01:31:47 checks._check                            L0653 WARNING| Inconsistent mux status for active-active ports on dualtors,                                                    please check output of "show mux status"
01:32:00 recover.recover                          L0185 WARNING| Try to recover svcstr-7050-acs-1 using method adaptive
01:32:00 recover.adaptive_recover                 L0169 WARNING| Restoring {'failed': True, 'failed_reason': 'Inconsistent mux status for active-active ports on dualtors,                                                    please check output of "show mux status"', 'check_item': 'mux_simulator', 'action': <function check_mux_simulator.<locals>._recover at 0x7f7229443670>, 'hosts': ['svcstr-7050-acs-1', 'svcstr-7050-acs-2']} with proposed action: config_reload, final action: config_reload
01:32:00 config_reload.config_reload              L0093 INFO   | reloading running_golden_config
... ...
01:34:34 recover.recover                          L0185 WARNING| Try to recover svcstr-7050-acs-2 using method adaptive
01:34:34 recover.adaptive_recover                 L0169 WARNING| Restoring {'failed': True, 'failed_reason': 'Inconsistent mux status for active-active ports on dualtors,                                                    please check output of "show mux status"', 'check_item': 'mux_simulator', 'action': <function check_mux_simulator.<locals>._recover at 0x7f7229443670>, 'hosts': ['svcstr-7050-acs-1', 'svcstr-7050-acs-2']} with proposed action: config_reload, final action: config_reload
01:34:34 config_reload.config_reload              L0093 INFO   | reloading running_golden_config
... ...
01:36:55 __init__.sanity_check                    L0269 INFO   | Run sanity check again after recovery
01:36:55 checks._check_processes_on_dut           L0773 INFO   | Checking process status on svcstr-7050-acs-1...
01:36:55 checks._check_processes_on_dut           L0773 INFO   | Checking process status on svcstr-7050-acs-2...
01:36:56 checks._check_processes_on_dut           L0778 INFO   | networking_uptime=90 seconds, timeout=210 seconds, interval=20 seconds
01:36:56 checks._check_processes_on_dut           L0778 INFO   | networking_uptime=247 seconds, timeout=53 seconds, interval=20 seconds
01:37:07 checks._check_processes_on_dut           L0811 INFO   | Done checking processes status on svcstr-7050-acs-1
01:37:07 parallel.on_terminate                    L0085 INFO   | process _check_processes_on_dut--<MultiAsicSonicHost svcstr-7050-acs-1> terminated with exit code None
01:37:07 checks._check_processes_on_dut           L0811 INFO   | Done checking processes status on svcstr-7050-acs-2
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
