### PR TITLE
[bgp]: Don't flush link-local addr during teardown

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -282,7 +282,7 @@ class BgpDualAsn:
         logger.info("exabgp stopped")
 
         for port in self.ptf_ports:
-            ptfhost.shell("ip addr flush dev %s" % port)
+            ptfhost.shell("ip addr flush dev {} scope global".format(port))
         duthost.command("sonic-clear arp")
         duthost.command("sonic-clear ndp")
         duthost.command("sonic-clear fdb all")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
During the teardown for `bgp/test_bgp_dual_asn.py::test_bgp_dual_asn_v4`, the PTF interface used for the test is flushed of all IPv4 and IPv6 addresses, including the IPv6 link local address. As a result, NDP and other IPv6 functionality is broken for the flushed interface.

#### How did you do it?
Specify 'global' scope when flushing the PTF interface to avoid removing IPv6 link local addresses.

#### How did you verify/test it?
Run the test, verify that all PTF addresses still have an IPv6 link local address after the test is finished.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
