### PR TITLE
[Recover via console] Change the method of downloading sonic image in ONIE.

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -89,44 +89,40 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                     dut_console.remote_conn.send("\n")
 
                     # TODO: Define a function to send command here
+                    dut_console.remote_conn.send('onie-discovery-stop\n')
+                    dut_console.remote_conn.send("\n")
+
+                    if is_nokia:
+                        enter_onie_flag = False
+                        dut_console.remote_conn.send('umount /dev/sda2\n')
+
+                    dut_console.remote_conn.send("ifconfig eth0 {} netmask {}".format(mgmt_ip.split('/')[0],
+                                                 ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1]))
+                    dut_console.remote_conn.send("\n")
+
+                    dut_console.remote_conn.send("ip route add default via {}".format(gw_ip))
+                    dut_console.remote_conn.send("\n")
+
+                    # Remove the image if it already exists
+                    dut_console.remote_conn.send("rm -f {}".format(image_url.split("/")[-1]))
+                    dut_console.remote_conn.send("\n")
+
+                    dut_console.remote_conn.send("wget {}".format(image_url))
+                    dut_console.remote_conn.send("\n")
+
+                    # Waiting downloading finishing
                     for i in range(5):
-                        dut_console.remote_conn.send('onie-discovery-stop\n')
-                        dut_console.remote_conn.send("\n")
-
-                        if is_nokia:
-                            enter_onie_flag = False
-                            dut_console.remote_conn.send('umount /dev/sda2\n')
-
-                        dut_console.remote_conn.send("ifconfig eth0 {} netmask {}".format(mgmt_ip.split('/')[0],
-                                                     ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1]))
-                        dut_console.remote_conn.send("\n")
-
-                        dut_console.remote_conn.send("ip route add default via {}".format(gw_ip))
-                        dut_console.remote_conn.send("\n")
-
-                        # Remove the image if it already exists
-                        dut_console.remote_conn.send("rm -f {}".format(image_url.split("/")[-1]))
-                        dut_console.remote_conn.send("\n")
-
-                        dut_console.remote_conn.send("wget {}".format(image_url))
-                        dut_console.remote_conn.send("\n")
-                        # We will wait some time to connect to image server
                         time.sleep(60)
+                        x = dut_console.remote_conn.recv(1024)
+                        x = x.decode('ISO-8859-9')
+                        # If we see "0:00:00", it means we finish downloading sonic image
+                        # Sample output:
+                        # sonic-mellanox-202012 100% |*******************************|  1196M  0:00:00 ETA
+                        if "0:00:00" in x:
+                            break
 
-                        # Waiting downloading finishing
-                        for i in range(5):
-                            time.sleep(60)
-                            x = dut_console.remote_conn.recv(1024)
-                            x = x.decode('ISO-8859-9')
-                            # If we see "0:00:00", it means we finish downloading sonic image
-                            # Sample output:
-                            # sonic-mellanox-202012 100% |*******************************|  1196M  0:00:00 ETA
-                            if "0:00:00" in x:
-                                break
-
-                        dut_console.remote_conn.send("onie-nos-install {}".format(image_url.split("/")[-1]))
-                        dut_console.remote_conn.send("\n")
-                        break
+                    dut_console.remote_conn.send("onie-nos-install {}".format(image_url.split("/")[-1]))
+                    dut_console.remote_conn.send("\n")
 
                 if SONIC_PROMPT in x:
                     dut_console.remote_conn.close()

--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -104,15 +104,29 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                         dut_console.remote_conn.send("ip route add default via {}".format(gw_ip))
                         dut_console.remote_conn.send("\n")
 
-                        dut_console.remote_conn.send("onie-nos-install {}".format(image_url))
+                        # Remove the image if it already exists
+                        dut_console.remote_conn.send("rm -f {}".format(image_url.split("/")[-1]))
+                        dut_console.remote_conn.send("\n")
+
+                        dut_console.remote_conn.send("wget {}".format(image_url))
                         dut_console.remote_conn.send("\n")
                         # We will wait some time to connect to image server
                         time.sleep(60)
-                        x = dut_console.remote_conn.recv(1024)
-                        x = x.decode('ISO-8859-9')
-                        # TODO: Give a sample output here
-                        if "ETA" in x:
-                            break
+
+                        # Waiting downloading finishing
+                        for i in range(5):
+                            time.sleep(60)
+                            x = dut_console.remote_conn.recv(1024)
+                            x = x.decode('ISO-8859-9')
+                            # If we see "0:00:00", it means we finish downloading sonic image
+                            # Sample output:
+                            # sonic-mellanox-202012 100% |*******************************|  1196M  0:00:00 ETA
+                            if "0:00:00" in x:
+                                break
+
+                        dut_console.remote_conn.send("onie-nos-install {}".format(image_url.split("/")[-1]))
+                        dut_console.remote_conn.send("\n")
+                        break
 
                 if SONIC_PROMPT in x:
                     dut_console.remote_conn.close()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We use `onie-nos-install` to get sonic image from image server, download it and install it previously. But in bjw, it will cost some time to connect to the image server which cause timeout error in `onie-nos-install` itself. To avoid this error, we change the method of downloading sonic image in ONIE. First, we will use `wget` to get sonic image from image server and download it, which will not result in timeout issue. And then, we will use `onie-nos-install` to just install the image on device. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We use `onie-nos-install` to get sonic image from image server, download it and install it previously. But in bjw, it will cost some time to connect to the image server which cause timeout error in `onie-nos-install` itself. To avoid this error, we change the method of downloading sonic image in ONIE. First, we will use `wget` to get sonic image from image server and download it, which will not result in timeout issue. And then, we will use `onie-nos-install` to just install the image on device. 

#### How did you do it?
 First, we will use `wget` to get sonic image from image server and download it, which will not result in timeout issue. And then, we will use `onie-nos-install` to just install the image on device. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
