### PR TITLE
Fix fabric status check test to pass on t2min systems

### DIFF
--- a/tests/voq/test_voq_fabric_status_all.py
+++ b/tests/voq/test_voq_fabric_status_all.py
@@ -183,7 +183,7 @@ def test_voq_fabric_link_status(duthosts, refData, fabricSlots):
                         continue
                     else:
                         # check link status
-                        cmd = "sonic-db-cli -n {} STATE_DB hget 'FABRIC_PORT_TABLE|PORT{}' REMOTE_MOD".format(asic,lk)
+                        cmd = "sonic-db-cli -n {} STATE_DB hget 'FABRIC_PORT_TABLE|PORT{}' REMOTE_MOD".format(asic, lk)
                         cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                         logger.info(cmd_output)
                         module = cmd_output[0]

--- a/tests/voq/test_voq_fabric_status_all.py
+++ b/tests/voq/test_voq_fabric_status_all.py
@@ -87,6 +87,16 @@ def test_voq_fabric_link_status(duthosts, refData, fabricSlots):
     for i in range(totalAsics):
         keys.append('asic' + str(i))
     supReferenceData = {key: {} for key in keys}
+    linecardModule = []
+    localModule = 0
+    asicPerSlot = 2
+
+    for duthost in duthosts.frontend_nodes:
+        num_asics = duthost.num_asics()
+        for asic in range(num_asics):
+            if localModule not in linecardModule:
+                linecardModule.append(localModule)
+            localModule += asicPerSlot
 
     # skip supervisors, on Linecards now:
     for duthost in duthosts.frontend_nodes:
@@ -117,7 +127,10 @@ def test_voq_fabric_link_status(duthosts, refData, fabricSlots):
                 if asic not in referenceData:
                     pytest_assert(False, "{} is not expected to be up.".format(asic))
                 if lk not in referenceData[asic]:
-                    pytest_assert(False, "link {} is not expected to be up.".format(lk))
+                    pytest_assert(status.lower() != 'up',
+                                  "link {} is not expected to be up.".format(lk))
+                    logger.info("Skip udpating the information as this is designed to be down")
+                    continue
 
                 # update link information on suppervisor
                 lkData = {'peer slot': slot, 'peer lk': lk, 'peer asic': asic}
@@ -134,8 +147,9 @@ def test_voq_fabric_link_status(duthosts, refData, fabricSlots):
 
                 if status.lower() != 'up':
                     if fabricSlot in fabricSlots:
+                        logger.info("link {}. is expected to be up.".format(linkKey))
                         pytest_assert(status.lower() == 'up',
-                                      "link {}. is expected to be up.".format(lk))
+                                      "link {}. is expected to be up.".format(linkKey))
             else:
                 logger.info("Header line {}".format(content))
 
@@ -169,6 +183,12 @@ def test_voq_fabric_link_status(duthosts, refData, fabricSlots):
                         continue
                     else:
                         # check link status
+                        cmd = "sonic-db-cli -n {} STATE_DB hget 'FABRIC_PORT_TABLE|PORT{}' REMOTE_MOD".format(asic,lk)
+                        cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                        logger.info(cmd_output)
+                        module = cmd_output[0]
+                        if module not in linecardModule:
+                            continue
                         pytest_assert(False, "link {} is not expected to be up.".format(lk))
                 pytest_assert(status.lower() == 'up',
-                              "link {}. is expected to be up.".format(lk))
+                              "link {}. is expected to be up.".format(linkKey))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Fix fabric status check test to pass on t2min systems
Fixes # (issue)
test_voq_fabric_status_all.py might failed on t2min systems if more than 2 Linecards are inserted in that system. For these systems, fabric serdes links that connect to any of the linecards on supervisor will be up and running. But t2min only init 2 linecards for testing, so those fabric links that connected to none inited  linecards by the topology will failed test. 

In this change, the test will not failed  for those links anymore.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
