### PR TITLE
Adding the new script for pfcwd in cisco-8000.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -923,6 +923,12 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions:
         - "asic_type in ['cisco-8000']"
 
+pfcwd/test_pfcwd_timer_accuracy_cisco_8000.py:
+   skip:
+     reason: "The test is only for cisco-8000."
+     conditions:
+        - "asic_type not in ['cisco-8000']"
+
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:
      reason: "Warm Reboot is not supported in T2."

--- a/tests/pfcwd/test_pfcwd_timer_accuracy_cisco_8000.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy_cisco_8000.py
@@ -1,0 +1,252 @@
+import logging
+import pytest
+import time
+
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
+from tests.common.helpers.pfc_storm import PFCStorm
+from .files.pfcwd_helper import start_wd_on_ports
+from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
+
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """
+    Fixture that stops PFC Watchdog before each test run
+
+    Args:
+        duthost (AnsibleHost): DUT instance
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    logger.info("--- Stop Pfcwd --")
+    duthost.command("pfcwd stop")
+
+
+@pytest.fixture(autouse=True)
+def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+    """
+    Fixture that ignores expected failures during test execution.
+
+    Args:
+        duthost (AnsibleHost): DUT instance
+        loganalyzer (loganalyzer): Loganalyzer utility fixture
+    """
+    if loganalyzer:
+        ignoreRegex = [
+            (".*ERR syncd#syncd: :- process_on_fdb_event: "
+             "invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*"),
+            (".*ERR syncd#syncd: :- process_on_fdb_event: "
+             "FDB notification was not sent since it contain invalid OIDs, bug.*")
+        ]
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
+
+    yield
+
+
+@pytest.fixture(scope='class', autouse=True)
+def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa F811
+                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+    """
+    Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
+
+    Args:
+        setup_pfc_test (fixture): module scoped, autouse PFC fixture
+        enum_fanout_graph_facts (fixture): fanout graph info
+        duthost (AnsibleHost): DUT instance
+        fanouthosts (AnsibleHost): fanout instance
+
+    Yields:
+        timers (dict): pfcwd timer values
+        storm_handle (PFCStorm): class PFCStorm instance
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    logger.info("--- Pfcwd timer test setup ---")
+    setup_info = setup_pfc_test
+    test_ports = setup_info['test_ports']
+    timers = setup_info['pfc_timers']
+    eth0_ip = setup_info['eth0_ip']
+    # In Python2, dict.keys() returns list object, but in Python3 returns an iterable but not indexable object.
+    # So that convert to list explicitly.
+    pfc_wd_test_port = list(test_ports.keys())[0]
+    neighbors = setup_info['neighbors']
+    fanout_info = enum_fanout_graph_facts
+    dut = duthost
+    fanout = fanouthosts
+    peer_params = populate_peer_info(neighbors, fanout_info, pfc_wd_test_port)
+    storm_handle = set_storm_params(dut, fanout_info, fanout, peer_params)
+    timers['pfc_wd_restore_time'] = 400
+    start_wd_on_ports(dut, pfc_wd_test_port, timers['pfc_wd_restore_time'],
+                      timers['pfc_wd_detect_time'])
+    # enable routing from mgmt interface to localhost
+    dut.sysctl(name="net.ipv4.conf.eth0.route_localnet", value=1, sysctl_set=True)
+    # rule to forward syslog packets from mgmt interface to localhost
+    syslog_ip = duthost.get_rsyslog_ipv4()
+    dut.iptables(action="insert", chain="PREROUTING", table="nat", protocol="udp",
+                 destination=eth0_ip, destination_port=514, jump="DNAT",
+                 to_destination="{}:514".format(syslog_ip))
+
+    logger.info("--- Pfcwd Timer Testrun ---")
+    yield {'timers': timers,
+           'storm_handle': storm_handle
+           }
+
+    logger.info("--- Pfcwd timer test cleanup ---")
+    dut.iptables(table="nat", flush="yes")
+    dut.sysctl(name="net.ipv4.conf.eth0.route_localnet", value=0, sysctl_set=True)
+    storm_handle.stop_storm()
+
+
+def populate_peer_info(neighbors, fanout_info, port):
+    """
+    Build the peer_info map which will be used by the storm generation class
+
+    Args:
+        neighbors (dict): fanout info for each DUT port
+        fanout_info (dict): fanout graph info
+        port (string): test port
+
+    Returns:
+        peer_info (dict): all PFC params needed for fanout for storm generation
+    """
+    peer_dev = neighbors[port]['peerdevice']
+    peer_port = neighbors[port]['peerport']
+    peer_info = {'peerdevice': peer_dev,
+                 'hwsku': fanout_info[peer_dev]['device_info']['HwSku'],
+                 'pfc_fanout_interface': peer_port
+                 }
+    return peer_info
+
+
+def set_storm_params(dut, fanout_info, fanout, peer_params):
+    """
+    Setup storm parameters
+
+    Args:
+        dut (AnsibleHost): DUT instance
+        fanout_info (fixture): fanout graph info
+        fanout (AnsibleHost): fanout instance
+        peer_params (dict): all PFC params needed for fanout for storm generation
+
+    Returns:
+        storm_handle (PFCStorm): class PFCStorm intance
+    """
+    logger.info("Setting up storm params")
+    pfc_queue_index = 4
+    pfc_frames_count = 1000000
+    peer_device = peer_params['peerdevice']
+    if dut.topo_type == 't2' and fanout[peer_device].os == 'sonic':
+        pfc_gen_file = 'pfc_gen_t2.py'
+        pfc_send_time = 8
+    else:
+        pfc_gen_file = 'pfc_gen.py'
+        pfc_send_time = None
+    storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
+                            pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file,
+                            pfc_send_period=pfc_send_time, peer_info=peer_params)
+    storm_handle.deploy_pfc_gen()
+    return storm_handle
+
+
+@pytest.mark.usefixtures('pfcwd_timer_setup_restore')
+class TestPfcwdAllTimer(object):
+    """ PFCwd timer test class """
+    def run_test(self):
+        """
+        Test execution
+        """
+        with DisableLogrotateCronContext(self.dut):
+            logger.info("Flush logs")
+            self.dut.shell("logrotate -f /etc/logrotate.conf")
+        self.storm_handle.start_storm()
+        logger.info("Wait for queue to recover from PFC storm")
+        time.sleep(16)
+        self.retrieve_timestamp("[P]FC_STORM_START")
+        self.verify_no_detection(self.dut)
+        time.sleep(16)
+        self.retrieve_timestamp("[P]FC_STORM_END")
+        self.verify_no_restore(self.dut)
+
+    def retrieve_timestamp(self, pattern):
+        """
+        Retreives the syslog timestamp in ms associated with the pattern
+
+        Args:
+            pattern (string): pattern to be searched in the syslog
+
+        Returns:
+            timestamp_ms (int): syslog timestamp in ms for the line matching the pattern
+        """
+        cmd = "grep \"{}\" /var/log/syslog".format(pattern)
+        syslog_msg = self.dut.shell(cmd)['stdout']
+        timestamp = syslog_msg.replace('  ', ' ').split(' ')[2]
+        timestamp_ms = self.dut.shell("date -d {} +%s%3N".format(timestamp))['stdout']
+        return int(timestamp_ms)
+
+    def verify_no_detection(self):
+        if self.retrieve_timestamp("[d]etected PFC storm"):
+            raise RuntimeError(
+                "PFCwd detected a storm, "
+                "though it shouldn't detect with no traffic.")
+
+    def verify_no_restore(self):
+        if self.retrieve_timestamp("[s]torm restored"):
+            raise RuntimeError(
+                "PFCwd reports a restore from a storm,"
+                " though it shouldn't be detecting with no traffic.")
+
+    def test_pfcwd_timer_accuracy(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                  pfcwd_timer_setup_restore):
+        """
+        Tests PFCwd timer accuracy
+
+        Args:
+            duthost (AnsibleHost): DUT instance
+            pfcwd_timer_setup_restore (fixture): class scoped autouse setup fixture
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        setup_info = pfcwd_timer_setup_restore
+        self.storm_handle = setup_info['storm_handle']
+        self.timers = setup_info['timers']
+        self.dut = duthost
+        try:
+            if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
+                for i in range(1, 11):
+                    logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
+                    self.run_test()
+                self.verify_pfcwd_timers_t2()
+            else:
+                for i in range(1, 20):
+                    logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
+
+                    cmd = "show pfc counters"
+                    pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+                    logger.debug("loop {} cmd {} rsp {}".format(i, cmd, pfcwd_cmd_response.get('stdout', None)))
+
+                    cmd = "show pfcwd stats"
+                    pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+                    logger.debug("loop {} cmd {} rsp {}".format(i, cmd, pfcwd_cmd_response.get('stdout', None)))
+
+                    self.run_test()
+                self.verify_pfcwd_timers()
+
+        except Exception as e:
+            logger.info("exception: ")
+            cmd = "show pfc counters"
+            pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+            logger.info("pfcwd_cmd {} response: {}".format(cmd, pfcwd_cmd_response.get('stdout', None)))
+
+            cmd = "show pfcwd stats"
+            pfcwd_cmd_response = self.dut.shell(cmd, module_ignore_errors=True)
+            logger.info("pfcwd_cmd {} response: {}".format(cmd, pfcwd_cmd_response.get('stdout', None)))
+
+            pytest.fail(str(e))
+
+        finally:
+            if self.storm_handle:
+                self.storm_handle.stop_storm()


### PR DESCRIPTION
### Description of PR
A recent change in pfcwd implementation in cisco-8000 platforms causes the pfcwd *not* to trigger with xoff and no traffic condition. The current script at pfcwd/test_pfwcd_timer_accuracy.py will not work with this new implementation - since the script expects the watchdog to trigger with no traffic. So to handle the new behaviour, we are adding this new script, and enable it only for cisco-8000.

Summary:
Handle the failure of pfcwd_timer_accuracy for the new behaviour of pfcwd in cisco-8000.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Pls see the description. The pfcwd behaviour is changed in cisco-8000.

#### How did you do it?
Added a new script only for cisco-8000.

#### How did you verify/test it?
Run it in my testbed.

#### Any platform specific information?
Applicable only for cisco-8000 for now.