### PR TITLE
[crm/test_crm_nexthop]: Enhance test_crm_nexthop to cleanup ip addres…

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -217,3 +217,26 @@ def collector(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         data[asic.asic_index] = {}
 
     yield data
+
+
+@pytest.fixture(scope="function")
+def cleanup_ptf_interface(duthosts, ip_ver, enum_rand_one_per_hwsku_frontend_hostname,
+                          enum_frontend_asic_index, ptfhost):
+
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
+    if ip_ver == "4":
+        ip_remove_cmd = "config interface ip remove Ethernet1 2.2.2.1/24"
+    else:
+        ip_remove_cmd = "config interface ip remove Ethernet1 2001::2/64"
+    check_vlan_cmd = "show vlan br | grep -w 'Ethernet1'"
+
+    yield
+
+    if duthost.facts["asic_type"] == "marvell":
+        asichost.shell(ip_remove_cmd)
+        # Check if member not removed
+        output = asichost.shell(check_vlan_cmd, module_ignore_errors=True)
+        if "Ethernet1" not in output['stdout']:
+            asichost.sonichost.add_member_to_vlan(1000, 'Ethernet1', is_tagged=False)
+        ptfhost.remove_ip_addresses()

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -603,7 +603,7 @@ def get_expected_crm_stats_route_available(crm_stats_route_available, crm_stats_
 
 @pytest.mark.parametrize("ip_ver,nexthop", [("4", "2.2.2.2"), ("6", "2001::1")])
 def test_crm_nexthop(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                     enum_frontend_asic_index, crm_interface, ip_ver, nexthop, ptfhost):
+                     enum_frontend_asic_index, crm_interface, ip_ver, nexthop, ptfhost, cleanup_ptf_interface):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_nexthop".format(ip_ver=ip_ver)


### PR DESCRIPTION
…ses added to ptf interfaces if test fails


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The crm test - test_crm_nexthop does not cleanup the ip added to PTF interfaces correctly when the testcase fails. This PR is an enhancement to include a fixture to cleanup correctly after the testcase runs regardless of the outcome of the testcase.  
#### How did you do it?
A fixture cleanup_ptf_interface() was added in tests/crm/conftest.py to run after the test completes. This fixture calls the function remove_ip_addresses() to remove the ip addresses assigned to the ptf interfaces during the test run. 
#### How did you verify/test it?
Ran the test - test_crm_nexthop to see if the testcase passes and cleanup is correctly executed through the fixture. 
test_crm_nexthop scenarios tested:
    1. Fail ipv4 test_crm_nexthop to see if cleanup is executed correctly. Check if ipv6 scenario passes correctly.
    2. Fail ipv6 scenario to see if cleanup is executed correctly. Check ipv4 scenario passes correctly with cleanup.
    3. Fail both scenarios to see if cleanup is executed correctly.
    4. Pass both scenarios and see if cleanup is executed correctly.
    5. Run the entire test_crm.py suite to see if all testcases pass and cleanup is executed correctly.
    
![crm_nexthopall](https://github.com/sonic-net/sonic-mgmt/assets/143127557/a58c1ca7-be07-48c6-901d-60ef5400e5dc)

#### Any platform specific information?
This is done only for platforms having Marvell ASIC

