### PR TITLE
Fix advanced-reboot.py not detecting the retry count option in warm-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1475,7 +1475,7 @@ class ReloadTest(BaseTest):
             # Check to see if the warm-reboot script knows about the retry count feature
             stdout, stderr, return_code = self.dut_connection.execCommand(
                 "sudo " + self.reboot_type + " -h", timeout=5)
-            if "retry count" in stdout:
+            if "retry count" in "\n".join(stdout):
                 if self.test_params['neighbor_type'] == "sonic":
                     reboot_command = self.reboot_type + " -N"
                 else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

On images where the warm-reboot (and fast-reboot) script supports the `-n` and `-N` flags, which either require or not require the teamd retry count feature to be enabled, the advanced-reboot.py script is supposed to check to see if this feature is present, and then use `-n` or `-N` depending on if SONiC neighbors are being used or not. However, this never appeared to be being used. The reason for this is that `stdout` is actually an array of strings, so using `in` just meant if the test string exactly matched some line from the help output, which will never be true here.

#### How did you do it?

The quick and dirty way to fix this is to concatenate this into a single string (newline-separated), and then use `in`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
