### PR TITLE
Copp Testcase fix for no BGP trap scenario

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -251,17 +251,25 @@ class PolicyTest(ControlPlaneBaseTest):
 
     def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
         self.log("")
-        self.log("Checking constraints (PolicyApplied):")
-        self.log(
-            "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
-            (int(self.PPS_LIMIT_MIN),
-             int(rx_pps),
-             int(self.PPS_LIMIT_MAX),
-             str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
-        )
-
-        assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(
-            rx_pps)
+        if self.has_trap:
+            self.log("Checking constraints (PolicyApplied):")
+            self.log(
+                "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+                (int(self.PPS_LIMIT_MIN),
+                 int(rx_pps),
+                 int(self.PPS_LIMIT_MAX),
+                 str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+            )
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "rx_pps {}".format(rx_pps)
+        else:
+            self.log("Checking constraints (NoPolicyApplied):")
+            self.log(
+                "rx_pps (%d) <= PPS_LIMIT_MIN (%d): %s" %
+                (int(rx_pps),
+                 int(self.PPS_LIMIT_MIN),
+                 str(rx_pps <= self.PPS_LIMIT_MIN))
+            )
+            assert rx_pps <= self.PPS_LIMIT_MIN, "rx_pps {}".format(rx_pps)
 
 
 # SONIC config contains policer CIR=600 for ARP

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -288,12 +288,16 @@ def configure_always_enabled_for_trap(dut, trap_id, always_enabled):
         always_enabled (str): true or false
     """
     copp_trap_config_json = "/tmp/copp_{}.json".format(trap_id)
+    # Need to remove ip2me trap to test no trap condition to avoid packets being trapped by ip2me after bgp trap removal
     cmd_copp_trap_always_enabled_config = """
 cat << EOF >  %s
 {
    "COPP_TRAP": {
        "%s": {
        "always_enabled": "%s"
+       },
+       "ip2me": {
+       "always_enabled": "false"
        }
     }
 }

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -288,16 +288,12 @@ def configure_always_enabled_for_trap(dut, trap_id, always_enabled):
         always_enabled (str): true or false
     """
     copp_trap_config_json = "/tmp/copp_{}.json".format(trap_id)
-    # Need to remove ip2me trap to test no trap condition to avoid packets being trapped by ip2me after bgp trap removal
     cmd_copp_trap_always_enabled_config = """
 cat << EOF >  %s
 {
    "COPP_TRAP": {
        "%s": {
        "always_enabled": "%s"
-       },
-       "ip2me": {
-       "always_enabled": "false"
        }
     }
 }
@@ -377,7 +373,10 @@ def uninstall_trap(dut, feature_name, trap_id):
         feature_name (str): feature name corresponding to the trap
         trap_id (str): trap id
     """
-    disable_feature_entry(dut, feature_name)
+    feature_list, _ = dut.get_feature_status()
+    if feature_name in feature_list.keys():
+        disable_feature_entry(dut, feature_name)
+
     configure_always_enabled_for_trap(dut, trap_id, "false")
 
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -111,8 +111,9 @@ class TestCOPP(object):
         logger.info("Uninstall trap {}".format(self.trap_id))
         copp_utils.uninstall_trap(duthost, self.feature_name, self.trap_id)
         # remove ip2me because bgp traffic can fall back to ip2me trap then interfere following traffic tests
-        logger.info("Uninstall trap ip2me")
-        copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
+        if self.trap_id == "bgp":
+            logger.info("Uninstall trap ip2me")
+            copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
 
         logger.info("Verify {} trap status is uninstalled by sending traffic".format(self.trap_id))
         _copp_runner(duthost,
@@ -145,8 +146,9 @@ class TestCOPP(object):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        logger.info("Uninstall trap ip2me")
-        copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
+        if self.trap_id == "bgp":
+            logger.info("Uninstall trap ip2me")
+            copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
 
         logger.info("Pre condition: make trap {} is installed".format(self.feature_name))
         pre_condition_install_trap(ptfhost, duthost, copp_testbed, self.trap_id, self.feature_name)

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -110,6 +110,9 @@ class TestCOPP(object):
 
         logger.info("Uninstall trap {}".format(self.trap_id))
         copp_utils.uninstall_trap(duthost, self.feature_name, self.trap_id)
+        # remove ip2me because bgp traffic can fall back to ip2me trap then interfere following traffic tests
+        logger.info("Uninstall trap ip2me")
+        copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
 
         logger.info("Verify {} trap status is uninstalled by sending traffic".format(self.trap_id))
         _copp_runner(duthost,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -145,6 +145,9 @@ class TestCOPP(object):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
+        logger.info("Uninstall trap ip2me")
+        copp_utils.uninstall_trap(duthost, "ip2me", "ip2me")
+
         logger.info("Pre condition: make trap {} is installed".format(self.feature_name))
         pre_condition_install_trap(ptfhost, duthost, copp_testbed, self.trap_id, self.feature_name)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR fixes the copp_utils.py to uninstall ip2me traps that captured packets after bgp trap uninstall and lead to unexpected delivery of packets to PTF
Also,
this PR brings back the PR[11444 ](https://github.com/sonic-net/sonic-mgmt/pull/11444) that added a condition to check trap presence status with added accurate log messages
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
[11434](https://github.com/sonic-net/sonic-mgmt/issues/11434)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To fix copp testcase failure due to IP2ME trap capturing packets after bgp trap uninstall and missing condition to check trap status
#### How did you do it?
Added ip2me and bgp trap to be uninstalled in copp_utils.py
#### How did you verify/test it?
Ran copp suite on M0/MX topology
![image](https://github.com/sonic-net/sonic-mgmt/assets/92752170/7c41777c-7d91-4ea1-b67b-2e43b974d21f)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
