### PR TITLE
Fix issue with vSONiC neighbor sometimes getting disconnected over SSH

### DIFF
--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -77,9 +77,8 @@ class Sonic(host_device.HostDevice):
             except socket.timeout:
                 self.log("Timeout when running command: {}".format(cmd))
                 return ""
-            except (paramiko.SSHException, EOFError):
-                # paramiko.SSHException is possibly caused by https://github.com/paramiko/paramiko/issues/822
-                # Disconnect and reconnect as a possible workaround?
+            except Exception:
+                # Something went wrong (network issue?), try disconnecting and reconnecting
                 self.disconnect()
                 self.connect()
         self.log("Unable to get the output of '{}' after {} attempts".format(cmd, attempts))

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -77,8 +77,8 @@ class Sonic(host_device.HostDevice):
             except socket.timeout:
                 self.log("Timeout when running command: {}".format(cmd))
                 return ""
-            except paramiko.SSHException:
-                # Possibly caused by https://github.com/paramiko/paramiko/issues/822
+            except (paramiko.SSHException, EOFError):
+                # paramiko.SSHException is possibly caused by https://github.com/paramiko/paramiko/issues/822
                 # Disconnect and reconnect as a possible workaround?
                 self.disconnect()
                 self.connect()


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

Sometimes (appears to be fairly rare), the SSH connection from the PTF to one of the vSONiC neighbors gets disconnected for whatever reason. It doesn't seem like it's because of inactivity; something else is at play.

Backtrace:

```
2024-02-13 01:22:21 : Error in HostDevice: Traceback (most recent call last):
  File "ptftests/py3/advanced-reboot.py", line 1602, in peer_state_check
    self.fails[ip], self.info[ip], self.cli_info[ip], self.logs_info[ip], self.lacp_pdu_times[ip] = ssh.run()
  File "ptftests/sonic.py", line 147, in run
    v6_routing, bgp_route_v6_output = self.check_bgp_route(self.v6_routes, ipv6=True)
  File "ptftests/sonic.py", line 411, in check_bgp_route
    output = self.do_cmd(cmd)
  File "ptftests/sonic.py", line 63, in do_cmd
    stdin, stdout, stderr = self.conn.exec_command(cmd, timeout=Sonic.SSH_CMD_TIMEOUT)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/client.py", line 560, in exec_command
    chan = self._transport.open_session(timeout=timeout)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/transport.py", line 963, in open_session
    timeout=timeout,
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/transport.py", line 1082, in open_channel
    self._send_user_message(m)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/transport.py", line 1953, in _send_user_message
    self._send_message(data)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/transport.py", line 1929, in _send_message
    self.packetizer.send_message(data)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/packet.py", line 435, in send_message
    self.write_all(out)
  File "/root/env-python3/lib/python3.7/site-packages/paramiko/packet.py", line 368, in write_all
    raise EOFError()
EOFError
```

#### How did you do it?

To work around this, just disconnect and reconnect, and hope that fixes it.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
