### PR TITLE
Refactor upgrade path tests

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -585,7 +585,7 @@ class AdvancedReboot:
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
                 log_dir = self.__fetchTestLogs(rebootOper)
                 self.print_test_logs_summary(log_dir)
-                if self.advanceboot_loganalyzer:
+                if self.advanceboot_loganalyzer and post_reboot_analysis:
                     verification_errors = post_reboot_analysis(marker, event_counters=event_counters,
                                                                reboot_oper=rebootOper, log_dir=log_dir)
                     if verification_errors:

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -149,3 +149,8 @@ def add_advanced_reboot_args(parser):
         "sad(3h45m), multi_sad(5h), sad_bgp(1h5m), sad_lag_member(1h15m), sad_lag(1h15m), " +
         "sad_vlan_port(1h10m), sad_inboot(1h20m)",
         )
+
+    parser.addoption(
+        "--enable_cpa",
+        action="store_true",
+        help="Enable control-plane assistant (only applicable for warm upgrade)")

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,12 +1,9 @@
 import pytest
 import logging
 import re
-from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot
-from tests.common.reboot import get_reboot_cause
-from tests.common.reboot import REBOOT_TYPE_COLD
-from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version,\
-    get_reboot_command, check_copp_config
+from tests.upgrade_path.upgrade_helpers import install_sonic, check_sonic_version,\
+    upgrade_test_helper
 from tests.upgrade_path.upgrade_helpers import restore_image            # noqa F401
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
 from tests.platform_tests.verify_dut_health import verify_dut_health    # noqa F401
@@ -47,59 +44,89 @@ def upgrade_path_lists(request):
     return upgrade_type, from_list, to_list, restore_to_image
 
 
+def cleanup_prev_images(duthost):
+    logger.info("Cleaning up previously installed images on DUT")
+    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+    duthost.shell("sonic_installer set_next_boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer set-next-boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer cleanup -y", module_ignore_errors=True)
+
+
+def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
+                       upgrade_type, modify_reboot_script=None, allow_fail=False):
+    logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
+    cleanup_prev_images(duthost)
+    # Install base image
+    logger.info("Installing {}".format(from_image))
+    try:
+        target_version = install_sonic(duthost, from_image, tbinfo)
+    except RunAnsibleModuleFail as err:
+        migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
+        msg = err.results['msg'].replace('\n', '')
+        if re.search(migration_err_regexp, msg):
+            logger.info(
+                "Ignore the package migration error when downgrading to from_image")
+            target_version = duthost.shell(
+                "cat /tmp/downloaded-sonic-image-version")['stdout']
+        else:
+            raise err
+    # Remove old config_db before rebooting the DUT in case it is not successfully
+    # removed in install_sonic due to migration error
+    logger.info("Remove old config_db file if exists, to load minigraph from scratch")
+    if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
+        duthost.shell("rm -f /host/old_config/config_db.json")
+    # Perform a cold reboot
+    logger.info("Cold reboot the DUT to make the base image as current")
+    # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
+    reboot_type = 'soft' if "6100" in duthost.facts["hwsku"] else 'cold'
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    check_sonic_version(duthost, target_version)
+
+    # Install target image
+    logger.info("Upgrading to {}".format(to_image))
+    target_version = install_sonic(duthost, to_image, tbinfo)
+
+    if allow_fail and modify_reboot_script:
+        # add fail step to reboot script
+        modify_reboot_script(upgrade_type)
+
+
+@pytest.mark.device_type('vs')
+def test_double_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
+                      nbrhosts, fanouthosts, tbinfo, restore_image,                     # noqa F811
+                      get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
+                      upgrade_path_lists, create_hole_in_tcam):                         # noqa F811
+    duthost = duthosts[rand_one_dut_hostname]
+    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
+
+    def upgrade_path_preboot_setup():
+        setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
+                           upgrade_type)
+
+    upgrade_test_helper(duthost, localhost, ptfhost, from_image,
+                        to_image, tbinfo, upgrade_type, get_advanced_reboot,
+                        advanceboot_loganalyzer=advanceboot_loganalyzer,
+                        preboot_setup=upgrade_path_preboot_setup, reboot_count=2)
+
+
 @pytest.mark.device_type('vs')
 def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
                       nbrhosts, fanouthosts, tbinfo, restore_image,                     # noqa F811
                       get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
                       upgrade_path_lists):
     duthost = duthosts[rand_one_dut_hostname]
-    upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
-    from_list = from_list_images.split(',')
-    to_list = to_list_images.split(',')
-    assert (from_list and to_list)
-    for from_image in from_list:
-        for to_image in to_list:
-            logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
-            # Install base image
-            logger.info("Installing {}".format(from_image))
-            try:
-                target_version = install_sonic(duthost, from_image, tbinfo)
-            except RunAnsibleModuleFail as err:
-                migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
-                msg = err.results['msg'].replace('\n', '')
-                if re.search(migration_err_regexp, msg):
-                    logger.info(
-                        "Ignore the package migration error when downgrading to from_image")
-                    target_version = duthost.shell(
-                        "cat /tmp/downloaded-sonic-image-version")['stdout']
-                else:
-                    raise err
-            # Remove old config_db before rebooting the DUT in case it is not successfully
-            # removed in install_sonic due to migration error
-            logger.info("Remove old config_db file if exists, to load minigraph from scratch")
-            if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
-                duthost.shell("rm -f /host/old_config/config_db.json")
-            # Perform a cold reboot
-            logger.info("Cold reboot the DUT to make the base image as current")
-            reboot(duthost, localhost)
-            check_sonic_version(duthost, target_version)
+    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
 
-            # Install target image
-            logger.info("Upgrading to {}".format(to_image))
-            install_sonic(duthost, to_image, tbinfo)
-            if upgrade_type == REBOOT_TYPE_COLD:
-                # advance-reboot test (on ptf) does not support cold reboot yet
-                reboot(duthost, localhost)
-            else:
-                advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, upgrade_type),
-                                                     advanceboot_loganalyzer=advanceboot_loganalyzer)
-                advancedReboot.runRebootTestcase()
-            reboot_cause = get_reboot_cause(duthost)
-            logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
-            pytest_assert(reboot_cause == upgrade_type,
-                          "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
-            check_services(duthost)
-            check_copp_config(duthost)
+    def upgrade_path_preboot_setup():
+        setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
+                           upgrade_type)
+
+    upgrade_test_helper(duthost, localhost, ptfhost, from_image,
+                        to_image, tbinfo, upgrade_type, get_advanced_reboot,
+                        advanceboot_loganalyzer=advanceboot_loganalyzer,
+                        preboot_setup=upgrade_path_preboot_setup)
 
 
 @pytest.mark.device_type('vs')
@@ -109,34 +136,18 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
                                upgrade_path_lists, backup_and_restore_config_db,                    # noqa F811
                                advanceboot_neighbor_restore, sad_case_type):                        # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
-    upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
-    from_list = from_list_images.split(',')
-    to_list = to_list_images.split(',')
-    assert (from_list and to_list)
-    for from_image in from_list:
-        for to_image in to_list:
-            logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
-            # Install base image
-            logger.info("Installing {}".format(from_image))
-            target_version = install_sonic(duthost, from_image, tbinfo)
-            # Perform a cold reboot
-            logger.info("Cold reboot the DUT to make the base image as current")
-            reboot(duthost, localhost)
-            check_sonic_version(duthost, target_version)
+    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
 
-            # Install target image
-            logger.info("Upgrading to {}".format(to_image))
-            install_sonic(duthost, to_image, tbinfo)
-            advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, "warm"),
-                                                 advanceboot_loganalyzer=advanceboot_loganalyzer)
-            sad_preboot_list, sad_inboot_list = get_sad_case_list(
-                duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type)
-            advancedReboot.runRebootTestcase(
-                prebootList=sad_preboot_list,
-                inbootList=sad_inboot_list
-            )
-            reboot_cause = get_reboot_cause(duthost)
-            logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
-            pytest_assert(reboot_cause == upgrade_type,
-                          "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
-            check_services(duthost)
+    def upgrade_path_preboot_setup():
+        setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
+                           upgrade_type)
+
+    sad_preboot_list, sad_inboot_list = get_sad_case_list(
+        duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type)
+    upgrade_test_helper(duthost, localhost, ptfhost, from_image,
+                        to_image, tbinfo, "warm", get_advanced_reboot,
+                        advanceboot_loganalyzer=advanceboot_loganalyzer,
+                        preboot_setup=upgrade_path_preboot_setup,
+                        sad_preboot_list=sad_preboot_list,
+                        sad_inboot_list=sad_inboot_list)

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -78,7 +78,7 @@ def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
     # Perform a cold reboot
     logger.info("Cold reboot the DUT to make the base image as current")
     # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
-    reboot_type = 'soft' if "6100" in duthost.facts["hwsku"] else 'cold'
+    reboot_type = 'soft' if "s6100" in duthost.facts["platform"] else 'cold'
     reboot(duthost, localhost, reboot_type=reboot_type)
     check_sonic_version(duthost, target_version)
 

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -41,7 +41,8 @@ def upgrade_path_lists(request):
     from_list = request.config.getoption('base_image_list')
     to_list = request.config.getoption('target_image_list')
     restore_to_image = request.config.getoption('restore_to_image')
-    return upgrade_type, from_list, to_list, restore_to_image
+    enable_cpa = request.config.getoption('enable_cpa')
+    return upgrade_type, from_list, to_list, restore_to_image, enable_cpa
 
 
 def cleanup_prev_images(duthost):
@@ -97,7 +98,7 @@ def test_double_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname
                       get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
                       upgrade_path_lists):                                              # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
-    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    upgrade_type, from_image, to_image, _, enable_cpa = upgrade_path_lists
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
 
     def upgrade_path_preboot_setup():
@@ -107,7 +108,8 @@ def test_double_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname
     upgrade_test_helper(duthost, localhost, ptfhost, from_image,
                         to_image, tbinfo, upgrade_type, get_advanced_reboot,
                         advanceboot_loganalyzer=advanceboot_loganalyzer,
-                        preboot_setup=upgrade_path_preboot_setup, reboot_count=2)
+                        preboot_setup=upgrade_path_preboot_setup, enable_cpa=enable_cpa,
+                        reboot_count=2)
 
 
 @pytest.mark.device_type('vs')
@@ -116,7 +118,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
                       get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
                       upgrade_path_lists):
     duthost = duthosts[rand_one_dut_hostname]
-    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    upgrade_type, from_image, to_image, _, enable_cpa = upgrade_path_lists
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
 
     def upgrade_path_preboot_setup():
@@ -126,7 +128,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
     upgrade_test_helper(duthost, localhost, ptfhost, from_image,
                         to_image, tbinfo, upgrade_type, get_advanced_reboot,
                         advanceboot_loganalyzer=advanceboot_loganalyzer,
-                        preboot_setup=upgrade_path_preboot_setup)
+                        preboot_setup=upgrade_path_preboot_setup, enable_cpa=enable_cpa)
 
 
 @pytest.mark.device_type('vs')
@@ -136,7 +138,7 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
                                upgrade_path_lists, backup_and_restore_config_db,                    # noqa F811
                                advanceboot_neighbor_restore, sad_case_type):                        # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
-    upgrade_type, from_image, to_image, _ = upgrade_path_lists
+    upgrade_type, from_image, to_image, _, enable_cpa = upgrade_path_lists
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
 
     def upgrade_path_preboot_setup():
@@ -150,4 +152,4 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
                         advanceboot_loganalyzer=advanceboot_loganalyzer,
                         preboot_setup=upgrade_path_preboot_setup,
                         sad_preboot_list=sad_preboot_list,
-                        sad_inboot_list=sad_inboot_list)
+                        sad_inboot_list=sad_inboot_list, enable_cpa=enable_cpa)

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -95,7 +95,7 @@ def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
 def test_double_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname,
                       nbrhosts, fanouthosts, tbinfo, restore_image,                     # noqa F811
                       get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
-                      upgrade_path_lists, create_hole_in_tcam):                         # noqa F811
+                      upgrade_path_lists):                                              # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
     upgrade_type, from_image, to_image, _ = upgrade_path_lists
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -31,7 +31,7 @@ def pytest_runtest_setup(item):
 
 @pytest.fixture(scope="module")
 def restore_image(localhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
-    _, _, _, restore_to_image = upgrade_path_lists
+    _, _, _, restore_to_image, _ = upgrade_path_lists
     yield
     duthost = duthosts[rand_one_dut_hostname]
     if restore_to_image:

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -8,8 +8,10 @@ from six.moves.urllib.parse import urlparse
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
-from tests.common.reboot import REBOOT_TYPE_WARM
+from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
+from tests.common.utilities import wait_until, setup_ferret
 
+SYSTEM_STABILIZE_MAX_TIME = 300
 logger = logging.getLogger(__name__)
 
 TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
@@ -167,3 +169,59 @@ def get_copp_cfg_formatted_dict(copp_cfg, feature_status):
     formatted_dict.update({"default": copp_cfg["COPP_GROUP"]["default"]})
     logging.debug("Formatted copp_cfg.json dictionary: {}".format(formatted_dict))
     return formatted_dict
+
+
+def upgrade_test_helper(duthost, localhost, ptfhost, from_image, to_image,
+                        tbinfo, upgrade_type, get_advanced_reboot,
+                        advanceboot_loganalyzer, modify_reboot_script=None, allow_fail=False,
+                        sad_preboot_list=None, sad_inboot_list=None, reboot_count=1,
+                        enable_cpa=False, preboot_setup=None, postboot_setup=None):
+
+    reboot_type = get_reboot_command(duthost, upgrade_type)
+    if enable_cpa and "warm-reboot" in reboot_type:
+        # always do warm-reboot with CPA enabled
+        setup_ferret(duthost, ptfhost, tbinfo)
+        ptf_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
+        reboot_type = reboot_type + " -c {}".format(ptf_ip)
+
+    if upgrade_type == REBOOT_TYPE_COLD:
+        # advance-reboot test (on ptf) does not support cold reboot yet
+        if preboot_setup:
+            preboot_setup()
+
+        for i in range(reboot_count):
+            reboot(duthost, localhost)
+            if postboot_setup:
+                postboot_setup()
+
+            if not allow_fail:
+                logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
+                networking_uptime = duthost.get_networking_uptime().seconds
+                timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 1)
+                pytest_assert(wait_until(timeout, 5, 0, check_reboot_cause, duthost, upgrade_type),
+                              "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost),
+                                                                                      upgrade_type))
+                check_services(duthost)
+                check_copp_config(duthost)
+    else:
+        advancedReboot = get_advanced_reboot(rebootType=reboot_type,
+                                             advanceboot_loganalyzer=advanceboot_loganalyzer,
+                                             allow_fail=allow_fail)
+
+        for i in range(reboot_count):
+            advancedReboot.runRebootTestcase(prebootList=sad_preboot_list, inbootList=sad_inboot_list,
+                                             preboot_setup=preboot_setup if i == 0 else None,
+                                             postboot_setup=postboot_setup)
+
+            if not allow_fail:
+                logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
+                networking_uptime = duthost.get_networking_uptime().seconds
+                timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 1)
+                pytest_assert(wait_until(timeout, 5, 0, check_reboot_cause, duthost, upgrade_type),
+                              "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost),
+                                                                                      upgrade_type))
+                check_services(duthost)
+                check_copp_config(duthost)
+
+    if enable_cpa and "warm-reboot" in reboot_type:
+        ptfhost.shell('supervisorctl stop ferret')

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -214,7 +214,7 @@ def upgrade_test_helper(duthost, localhost, ptfhost, from_image, to_image,
                           "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost),
                                                                                   upgrade_type))
             check_services(duthost)
-            check_neighbors(duthost)
+            check_neighbors(duthost, tbinfo)
             check_copp_config(duthost)
 
     if enable_cpa and "warm-reboot" in reboot_type:

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -10,6 +10,7 @@ from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
 from tests.common.utilities import wait_until, setup_ferret
+from tests.platform_tests.verify_dut_health import check_neighbors
 
 SYSTEM_STABILIZE_MAX_TIME = 300
 logger = logging.getLogger(__name__)
@@ -213,6 +214,7 @@ def upgrade_test_helper(duthost, localhost, ptfhost, from_image, to_image,
                           "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost),
                                                                                   upgrade_type))
             check_services(duthost)
+            check_neighbors(duthost)
             check_copp_config(duthost)
 
     if enable_cpa and "warm-reboot" in reboot_type:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Currently, the upgrade path tests (of which there are two defined) only support a single warm upgrade. Also, there is duplicated code between the two test definitions, and doesn't include some checks that ideally should be done. This makes adding support for a double-upgrade test a bit harder.

In addition, there is duplicated code between the current update path code and internal upgrade scripts. This is because there are some pre/post upgrade checks/steps that need to be added, and the current code doesn't make it easy to extend it from another file.

#### How did you do it?

Refactor the existing code to move the duplicated code into a helper function. Add support for running pre-upgrade and post-upgrade hooks (which are already provided in the `AdvancedReboot` class). Add checks for sonic-installer errors (which likely wouldn't happen with current images, but it's probably nice-to-handle, just in case) and for S6100 devices potentially needing a soft-reboot instead of a normal reboot. Also add support for optionally enabling CPA. Finally, add a test case for testing double-upgrade.

This also makes it easier to add support for some other cases, such as MAC jumping test case.

This also makes it easier to share code with other versions of upgrade path, like ones that may want to replace files before/after the upgrade.

In addition to this, it was seen that when testing with a PTF container that's running on a remote container, if there's some NAT/firewall present, then it's possible that there is no data transmitted for an extended period of time. If this happens, it's possible that the TCP connection entry may get removed from the firewall/NAT table, and it will appear to hang. To fix this, enable SSH keepalive, where SSH sends a keepalive packet every 15 seconds to keep the connection active.

#### How did you verify/test it?

Tested with KVM upgrade path and with physical device upgrade path to make sure they at least succeeded.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
