### PR TITLE
[add-topo] Increase server IPv6 route cache size from default 4096 to 16384

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -168,6 +168,13 @@
     sysctl_set: yes
   become: yes
 
+- name: Increase IPv6 route cache size
+  sysctl:
+    name: "net.ipv6.route.max_size"
+    value: "16384"
+    sysctl_set: yes
+  become: yes
+
 - name: Setup external front port
   include_tasks: external_port.yml
   when: external_port is defined


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
On testbed server, the IPv6 route cache may be full. When the issue is hit, we can observe messages like below in dmesg:

[2615625.047483] Route cache is full: consider increasing sysctl net.ipv[4|6].route.max_size.
[2615625.967008] Route cache is full: consider increasing sysctl net.ipv[4|6].route.max_size.

The impact is that static IPv6 configured on testbed server interface may stop working. Just ping the IP would get "Network is unreachable".

Reason:
The current SONiC testbed design needs to create many bridges on test server. Each bridge may consume some IPv6 route cache. When multiple testbeds are deployed on single server, the default route cache size 4096 may be hit.

#### How did you do it?
The fix is to increase IPv6 route cache size on test server from default 4096 to 16384 while deploying a testbed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
