### PR TITLE
[Snappi] Bug fix for PFC class enable vector test

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -552,6 +552,9 @@ def verify_pause_frame_count_dut(duthost,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "Global pause frames should not be counted in RX PFC counters for priority {}"
                               .format(prio))
+            elif not snappi_extra_params.set_pfc_class_enable_vec:
+                pytest_assert(pfc_pause_rx_frames == 0,
+                              "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
                 pytest_assert(pfc_pause_rx_frames > 0,
                               "PFC pause frames should be received and counted in RX PFC counters for priority {}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: PR #11400 introduced a logical regression for the unset_cev test whereby in the test, we send invalid PFC pause frames from the TGEN which we do not expect the DUT to be counting. This PR introduces a specific check for this scenario which was missing from the previous PR.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Bug fix for nightly triage
#### How did you do it?
Added test specific logic
#### How did you verify/test it?
Ran on lab device
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
