### PR TITLE
ignore rsyslog ERR message in test_stress_routes

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -45,8 +45,15 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
         ignoreRegex = [
             ".*ERR route_check.py:.*",
             ".*ERR.* \'routeCheck\' status failed.*",
-            ".*Process \'orchagent\' is stuck in namespace \'host\'.*"
+            ".*Process \'orchagent\' is stuck in namespace \'host\'.*",
+            ".*ERR rsyslogd: .*"
         ]
+
+        hwsku = duthost.facts['hwsku']
+        if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31']:
+            ignoreRegex.append(".*ERR memory_threshold_check:.*")
+            ignoreRegex.append(".*ERR monit.*memory_check.*")
+            ignoreRegex.append(".*ERR monit.*mem usage of.*matches resource limit.*")
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 
     normalized_level = get_function_conpleteness_level


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
26638188

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
test_stress_routes case would create so much swss logs which would cause /var/log file system full.

#### How did you do it?
Since test_stress_routes is the stress case, it should be a very low chance to hit the isssue in production.
And for syslog file system full issue, log rotate would delete the old logs to fix the issue. 
In production, Syslog would sync to the kusto which could make sure no syslog lost in production.

#### How did you verify/test it?
Run case locally.

#### Any platform specific information?
small disk and low memory device

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
