### PR TITLE
Revert adding 'any' topology to pre/post tests

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.posttest,
-    pytest.mark.topology('util', 'any'),
+    pytest.mark.topology('util'),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.skip_check_dut_health

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.pretest,
-    pytest.mark.topology('util', 'any'),
+    pytest.mark.topology('util'),
     pytest.mark.disable_loganalyzer,
     pytest.mark.skip_check_dut_health
 ]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The pre/post tests are intended to be run before and after the entire body of tests run, respectively. They were marked with the 'util' topology as such, so that they would not be considered for being run in the middle of the test run. However, a change was made which added the 'any' topology, which caused the pre- and post-tests to run twice: once at the start and end, and once in the middle of the test run in the lexicographical sequence.

Removing 'any' means it will only be run at the start and end of the test run as intended.

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR removes the redundant execution of pre- and post-tests in the middle of the test run.

#### How did you do it?
I removed the 'any' topology from these tests.

#### How did you verify/test it?
The changes were verified manually by doing a test run and verifying through manual inspection that the pre- and post-tests executed at the start and end, respectively, but not in the middle of the test run in the lexicographical sequence.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
