### PR TITLE
Generic fix to unskip pfcwd_multi_port test from skipped list for t2

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -318,19 +318,22 @@ def select_test_ports(test_ports):
     """
     selected_ports = dict()
     rx_ports = set()
-    seed = int(datetime.datetime.today().day)
-    for port, port_info in list(test_ports.items()):
-        rx_port = port_info["rx_port"]
-        if isinstance(rx_port, (list, tuple)):
-            rx_ports.update(rx_port)
-        else:
-            rx_ports.add(rx_port)
-        if (int(port_info['test_port_id']) % 15) == (seed % 15):
-            selected_ports[port] = port_info
-
-    # filter out selected ports that also act as rx ports
-    selected_ports = {p: pi for p, pi in list(selected_ports.items())
-                      if p not in rx_port}
+    if len(test_ports) > 2:
+        modulo = int(len(test_ports)/3)
+        seed = int(len(test_ports)/2)
+        for port, port_info in test_ports.items():
+            rx_port = port_info["rx_port"]
+            if isinstance(rx_port, (list, tuple)):
+                rx_ports.update(rx_port)
+            else:
+                rx_ports.add(rx_port)
+            if (int(port_info['test_port_id']) % modulo) == (seed % modulo):
+                selected_ports[port] = port_info
+        # filter out selected ports that also act as rx ports
+        selected_ports = {p: pi for p, pi in list(selected_ports.items())
+                          if p not in rx_port}
+    elif len(test_ports) == 2:
+        selected_ports = test_ports
 
     if not selected_ports:
         random_port = list(test_ports.keys())[0]

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -1,4 +1,3 @@
-import datetime
 import ipaddress
 import sys
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -817,6 +817,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
         self.test_ports_info = setup_info['test_ports']
+        if self.dut.topo_type == 't2':
+            key, value = list(self.ports.items())[0]
+            self.ports = {key: value}
         self.neighbors = setup_info['neighbors']
         self.peer_dev_list = dict()
         self.fake_storm = fake_storm
@@ -1065,6 +1068,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
         self.test_ports_info = setup_info['test_ports']
+        if self.dut.topo_type == 't2':
+            key, value = list(self.ports.items())[0]
+            self.ports = {key: value}
         self.neighbors = setup_info['neighbors']
         self.peer_dev_list = dict()
         self.fake_storm = fake_storm


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- PFCWD test ‘_test_pfcwd_multi_port_’ is SKIPPED for T2-Chassis, with the following error.
    ` 'Skipped: Pfcwd multi port test needs at least 2 ports'`
- This PR addresses the above issue, unskips the multi-port test for pfcwd suite with a generic fix.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
-  _pfcwd/conftest.py : setup_pfc_test:_ - the modulo logic used to pick ports from the test_ports is always false in T2 case.
- Due to which, the test gets skipped because of the number of selected ports check, which is always 1 for a T2 DUT.
   `pytest_require(len(selected_ports) == 2, 'Pfcwd multi port test needs at least 2 ports'))`

#### How did you do it?
- Added a generic fix based on the total number of test ports.

#### How did you verify/test it?
- Ran PFCWD suite including, _test_pfcwd_multi_port_ and made sure the test is not skipped for run.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
