### PR TITLE
[snmp] skip snmp mem load for small mem device

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -142,6 +142,9 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     mem_free = int(outputs['results'][1]['stdout'])
     mem_total = int(outputs['results'][2]['stdout'])
     percentage = get_percentage_threshold(int(mem_total))
+    # if total mem less than 2G
+    if mem_total <= 2 * 1024 * 1024:
+        pytest.skip("Total memory is too small for percentage.")
     logger.info("SNMP Free Memory: {}".format(snmp_free_memory))
     logger.info("DUT Free Memory: {}".format(mem_free))
     logger.info("Difference: {}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Snmp memory load test has very unstable result on small memory device. Small differences can be significant when they are converted to percentage. So skip this test for small memory devices after getting snmp memory. This way we can still make sure snmp memory still returns result, but skip checking for the value.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix snmp_memory_load

#### How did you do it?
Skip test for small mem device.

#### How did you verify/test it?
Run test manually.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
