### PR TITLE
[Mellanox] Improve the setting speed function for onyx fanout

### DIFF
--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -92,11 +92,13 @@ class OnyxHost(AnsibleHostBase):
         if res["localhost"]["rc"] != 0:
             raise Exception("Unable to execute template\n{}".format(res["localhost"]["stdout"]))
 
-    def get_supported_speeds(self, interface_name):
+    def get_supported_speeds(self, interface_name, raw_data=False):
         """Get supported speeds for a given interface
 
         Args:
             interface_name (str): Interface name
+            raw_data (bool): when it is True ,
+            return raw data, else return the data which has been handled
 
         Returns:
             list: A list of supported speed strings or None
@@ -110,6 +112,8 @@ class OnyxHost(AnsibleHostBase):
 
         out = show_int_result['stdout'][0].strip()
         logger.debug('Get supported speeds for port {} from onyx: {}'.format(interface_name, out))
+        if raw_data:
+            return out.split(':')[-1].strip().split()
         if not out:
             return None
 
@@ -185,6 +189,19 @@ class OnyxHost(AnsibleHostBase):
             speed = 'auto'
         else:
             speed = speed[:-3] + 'G'
+            # The speed support list for onyx is like '1G 10G 25G 40G 50Gx1 50Gx2 100Gx2 100Gx4 200Gx4'.
+            # We need to set the speed according to the speed support list.
+            # For example, when dut and fanout all support 50G,
+            # if support speed list of fanout just includes 50Gx1 not 50G,
+            # we need to set the speed with 50Gx1 instead of 50G, otherwise, the port can not be up.
+            all_support_speeds = self.get_supported_speeds(interface_name, raw_data=True)
+            for support_speed in all_support_speeds:
+                if speed in support_speed:
+                    logger.info("Speed {} find the matched support speed:{} ".format(speed, support_speed))
+                    speed = support_speed
+                    break
+            logger.info("set speed is {}".format(speed))
+
         if autoneg_mode or speed == 'auto':
             out = self.host.onyx_config(
                     lines=['shutdown', 'speed {}'.format(speed), 'no shutdown'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The speed support list for onyx is like '1G 10G 25G 40G 50Gx1 50Gx2 100Gx2 100Gx4 200Gx4'. When the fanout is onyx, we need to set the speed according to the speed support list.
For example, when dut and fanout all support 50G, if the support speed list of fanout just includes 50Gx1 not includes 50G, we need to set the speed with 50Gx1 instead of 50G, otherwise, the port can not be up.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Improve the setting speed function for onyx fanout

#### How did you do it?
Select the match speed from the support speed list

#### How did you verify/test it?
Run testQosSaiDwrr with onyx fanout

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
