### PR TITLE
Mutli_asic check for T2_arppopulate qos_test_corrected

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -807,6 +807,10 @@ class QosSaiBase(QosBase):
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         src_mgFacts = src_dut.get_extended_minigraph_facts(tbinfo)
         topo = tbinfo["topo"]["name"]
+        multi_asic_dut = False
+        if get_src_dst_asic_and_duts['src_dut'].sonichost.is_multi_asic \
+                and get_src_dst_asic_and_duts['dst_dut'].sonichost.is_multi_asic:
+            multi_asic_dut = True
 
         # LAG ports in T1 TOPO need to be removed in Mellanox devices
         if topo in self.SUPPORTED_T0_TOPOS or (topo in self.SUPPORTED_PTF_TOPOS and isMellanoxDevice(src_dut)):
@@ -1087,7 +1091,8 @@ class QosSaiBase(QosBase):
             "srcDutInstance": src_dut,
             "dstDutInstance": dst_dut,
             "dualTor": request.config.getoption("--qos_dual_tor"),
-            "dualTorScenario": len(dualtor_ports_for_duts) != 0
+            "dualTorScenario": len(dualtor_ports_for_duts) != 0,
+            "is_multi_asic": multi_asic_dut
         }
 
     @pytest.fixture(scope='class')
@@ -1616,7 +1621,8 @@ class QosSaiBase(QosBase):
             testParams.update({
                 "testPortIds": dutConfig["testPortIds"],
                 "testPortIps": dutConfig["testPortIps"],
-                "testbed_type": dutTestParams["topo"]
+                "testbed_type": dutTestParams["topo"],
+                "is_multi_asic": dutConfig["is_multi_asic"]
             })
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.ARPpopulate", testParams=testParams

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1614,9 +1614,10 @@ class QosSaiBase(QosBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
+        testParams = dict()
         if ('platform_asic' in dutTestParams["basicParams"] and
                 dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
-            testParams = dutTestParams["basicParams"]
+            testParams.update(dutTestParams["basicParams"])
             testParams.update(dutConfig["testPorts"])
             testParams.update({
                 "testPortIds": dutConfig["testPortIds"],

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -562,18 +562,20 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
             dst_port_ips = [self.dst_port_ip, self.dst_port_2_ip, self.dst_port_3_ip]
             for ip in dst_port_ips:
                 if dst_is_multi_asic:
-                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                                self.test_params['dut_password'],
-                                                                'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
-                                                                    self.dst_asic_index, ip))
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip,
+                                                                    self.test_params['dut_username'],
+                                                                    self.test_params['dut_password'],
+                                                                    'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
+                                                                        self.dst_asic_index, ip))
                     assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
-                    ip, self.dst_asic_index, self.dst_server_ip)
+                        ip, self.dst_asic_index, self.dst_server_ip)
                 else:
-                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                                self.test_params['dut_password'],
-                                                                'ping -q -c 3 {}'.format(ip))
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip,
+                                                                    self.test_params['dut_username'],
+                                                                    self.test_params['dut_password'],
+                                                                    'ping -q -c 3 {}'.format(ip))
                     assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on Dut '{}'".format(
-                    ip, self.dst_server_ip)
+                        ip, self.dst_server_ip)
             if src_is_multi_asic:
                 stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip, self.test_params['dut_username'],
                                                                 self.test_params['dut_password'],

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -549,7 +549,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_dut_index = self.test_params['dst_dut_index']
         self.dst_asic_index = self.test_params.get('dst_asic_index', None)
         self.testbed_type = self.test_params['testbed_type']
-        self.is_multi_asic = (self.clients['src'] != self.clients['dst'])
+        self.is_multi_asic = self.test_params['is_multi_asic']
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -549,7 +549,6 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_dut_index = self.test_params['dst_dut_index']
         self.dst_asic_index = self.test_params.get('dst_asic_index', None)
         self.testbed_type = self.test_params['testbed_type']
-        self.is_multi_asic = self.test_params['is_multi_asic']
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -557,31 +556,37 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         # ARP Populate
         # Ping only  required for testports
-        if 't2' in self.testbed_type and self.is_multi_asic:
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                            self.test_params['dut_password'],
-                                                            'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
-                                                            self.dst_asic_index, self.dst_port_ip))
-            assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
-                self.dst_port_ip, self.dst_asic_index, self.dst_server_ip)
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                            self.test_params['dut_password'],
-                                                            'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
-                                                            self.dst_asic_index, self.dst_port_2_ip))
-            assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
-                self.dst_port_2_ip, self.dst_asic_index, self.dst_server_ip)
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
-                                                            self.test_params['dut_password'],
-                                                            'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
-                                                            self.dst_asic_index, self.dst_port_3_ip))
-            assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
-                self.dst_port_3_ip, self.dst_asic_index, self.dst_server_ip)
-            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip, self.test_params['dut_username'],
-                                                            self.test_params['dut_password'],
-                                                            'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
-                                                            self.src_asic_index, self.src_port_ip))
-            assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
-                self.src_port_ip, self.src_asic_index, self.src_server_ip)
+        if 't2' in self.testbed_type:
+            src_is_multi_asic = self.test_params['src_is_multi_asic']
+            dst_is_multi_asic = self.test_params['dst_is_multi_asic']
+            dst_port_ips = [self.dst_port_ip, self.dst_port_2_ip, self.dst_port_3_ip]
+            for ip in dst_port_ips:
+                if dst_is_multi_asic:
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                                                self.test_params['dut_password'],
+                                                                'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
+                                                                    self.dst_asic_index, ip))
+                    assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
+                    ip, self.dst_asic_index, self.dst_server_ip)
+                else:
+                    stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                                                self.test_params['dut_password'],
+                                                                'ping -q -c 3 {}'.format(ip))
+                    assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on Dut '{}'".format(
+                    ip, self.dst_server_ip)
+            if src_is_multi_asic:
+                stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip, self.test_params['dut_username'],
+                                                                self.test_params['dut_password'],
+                                                                'sudo ip netns exec asic{} ping -q -c 3 {}'.format(
+                                                                    self.src_asic_index, self.src_port_ip))
+                assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on asic '{}' on Dut '{}'".format(
+                    self.src_port_ip, self.src_asic_index, self.src_server_ip)
+            else:
+                stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.src_server_ip, self.test_params['dut_username'],
+                                                                self.test_params['dut_password'],
+                                                                'ping -q -c 3 {}'.format(self.src_port_ip))
+                assert ' 0% packet loss' in stdOut[3], "Ping failed for IP:'{}' on Dut '{}'".format(
+                    self.src_port_ip, self.src_server_ip)
         else:
             arpreq_pkt = construct_arp_pkt('ff:ff:ff:ff:ff:ff', self.src_port_mac,
                                            1, self.src_port_ip, '192.168.0.1', '00:00:00:00:00:00', self.src_vlan)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The check - if the chassis is multi_asic , should be verified with the num_asic count on the dut.
Adding the correct method to verify multi_asic chassis in sai_qos_tests 
In continuation to PR #11282 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
For verifying the chassis is multi_asic ,the num_asic count on the dut should be greater than 1.

#### What is the motivation for this PR?
Found issue -
https://github.com/sonic-net/sonic-mgmt/issues/11236

#### How did you do it?

#### How did you verify/test it?
Executed qos  tests on t2 chassis & verified.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
