### PR TITLE
Clean up image file after recover testbeds from boot loader. 

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -71,6 +71,10 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
             if type(dut_ssh) == tuple:
                 logger.info("SSH success.")
 
+                # May recover from boot loader, need to delete image file
+                sonichost.shell("sudo rm -f /host/{}".format(image_url.split("/")[-1]),
+                                module_ignore_errors=True)
+
                 # Add ip info into /etc/network/interface
                 extra_vars = {
                     'addr': mgmt_ip.split('/')[0],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
During our recovery process, it may be necessary to reinstall the sonic image in the boot loader. This may result in a `.swi` file being left on the device. To prevent excessive disk usage on low-memory devices, we will delete this image file after the testbeds have been recovered.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
During our recovery process, it may be necessary to reinstall the sonic image in the boot loader. This may result in a `.swi` file being left on the device. To prevent excessive disk usage on low-memory devices, we will delete this image file after the testbeds have been recovered.

#### How did you do it?
Delete the image file after the testbeds have been recovered from boot loader.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
