### PR TITLE
[Recover via console]  Add pause to wait for SONiC initialization.

### DIFF
--- a/.azure-pipelines/recover_testbed/testbed_status.py
+++ b/.azure-pipelines/recover_testbed/testbed_status.py
@@ -22,4 +22,5 @@ def dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip):
         logging.info(e)
     finally:
         logger.info("=====Recover finish=====")
+        localhost.pause(seconds=60, prompt="Wait for SONiC initialization")
         dut_console.disconnect()

--- a/.azure-pipelines/recover_testbed/testbed_status.py
+++ b/.azure-pipelines/recover_testbed/testbed_status.py
@@ -22,5 +22,5 @@ def dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip):
         logging.info(e)
     finally:
         logger.info("=====Recover finish=====")
-        localhost.pause(seconds=60, prompt="Wait for SONiC initialization")
+        localhost.pause(seconds=120, prompt="Wait for SONiC initialization")
         dut_console.disconnect()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We need to add ip configurations on SONIC at the end of recovery. In this PR, after adding ip configuration, we add a pause to wait for SONiC initialization.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We need to add ip configurations on SONIC at the end of recovery. In this PR, after adding ip configuration, we add a pause to wait for SONiC initialization.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
