### PR TITLE
[Recover via console] Shorten the constant ONIE_START_TO_DISCOVERY to fit for Celestica.

### DIFF
--- a/.azure-pipelines/recover_testbed/constants.py
+++ b/.azure-pipelines/recover_testbed/constants.py
@@ -42,7 +42,8 @@ INSTALL_OS_IN_ONIE = "Install OS"
 
 # After enter into the installation in ONIE, it will discover some configuration
 # And finally, we will get the string "ONIE: Starting ONIE Service Discovery"
-ONIE_START_TO_DISCOVERY = "Discovery"
+# To fit the scenario of Celestica, we finally use the string "covery"
+ONIE_START_TO_DISCOVERY = "covery"
 
 # At last, if installation successes in ONIE, we will get the prompt
 SONIC_PROMPT = "sonic login:"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Previously, in order to install the sonic image in ONIE, we would catch the word "Discovery" in the string "ONIE: Starting ONIE Service Discovery" as the symbol. However, in the Celestica scenario, we cannot catch the whole word "Discovery," no matter how we adjust the buffer we set. Therefore, in this PR, we shorten the symbol to fit the Celestica scenario.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
ONIE Service Discovery" as the symbol. However, in the Celestica scenario, we cannot catch the whole word "Discovery," no matter how we adjust the buffer we set. Therefore, in this PR, we shorten the symbol to fit the Celestica scenario.

#### How did you do it?
Shorten the symbol to fit the Celestica scenario.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
