### PR TITLE
[MGFX] Skip telemetry.swss_events test on MGFX topologies

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -26,7 +26,7 @@ WAIT_TIME = 3
 
 
 def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
-    if duthost.topo_type.lower() in ["m0", "mx", "m0-2vlan"]:
+    if duthost.topo_type.lower() in ["m0", "mx"]:
         logger.info("Skipping swss events test on MGFX topologies")
         return
     logger.info("Beginning to test swss events")

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -26,6 +26,9 @@ WAIT_TIME = 3
 
 
 def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
+    if duthost.topo_type.lower() in ["m0", "mx", "m0-2vlan"]:
+        logger.info("Skipping swss events test on MGFX topologies")
+        return
     logger.info("Beginning to test swss events")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, shutdown_interface,
              "if_state.json", "sonic-events-swss:if-state", tag)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip `telemetry.swss_events` test on MGFX topologies because Queue OID is not supported on MGFX devices.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Skip `telemetry.swss_events` test on MGFX topologies because Queue OID is not supported on MGFX devices.

#### How did you do it?
Function `test_event` in [telemetry/events/swss_events.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/telemetry/events/swss_events.py) is called by [telemetry/test_telemetry.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/telemetry/test_telemetry.py) instead of pytest framework. Hence conditional mark or pytest.skip doesn't work. The only way to skip this testcase is check the DUT topology and return for MGFX.

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
