### PR TITLE
Remove the AZNGHub check when getting upstream neighbors for test_default_route_with_bgp_flap

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -37,8 +37,6 @@ def get_upstream_neigh(tb, device_neigh_metadata):
     for neigh_name, neigh_cfg in list(topo_cfg_facts.items()):
         if neigh_type not in neigh_name:
             continue
-        if neigh_type == 'T3' and device_neigh_metadata[neigh_name]['type'] == 'AZNGHub':
-            continue
         interfaces = neigh_cfg.get('interfaces', {})
         ipv4_addr = None
         ipv6_addr = None
@@ -65,8 +63,6 @@ def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping, device_neigh_metadata):
     asics = set()
     for name, asic in list(bgp_name_to_ns_mapping.items()):
         if neigh_type not in name:
-            continue
-        if neigh_type == 'T3' and device_neigh_metadata[name]['type'] == 'AZNGHub':
             continue
         asics.add(asic)
     return asics


### PR DESCRIPTION
### Description of PR
As of PR8779, half of the T3 devices will be AZNGHub, causing test_default_route_with_bgp_flap to fail if AZNGHub are excluded from the neighbor count.

Summary:
Fixes # 9052

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix issue 9052 caused by PR8779.

#### How did you do it?

#### How did you verify/test it?
Run sonic-mgmt tests in our environement.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

