### PR TITLE
[GCU E2E Testing] Consider `replace` test_incremental_qos.py test when field does not already exist

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -226,6 +226,8 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
         if is_mellanox_device(duthost):
             pytest.skip("Skip remove test, because the mellanox device doesn't support removing qos config fields")
         value = ""
+    elif op == "replace" and not field_value:
+        pytest.skip("Skip replace test, because the field does not already exist on the DUT")
     else:
         value = calculate_field_value(duthost, tbinfo, configdb_field)
     logger.info("value to be added to json patch: {} operation: {} field: {}".format(value, op, configdb_field))

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -226,8 +226,6 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
         if is_mellanox_device(duthost):
             pytest.skip("Skip remove test, because the mellanox device doesn't support removing qos config fields")
         value = ""
-    elif op == "replace" and not field_value:
-        pytest.skip("Skip replace test, because the field does not already exist on the DUT")
     else:
         value = calculate_field_value(duthost, tbinfo, configdb_field)
     logger.info("value to be added to json patch: {} operation: {} field: {}".format(value, op, configdb_field))
@@ -241,6 +239,9 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        if op == "replace" and not field_value:
+            expect_op_failure(output)
+        
         if is_valid_platform_and_version(duthost, "BUFFER_POOL", "Shared/headroom pool size changes", op, field_value):
             expect_op_success(duthost, output)
             ensure_application_of_updated_config(duthost, configdb_field, value)

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -241,7 +241,7 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         if op == "replace" and not field_value:
             expect_op_failure(output)
-        
+
         if is_valid_platform_and_version(duthost, "BUFFER_POOL", "Shared/headroom pool size changes", op, field_value):
             expect_op_success(duthost, output)
             ensure_application_of_updated_config(duthost, configdb_field, value)


### PR DESCRIPTION
ADO 26611267
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
`replace` is only expected to succeed on devices where the field already exists, failure expected on other devices For some devices, BUFFER_POOL table does not include `xoff` field. For example, 
    "BUFFER_POOL": {
        "egress_lossless_pool": {
            "mode": "dynamic",
            "size": "34287552",
            "type": "egress"
        },
        "egress_lossy_pool": {
            "mode": "dynamic",
            "size": "13924352",
            "type": "egress"
        },
        "ingress_lossless_pool": {
            "mode": "dynamic",
            "size": "13924352",
            "type": "ingress"
        },
        "ingress_lossy_pool": {
            "mode": "dynamic",
            "size": "13924352",
            "type": "ingress"
        },
        "ingress_zero_pool": {
            "mode": "static",
            "size": "0",
            "type": "ingress"
        }
    },
#### How did you do it?

#### How did you verify/test it?
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-ingress_lossless_pool/xoff] SKIPPED (Skip replace test, because the field does not alread...) [100%]
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
