### PR TITLE
[E1031] Update loganalyzer regex in test_autostate_disabled

### DIFF
--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -22,7 +22,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer and duthost.facts["platform"] == "x86_64-cel_e1031-r0":
         loganalyzer_ignore_regex = [
-            ".*ERR swss#orchagent: :- doPortTask: .*: autoneg is not supported.*",
+            ".*ERR swss#orchagent:.*:- doPortTask: .*: autoneg is not supported.*",
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR #11383, we try to ignore `autoneg` related error logs in loganalyzer.
However, some logs with below format are not marched by previous regex.
```
Feb 17 11:39:40.131019 e1031-1 ERR swss#orchagent: message repeated 2 times: [ :- doPortTask: Ethernet52: autoneg is not supported (cap=0)]
```
In current PR, I updated the regex to ignore above logs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Update loganalyzer regex in `test_autostate_disabled` to ensure all the `autoneg` related error logs are ignored on Celestica-E1031 platform.

#### How did you do it?
Updated regex in testcase.

#### How did you verify/test it?
Verified on Celestica-E1031 M0 testbed with SONiC.202305 image.
 
#### Any platform specific information?
This PR only for Celestica-E1031 platform.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
