### PR TITLE
Fix telemetry container in generate_telemetry_config

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -52,7 +52,7 @@ class GNMIEnvironment(object):
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
                 # GNMI program is telemetry or gnmi-native
-                res = duthost.shell("docker exec gnmi supervisorctl status", module_ignore_errors=True)
+                res = duthost.shell("docker exec telemetry supervisorctl status", module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"
                 else:

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -51,7 +51,7 @@ class GNMIEnvironment(object):
             if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
-                # GNMI program is telemetry or gnmi-native
+                # GNMI program is telemetry or gnmi-native 
                 res = duthost.shell("docker exec telemetry supervisorctl status", module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -51,7 +51,7 @@ class GNMIEnvironment(object):
             if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
                 self.gnmi_config_table = "TELEMETRY"
                 self.gnmi_container = "telemetry"
-                # GNMI program is telemetry or gnmi-native 
+                # GNMI program is telemetry or gnmi-native
                 res = duthost.shell("docker exec telemetry supervisorctl status", module_ignore_errors=True)
                 if 'telemetry' in res['stdout']:
                     self.gnmi_program = "telemetry"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The gnmi/test_gnmi_condifgb.py tests are failing stating that the right process (telemetry) is not running based on the supervisorctl status. The issues is caused because of generate_telemetry_config function checking the wrong container (gnmi) instead of telemetry for either gnmi-native, or telemetry processes. 


#### How did you do it?
Changed the container generate_telemetry_config function was checking to telemetry instead of gnmi which was the wrong  container. 


#### How did you verify/test it?
[gnmi/test_gnmi_configdb.py - gnmi_utils_results.log](https://github.com/sonic-net/sonic-mgmt/files/14249347/gnmi_utilg_results.log)

gnmi/test_gnmi_configdb.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Cherry pick to master branch PR - https://github.com/sonic-net/sonic-mgmt/pull/11943