### PR TITLE
[Recover via console] Extend waiting time of installing sonic image.

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -178,7 +178,7 @@ def posix_shell_aboot(dut_console, mgmt_ip, image_url):
                         dut_console.remote_conn.send("\n")
 
                         for i in range(5):
-                            time.sleep(10)
+                            time.sleep(60)
                             x = dut_console.remote_conn.recv(1024)
                             x = x.decode('ISO-8859-9')
                             if "ETA" in x:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
While recovering via console, we need to re-install sonic image in boot loader. When installing in Aboot, we need to download the image file from a HTTP or TFTP server, and then use the boot command to load and boot the image. The installation process may take some time depending on the network speed and the image size. Previous waiting time is not enough for some situation, so in this PR, I add the waiting time while downloading image. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
While recovering via console, we need to re-install sonic image in boot loader. When installing in Aboot, we need to download the image file from a HTTP or TFTP server, and then use the boot command to load and boot the image. The installation process may take some time depending on the network speed and the image size. Previous waiting time is not enough for some situation, so in this PR, I add the waiting time while downloading image. 

#### How did you do it?
Add the waiting time while downloading image in Aboot.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
