### PR TITLE
Add check that telemetry port must be freed after process has been stopped

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -74,7 +74,11 @@ def restore_telemetry_forpyclient(duthost, default_client_auth):
                       % (env.gnmi_config_table, default_client_auth),
                       module_ignore_errors=False)
         duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
-        duthost.service(name=env.gnmi_container, state="restarted")
+        duthost.service(name=env.gnmi_container, state="stopped")
+        output = duthost.shell("netstat -nap | grep %d" % (env.gnmi_port))
+        if env.gnmi_process in output['stdout']:
+            pytest.fail("Port %d is still active after %s has been stopped" % (env.gnmi_port, env.gnmi_process))
+        duthost.service(name=env.gnmi_container, state="started")
 
 
 def check_gnmi_cli_running(ptfhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

sonic-mgmt testcase to support https://github.com/sonic-net/sonic-gnmi/pull/179


#### How did you do it?

Add check that stopping telemetry process frees gnmi server from using telemetry port.

#### How did you verify/test it?

Pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
