### PR TITLE
[TACACS] Fix test_ro_user_ipv6 failed caused by IPV6 address not pingable.

### DIFF
--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -29,8 +29,8 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_cre
     logger.info('tacacs_creds: {}'.format(str(print_tacacs_creds)))
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     tacacs_server_ip = ptfhost.mgmt_ip
-    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
 
     yield
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -73,7 +73,8 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    check_result = duthost.shell("(echo >/dev/tcp/{}/49) &>/dev/null && echo \"open\" || echo \"close\"".format(tacacs_server_ip))['stdout']
+    check_result = duthost.shell("(echo >/dev/tcp/{}/49) &>/dev/null && echo \"open\" || echo \"close\""
+                                 .format(tacacs_server_ip))['stdout']
     logger.warning("TACACS server {} check result: {}".format(tacacs_server_ip, check_result))
     if "close" in check_result:
         pytest_assert(False, "TACACS server {} not reachable: {}".format(tacacs_server_ip, check_result))

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -73,10 +73,10 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip))['stdout']
-    logger.info("TACACS server ping result: {}".format(ping_result))
-    if "100% packet loss" in ping_result:
-        pytest_assert(False, "TACACS server not reachable: {}".format(ping_result))
+    check_result = duthost.shell("(echo >/dev/tcp/{}/49) &>/dev/null && echo \"open\" || echo \"close\"".format(tacacs_server_ip))['stdout']
+    logger.warning("TACACS server {} check result: {}".format(tacacs_server_ip, check_result))
+    if "close" in check_result:
+        pytest_assert(False, "TACACS server {} not reachable: {}".format(tacacs_server_ip, check_result))
 
     # configure tacacs client
     default_tacacs_servers = []

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -75,9 +75,10 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
     check_result = duthost.shell("(echo >/dev/tcp/{}/49) &>/dev/null && echo \"open\" || echo \"close\""
                                  .format(tacacs_server_ip))['stdout']
-    logger.warning("TACACS server {} check result: {}".format(tacacs_server_ip, check_result))
+    logger.info("TACACS server {} check result: {}".format(tacacs_server_ip, check_result))
     if "close" in check_result:
-        pytest_assert(False, "TACACS server {} not reachable: {}".format(tacacs_server_ip, check_result))
+        message = "TACACS server {} not reachable: {}".format(tacacs_server_ip, check_result)
+        pytest.skip(message)
 
     # configure tacacs client
     default_tacacs_servers = []


### PR DESCRIPTION
[TACACS] Fix test_ro_user_ipv6 failed caused by IPV6 address not pingable.

### Description of PR
[TACACS] Fix test_ro_user_ipv6 failed caused by IPV6 address not pingable.

##### Work item tracking
- Microsoft ADO: 26544335

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
test_ro_user_ipv6 failed on some lab hardware because IPV6 address not pingable.

#### How did you do it?
Check TACACS server reachable with Linux /dev/tcp/{address}/{port}/ file.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
