### PR TITLE
[dhcp_relay] Increase timeout in dhcpmon loganalyzer check

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -375,7 +375,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                "testing_mode": testing_mode},
                        log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
             if not skip_dhcpmon:
-                time.sleep(18)      # dhcpmon debug counter prints every 18 seconds
+                time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
                 loganalyzer.analyze(marker)
                 if testing_mode == DUAL_TOR_MODE:
                     loganalyzer_standby.analyze(marker_standby)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
There has been failed test runs where DHCP REQUEST count in dhcpmon debug syslog and state db counter is 100-140, when the expected count is 144. 
Ran tests manually and original test case passes most of the time, failed cases had a slight under count in REQUEST.

Checked packet capture in ptf and there are always 144 REQUEST packets, which indicates dhcpmon terminated early.

After increasing timeout, count is always 144.
After dhcp relay default ptf test, which doesn't wait for all 144 REQUEST packet. Checking dhcpmon counter immediately after may not have the most up to date output

#### How did you do it?
Increase timeout after dhcp relay default ptf test

#### How did you verify/test it?
Ran test a dozen times on a device that had a failed run prior to timeout increase and test passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
