### PR TITLE
Improve the venv content in README of test_reporting

### DIFF
--- a/test_reporting/README.md
+++ b/test_reporting/README.md
@@ -1,20 +1,28 @@
 # SONiC Test Reporting
 
 ## Setup environment
-In the sonic-mgmt container:
+
+There are two options to run the test reporting scripts:
+1. Inside the sonic-mgmt container (recommended)
+2. On a Linux host
+
+### Option 1, inside the sonic-mgmt container (recommended)
+Go to this folder in the sonic-mgmt container:
 ```
-source /var/johnar/env-python3/bin/activate
+cd <your_path_to_sonic-mgmt>/test_reporting
 ```
 
+### Option 2, on a Linux host
 On a Linux host (verified against Ubuntu 20.04, but should work anywhere python3/virtualenv are supported):
 ```
 virtualenv env
 source env/bin/activate
+cd <your_path_to_sonic-mgmt>/test_reporting
 pip3 install -r requirements.txt
 ```
 
 ## Uploading test results to a Kusto/Azure Data Explorer (ADX) cluster
-You need to add the following environment variables first:
+You need to export the following environment variables first:
 - TEST_REPORT_INGEST_KUSTO_CLUSTER: The ingest URL of your kusto/ADX cluster
 - TEST_REPORT_AAD_TENANT_ID: The tenant ID of your Azure Active Directory (AAD) tenant
 - TEST_REPORT_AAD_CLIENT_ID: The client ID for your AAD application
@@ -23,7 +31,7 @@ You need to add the following environment variables first:
 Check out [this doc from Kusto](https://docs.microsoft.com/en-us/azure/data-explorer/provision-azure-ad-app) for more details about setting up AAD client applications for accessing Kusto.
 
 If you want to upload data into a new table, please add the related create table commands in setup.kql file and run them manually in Kusto.
-Make sure the table is created and mapping is generated sucessfully.
+Make sure the table is created and mapping is generated successfully.
 
 Once these have been added, you can use the `report_uploader.py` script to upload test report data to Kusto:
 ```


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The packages required by test report uploader have been built into the sonic-mgmt image. If run test report uploading inside sonic-mgmt container, activating python3 virtual environment is no longer needed.

#### How did you do it?
This change improved the README.md under test_reporting folder accordingly.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
