### PR TITLE
Enhance multi_passwd_ssh plugin to support list of alternate passwords

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -3,7 +3,7 @@ ansible_connection: multi_passwd_ssh
 ansible_altpassword: YourPaSsWoRd
 # ansible_altpasswords:
 #   - fakepassword1
-#   - fakepassword3
+#   - fakepassword2
 
 sonic_version: "v2"
 

--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -1,6 +1,9 @@
 ansible_ssh_user: admin
 ansible_connection: multi_passwd_ssh
 ansible_altpassword: YourPaSsWoRd
+# ansible_altpasswords:
+#   - fakepassword1
+#   - fakepassword3
 
 sonic_version: "v2"
 

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -21,6 +21,11 @@ DOCUMENTATION += """
               - name: ansible_altpassword
               - name: ansible_ssh_altpass
               - name: ansible_ssh_altpassword
+      altpasswords:
+          description: Alternative authentication passwords list for the C(remote_user). Can be supplied as CLI option.
+          vars:
+              - name: ansible_altpasswords
+              - name: ansible_ssh_altpasswords
 """.lstrip("\n")
 
 
@@ -28,7 +33,7 @@ def _password_retry(func):
     """
     Decorator to retry ssh/scp/sftp in the case of invalid password
 
-    Will retry for password in (ansible_password, ansible_altpassword):
+    Will retry for password in (ansible_password, ansible_altpassword, ansible_altpasswords):
     """
     @wraps(func)
     def wrapped(self, *args, **kwargs):
@@ -37,6 +42,9 @@ def _password_retry(func):
         altpassword = self.get_option("altpassword")
         if altpassword:
             conn_passwords.append(altpassword)
+        altpasswds = self.get_option("altpasswords")
+        if altpasswds:
+            conn_passwords.extend(altpasswds)
 
         while conn_passwords:
             conn_password = conn_passwords.pop(0)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The existing multi_passwd_ssh plugin supports specifying single alternate password in ansible variable or command line.

This change enhanced the plugin to support a list of alternate passwords.

#### How did you do it?
New ansible variable introduced by this change:
  ansible_altpasswords
  ansible_ssh_altpasswords

For backward compatibility, the existing "ansible_altpassword" variable is till kept.

Two ways to use this new variable:

1. From ansible variable files, for example in ansible/group_vars/sonic/variables: 
```
ansible_altpasswords:
  - fakepassword1
  - fakepassword2
```
2. From ansible-playbook cli:
```
ansible-playbook -i <inv_file> -l <target_host> <playbook_file.yml> --extra-vars='{"ansible_altpasswords": ["fakepassword1"]}'
```

#### How did you verify/test it?
Tested on VS setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
