### PR TITLE
[Recover via console] Persistent management IP across reboot

### DIFF
--- a/.azure-pipelines/recover_testbed/interfaces.j2
+++ b/.azure-pipelines/recover_testbed/interfaces.j2
@@ -5,9 +5,20 @@ auto eth0
 iface eth0 inet static
     address {{ addr }}
     netmask {{ mask }}
+    network {{ network }}
+    broadcast {{ brd_ip }}
     ################ management network policy routing rules
     #### management port up rules"
-    up ip route add default via {{ gwaddr }} dev eth0 table default
-    up ip rule add from {{ addr }}/32 table default
+    up ip -4 route add default via {{ gwaddr }} dev eth0 table default metric 201
+    up ip -4 route add {{ mgmt_ip }} dev eth0 table default
+
+    # management port down rules
+    pre-down ip -4 route delete default via {{ gwaddr }} dev eth0 table default
+    pre-down ip -4 route delete {{ mgmt_ip }} dev eth0 table default
+
+#
+source /etc/network/interfaces.d/*
+#
+
 {% endblock mgmt_interface %}
 #

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import ipaddress
+import traceback
 from common import do_power_cycle, check_sonic_installer, posix_shell_aboot, posix_shell_onie
 from constants import RC_SSH_FAILED
 
@@ -54,6 +55,7 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
         dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip)
     except Exception as e:
         logger.info(e)
+        traceback.print_exc()
         return
 
 
@@ -73,11 +75,21 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
                 extra_vars = {
                     'addr': mgmt_ip.split('/')[0],
                     'mask': ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1],
-                    'gwaddr': list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
+                    'gwaddr': list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0],
+                    'mgmt_ip': mgmt_ip,
+                    'brd_ip': ipaddress.ip_interface(mgmt_ip).network.broadcast_address,
+                    'network': str(ipaddress.ip_interface(mgmt_ip).network).split('/')[0]
                 }
                 sonichost.vm.extra_vars.update(extra_vars)
                 sonichost.template(src="../.azure-pipelines/recover_testbed/interfaces.j2",
-                                   dest="/etc/network/interface")
+                                   dest="/etc/network/interfaces")
+
+                # Add management ip info into config_db.json
+                sonichost.template(src="../.azure-pipelines/recover_testbed/mgmt_ip.j2",
+                                   dest="/etc/sonic/mgmt_ip.json")
+                sonichost.shell("configlet -u -j {}".format("/etc/sonic/mgmt_ip.json"))
+
+                sonichost.shell("sudo config save -y")
 
                 sonic_username = dut_ssh[0]
                 sonic_password = dut_ssh[1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After re-install in ONIE/Aboot etc. , we notice that the management ip is temporarily. After reboot, it will loss again. In this PR, we write management ip in `/etc/network/interfaces` to keep management ip static. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
After re-install in ONIE/Aboot etc. , we notice that the management ip is temporarily. After reboot, it will loss again. In this PR, we write management ip in `/etc/network/interfaces` to keep management ip static. 

#### How did you do it?
Re-format the file `interfaces.j2` and write management ip in `/etc/network/interfaces` to keep management ip static. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
