### PR TITLE
Modify test_get_transceiver_info to handle get_transceiver_info_firmware_versions API

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -65,6 +65,8 @@ def is_replaceable(conn, index):
 def get_transceiver_info(conn, index):
     return sfp_api(conn, index, 'get_transceiver_info')
 
+def get_transceiver_info_firmware_versions(conn, index):
+    return sfp_api(conn, index, 'get_transceiver_info_firmware_versions')
 
 def get_transceiver_bulk_status(conn, index):
     return sfp_api(conn, index, 'get_transceiver_bulk_status')

--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -65,8 +65,10 @@ def is_replaceable(conn, index):
 def get_transceiver_info(conn, index):
     return sfp_api(conn, index, 'get_transceiver_info')
 
+
 def get_transceiver_info_firmware_versions(conn, index):
     return sfp_api(conn, index, 'get_transceiver_info_firmware_versions')
+
 
 def get_transceiver_bulk_status(conn, index):
     return sfp_api(conn, index, 'get_transceiver_bulk_status')

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -393,8 +393,10 @@ class TestSfpApi(PlatformApiTestBase):
                                 self.EXPECTED_XCVR_NEW_QSFP_DD_OSFP_FIRMWARE_INFO_KEYS + \
                                 ["active_apsel_hostlane{}".format(n) for n in range(1, active_apsel_hostlane_count + 1)]
                             firmware_info_dict = sfp.get_transceiver_info_firmware_versions(platform_api_conn, i)
-                            if self.expect(firmware_info_dict is not None, "Unable to retrieve transceiver {} firmware info".format(i)):
-                                if self.expect(isinstance(firmware_info_dict, dict), "Transceiver {} firmware info appears incorrect".format(i)):
+                            if self.expect(firmware_info_dict is not None,
+                                           "Unable to retrieve transceiver {} firmware info".format(i)):
+                                if self.expect(isinstance(firmware_info_dict, dict),
+                                               "Transceiver {} firmware info appears incorrect".format(i)):
                                     actual_keys.extend(list(firmware_info_dict.keys()))
                             if 'ZR' in info_dict['media_interface_code']:
                                 UPDATED_EXPECTED_XCVR_INFO_KEYS = UPDATED_EXPECTED_XCVR_INFO_KEYS + \

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -97,16 +97,17 @@ class TestSfpApi(PlatformApiTestBase):
     ]
 
     # some new keys added for QSFP-DD and OSFP in 202205 or later branch
-    EXPECTED_XCVR_NEW_QSFP_DD_OSFP_INFO_KEYS = ['active_firmware',
-                                                'host_lane_count',
+    EXPECTED_XCVR_NEW_QSFP_DD_OSFP_INFO_KEYS = ['host_lane_count',
                                                 'media_lane_count',
                                                 'cmis_rev',
                                                 'host_lane_assignment_option',
-                                                'inactive_firmware',
                                                 'media_interface_technology',
                                                 'media_interface_code',
                                                 'host_electrical_interface',
                                                 'media_lane_assignment_option']
+
+    EXPECTED_XCVR_NEW_QSFP_DD_OSFP_FIRMWARE_INFO_KEYS = ['active_firmware',
+                                                         'inactive_firmware']
 
     # These are fields which have been added in the common parsers
     # in sonic-platform-common/sonic_sfp, but since some vendors are
@@ -389,7 +390,12 @@ class TestSfpApi(PlatformApiTestBase):
                             active_apsel_hostlane_count = 8
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS + \
                                 self.EXPECTED_XCVR_NEW_QSFP_DD_OSFP_INFO_KEYS + \
+                                self.EXPECTED_XCVR_NEW_QSFP_DD_OSFP_FIRMWARE_INFO_KEYS + \
                                 ["active_apsel_hostlane{}".format(n) for n in range(1, active_apsel_hostlane_count + 1)]
+                            firmware_info_dict = sfp.get_transceiver_info_firmware_versions(platform_api_conn, i)
+                            if self.expect(firmware_info_dict is not None, "Unable to retrieve transceiver {} firmware info".format(i)):
+                                if self.expect(isinstance(firmware_info_dict, dict), "Transceiver {} firmware info appears incorrect".format(i)):
+                                    actual_keys.extend(list(firmware_info_dict.keys()))
                             if 'ZR' in info_dict['media_interface_code']:
                                 UPDATED_EXPECTED_XCVR_INFO_KEYS = UPDATED_EXPECTED_XCVR_INFO_KEYS + \
                                                                   self.QSFPZR_EXPECTED_XCVR_INFO_KEYS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Since we are now planning to remove "active_firmware" and "inactive_firmware" version fields from TRANSCEIVER_INFO and are replacing it with TRANSCEIVER_FIRMWARE_INFO, we need to add a testcase for get_transceiver_info_firmware_versions API.
Also, we need to remove these fields from the existing testcase for https://github.com/sonic-net/sonic-mgmt/blob/aba8a1c001706e5117b028d43aa3041cba70722c/tests/platform_tests/api/test_sfp.py#L373

MSFT ADO - 26818128

Summary:
Fixes # (issue)
This issue should be merged along with https://github.com/sonic-net/sonic-platform-daemons/pull/435 and https://github.com/sonic-net/sonic-platform-common/pull/440

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ensured that platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info testcase passes for a CMIS supported transceiver.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
