### PR TITLE
adding tolerance to check_nexthops_single_downlink

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1073,6 +1073,8 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
                                    tbinfo, downlink_ints):
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     expect_packet_num = 1000
+    expect_packet_num_high = expect_packet_num * (0.90)
+    expect_packet_num_low = expect_packet_num * (1.1)
 
     # expect this packet to be sent to downlinks (active mux) and uplink (stanby mux)
     expected_downlink_ports = [get_ptf_server_intf_index(rand_selected_dut, tbinfo, iface) for iface in downlink_ints]
@@ -1098,7 +1100,7 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
         # packets should be either 0 or expect_packet_num:
         count = port_packet_count.get(downlink_int, 0)
         logging.info("Packets received on downlink port {}: {}".format(downlink_int, count))
-        if count > 0 and count != expect_packet_num:
+        if count > 0 and count <= expect_packet_num_high and count >= expect_packet_num_low:
             pytest.fail("Packets not sent down single active port {}".format(downlink_int))
 
     if len(downlink_ints) == 0:


### PR DESCRIPTION
Adding a small tolerance to check_nexthops_single_downlink. Test was failing because all packets were being recieved by single downstream port, however not all 1000 packets were being recorded. We used to have a small tolerance in this test before expecting all packets down one port, but this was removed once the test was changed. This should fix this test.

### Description of PR
Fixing check_nexthops_single_downlink

Summary:
Fixes #26899373

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fixing failures in check_nexthops_single_downlink

#### How did you do it?
Added small tolerance. Packets were going to the right place, but we were off by < 0.2%

#### How did you verify/test it?
ran test on testbed