### PR TITLE
Memory exhaustion test case takes an indeterminate amount of time to trigger Kernel panic.

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -67,7 +67,8 @@ class TestMemoryExhaustion:
         # Swapping is turned off so the OOM is triggered in a shorter time.
 
         res = duthost.command("sudo swapoff -a")
-        logging.info(res)
+        if res['rc']:
+            logging.error("Swapoff command failed: {}".format(res))
 
         cmd = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
         res = duthost.shell(cmd)

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -64,6 +64,11 @@ class TestMemoryExhaustion:
         #    background process.
         #  * Some DUTs with few free memory may reboot before ansible receive the result of shell
         #    command, so we add `sleep 5` to ensure ansible receive the result first.
+        # Swapping is turned off so the OOM is triggered in a shorter time.
+
+        res = duthost.command("sudo swapoff -a")
+        logging.info(res)
+
         cmd = 'nohup bash -c "sleep 5 && tail /dev/zero" &'
         res = duthost.shell(cmd)
         if not res.is_successful:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [11737](https://github.com/sonic-net/sonic-mgmt/issues/11737)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
#### How did you do it?

It seems the time it takes for the kernel to raise Out of Memory condition and trigger oom_killer is not very deterministic in this test case. Once memory is exhausted in the system, the node becomes very unresponsive as no new processes can be created. Under most cases the test does complete in 10 mts,  however for some of the PIDs, the test takes 20, 30 mts or more.

It seems the issue is seen in Linux operation in other scenarios - https://unix.stackexchange.com/questions/373312/oom-killer-doesnt-work-properly-leads-to-a-frozen-os

The solution seems to be to disable the swapping so the kernel raises the OOM condition much faster. 

https://askubuntu.com/questions/1188024/how-to-test-oom-killer-from-command-line


#### How did you verify/test it?

Ran the test case on a number of PIDs. 


