### PR TITLE
Add retry to get elastictest token

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -117,7 +117,7 @@ parameters:
 
   - name: DUMP_KVM_IF_FAIL
     type: string
-    default: "True"
+    default: "False"  # KVM dump has beed deleted
     values:
       - "True"
       - "False"

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -188,8 +188,8 @@ class TestPlanManager(object):
             "client_secret": self.client_secret,
             "scope": get_scope(self.url)
         }
-        retry_times = 3
-        while retry_times > 0:
+        max_attempts = 3
+        for attempt in range(max_attempts):
             try:
                 resp = requests.post(token_url, headers=headers, data=payload, timeout=10).json()
                 self._token = resp["access_token"]
@@ -197,9 +197,9 @@ class TestPlanManager(object):
                 return self._token
             except Exception as exception:
                 print("Get token failed with exception: {}. Retry {} times to get token."
-                      .format(repr(exception), retry_times))
-                retry_times -= 1
-        raise Exception("Get token failed with exception: {}".format(repr(exception)))
+                      .format(repr(exception), max_attempts - attempt))
+                attempt += 1
+        raise Exception("Failed to get token after {} attempts".format(max_attempts))
 
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
                min_worker=None, max_worker=None, pr_id="unknown", output=None,

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -188,13 +188,18 @@ class TestPlanManager(object):
             "client_secret": self.client_secret,
             "scope": get_scope(self.url)
         }
-        try:
-            resp = requests.post(token_url, headers=headers, data=payload, timeout=10).json()
-            self._token = resp["access_token"]
-            self._token_generate_time = datetime.utcnow()
-            return self._token
-        except Exception as exception:
-            raise Exception("Get token failed with exception: {}".format(repr(exception)))
+        retry_times = 3
+        while retry_times > 0:
+            try:
+                resp = requests.post(token_url, headers=headers, data=payload, timeout=10).json()
+                self._token = resp["access_token"]
+                self._token_generate_time = datetime.utcnow()
+                return self._token
+            except Exception as exception:
+                print("Get token failed with exception: {}. Retry {} times to get token."
+                      .format(repr(exception), retry_times))
+                retry_times -= 1
+        raise Exception("Get token failed with exception: {}".format(repr(exception)))
 
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
                min_worker=None, max_worker=None, pr_id="unknown", output=None,

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -23,6 +23,7 @@ PR_TEST_SCRIPTS_FILE = "pr_test_scripts.yaml"
 SPECIFIC_PARAM_KEYWORD = "specific_param"
 TOLERATE_HTTP_EXCEPTION_TIMES = 20
 TOKEN_EXPIRE_HOURS = 6
+MAX_GET_TOKEN_RETRY_TIMES = 3
 
 
 class TestPlanStatus(Enum):
@@ -188,18 +189,18 @@ class TestPlanManager(object):
             "client_secret": self.client_secret,
             "scope": get_scope(self.url)
         }
-        max_attempts = 3
-        for attempt in range(max_attempts):
+        attempt = 0
+        while(attempt < MAX_GET_TOKEN_RETRY_TIMES):
             try:
                 resp = requests.post(token_url, headers=headers, data=payload, timeout=10).json()
                 self._token = resp["access_token"]
                 self._token_generate_time = datetime.utcnow()
                 return self._token
             except Exception as exception:
-                print("Get token failed with exception: {}. Retry {} times to get token."
-                      .format(repr(exception), max_attempts - attempt))
                 attempt += 1
-        raise Exception("Failed to get token after {} attempts".format(max_attempts))
+                print("Get token failed with exception: {}. Retry {} times to get token."
+                      .format(repr(exception), MAX_GET_TOKEN_RETRY_TIMES - attempt))
+        raise Exception("Failed to get token after {} attempts".format(MAX_GET_TOKEN_RETRY_TIMES))
 
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
                min_worker=None, max_worker=None, pr_id="unknown", output=None,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
There is no retry to get elastictest token, if get token fails, whole build would fail
#### How did you do it?
Add a retry to get elastictest token
Since kvm dump is no longer supported, set default value to false
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
