### PR TITLE
set get() default value to dict in order to avoid keys() error

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -61,7 +61,7 @@ def extract_fw_data(fw_pkg_path):
 @pytest.fixture(scope='function')
 def random_component(duthost, fw_pkg):
     chass = list(show_firmware(duthost)["chassis"].keys())[0]
-    components = list(fw_pkg["chassis"].get(chass, {}).get("component", []).keys())
+    components = list(fw_pkg["chassis"].get(chass, {}).get("component", {}).keys())
     if 'ONIE' in components:
         components.remove('ONIE')
     if len(components) == 0:


### PR DESCRIPTION
Change-Id: I62486e8265c0f90791d79dc72a37305c2e93c33b

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes `AttributeError: 'list' object has no attribute 'keys'` error by replacing `.get()` default value to be dict instead of list in `random_component` fwutil fixture

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Avoid AttributeError when dict has no expected key

#### How did you do it?
Use dict as default value instead of a list

#### How did you verify/test it?
Run TC, no error is raised

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
