### PR TITLE
Add debug logging to proxy_arp test

### DIFF
--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -73,15 +73,16 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
 
     if ip_version == 'v6':
         running_config = rand_selected_dut.get_running_config_facts()
+        logger.debug("NDP Debug Logs Start")
         for table_name, table in running_config.items():
             if "VLAN" in table_name:
-                logger.info("{}: {}".format(table_name, table))
+                logger.debug("{}: {}".format(table_name, table))
         swss_status = rand_selected_dut.shell('docker exec swss supervisorctl status',
                                               module_ignore_errors=True)['stdout']
-        logger.info(swss_status)
+        logger.debug(swss_status)
         ndppd_conf = rand_selected_dut.shell('docker exec swss cat /etc/ndppd.conf',
                                              module_ignore_errors=True)['stdout']
-        logger.info(ndppd_conf)
+        logger.debug(ndppd_conf)
 
     testutils.send_packet(ptfadapter, ptf_intf_index, outgoing_packet)
     testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -52,7 +52,7 @@ def test_arp_garp_enabled(rand_selected_dut, garp_enabled, ip_and_intf_info, int
     pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
 
 
-def test_proxy_arp(proxy_arp_enabled, ip_and_intf_info, ptfadapter, packets_for_test):
+def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfadapter, packets_for_test):
     """
     Send an ARP request or neighbor solicitation (NS) to the DUT for an IP address within the subnet of the DUT's VLAN.
 
@@ -70,5 +70,18 @@ def test_proxy_arp(proxy_arp_enabled, ip_and_intf_info, ptfadapter, packets_for_
         pytest_require(ptf_intf_ipv6_addr is not None, 'No IPv6 VLAN address configured on device')
 
     ptfadapter.dataplane.flush()
+
+    if ip_version == 'v6':
+        running_config = rand_selected_dut.get_running_config_facts()
+        for table_name, table in running_config.items():
+            if "VLAN" in table_name:
+                logger.info("{}: {}".format(table_name, table))
+        swss_status = rand_selected_dut.shell('docker exec swss supervisorctl status',
+                                              module_ignore_errors=True)['stdout']
+        logger.info(swss_status)
+        ndppd_conf = rand_selected_dut.shell('docker exec swss cat /etc/ndppd.conf',
+                                             module_ignore_errors=True)['stdout']
+        logger.info(ndppd_conf)
+
     testutils.send_packet(ptfadapter, ptf_intf_index, outgoing_packet)
     testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -84,5 +84,11 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
                                              module_ignore_errors=True)['stdout']
         logger.debug(ndppd_conf)
 
+        neigh_table = rand_selected_dut.shell('ip -6 neigh')['stdout']
+        logger.debug(neigh_table)
+
     testutils.send_packet(ptfadapter, ptf_intf_index, outgoing_packet)
+    if ip_version == 'v6':
+        neigh_table = rand_selected_dut.shell('ip -6 neigh')['stdout']
+        logger.debug(neigh_table)
     testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The proxy_arp test is flaky for IPv6. Add debug logging to provide more info into failures. The test has been inconsistently failing on KVM testbeds when the expect NA packet is not received.

#### How did you do it?
Add debug logging during the IPv6 proxy NDP test case to capture relevant DUT state/ndppd state and configs.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
