### PR TITLE
[Snappi] Bug fix for checking counters to account for forwarding lag

### DIFF
--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -308,3 +308,21 @@ def wait_for_arp(snappi_api, max_attempts=10, poll_interval_sec=1):
                   "ARP is not resolved in {} seconds".format(max_attempts * poll_interval_sec))
 
     return attempts
+
+
+def fetch_snappi_flow_metrics(api, flow_names):
+    """
+    Fetches the flow metrics from the corresponding snappi session using the api
+
+    Args:
+    api: snappi api
+    flow_names: list of flow names
+
+    Returns:
+    flow_metrics (obj): list of metrics
+    """
+    request = api.metrics_request()
+    request.flow.flow_names = flow_names
+    flow_metrics = api.get_metrics(request).flow_metrics
+
+    return flow_metrics

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -288,9 +288,11 @@ def run_pfc_test(api,
         # Verify TX frame count on the DUT when traffic is expected to be paused
         # and only test traffic flows are generated
         verify_tx_frame_count_dut(duthost=duthost,
+                                  api=api,
                                   snappi_extra_params=snappi_extra_params)
 
         # Verify TX frame count on the DUT when traffic is expected to be paused
         # and only test traffic flows are generated
         verify_rx_frame_count_dut(duthost=duthost,
+                                  api=api,
                                   snappi_extra_params=snappi_extra_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The current devices used in RDMA testing recently migrated to a L1 switch setup resulting in longer cables (5x) and forwarding lag that allows for the storage of greater frames in the cable. This lag is not accounted for in the tolerance threshold of 5%. As a result, the code has been modified to poll the TGEN counters at verification time after all traffic flows have been paused to allow for additional frames in the cable + buffer to propagate to the receiving port. There is also a bit of code cleanup done.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Bug fix for nightly test failure

#### How did you do it?
Polled TGEN device at end of test (at verification time) as done with DUT polling

#### How did you verify/test it?
Tested on lab device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
