### PR TITLE
[E1031] Xfail or Skip some platform testcases on Celestica-E1031 due to known issue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -36,10 +36,11 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_presence:
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_revision:
   xfail:
-    reason: "Testcase consistently fails, raised issue to track"
+    reason: "[DX010] Testcase consistently fails, raised issue to track; [E1031] API 'get_revision' not implemented"
+    conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Celestica-DX010-C32']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6512
+      - "hwsku in ['Celestica-DX010-C32'] and https://github.com/sonic-net/sonic-mgmt/issues/6512"
+      - "platform in ['x86_64-cel_e1031-r0'] and https://github.com/sonic-net/sonic-buildimage/issues/18229"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_get_status:
   # Skip unsupported API test on Mellanox platform
@@ -318,8 +319,10 @@ platform_tests/api/test_module.py::TestModuleApi::test_reboot:
 platform_tests/api/test_psu.py::TestPsuApi::test_fans:
   skip:
     reason: "Unsupported platform API"
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_type in ['mellanox']"
+      - "platform in ['x86_64-cel_e1031-r0'] and https://github.com/sonic-net/sonic-buildimage/issues/18229"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_model:
   skip:
@@ -329,10 +332,11 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_model:
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_revision:
   xfail:
-    reason: "case failed and waiting for fix"
+    reason: "[DX010] case failed and waiting for fix; [E1031] API 'get_revision' not implemented"
+    conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Celestica-DX010-C32']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6767
+      - "hwsku in ['Celestica-DX010-C32'] and https://github.com/sonic-net/sonic-mgmt/issues/6767"
+      - "platform in ['x86_64-cel_e1031-r0'] and https://github.com/sonic-net/sonic-buildimage/issues/18229"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_serial:
   skip:
@@ -412,6 +416,13 @@ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed:
 #######################################
 #####        api/test_sfp.py      #####
 #######################################
+platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description:
+  xfail:
+    reason: "Platform API 'get_error_description' not implemented"
+    conditions:
+      - "platform in ['x86_64-cel_e1031-r0']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/18229
+
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_model:
   skip:
     reason: "Unsupported platform API"
@@ -902,3 +913,13 @@ platform_tests/test_service_warm_restart.py:
     reason: "Skip test_service_warm_restart on mellanox platform"
     conditions:
       - "asic_type in ['mellanox']"
+
+#######################################
+#####   test_xcvr_info_in_db.py   #####
+#######################################
+platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
+  xfail:
+    reason: "CLI Utility sfpshow not working correctly"
+    conditions:
+      - "platform in ['x86_64-cel_e1031-r0']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/18231


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**
Xfail or Skip below testcases on Celestica-E1031 due to sonic-net/sonic-buildimage#18229:
- platform_tests/api/test_chassis.py::TestChassisApi::test_get_revision
- platform_tests/api/test_psu.py::TestPsuApi::test_fans
- platform_tests/api/test_psu.py::TestPsuApi::test_get_revision
- platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description

Xfail below testcase on Celestica-E1031 due to sonic-net/sonic-buildimage#18231:
- platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Xfail or Skip testcases on Celestica-E1031 due to known issue.

#### How did you do it?
Update conditional mark file.

#### How did you verify/test it?
Verified on Celestica-E1031 M0 testbed.

```
=========================================================================== short test summary info ===========================================================================
XFAIL platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description[e1031-1] - Platform API 'get_error_description' not implemented
XFAIL platform_tests/api/test_psu.py::TestPsuApi::test_get_revision[e1031-1] - [DX010] case failed and waiting for fix; [E1031] API 'get_revision' not implemented
XFAIL platform_tests/api/test_psu.py::TestPsuApi::test_get_revision[e1031-1] - [DX010] case failed and waiting for fix; [E1031] API 'get_revision' not implemented
SKIPPED [1] platform_tests/api/test_psu.py: Unsupported platform API
XFAIL platform_tests/api/test_chassis.py::TestChassisApi::test_get_revision[e1031-1] - [DX010] Testcase consistently fails, raised issue to track; [E1031] API 'get_revision' not implemented
XFAIL platform_tests/api/test_chassis.py::TestChassisApi::test_get_revision[e1031-1] - [DX010] Testcase consistently fails, raised issue to track; [E1031] API 'get_revision' not implemented
XFAIL platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db[e1031-1-None] - CLI Utility sfpshow not working correctly
```

#### Any platform specific information?
This PR only for Celestica-E1031 platform.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
