### PR TITLE
Added year to FMT time template

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -19,7 +19,7 @@ from .mellanox.mellanox_thermal_control_test_helper import suspend_hw_tc_service
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), "templates")
-FMT = "%b %d %H:%M:%S.%f"
+FMT = "%Y %b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
 FMT_ALT = "%Y-%m-%dT%H:%M:%S.%f%z"
 LOGS_ON_TMPFS_PLATFORMS = [

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -46,6 +46,7 @@ def _parse_timestamp(timestamp):
             continue
     raise ValueError("Unable to parse {} with any known format".format(timestamp))
 
+
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -38,19 +38,13 @@ LOGS_ON_TMPFS_PLATFORMS = [
 
 
 def _parse_timestamp(timestamp):
-    try:
-        time = datetime.strptime(timestamp, FMT)
-    except ValueError:
+    for format in [FMT, FMT_YEAR, FMT_SHORT, FMT_ALT]:
         try:
-            time = datetime.strptime(timestamp, FMT_SHORT)
+            time = datetime.strptime(timestamp, format)
+            return time
         except ValueError:
-            try:
-                time = datetime.strptime(timestamp, FMT_ALT)
-            except ValueError:
-                time = datetime.strptime(timestamp, FMT_YEAR)
-
-    return time
-
+            continue
+    raise ValueError("Unable to parse {} with any known format".format(timestamp))
 
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -19,9 +19,12 @@ from .mellanox.mellanox_thermal_control_test_helper import suspend_hw_tc_service
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), "templates")
-FMT = "%Y %b %d %H:%M:%S.%f"
+
+FMT = "%b %d %H:%M:%S.%f"
+FMT_YEAR = "%Y %b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
 FMT_ALT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
 LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-arista_7050_qx32",
     "x86_64-arista_7050_qx32s",
@@ -41,9 +44,12 @@ def _parse_timestamp(timestamp):
         try:
             time = datetime.strptime(timestamp, FMT_SHORT)
         except ValueError:
-            time = datetime.strptime(timestamp, FMT_ALT)
-    return time
+            try:
+                time = datetime.strptime(timestamp, FMT_ALT)
+            except ValueError:
+                time = datetime.strptime(timestamp, FMT_YEAR)
 
+    return time
 
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -51,6 +51,7 @@ def _parse_timestamp(timestamp):
 
     return time
 
+
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
### Description of PR

This is a sister PR to the image change PR [18099](https://github.com/sonic-net/sonic-buildimage/pull/18099) that introduces the current year to all logs.

Summary:

Fixes Microsoft ADO 26907533

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The motivation for this PR is to ensure that the sonic-mgmt tests keep up with the updated log template that is introduced by sonic-buildimage PR [18099](https://github.com/sonic-net/sonic-buildimage/pull/18099) that introduces the current year to all logs.

#### How did you do it?
Modified FMT template in conftest.py to match the new syslog format with current year

#### How did you verify/test it?

**Test 1 : Standard format - Standard Test**

```
admin@str-s6100-acs-1:~$ show ver

SONiC Software Version: SONiC.20230531.26
SONiC OS Version: 11
Distribution: Debian 11.8
Kernel: 5.10.0-23-2-amd64
Build commit: a899d082be
Build date: Tue Apr 23 11:26:32 UTC 2024
Built by: cloudtest@ab3ceb0ac000000
```


**syslog:**

```
admin@str-s6100-acs-1:~$ sudo tail /var/log/syslog

May  6 21:15:14.971516 str-s6100-acs-1 INFO swss#supervisord: orchagent
May  6 21:15:29.195245 str-s6100-acs-1 NOTICE swss#orchagent: :- getResAvailability: CRM resource MPLS_INSEG not supported
May  6 21:15:29.196643 str-s6100-acs-1 NOTICE swss#orchagent: :- getResAvailability: CRM resource MPLS_NEXTHOP not supported
May  6 21:15:29.197865 str-s6100-acs-1 NOTICE swss#orchagent: :- getResAvailability: CRM resource SRV6_MY_SID_ENTRY not supported
May  6 21:15:29.199103 str-s6100-acs-1 NOTICE swss#orchagent: :- getResAvailability: CRM resource SRV6_NEXTHOP not supported
May  6 21:15:29.200392 str-s6100-acs-1 NOTICE swss#orchagent: :- getResAvailability: CRM resource NEXTHOP_GROUP_MAP not supported
May  6 21:15:35.732340 str-s6100-acs-1 NOTICE restapi#root: Waiting for certificates...
```

**Test result:**
```
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
21:32:20 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] platform_tests/test_advanced_reboot.py:92: skip DUAL_TOR_MODE tests on Single ToR testbeds
============================================================================ 1 passed, 1 skipped, 1 warning in 991.85s (0:16:31) =============================================================================
```

**Test 2: Standard format - Modified Test**


```
admin@str-s6100-acs-1:~$ show ver

SONiC Software Version: SONiC.20230531.26
SONiC OS Version: 11
Distribution: Debian 11.8
Kernel: 5.10.0-23-2-amd64
Build commit: a899d082be
Build date: Tue Apr 23 11:26:32 UTC 2024
Built by: cloudtest@ab3ceb0ac000000
```


**syslog:**

```
admin@str-s6100-acs-1:~$ sudo tail /var/log/syslog
May  6 21:36:37.663171 str-s6100-acs-1 INFO swss#supervisord: arp_update ping6: Warning: source address might be selected on device other than: PortChannel102
May  6 21:36:37.684075 str-s6100-acs-1 INFO swss#supervisord: arp_update ping6: Warning: source address might be selected on device other than: PortChannel103
May  6 21:36:37.697267 str-s6100-acs-1 INFO swss#supervisord: arp_update ping6: Warning: source address might be selected on device other than: PortChannel104
May  6 21:36:38.036401 str-s6100-acs-1 INFO swss#supervisord: orchagent
May  6 21:36:38.561647 str-s6100-acs-1 INFO swss#supervisord: arp_update ping6: Warning: source address might be selected on device other than: Vlan1000
May  6 21:36:48.036524 str-s6100-acs-1 INFO swss#supervisord: orchagent
May  6 21:36:51.791191 str-s6100-acs-1 NOTICE restapi#root: Waiting for certificates...
May  6 21:36:56.785556 str-s6100-acs-1 INFO systemd[1]: run-docker-runtime\x2drunc-moby-57a2ea79a91b8b6664b0ca0e988c2e9178a4fd0516f27270d4c64f540a6998c3-runc.MbMdcw.mount: Succeeded.
May  6 21:36:57.554762 str-s6100-acs-1 INFO systemd[1]: run-docker-runtime\x2drunc-moby-b5205856846e2ed511d096a7c0006b1f6ffc8b8b762651e0d1839ec71d28d983-runc.wcEf2N.mount: Succeeded.
May  6 21:37:03.114959 str-s6100-acs-1 INFO systemd[1]: run-docker-runtime\x2drunc-moby-344f967147b3c67e6998f6353c69ac404b645ebbd5800d57315f1ba0eaca5136-runc.ZyBomC.mount: Succeeded.
```

**syslogs**

```
May  6 21:37:03.114959 str-s6100-acs-1 INFO systemd[1]: run-docker-runtime\x2drunc-moby-344f967147b3c67e6998f6353c69ac404b645ebbd5800d57315f1ba0eaca5136-runc.ZyBomC.mount: Succeeded.
admin@str-s6100-acs-1:~$ client_loop: send disconnect: Broken pipe
assrinivasan@assrinivasan-dev-vm-1:/data/sonic$
assrinivasan@assrinivasan-dev-vm-1:/data/sonic$ ash str-s6100-acs-1
.
.
admin@str-s6100-acs-1:~$ show reboot-cause
User issued 'warm-reboot' command [User: admin, Time: Mon 06 May 2024 09:44:23 PM UTC]
admin@str-s6100-acs-1:~$
```


**Test result:**

```
21:54:17 advanced_reboot.acl_manager_checker      L0545 INFO   | Checking ACL manager status
21:54:18 advanced_reboot.__clearArpAndFdbTables   L0422 INFO   | Clearing arp entries on DUT  str-s6100-acs-1
21:54:20 advanced_reboot.__clearArpAndFdbTables   L0425 INFO   | Clearing all fdb entries on DUT  str-s6100-acs-1
PASSED                                                                                                                                                                                                 [ 50%]
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
21:54:38 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture verify_dut_health teardown starts --------------------
21:54:38 verify_dut_health.check_services         L0040 INFO   | Wait until all critical services are fully started

------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
21:55:16 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] platform_tests/test_advanced_reboot.py:92: skip DUAL_TOR_MODE tests on Single ToR testbeds
============================================================================ 1 passed, 1 skipped, 1 warning in 1023.65s (0:17:03) ============================================================================


```
**Test 3: Modified format - Modified Test**

```
Installing image SONiC-OS-HEAD.0-3c3d6c67d6 and setting it as default...
Command: bash /tmp/sonic_image
.
.
Command: sync

Command: sleep 3

Done
admin@str-s6100-acs-1:~$ sudo reboot
.
.
admin@str-s6100-acs-1:~$ show ver

SONiC Software Version: SONiC.master-18099.478220-6007be210
SONiC OS Version: 12
Distribution: Debian 12.4
Kernel: 6.1.0-11-2-amd64
Build commit: 6007be210
Build date: Thu Feb 15 07:05:53 UTC 2024
Built by: AzDevOps@vmss-soni00336P
```

```
admin@str-s6100-acs-1:~$ sudo tail /var/log/syslog
2024 May  8 18:50:43.578311 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000006 is set on queue 0x0009011500000005, port 9 qid 4
2024 May  8 18:50:43.579988 str-s6100-acs-1 NOTICE swss#orchagent: :- processQueue: Set buffer queue Ethernet14:5-6 to BUFFER_PROFILE_TABLE:egress_lossy_profile
2024 May  8 18:50:43.582028 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000007 is set on queue 0x0009011500000006, port 9 qid 5
2024 May  8 18:50:43.590714 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000007 is set on queue 0x0009011500000007, port 9 qid 6
2024 May  8 18:50:43.590714 str-s6100-acs-1 NOTICE swss#orchagent: :- processQueue: Set buffer queue Ethernet15:0-2 to BUFFER_PROFILE_TABLE:egress_lossy_profile
2024 May  8 18:50:43.590714 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000007 is set on queue 0x000a011500000001, port 10 qid 0
2024 May  8 18:50:43.593307 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000007 is set on queue 0x000a011500000002, port 10 qid 1
2024 May  8 18:50:43.593898 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000007 is set on queue 0x000a011500000003, port 10 qid 2
2024 May  8 18:50:43.595344 str-s6100-acs-1 NOTICE swss#orchagent: :- processQueue: Set buffer queue Ethernet15:3-4 to BUFFER_PROFILE_TABLE:egress_lossless_profile
2024 May  8 18:50:43.597876 str-s6100-acs-1 INFO syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_set_buffer_profile_id:2952 Buffer profile 0x0000001900000006 is set on queue 0x000a011500000004, port 10 qid 3
```

**syslogs**:

```
admin@str-s6100-acs-1:~$ client_loop: send disconnect: Broken pipe
.
.
admin@str-s6100-acs-1:~$
admin@str-s6100-acs-1:~$ show reboot
User issued 'warm-reboot' command [User: admin, Time: Wed May  8 06:59:26 PM UTC 2024]
admin@str-s6100-acs-1:~$
```


**Test Result:**
```
}
19:10:18 advanced_reboot.acl_manager_checker      L0545 INFO   | Checking ACL manager status
19:10:19 advanced_reboot.__clearArpAndFdbTables   L0422 INFO   | Clearing arp entries on DUT  str-s6100-acs-1
19:10:22 advanced_reboot.__clearArpAndFdbTables   L0425 INFO   | Clearing all fdb entries on DUT  str-s6100-acs-1
PASSED
----------------


------------------------------------------------------- generated xml file: /var/src/logs/platform_tests/test_advanced_reboot.py::test_warm_reboot.xml -----------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------
19:11:28 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================================================================================== short test summary info =================================================================
SKIPPED [1] platform_tests/test_advanced_reboot.py:92: skip DUAL_TOR_MODE tests on Single ToR testbeds
============================================================================ 1 passed, 1 skipped, 1 warning in 1115.02s (0:18:35) ==================================================

```

Full test logs: [test_advanced_reboot_py--test_warm_reboot.log](https://github.com/sonic-net/sonic-mgmt/files/15254432/test_advanced_reboot_py--test_warm_reboot.log)

[warmreboot-202012-to-202305-logs.txt](https://github.com/sonic-net/sonic-mgmt/files/15300439/warmreboot-202012-to-202305-logs.txt) 