### PR TITLE
[Recover via console] Remove image to avoid "File exists" error.

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -154,23 +154,24 @@ def posix_shell_aboot(dut_console, mgmt_ip, image_url):
                         # TODO: Define a function to send command here
                         dut_console.remote_conn.send("cd /mnt/flash")
                         dut_console.remote_conn.send("\n")
-
                         time.sleep(1)
 
                         dut_console.remote_conn.send("ifconfig ma1 {} netmask {}".format(mgmt_ip.split('/')[0],
                                                      ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1]))
                         dut_console.remote_conn.send("\n")
-
                         time.sleep(1)
 
                         dut_console.remote_conn.send("route add default gw {}".format(gw_ip))
                         dut_console.remote_conn.send("\n")
-
                         time.sleep(1)
 
                         dut_console.remote_conn.send("ip route add default via {} dev ma1".format(gw_ip))
                         dut_console.remote_conn.send("\n")
+                        time.sleep(1)
 
+                        # Remove image to avoid "File exists" error
+                        dut_console.remote_conn.send("rm -f {}".format(image_url.split("/")[-1]))
+                        dut_console.remote_conn.send("\n")
                         time.sleep(1)
 
                         dut_console.remote_conn.send("wget {}".format(image_url))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When recovering testbeds whose hwsku are Arista, we need to re-install image in Aboot. But the previous downloaded image will not be deleted in Aboot, and if we download the same image again, it will case `File exists` error in Aboot. We can either remove or rename the existing image on device, but rename image may cause error `free memory or disk space size is not enough`. So in this PR, we will remove the same image in Aboot. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
When recovering testbeds whose hwsku are Arista, we need to re-install image in Aboot. But the previous downloaded image will not be deleted in Aboot, and if we download the same image again, it will case `File exists` error in Aboot. We can either remove or rename the existing image on device, but rename image may cause error `free memory or disk space size is not enough`. So in this PR, we will remove the same image in Aboot. 

#### How did you do it?
Remove the same image if existing before download new image. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
