### PR TITLE
Fix TypeError when assertion message is not string

### DIFF
--- a/tests/common/helpers/assertions.py
+++ b/tests/common/helpers/assertions.py
@@ -4,6 +4,8 @@ import pytest
 def pytest_assert(condition, message=None):
     __tracebackhide__ = True
     if not condition:
+        if not isinstance(message, str):
+            message = str(message)
         pytest.fail(message)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In python3 environment, current pytest version is 7.4.0. Comparing
with old pytest version in python2 environment, this pytest version
expect string type message argument passed to the pytest.fail function.

Some tests scripts may pass non-string error message to the pytest_assert
function which calls pytest.fail under the hood. In this case, pytest
will throw exception TypeError.

Example traceback:

        pytest.fail(message)
    File "/usr/local/lib/python3.8/dist-packages/_pytest/outcomes.py", line 198, in fail
        raise Failed(msg=reason, pytrace=pytrace)
    File "/usr/local/lib/python3.8/dist-packages/_pytest/outcomes.py", line 38, in __init__
        raise TypeError(error_msg.format(type(self).__name__, type(msg).__name__))
    TypeError: Failed expected string as 'msg' parameter, got 'defaultdict' instead.

#### How did you do it?
This patch fixes the issue by converting the non-string type message
passed in by test scripts to string type.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
