### PR TITLE
Add support of t0-56-o8v48 to continuous_reboot test

### DIFF
--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -49,7 +49,7 @@ testcases:
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     copp:
       filename: copp.yml


### PR DESCRIPTION
Add support of t0-56-o8v48 to continuous_reboot test

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add support of t0-56-o8v48 to continuous_reboot test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Add support of topology t0-56-o8v48 to continuous_reboot test
#### How did you do it?
Add support of topology t0-56-o8v48 to continuous_reboot test
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
