### PR TITLE
[Recover via console] Send `enter` while booting ONIE on celestica testbeds

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -7,7 +7,7 @@ import time
 import pexpect
 import ipaddress
 from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, INSTALL_OS_IN_ONIE, \
-    ONIE_START_TO_DISCOVERY, SONIC_PROMPT, MARVELL_ENTRY
+    ONIE_START_TO_DISCOVERY, SONIC_PROMPT, MARVELL_ENTRY, BOOTING_INSTALL_OS
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
@@ -46,7 +46,7 @@ def get_pdu_managers(sonichosts, conn_graph_facts):
     return pdu_managers
 
 
-def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=False):
+def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=False, is_celestica=False):
     enter_onie_flag = True
     gw_ip = list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
 
@@ -83,6 +83,9 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                 if ONIE_ENTRY_IN_GRUB in x and INSTALL_OS_IN_ONIE not in x:
                     dut_console.remote_conn.send("\n")
                     enter_onie_flag = False
+
+                if is_celestica and BOOTING_INSTALL_OS in x:
+                    dut_console.remote_conn.send("\n")
 
                 # "ONIE: Starting ONIE Service Discovery"
                 if ONIE_START_TO_DISCOVERY in x:

--- a/.azure-pipelines/recover_testbed/constants.py
+++ b/.azure-pipelines/recover_testbed/constants.py
@@ -40,6 +40,11 @@ ONIE_ENTRY_IN_GRUB = "*ONIE"
 
 INSTALL_OS_IN_ONIE = "Install OS"
 
+# While entering into ONIE, we will get some output like
+# " Booting `ONIE: Install OS' "
+# " OS Install Mode"
+BOOTING_INSTALL_OS = "Booting"
+
 # After enter into the installation in ONIE, it will discover some configuration
 # And finally, we will get the string "ONIE: Starting ONIE Service Discovery"
 # To fit the scenario of Celestica, we finally use the string "covery"

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -46,7 +46,8 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
         elif device_type in ["nexus"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=True)
         elif device_type in ["mellanox", "cisco", "acs", "celestica"]:
-            posix_shell_onie(dut_console, mgmt_ip, image_url)
+            is_celestica = device_type in ["celestica"]
+            posix_shell_onie(dut_console, mgmt_ip, image_url, is_celestica=is_celestica)
         elif device_type in ["nokia"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_nokia=True)
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR addresses the issue of celestica testbeds getting stuck during ONIE booting. We found that sending an enter to the terminal can prevent this problem. Therefore, we added a step to send an enter while recovering celestica testbeds in ONIE mode. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
This PR addresses the issue of celestica testbeds getting stuck during ONIE booting. We found that sending an enter to the terminal can prevent this problem. Therefore, we added a step to send an enter while recovering celestica testbeds in ONIE mode.

#### How did you do it?
Add a step to send an enter while recovering celestica testbeds in ONIE mode.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
