### PR TITLE
[TACACS] Fix TACACS accounting UT issue caused by auditd log rotate.

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -315,7 +315,7 @@ def check_server_received(ptfhost, data, timeout=30):
 
 
 def get_auditd_config_reload_timestamp(duthost):
-    res = duthost.command("sudo service auditd status | grep 'audisp-tacplus re-initializing configuration'")
+    res = duthost.shell("sudo journalctl -u auditd --boot | grep 'audisp-tacplus re-initializing configuration'")
     logger.info("aaa config file timestamp {}".format(res["stdout_lines"]))
 
     if len(res["stdout_lines"]) == 0:


### PR DESCRIPTION
Fix TACACS accounting UT issue caused by auditd log rotate

### Description of PR
Fix TACACS accounting UT issue caused by auditd log rotate

##### Work item tracking
- Microsoft ADO: 26710599

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Fix TACACS accounting UT issue caused by auditd log rotate.
There are 2 code issue:
1. when auditd log rotate, some auditd log will missing from output of 'service auditd status'
1. duthost.command() can only run 1 command, so can't handle piping output to grep

#### How did you do it?
show auditd log with 'sudo journalctl -u auditd --boot' and run command with duthost.shell() to support grep.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
