### PR TITLE
[test_route_flap] Route flap multi-dut fix if the selected duthost has downstream neighbors

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -99,6 +99,15 @@ def get_ptf_recv_ports(duthost, tbinfo):
 
 
 def get_neighbor_info(duthost, dev_port, tbinfo):
+    """
+    This function returns the neighbor type of
+    the chosen dev_port based on route info
+
+    Args:
+        duthost: DUT belong to the testbed.
+        dev_port: Chosen dev_port based on route info
+        tbinfo: A fixture to gather information about the testbed.
+    """
     neighbor_type = ''
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     neighs = config_facts['BGP_NEIGHBOR']
@@ -122,6 +131,9 @@ def get_neighbor_info(duthost, dev_port, tbinfo):
 
 
 def get_port_by_ip(config_facts, ipaddr):
+    """
+    This function returns port name based on ip address
+    """
     if ':' in ipaddr:
         iptype = "ipv6"
     else:
@@ -143,6 +155,10 @@ def get_port_by_ip(config_facts, ipaddr):
 
 
 def get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list):
+    """
+    This function returns all the ptf ports of
+    all the duts w.r.t received neighbors' list, even for multi dut chassis
+    """
     recv_ports = []
     for duthost in duthosts:
         if duthost.is_supervisor_node():
@@ -156,6 +172,10 @@ def get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list):
 
 
 def get_all_recv_neigh(duthosts, neigh_type):
+    """
+    This function returns all the neighbors of
+    same type for dut, including multi dut chassis
+    """
     recv_neigh_list = []
     for duthost in duthosts:
         if duthost.is_supervisor_node():
@@ -212,6 +232,7 @@ def send_recv_ping_packet(ptfadapter, ptf_send_port, ptf_recv_ports, dst_mac, ex
     ext_pkt['Ether'].src = exp_src_mac
 
     masked_exp_pkt = Mask(ext_pkt)
+    # Mask src_mac for T2 multi-dut chassis, since the packet can be received on any of the dut's ptf-ports
     if 't2' in tbinfo["topo"]["name"]:
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
     masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -235,7 +235,7 @@ def send_recv_ping_packet(ptfadapter, ptf_send_port, ptf_recv_ports, dst_mac, ex
     # Mask src_mac for T2 multi-dut chassis, since the packet can be received on any of the dut's ptf-ports
     if 't2' in tbinfo["topo"]["name"]:
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "tos")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -97,6 +97,70 @@ def get_ptf_recv_ports(duthost, tbinfo):
         recv_ports.append(ptf_idx)
     return recv_ports
 
+def get_neighbor_info(duthost, dev_port):
+    nbr = []
+    neighbor_name = ''
+    neighbor_type = ''
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    neighs = config_facts['BGP_NEIGHBOR']
+    dev_neigh_mdata = config_facts['DEVICE_NEIGHBOR_METADATA'] if 'DEVICE_NEIGHBOR_METADATA' in config_facts else {}
+    for neighbor in neighs:
+        local_ip = neighs[neighbor]['local_addr']
+        nbr_port = get_port_by_ip(config_facts, local_ip)
+        if dev_port == nbr_port:
+            neighbor_name = neighs[neighbor]['name']
+            nbr.append(neighbor)
+    for k, v in dev_neigh_mdata.items():
+        if k == neighbor_name:
+            neighbor_type = v['type']
+    return nbr, neighbor_name, neighbor_type
+
+def get_port_by_ip(config_facts, ipaddr):
+    if ':' in ipaddr:
+        iptype = "ipv6"
+    else:
+        iptype = "ipv4"
+
+    intf = {}
+    intf.update(config_facts.get('INTERFACE', {}))
+    if "PORTCHANNEL_INTERFACE" in config_facts:
+        intf.update(config_facts['PORTCHANNEL_INTERFACE'])
+    for a_intf in intf:
+        for addrs in intf[a_intf]:
+            intf_ip = addrs.split('/')
+            if iptype == 'ipv6' and ':' in intf_ip[0] and intf_ip[0].lower() == ipaddr.lower():
+                return a_intf
+            elif iptype == 'ipv4' and ':' not in intf_ip[0] and intf_ip[0] == ipaddr:
+                return a_intf
+
+    raise Exception("Dod not find port for IP %s" % ipaddr)
+
+
+def get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list):
+    recv_ports = []
+    for duthost in duthosts:
+        if duthost.is_supervisor_node():
+            continue
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        for interface, neighbor in mg_facts["minigraph_neighbors"].items():
+            if neighbor['name'] in recv_neigh_list and interface in mg_facts["minigraph_ptf_indices"]:
+                ptf_idx = mg_facts["minigraph_ptf_indices"][interface]
+                recv_ports.append(ptf_idx)
+    return recv_ports
+
+
+def get_all_recv_neigh(duthosts, neigh_type):
+    recv_neigh_list = []
+    for duthost in duthosts:
+        if duthost.is_supervisor_node():
+            continue
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        device_neighbor_metadata = config_facts['DEVICE_NEIGHBOR_METADATA']
+        for k, v in device_neighbor_metadata.items():
+            if v['type'] == neigh_type:
+                recv_neigh_list.append(k)
+    return recv_neigh_list
+
 
 def get_ptf_send_ports(duthost, tbinfo, dev_port):
     if tbinfo['topo']['name'] in ['t0', 't1-lag', 'm0']:
@@ -132,7 +196,7 @@ def check_route(duthost, route, dev_port, operation):
                       "Route {} was not announced {}".format(route, result))
 
 
-def send_recv_ping_packet(ptfadapter, ptf_send_port, ptf_recv_ports, dst_mac, exp_src_mac, src_ip, dst_ip):
+def send_recv_ping_packet(ptfadapter, ptf_send_port, ptf_recv_ports, dst_mac, exp_src_mac, src_ip, dst_ip, tbinfo):
     # use ptf sender interface mac for easy identify testing packets
     src_mac = ptfadapter.dataplane.get_mac(0, ptf_send_port)
     pkt = testutils.simple_icmp_packet(
@@ -142,7 +206,9 @@ def send_recv_ping_packet(ptfadapter, ptf_send_port, ptf_recv_ports, dst_mac, ex
     ext_pkt['Ether'].src = exp_src_mac
 
     masked_exp_pkt = Mask(ext_pkt)
-    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+    if 't2' in tbinfo["topo"]["name"]:
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "tos")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
@@ -227,7 +293,7 @@ def get_internal_interfaces(duthost):
 
     # Then check for voq chassis: get voq inband interface for later filtering
     voq_inband_interfaces = duthost.get_voq_inband_interfaces()
-    internal_intfs.append([voq_inband_interfaces])
+    internal_intfs += voq_inband_interfaces
 
     return internal_intfs
 
@@ -339,7 +405,15 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
 
     # choose one ptf port to send msg
     ptf_send_port = get_ptf_send_ports(duthost, tbinfo, dev_port)
-    ptf_recv_ports = get_ptf_recv_ports(duthost, tbinfo)
+
+    # Get the list of ptf ports to receive msg, even for multi-dut scenario
+    nbr_ip, neighbor_name, neighbor_type = get_neighbor_info(duthost, dev_port)
+    logger.info("Dev port neighbor ip {}, neighbor name {} and neighbor type {}"
+                .format(nbr_ip, neighbor_name, neighbor_type))
+    recv_neigh_list = get_all_recv_neigh(duthosts, neighbor_type)
+    logger.info("Receiving ports neighbor list : {}".format(recv_neigh_list))
+    ptf_recv_ports = get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list)
+    logger.info("Receiving ptf ports list : {}".format(ptf_recv_ports))
 
     exabgp_port = get_exabgp_port(duthost, tbinfo, dev_port)
     logger.info("exabgp_port = %d" % exabgp_port)
@@ -367,7 +441,7 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
 
             # test link status
             send_recv_ping_packet(
-                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip)
+                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip, tbinfo)
 
             withdraw_route(ptf_ip, dst_prefix, nexthop, exabgp_port, aspath)
             # Check if route is withdraw with first 3 routes
@@ -375,7 +449,7 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
                 time.sleep(1)
                 check_route(duthost, dst_prefix, dev_port, WITHDRAW)
             send_recv_ping_packet(
-                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip)
+                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip, tbinfo)
 
             announce_route(ptf_ip, dst_prefix, nexthop, exabgp_port, aspath)
             # Check if route is announced with first 3 routes
@@ -383,7 +457,7 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
                 time.sleep(1)
                 check_route(duthost, dst_prefix, dev_port, ANNOUNCE)
             send_recv_ping_packet(
-                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip)
+                ptfadapter, ptf_send_port, ptf_recv_ports, vlan_mac, dut_mac, ptf_ip, ping_ip, tbinfo)
 
             route_index += 1
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

-  This PR fixes issue #11460 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

- For T2 Chassis(topo-t2), route/test_route_flap works fine, if the selected duthost has upstream T3 neighbors.
- Similarly, if the selected duthost has downstream T1 neighbors and if there is only one dut with T1 neighbors, test works fine too.
- But if the selected duthost has downstream T1 neighbors and if there are more than one dut with downstream neighbors, route/test_route_flap fails.

#### How did you do it?

- Fetch the 'neighbor type' (_LeafRouter/SpineRouter/AZNGhub_) based on the chosen _dev_port_ from _get_dev_port_and_route_
- Get all the neighbors of same neighbor type and fetch the ptf receiving ports list based on the retrieved neighbors list.
- Pass the received ptf ports list to send_recv_ping_packet method for further testing. 

#### How did you verify/test it?

- Ran _route/test_route_flap_ test case on T2 Chassis with 'topo-t2' topology having 3-line cards with at least 2 cards having downstream T1 neighbors.
-  Test passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/sonic-net/sonic-mgmt/assets/114024719/a1bd3e01-b70d-4795-b057-6671973282a5)

