### PR TITLE
[Recover via console]  Send enter when getting the string "ONIE: Starting ONIE Service Discovery"

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -86,6 +86,8 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
 
                 # "ONIE: Starting ONIE Service Discovery"
                 if ONIE_START_TO_DISCOVERY in x:
+                    dut_console.remote_conn.send("\n")
+
                     # TODO: Define a function to send command here
                     for i in range(5):
                         dut_console.remote_conn.send('onie-discovery-stop\n')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After getting the string "ONIE: Starting ONIE Service Discovery", we need to send an enter to get the prompt `ONIE#`. So that  we can continually send other strings we want. Previously code doesn't send this enter, so in this PR, we add it after getting the string "ONIE: Starting ONIE Service Discovery" in ONIE.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
After getting the string "ONIE: Starting ONIE Service Discovery", we need to send an enter to get the prompt `ONIE#`. So that  we can continually send other strings we want. Previously code doesn't send this enter, so in this PR, we add it after getting the string "ONIE: Starting ONIE Service Discovery" in ONIE.

#### How did you do it?
Send enter after getting string "ONIE: Starting ONIE Service Discovery" in ONIE. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
