### PR TITLE
Disable test_bgp_queue mlnx 2700 T1

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -116,9 +116,9 @@ bgp/test_bgp_multipath_relax.py:
 
 bgp/test_bgp_queue.py:
   skip:
-    reason: "Unsupported topology"
+    reason: "Unsupported topology or mellanox T1 asic"
     conditions:
-      - "topo_type in ['m0', 'mx']"
+      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1', 't1-lag', 't1-64-lag', 't1-56-lag'])and (asic_type in ['mellanox']))"
 
 bgp/test_bgp_slb.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -118,7 +118,7 @@ bgp/test_bgp_queue.py:
   skip:
     reason: "Unsupported topology or mellanox T1 asic"
     conditions:
-      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1', 't1-lag', 't1-64-lag', 't1-56-lag'])and (asic_type in ['mellanox']))"
+      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1', 't1-lag', 't1-64-lag', 't1-56-lag'])and (platform in ['x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0']))"
 
 bgp/test_bgp_slb.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -116,7 +116,7 @@ bgp/test_bgp_multipath_relax.py:
 
 bgp/test_bgp_queue.py:
   skip:
-    reason: "Unsupported topology or mellanox T1 asic"
+    reason: "Unsupported topology or mellanox T1-LAG asic"
     conditions:
       - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1-lag']) and (asic_type in ['mellanox']))"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -118,7 +118,7 @@ bgp/test_bgp_queue.py:
   skip:
     reason: "Unsupported topology or mellanox T1 asic"
     conditions:
-      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1', 't1-lag', 't1-64-lag', 't1-56-lag'])and (platform in ['x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0']))"
+      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1-lag']) and (asic_type in ['mellanox']))"
 
 bgp/test_bgp_slb.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The Mellanox 2700 T1 devices do not support sending BGP packets on queue 7. This test is being disabled.

Summary:
Fixes # (issue)
ADO 25587938
### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
